### PR TITLE
[FLINK-39378][table] Add support for Context, timers and on_time to PTF test harness

### DIFF
--- a/docs/content.zh/docs/dev/table/functions/ptfs.md
+++ b/docs/content.zh/docs/dev/table/functions/ptfs.md
@@ -2465,6 +2465,126 @@ void testStateMutation() throws Exception {
 {{< /tab >}}
 {{< /tabs >}}
 
+#### Testing with Timers and Context
+
+The harness supports the `Context` parameter, timer registration via `TimeContext`, and `onTimer`
+callbacks. Use `.withOnTimeColumn()` to configure the event time column and `.setWatermark()` to
+advance watermarks and fire eligible timers.
+
+{{< tabs "timer-testing" >}}
+{{< tab "Java" >}}
+```java
+// A PTF that registers a named timer 5 seconds after each event, and emits when it fires.
+@DataTypeHint("ROW<message STRING>")
+public class TimerPTF extends ProcessTableFunction<Row> {
+  public void eval(
+      Context ctx,
+      @ArgumentHint({ArgumentTrait.SET_SEMANTIC_TABLE, ArgumentTrait.REQUIRE_ON_TIME})
+          Row input) {
+    String name = input.getFieldAs("name");
+    TimeContext<LocalDateTime> timeCtx = ctx.timeContext(LocalDateTime.class);
+    timeCtx.registerOnTime("timeout-" + name, timeCtx.time().plus(Duration.ofSeconds(5)));
+    collect(Row.of("registered-" + name));
+  }
+
+  public void onTimer(OnTimerContext ctx) {
+    collect(Row.of("timer-fired-" + ctx.currentTimer()));
+  }
+}
+
+@Test
+void testTimerRegistrationAndFiring() throws Exception {
+  try (ProcessTableFunctionTestHarness<Row> harness =
+      ProcessTableFunctionTestHarness.ofClass(TimerPTF.class)
+          .withTableArgument("input",
+              DataTypes.of("ROW<partition STRING, name STRING, ts TIMESTAMP(3)>"))
+          .withPartitionBy("input", "partition")
+          .withOnTimeColumn("ts")
+          .build()) {
+
+    harness.processElement(Row.of("P1", "Alice", LocalDateTime.of(2025, 1, 1, 0, 0, 1)));
+
+    // Verify the timer was registered
+    assertThat(harness.getPendingTimers()).hasSize(1);
+    Timer timer = harness.getPendingTimers().get(0);
+    assertThat(timer.getName()).isEqualTo("timeout-Alice");
+    assertThat(timer.getTimestampAs(LocalDateTime.class))
+        .isEqualTo(LocalDateTime.of(2025, 1, 1, 0, 0, 6));
+
+    // Only eval() output so far — the timer has not fired yet
+    assertThat(harness.getOutput())
+        .containsExactly(
+            Row.of("P1", "registered-Alice", LocalDateTime.of(2025, 1, 1, 0, 0, 1)));
+
+    // Advance watermark past the timer's timestamp to fire it
+    harness.clearOutput();
+    harness.setWatermark(LocalDateTime.of(2025, 1, 1, 0, 0, 7));
+
+    assertThat(harness.getOutput())
+        .containsExactly(
+            Row.of("P1", "timer-fired-timeout-Alice", LocalDateTime.of(2025, 1, 1, 0, 0, 6)));
+
+    assertThat(harness.getPendingTimers()).isEmpty();
+    assertThat(harness.getFiredTimers()).hasSize(1);
+  }
+}
+```
+{{< /tab >}}
+{{< /tabs >}}
+
+**Timers with State**: State persisted during `eval()` is accessible in `onTimer()`:
+
+{{< tabs "timer-state-testing" >}}
+{{< tab "Java" >}}
+```java
+@DataTypeHint("ROW<message STRING>")
+public class TimerWithStatePTF extends ProcessTableFunction<Row> {
+  public static class CounterState {
+    public long count = 0L;
+  }
+
+  public void eval(
+      Context ctx,
+      @StateHint CounterState state,
+      @ArgumentHint({ArgumentTrait.SET_SEMANTIC_TABLE, ArgumentTrait.REQUIRE_ON_TIME})
+          Row input) {
+    state.count++;
+    TimeContext<LocalDateTime> timeCtx = ctx.timeContext(LocalDateTime.class);
+    timeCtx.registerOnTime("check", timeCtx.time().plus(Duration.ofSeconds(5)));
+  }
+
+  public void onTimer(OnTimerContext ctx, @StateHint CounterState state) {
+    collect(Row.of("count=" + state.count));
+  }
+}
+
+@Test
+void testTimerWithState() throws Exception {
+  try (ProcessTableFunctionTestHarness<Row> harness =
+      ProcessTableFunctionTestHarness.ofClass(TimerWithStatePTF.class)
+          .withTableArgument("input",
+              DataTypes.of("ROW<partition STRING, ts TIMESTAMP(3)>"))
+          .withPartitionBy("input", "partition")
+          .withOnTimeColumn("ts")
+          .build()) {
+
+    harness.processElement(Row.of("P1", LocalDateTime.of(2025, 1, 1, 0, 0, 1)));
+    harness.processElement(Row.of("P1", LocalDateTime.of(2025, 1, 1, 0, 0, 1)));
+    harness.processElement(Row.of("P1", LocalDateTime.of(2025, 1, 1, 0, 0, 1)));
+    harness.processElement(Row.of("P2", LocalDateTime.of(2025, 1, 1, 0, 0, 2)));
+
+    // One watermark advancement fires both timers (P1 at +5s, P2 at +5s)
+    harness.setWatermark(LocalDateTime.of(2025, 1, 1, 0, 0, 8));
+    assertThat(harness.getOutput())
+        .containsExactly(
+            Row.of("P1", "count=3", LocalDateTime.of(2025, 1, 1, 0, 0, 6)),
+            Row.of("P2", "count=1", LocalDateTime.of(2025, 1, 1, 0, 0, 7)));
+  }
+}
+```
+{{< /tab >}}
+{{< /tabs >}}
+
 #### Optional Partitioning
 
 For PTFs with `OPTIONAL_PARTITION_BY`, you can omit `withPartitionBy()` during harness setup. The
@@ -2582,8 +2702,5 @@ void testPOJO() throws Exception {
 
 ### PTF Features Unsupported by the TestHarness
 
-- `Context` parameter
-- Timers (`onTimer`)
-- `on_time` / `rowtime`
 - Update traits (`SUPPORTS_UPDATES`, `REQUIRE_UPDATE_BEFORE`)
 - State TTL (state is supported but TTL expiration is not yet implemented)

--- a/docs/content/docs/dev/table/functions/ptfs.md
+++ b/docs/content/docs/dev/table/functions/ptfs.md
@@ -2468,6 +2468,126 @@ void testStateMutation() throws Exception {
 {{< /tab >}}
 {{< /tabs >}}
 
+#### Testing with Timers and Context
+
+The harness supports the `Context` parameter, timer registration via `TimeContext`, and `onTimer`
+callbacks. Use `.withOnTimeColumn()` to configure the event time column and `.setWatermark()` to
+advance watermarks and fire eligible timers.
+
+{{< tabs "timer-testing" >}}
+{{< tab "Java" >}}
+```java
+// A PTF that registers a named timer 5 seconds after each event, and emits when it fires.
+@DataTypeHint("ROW<message STRING>")
+public class TimerPTF extends ProcessTableFunction<Row> {
+  public void eval(
+      Context ctx,
+      @ArgumentHint({ArgumentTrait.SET_SEMANTIC_TABLE, ArgumentTrait.REQUIRE_ON_TIME})
+          Row input) {
+    String name = input.getFieldAs("name");
+    TimeContext<LocalDateTime> timeCtx = ctx.timeContext(LocalDateTime.class);
+    timeCtx.registerOnTime("timeout-" + name, timeCtx.time().plus(Duration.ofSeconds(5)));
+    collect(Row.of("registered-" + name));
+  }
+
+  public void onTimer(OnTimerContext ctx) {
+    collect(Row.of("timer-fired-" + ctx.currentTimer()));
+  }
+}
+
+@Test
+void testTimerRegistrationAndFiring() throws Exception {
+  try (ProcessTableFunctionTestHarness<Row> harness =
+      ProcessTableFunctionTestHarness.ofClass(TimerPTF.class)
+          .withTableArgument("input",
+              DataTypes.of("ROW<partition STRING, name STRING, ts TIMESTAMP(3)>"))
+          .withPartitionBy("input", "partition")
+          .withOnTimeColumn("ts")
+          .build()) {
+
+    harness.processElement(Row.of("P1", "Alice", LocalDateTime.of(2025, 1, 1, 0, 0, 1)));
+
+    // Verify the timer was registered
+    assertThat(harness.getPendingTimers()).hasSize(1);
+    Timer timer = harness.getPendingTimers().get(0);
+    assertThat(timer.getName()).isEqualTo("timeout-Alice");
+    assertThat(timer.getTimestampAs(LocalDateTime.class))
+        .isEqualTo(LocalDateTime.of(2025, 1, 1, 0, 0, 6));
+
+    // Only eval() output so far — the timer has not fired yet
+    assertThat(harness.getOutput())
+        .containsExactly(
+            Row.of("P1", "registered-Alice", LocalDateTime.of(2025, 1, 1, 0, 0, 1)));
+
+    // Advance watermark past the timer's timestamp to fire it
+    harness.clearOutput();
+    harness.setWatermark(LocalDateTime.of(2025, 1, 1, 0, 0, 7));
+
+    assertThat(harness.getOutput())
+        .containsExactly(
+            Row.of("P1", "timer-fired-timeout-Alice", LocalDateTime.of(2025, 1, 1, 0, 0, 6)));
+
+    assertThat(harness.getPendingTimers()).isEmpty();
+    assertThat(harness.getFiredTimers()).hasSize(1);
+  }
+}
+```
+{{< /tab >}}
+{{< /tabs >}}
+
+**Timers with State**: State persisted during `eval()` is accessible in `onTimer()`:
+
+{{< tabs "timer-state-testing" >}}
+{{< tab "Java" >}}
+```java
+@DataTypeHint("ROW<message STRING>")
+public class TimerWithStatePTF extends ProcessTableFunction<Row> {
+  public static class CounterState {
+    public long count = 0L;
+  }
+
+  public void eval(
+      Context ctx,
+      @StateHint CounterState state,
+      @ArgumentHint({ArgumentTrait.SET_SEMANTIC_TABLE, ArgumentTrait.REQUIRE_ON_TIME})
+          Row input) {
+    state.count++;
+    TimeContext<LocalDateTime> timeCtx = ctx.timeContext(LocalDateTime.class);
+    timeCtx.registerOnTime("check", timeCtx.time().plus(Duration.ofSeconds(5)));
+  }
+
+  public void onTimer(OnTimerContext ctx, @StateHint CounterState state) {
+    collect(Row.of("count=" + state.count));
+  }
+}
+
+@Test
+void testTimerWithState() throws Exception {
+  try (ProcessTableFunctionTestHarness<Row> harness =
+      ProcessTableFunctionTestHarness.ofClass(TimerWithStatePTF.class)
+          .withTableArgument("input",
+              DataTypes.of("ROW<partition STRING, ts TIMESTAMP(3)>"))
+          .withPartitionBy("input", "partition")
+          .withOnTimeColumn("ts")
+          .build()) {
+
+    harness.processElement(Row.of("P1", LocalDateTime.of(2025, 1, 1, 0, 0, 1)));
+    harness.processElement(Row.of("P1", LocalDateTime.of(2025, 1, 1, 0, 0, 1)));
+    harness.processElement(Row.of("P1", LocalDateTime.of(2025, 1, 1, 0, 0, 1)));
+    harness.processElement(Row.of("P2", LocalDateTime.of(2025, 1, 1, 0, 0, 2)));
+
+    // One watermark advancement fires both timers (P1 at +5s, P2 at +5s)
+    harness.setWatermark(LocalDateTime.of(2025, 1, 1, 0, 0, 8));
+    assertThat(harness.getOutput())
+        .containsExactly(
+            Row.of("P1", "count=3", LocalDateTime.of(2025, 1, 1, 0, 0, 6)),
+            Row.of("P2", "count=1", LocalDateTime.of(2025, 1, 1, 0, 0, 7)));
+  }
+}
+```
+{{< /tab >}}
+{{< /tabs >}}
+
 #### Optional Partitioning
 
 For PTFs with `OPTIONAL_PARTITION_BY`, you can omit `withPartitionBy()` during harness setup. The
@@ -2585,8 +2705,5 @@ void testPOJO() throws Exception {
 
 ### PTF Features Unsupported by the TestHarness
 
-- `Context` parameter
-- Timers (`onTimer`)
-- `on_time` / `rowtime`
 - Update traits (`SUPPORTS_UPDATES`, `REQUIRE_UPDATE_BEFORE`)
 - State TTL (state is supported but TTL expiration is not yet implemented)

--- a/flink-table/flink-table-test-utils/src/main/java/org/apache/flink/table/runtime/functions/InvocationContext.java
+++ b/flink-table/flink-table-test-utils/src/main/java/org/apache/flink/table/runtime/functions/InvocationContext.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.functions;
+
+import org.apache.flink.types.Row;
+
+import javax.annotation.Nullable;
+
+/**
+ * Per-invocation context for an eval() or onTimer() call in the test harness. partitionKey is
+ * always set. For eval(), row and tableArgumentName are set. For onTimer(), firingTimer is set.
+ */
+class InvocationContext {
+    final Row partitionKey;
+    @Nullable final Row row;
+    @Nullable final String tableArgumentName;
+    @Nullable final Timer firingTimer;
+
+    private InvocationContext(
+            Row partitionKey,
+            @Nullable Row row,
+            @Nullable String tableArgumentName,
+            @Nullable Timer firingTimer) {
+        this.partitionKey = partitionKey;
+        this.row = row;
+        this.tableArgumentName = tableArgumentName;
+        this.firingTimer = firingTimer;
+    }
+
+    static InvocationContext forEval(Row partitionKey, Row row, String tableArgumentName) {
+        return new InvocationContext(partitionKey, row, tableArgumentName, null);
+    }
+
+    static InvocationContext forTimer(Timer timer) {
+        return new InvocationContext(timer.partitionKey, null, null, timer);
+    }
+
+    boolean isTimerInvocation() {
+        return firingTimer != null;
+    }
+
+    boolean isEvalInvocation() {
+        return tableArgumentName != null;
+    }
+}

--- a/flink-table/flink-table-test-utils/src/main/java/org/apache/flink/table/runtime/functions/ProcessTableFunctionTestHarness.java
+++ b/flink-table/flink-table-test-utils/src/main/java/org/apache/flink/table/runtime/functions/ProcessTableFunctionTestHarness.java
@@ -20,7 +20,12 @@ package org.apache.flink.table.runtime.functions;
 
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.table.annotation.ArgumentTrait;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.api.TableRuntimeException;
+import org.apache.flink.table.api.dataview.ListView;
+import org.apache.flink.table.api.dataview.MapView;
 import org.apache.flink.table.catalog.DataTypeFactory;
+import org.apache.flink.table.connector.ChangelogMode;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.conversion.DataStructureConverter;
 import org.apache.flink.table.data.conversion.DataStructureConverters;
@@ -31,6 +36,7 @@ import org.apache.flink.table.functions.TableSemantics;
 import org.apache.flink.table.types.AbstractDataType;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.FieldsDataType;
+import org.apache.flink.table.types.extraction.ExtractionUtils;
 import org.apache.flink.table.types.inference.StateTypeStrategy;
 import org.apache.flink.table.types.inference.StaticArgument;
 import org.apache.flink.table.types.inference.StaticArgumentTrait;
@@ -43,18 +49,24 @@ import org.apache.flink.table.types.logical.MapType;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.logical.StructuredType;
 import org.apache.flink.table.types.utils.TypeConversions;
+import org.apache.flink.table.utils.DateTimeUtils;
 import org.apache.flink.types.Row;
 import org.apache.flink.types.RowKind;
 import org.apache.flink.util.Collector;
 
 import org.apache.commons.lang3.ClassUtils;
 
+import javax.annotation.Nullable;
+
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;
 import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -63,6 +75,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -113,7 +126,8 @@ public class ProcessTableFunctionTestHarness<OUT> implements AutoCloseable {
     private final TestHarnessStateManager stateManager;
 
     private final String defaultTableArgument;
-    private final Method evalMethod;
+    private final ResolvedMethod<ProcessTableFunction.Context> eval;
+    @Nullable private final ResolvedMethod<ProcessTableFunction.OnTimerContext> onTimer;
     private final List<ArgumentInfo> arguments;
 
     private final Map<String, ArgumentInfo> argumentsByName;
@@ -123,22 +137,35 @@ public class ProcessTableFunctionTestHarness<OUT> implements AutoCloseable {
     private final Map<String, TableArgumentConverters> argumentConverters;
     private final DataStructureConverter<Object, Object> harnessOutputConverter;
 
+    private final TestHarnessTimerManager timerManager;
+    @Nullable private final String onTimeColumnName;
+
+    @Nullable private final Class<?> rowtimeConversionClass;
+
+    @Nullable private InvocationContext currentInvocation;
+
     private ProcessTableFunctionTestHarness(
             ProcessTableFunction<OUT> function,
             FunctionContext functionContext,
-            Method evalMethod,
+            ResolvedMethod<ProcessTableFunction.Context> eval,
+            @Nullable ResolvedMethod<ProcessTableFunction.OnTimerContext> onTimer,
             List<ArgumentInfo> arguments,
             Map<String, TableArgumentConverters> argumentConverters,
             DataStructureConverter<Object, Object> harnessOutputConverter,
-            TestHarnessStateManager stateManager)
+            TestHarnessStateManager stateManager,
+            TestHarnessTimerManager timerManager,
+            @Nullable String onTimeColumnName)
             throws Exception {
         this.function = function;
         this.functionContext = functionContext;
-        this.evalMethod = evalMethod;
+        this.eval = eval;
+        this.onTimer = onTimer;
         this.arguments = arguments;
         this.argumentConverters = argumentConverters;
         this.harnessOutputConverter = harnessOutputConverter;
         this.stateManager = stateManager;
+        this.timerManager = timerManager;
+        this.onTimeColumnName = onTimeColumnName;
         this.output = new ArrayList<>();
         this.collector = new HarnessCollector();
         this.isOpen = false;
@@ -160,6 +187,8 @@ public class ProcessTableFunctionTestHarness<OUT> implements AutoCloseable {
             this.defaultTableArgument = null;
             this.isSingleTableFunction = false;
         }
+
+        this.rowtimeConversionClass = resolveRowtimeConversionClass(tableArguments);
 
         openFunction();
     }
@@ -258,7 +287,7 @@ public class ProcessTableFunctionTestHarness<OUT> implements AutoCloseable {
         Object[] args = arguments.stream().map(arg -> ((ScalarArgumentInfo) arg).value).toArray();
 
         try {
-            evalMethod.invoke(function, args);
+            eval.method.invoke(function, args);
         } catch (InvocationTargetException e) {
             handleEvalInvocationException(
                     "Exception occurred during scalar-only PTF eval() invocation.\n", args, e);
@@ -305,6 +334,420 @@ public class ProcessTableFunctionTestHarness<OUT> implements AutoCloseable {
         stateManager.clearStateForKey(stateName, partitionKey);
     }
 
+    // -------------------------------------------------------------------------
+    // Watermark & Timer API
+    // -------------------------------------------------------------------------
+
+    /**
+     * Sets the watermark for all tables to the given {@link LocalDateTime} and fires eligible
+     * timers.
+     */
+    public void setWatermark(LocalDateTime watermark) throws Exception {
+        checkNotNull(watermark, "watermark must not be null");
+        setWatermarkMillis(DateTimeUtils.toTimestampMillis(watermark));
+    }
+
+    /** Sets the watermark for all tables to the given {@link Instant} and fires eligible timers. */
+    public void setWatermark(Instant watermark) throws Exception {
+        checkNotNull(watermark, "watermark must not be null");
+        setWatermarkMillis(watermark.toEpochMilli());
+    }
+
+    /**
+     * Sets the watermark for a specific table. Fires eligible timers if this advances the global
+     * watermark (the minimum across all tables).
+     */
+    public void setWatermarkForTable(String tableArgument, LocalDateTime watermark)
+            throws Exception {
+        checkNotNull(watermark, "watermark must not be null");
+        setWatermarkForTableMillis(tableArgument, DateTimeUtils.toTimestampMillis(watermark));
+    }
+
+    /**
+     * Sets the watermark for a specific table. Fires eligible timers if this advances the global
+     * watermark (the minimum across all tables).
+     */
+    public void setWatermarkForTable(String tableArgument, Instant watermark) throws Exception {
+        checkNotNull(watermark, "watermark must not be null");
+        setWatermarkForTableMillis(tableArgument, watermark.toEpochMilli());
+    }
+
+    /** Returns all timers (both pending and fired), sorted by timestamp then name. */
+    public List<Timer> getAllTimers() {
+        return Stream.concat(
+                        timerManager.getPendingTimers().stream(),
+                        timerManager.getFiredTimers().stream())
+                .sorted()
+                .collect(Collectors.toList());
+    }
+
+    /** Returns all timers (both pending and fired) for the given partition key. */
+    public List<Timer> getAllTimers(Row partitionKey) {
+        return getAllTimers().stream()
+                .filter(t -> partitionKey.equals(t.getKey()))
+                .collect(Collectors.toList());
+    }
+
+    /** Returns all pending (not yet fired) timers, sorted by timestamp then name. */
+    public List<Timer> getPendingTimers() {
+        return timerManager.getPendingTimers();
+    }
+
+    /** Returns all pending timers for the given partition key. */
+    public List<Timer> getPendingTimers(Row partitionKey) {
+        return timerManager.getPendingTimers().stream()
+                .filter(t -> partitionKey.equals(t.getKey()))
+                .collect(Collectors.toList());
+    }
+
+    /** Returns all pending timers with the given name. */
+    public List<Timer> getPendingTimers(String timerName) {
+        return timerManager.getPendingTimers().stream()
+                .filter(t -> timerName.equals(t.getName()))
+                .collect(Collectors.toList());
+    }
+
+    /** Returns all timers that have fired, in the order they fired. */
+    public List<Timer> getFiredTimers() {
+        return timerManager.getFiredTimers();
+    }
+
+    /** Returns all fired timers for the given partition key. */
+    public List<Timer> getFiredTimers(Row partitionKey) {
+        return timerManager.getFiredTimers().stream()
+                .filter(t -> partitionKey.equals(t.getKey()))
+                .collect(Collectors.toList());
+    }
+
+    /** Returns all fired timers with the given name. */
+    public List<Timer> getFiredTimers(String timerName) {
+        return timerManager.getFiredTimers().stream()
+                .filter(t -> timerName.equals(t.getName()))
+                .collect(Collectors.toList());
+    }
+
+    /** Clears the fired timer history. */
+    public void clearFiredTimers() {
+        timerManager.clearFiredTimers();
+    }
+
+    private void setWatermarkMillis(long millis) throws Exception {
+        checkState(isOpen, "Harness is not open");
+        for (TableArgumentInfo tableArg : ArgumentInfo.filterTableArguments(arguments)) {
+            timerManager.setTableWatermark(tableArg.name, millis);
+        }
+        timerManager.updateGlobalWatermarkAndFireTimers(this::fireTimer);
+    }
+
+    private void setWatermarkForTableMillis(String tableArgument, long millis) throws Exception {
+        checkState(isOpen, "Harness is not open");
+        checkNotNull(tableArgument, "tableArgument must not be null");
+        checkArgument(
+                argumentsByName.get(tableArgument) instanceof TableArgumentInfo,
+                "Unknown or non-table argument: %s",
+                tableArgument);
+        timerManager.setTableWatermark(tableArgument, millis);
+        timerManager.updateGlobalWatermarkAndFireTimers(this::fireTimer);
+    }
+
+    private void fireTimer(Timer timer) throws Exception {
+        if (onTimer == null) {
+            throw new IllegalStateException(
+                    "Timer fired but no valid onTimer() method is defined in "
+                            + function.getClass().getSimpleName());
+        }
+
+        currentInvocation = InvocationContext.forTimer(timer);
+
+        Map<String, Object> stateMap = stateManager.loadStateForKey(timer.partitionKey);
+
+        List<StateArgumentInfo> stateArgs = ArgumentInfo.filterStateArguments(arguments);
+        Object[] methodArgs = new Object[stateArgs.size()];
+        for (int i = 0; i < stateArgs.size(); i++) {
+            methodArgs[i] = stateMap.get(stateArgs.get(i).name);
+        }
+
+        try {
+            onTimer.invoke(function, new TestOnTimerContext(stateMap), methodArgs);
+        } catch (InvocationTargetException e) {
+            Throwable cause = e.getCause();
+            if (cause instanceof Exception) {
+                throw (Exception) cause;
+            }
+            throw new RuntimeException("onTimer() invocation failed", e);
+        } finally {
+            currentInvocation = null;
+        }
+
+        stateManager.updateStateForKey(timer.partitionKey, stateMap);
+    }
+
+    // -------------------------------------------------------------------------
+    // Context implementations
+    // -------------------------------------------------------------------------
+
+    private class TestContext implements ProcessTableFunction.Context {
+        final Map<String, Object> stateMap;
+
+        TestContext(Map<String, Object> stateMap) {
+            this.stateMap = stateMap;
+        }
+
+        @Override
+        public <TimeType> ProcessTableFunction.TimeContext<TimeType> timeContext(
+                Class<TimeType> conversionClass) {
+            return new TestTimeContext<>(conversionClass);
+        }
+
+        @Override
+        public TableSemantics tableSemanticsFor(String argName) {
+            List<String> tableArgNames =
+                    ArgumentInfo.filterTableArguments(arguments).stream()
+                            .map(t -> t.name)
+                            .collect(Collectors.toList());
+            ArgumentInfo argInfo = argumentsByName.get(argName);
+            if (argInfo == null || !(argInfo instanceof TableArgumentInfo)) {
+                throw new IllegalArgumentException(
+                        String.format(
+                                "Argument '%s' is not a table argument. Available table arguments: %s",
+                                argName, tableArgNames));
+            }
+            TableArgumentInfo tableArg = (TableArgumentInfo) argInfo;
+            int[] partitionIndices = getPartitionColumnIndices(tableArg);
+            int timeColumnIndex =
+                    onTimeColumnName != null
+                            ? getFieldNames(tableArg.dataType).indexOf(onTimeColumnName)
+                            : -1;
+            return new TestHarnessTableSemantics(
+                    tableArg.dataType, partitionIndices, timeColumnIndex);
+        }
+
+        @Override
+        public void clearState(String stateName) {
+            stateMap.remove(stateName);
+        }
+
+        @Override
+        public void clearAllState() {
+            stateMap.clear();
+        }
+
+        @Override
+        public void clearAllTimers() {
+            timerManager.clearAll(currentInvocation.partitionKey);
+        }
+
+        @Override
+        public void clearAll() {
+            stateMap.clear();
+            timerManager.clearAll(currentInvocation.partitionKey);
+        }
+
+        @Override
+        public ChangelogMode getChangelogMode() {
+            return ChangelogMode.insertOnly();
+        }
+    }
+
+    private class TestTimeContext<TimeType> implements ProcessTableFunction.TimeContext<TimeType> {
+        private final Class<TimeType> conversionClass;
+
+        TestTimeContext(Class<TimeType> conversionClass) {
+            if (!Set.of(
+                            Long.class,
+                            long.class,
+                            Instant.class,
+                            LocalDateTime.class,
+                            java.sql.Timestamp.class)
+                    .contains(conversionClass)) {
+                throw new IllegalArgumentException(
+                        "Unsupported time type: " + conversionClass.getName());
+            }
+            this.conversionClass = conversionClass;
+        }
+
+        @Override
+        public TimeType time() {
+            InvocationContext ctx = currentInvocation;
+            if (ctx.isTimerInvocation()) {
+                return fromMillis(ctx.firingTimer.timestamp);
+            }
+            if (ctx.isEvalInvocation() && onTimeColumnName != null) {
+                ArgumentInfo argInfo = argumentsByName.get(ctx.tableArgumentName);
+                if (argInfo instanceof TableArgumentInfo) {
+                    TableArgumentInfo tableArg = (TableArgumentInfo) argInfo;
+                    if (!getFieldNames(tableArg.dataType).contains(onTimeColumnName)) {
+                        return null;
+                    }
+                }
+                Object timeValue = ctx.row.getField(onTimeColumnName);
+                if (timeValue == null) {
+                    return null;
+                }
+                return fromMillis(toMillis(timeValue));
+            }
+            return null;
+        }
+
+        @Override
+        public TimeType tableWatermark() {
+            InvocationContext ctx = currentInvocation;
+            if (!ctx.isEvalInvocation()) {
+                return null;
+            }
+            Long wm = timerManager.getWatermarkForTable(ctx.tableArgumentName);
+            return wm != null ? fromMillis(wm) : null;
+        }
+
+        @Override
+        public TimeType currentWatermark() {
+            Long wm = timerManager.getGlobalWatermark();
+            return wm != null ? fromMillis(wm) : null;
+        }
+
+        @Override
+        public void registerOnTime(String name, TimeType time) {
+            checkTimersEnabled();
+            checkNotNull(name, "Timer name must not be null");
+            checkNotNull(time, "Timer timestamp must not be null");
+            timerManager.register(currentInvocation.partitionKey, toMillis(time), name);
+        }
+
+        @Override
+        public void registerOnTime(TimeType time) {
+            checkTimersEnabled();
+            checkNotNull(time, "Timer timestamp must not be null");
+            timerManager.register(currentInvocation.partitionKey, toMillis(time), null);
+        }
+
+        @Override
+        public void clearTimer(String name) {
+            checkNotNull(name, "Timer name must not be null");
+            timerManager.clearByName(currentInvocation.partitionKey, name);
+        }
+
+        @Override
+        public void clearTimer(TimeType time) {
+            checkNotNull(time, "Timer timestamp must not be null");
+            timerManager.clearByTimestamp(currentInvocation.partitionKey, toMillis(time));
+        }
+
+        @Override
+        public void clearAllTimers() {
+            timerManager.clearAll(currentInvocation.partitionKey);
+        }
+
+        private void checkTimersEnabled() {
+            boolean enabled =
+                    ArgumentInfo.filterTableArguments(arguments).stream()
+                            .anyMatch(
+                                    t ->
+                                            t.isSetSemantic
+                                                    && t.prependStrategy
+                                                            != OutputPrependStrategy.ALL_COLUMNS);
+            if (!enabled) {
+                throw new TableRuntimeException(
+                        "Timers are not supported in the current PTF declaration. "
+                                + "Note that only PTFs that take set semantic tables support timers. "
+                                + "Also timers are not available for advanced traits such as "
+                                + "supporting pass-through columns or updates.");
+            }
+        }
+
+        private TimeType fromMillis(long millis) {
+            return convertFromMillis(millis, conversionClass);
+        }
+
+        private long toMillis(Object time) {
+            if (time instanceof Long) {
+                return (Long) time;
+            } else if (time instanceof Instant) {
+                return ((Instant) time).toEpochMilli();
+            } else if (time instanceof LocalDateTime) {
+                return DateTimeUtils.toTimestampMillis((LocalDateTime) time);
+            } else if (time instanceof java.sql.Timestamp) {
+                return DateTimeUtils.toInternal((java.sql.Timestamp) time);
+            }
+            throw new IllegalArgumentException(
+                    "Unsupported time type: " + time.getClass().getSimpleName());
+        }
+    }
+
+    private class TestOnTimerContext extends TestContext
+            implements ProcessTableFunction.OnTimerContext {
+
+        TestOnTimerContext(Map<String, Object> stateMap) {
+            super(stateMap);
+        }
+
+        @Override
+        public String currentTimer() {
+            if (currentInvocation.isTimerInvocation()) {
+                return currentInvocation.firingTimer.getName();
+            }
+            return null;
+        }
+    }
+
+    private static int[] getPartitionColumnIndices(TableArgumentInfo arg) {
+        if (arg.partitionColumnNames == null || arg.partitionColumnNames.length == 0) {
+            return new int[0];
+        }
+        List<String> fieldNames = getFieldNames(arg.dataType);
+        int[] indices = new int[arg.partitionColumnNames.length];
+        for (int i = 0; i < arg.partitionColumnNames.length; i++) {
+            String colName = arg.partitionColumnNames[i];
+            int index = fieldNames.indexOf(colName);
+            if (index < 0) {
+                throw new IllegalStateException(
+                        "Partition column '"
+                                + colName
+                                + "' not found in table argument. "
+                                + "Available fields: "
+                                + fieldNames);
+            }
+            indices[i] = index;
+        }
+        return indices;
+    }
+
+    @Nullable
+    private Class<?> resolveRowtimeConversionClass(List<TableArgumentInfo> tableArguments) {
+        if (onTimeColumnName == null) {
+            return null;
+        }
+        for (TableArgumentInfo tableArg : tableArguments) {
+            List<String> fieldNames = getFieldNames(tableArg.dataType);
+            int idx = fieldNames.indexOf(onTimeColumnName);
+            if (idx >= 0) {
+                return DataType.getFields(tableArg.dataType)
+                        .get(idx)
+                        .getDataType()
+                        .getConversionClass();
+            }
+        }
+        throw new IllegalStateException(
+                "Could not resolve rowtime conversion class for column: " + onTimeColumnName);
+    }
+
+    private Object rowtimeFromMillis(long millis) {
+        return convertFromMillis(millis, rowtimeConversionClass);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> T convertFromMillis(long millis, Class<T> targetClass) {
+        if (targetClass == Long.class || targetClass == long.class) {
+            return (T) Long.valueOf(millis);
+        } else if (targetClass == Instant.class) {
+            return (T) Instant.ofEpochMilli(millis);
+        } else if (targetClass == LocalDateTime.class) {
+            return (T) DateTimeUtils.toLocalDateTime(millis);
+        } else if (targetClass == java.sql.Timestamp.class) {
+            return (T) DateTimeUtils.toSQLTimestamp(millis);
+        }
+        throw new IllegalArgumentException("Unsupported time type: " + targetClass);
+    }
+
     private void invokeEval(TableArgumentInfo activeTableArg, Row activeRow) throws Exception {
         TableArgumentConverters converters = argumentConverters.get(activeTableArg.name);
 
@@ -312,31 +755,30 @@ public class ProcessTableFunctionTestHarness<OUT> implements AutoCloseable {
         Row namedRow = (Row) converters.toNamedRow.toExternal(rowData);
         Object evalArgument = converters.toEvalArgument.toExternal(rowData);
 
-        collector.setContext(activeTableArg, namedRow);
-
         Row partitionKey = extractPartitionKey(activeTableArg, namedRow);
+        currentInvocation = InvocationContext.forEval(partitionKey, namedRow, activeTableArg.name);
+
         Map<String, Object> stateMap = stateManager.loadStateForKey(partitionKey);
 
-        Object[] args = new Object[arguments.size()];
+        Object[] methodArgs = new Object[arguments.size()];
         int i = 0;
-
         for (ArgumentInfo arg : arguments) {
             if (arg instanceof StateArgumentInfo) {
-                args[i++] = stateMap.get(arg.name);
+                methodArgs[i++] = stateMap.get(arg.name);
             } else if (arg instanceof TableArgumentInfo) {
                 TableArgumentInfo tableArg = (TableArgumentInfo) arg;
                 if (tableArg.name.equals(activeTableArg.name)) {
-                    args[i++] = evalArgument;
+                    methodArgs[i++] = evalArgument;
                 } else {
-                    args[i++] = null;
+                    methodArgs[i++] = null;
                 }
             } else if (arg instanceof ScalarArgumentInfo) {
-                args[i++] = ((ScalarArgumentInfo) arg).value;
+                methodArgs[i++] = ((ScalarArgumentInfo) arg).value;
             }
         }
 
         try {
-            evalMethod.invoke(function, args);
+            eval.invoke(function, new TestContext(stateMap), methodArgs);
             stateManager.updateStateForKey(partitionKey, stateMap);
         } catch (InvocationTargetException e) {
             String partitionInfo =
@@ -350,7 +792,9 @@ public class ProcessTableFunctionTestHarness<OUT> implements AutoCloseable {
                     String.format(
                             "Exception occurred during PTF eval() while processing table argument '%s'%s.\n",
                             activeTableArg.name, partitionInfo);
-            handleEvalInvocationException(contextMessage, args, e);
+            handleEvalInvocationException(contextMessage, methodArgs, e);
+        } finally {
+            currentInvocation = null;
         }
     }
 
@@ -366,42 +810,51 @@ public class ProcessTableFunctionTestHarness<OUT> implements AutoCloseable {
 
     /** Collector implementation that stores output in the harness. */
     private class HarnessCollector implements Collector<OUT> {
-        private ArgumentInfo activeTableArg;
-        private Row activeRow;
-
-        void setContext(ArgumentInfo tableArg, Row row) {
-            this.activeTableArg = tableArg;
-            this.activeRow = row;
-        }
 
         @Override
         public void collect(OUT record) {
             OUT finalRecord;
 
-            if (activeTableArg == null || !(activeTableArg instanceof TableArgumentInfo)) {
-                finalRecord = record;
-            } else {
-                TableArgumentInfo tableArg = (TableArgumentInfo) activeTableArg;
-                switch (tableArg.prependStrategy) {
-                    case ALL_COLUMNS:
-                        finalRecord = prependAllColumns(record);
-                        break;
-                    case PARTITION_KEYS:
-                        finalRecord = prependPartitionKeys(record);
-                        break;
-                    case NONE:
-                        finalRecord = record;
-                        break;
-                    default:
-                        throw new IllegalStateException(
-                                "Unknown prepend strategy: " + tableArg.prependStrategy);
-                }
+            OutputPrependStrategy strategy = resolvePrependStrategy();
+            switch (strategy) {
+                case ALL_COLUMNS:
+                    finalRecord = prependAllColumns(record);
+                    break;
+                case PARTITION_KEYS:
+                    finalRecord = prependPartitionKeys(record);
+                    break;
+                case NONE:
+                    finalRecord = record;
+                    break;
+                default:
+                    throw new IllegalStateException("Unknown prepend strategy: " + strategy);
+            }
+
+            if (onTimeColumnName != null) {
+                finalRecord = appendRowtime(finalRecord);
             }
 
             // After prepending, round-trip through converter to ensure output has proper
             // field structure from derived output schema
             OUT structuredRecord = applyOutputConverter(finalRecord);
             output.add(structuredRecord);
+        }
+
+        private OutputPrependStrategy resolvePrependStrategy() {
+            InvocationContext ctx = currentInvocation;
+            if (ctx == null) {
+                return OutputPrependStrategy.NONE;
+            }
+            if (ctx.isTimerInvocation()) {
+                return OutputPrependStrategy.PARTITION_KEYS;
+            }
+            if (ctx.isEvalInvocation()) {
+                ArgumentInfo argInfo = argumentsByName.get(ctx.tableArgumentName);
+                if (argInfo instanceof TableArgumentInfo) {
+                    return ((TableArgumentInfo) argInfo).prependStrategy;
+                }
+            }
+            return OutputPrependStrategy.NONE;
         }
 
         @SuppressWarnings("unchecked")
@@ -415,6 +868,23 @@ public class ProcessTableFunctionTestHarness<OUT> implements AutoCloseable {
         }
 
         @SuppressWarnings("unchecked")
+        private OUT appendRowtime(OUT ptfOutput) {
+            if (!(ptfOutput instanceof Row)) {
+                throw new IllegalStateException(
+                        "Cannot append rowtime to non-Row output type: " + ptfOutput.getClass());
+            }
+            return (OUT) appendField((Row) ptfOutput, resolveRowtimeValue());
+        }
+
+        private Object resolveRowtimeValue() {
+            InvocationContext ctx = currentInvocation;
+            if (ctx.isTimerInvocation()) {
+                return rowtimeFromMillis(ctx.firingTimer.timestamp);
+            }
+            return ctx.row.getField(onTimeColumnName);
+        }
+
+        @SuppressWarnings("unchecked")
         private OUT prependPartitionKeys(OUT ptfOutput) {
             if (!(ptfOutput instanceof Row)) {
                 throw new IllegalStateException(
@@ -423,6 +893,7 @@ public class ProcessTableFunctionTestHarness<OUT> implements AutoCloseable {
             }
 
             Row ptfRow = (Row) ptfOutput;
+            Row partitionKey = currentInvocation.partitionKey;
 
             int totalPartitionKeyCount = 0;
             for (ArgumentInfo arg : arguments) {
@@ -439,21 +910,13 @@ public class ProcessTableFunctionTestHarness<OUT> implements AutoCloseable {
 
             Row result = new Row(ptfRow.getKind(), totalArity);
 
-            TableArgumentInfo activeTableInfo = (TableArgumentInfo) activeTableArg;
-            Object[] partitionKeyValues = new Object[activeTableInfo.partitionColumnNames.length];
-            for (int i = 0; i < activeTableInfo.partitionColumnNames.length; i++) {
-                String columnName = activeTableInfo.partitionColumnNames[i];
-                int columnIndex = getFieldIndex(activeTableInfo.dataType, columnName);
-                partitionKeyValues[i] = activeRow.getField(columnIndex);
-            }
-
             int resultIndex = 0;
             for (ArgumentInfo arg : arguments) {
                 if (arg instanceof TableArgumentInfo) {
                     TableArgumentInfo tableArg = (TableArgumentInfo) arg;
                     if (tableArg.isSetSemantic && tableArg.partitionColumnNames != null) {
                         for (int i = 0; i < tableArg.partitionColumnNames.length; i++) {
-                            result.setField(resultIndex++, partitionKeyValues[i]);
+                            result.setField(resultIndex++, partitionKey.getField(i));
                         }
                     }
                 }
@@ -466,17 +929,6 @@ public class ProcessTableFunctionTestHarness<OUT> implements AutoCloseable {
             return (OUT) result;
         }
 
-        /** Helper to get field index by name from a DataType. */
-        private int getFieldIndex(DataType dataType, String fieldName) {
-            List<String> fieldNames = getFieldNames(dataType);
-            int index = fieldNames.indexOf(fieldName);
-            if (index < 0) {
-                throw new IllegalStateException(
-                        String.format("Field '%s' not found in type %s", fieldName, dataType));
-            }
-            return index;
-        }
-
         @SuppressWarnings("unchecked")
         private OUT prependAllColumns(OUT ptfOutput) {
             if (!(ptfOutput instanceof Row)) {
@@ -485,14 +937,15 @@ public class ProcessTableFunctionTestHarness<OUT> implements AutoCloseable {
             }
 
             Row ptfRow = (Row) ptfOutput;
-            int inputArity = activeRow.getArity();
+            Row inputRow = currentInvocation.row;
+            int inputArity = inputRow.getArity();
             int ptfOutputArity = ptfRow.getArity();
             int totalArity = inputArity + ptfOutputArity;
 
             Row result = new Row(ptfRow.getKind(), totalArity);
 
             for (int i = 0; i < inputArity; i++) {
-                result.setField(i, activeRow.getField(i));
+                result.setField(i, inputRow.getField(i));
             }
 
             for (int i = 0; i < ptfOutputArity; i++) {
@@ -506,30 +959,34 @@ public class ProcessTableFunctionTestHarness<OUT> implements AutoCloseable {
         public void close() {}
     }
 
+    private static Row appendField(Row row, Object value) {
+        Row result = new Row(row.getArity() + 1);
+        for (int i = 0; i < row.getArity(); i++) {
+            result.setField(i, row.getField(i));
+        }
+        result.setField(row.getArity(), value);
+        return result;
+    }
+
     /** Extracts field names from RowType or StructuredType. */
     private static List<String> getFieldNames(DataType dataType) {
         LogicalType logicalType = dataType.getLogicalType();
-        List<String> fieldNames = new ArrayList<>();
-
         if (logicalType instanceof RowType) {
-            RowType rowType = (RowType) logicalType;
-            for (RowType.RowField field : rowType.getFields()) {
-                fieldNames.add(field.getName());
-            }
+            return ((RowType) logicalType)
+                    .getFields().stream()
+                            .map(RowType.RowField::getName)
+                            .collect(Collectors.toList());
         } else if (logicalType instanceof StructuredType) {
-            StructuredType structuredType = (StructuredType) logicalType;
-            for (StructuredType.StructuredAttribute attr : structuredType.getAttributes()) {
-                fieldNames.add(attr.getName());
-            }
-        } else {
-            throw new IllegalStateException(
-                    String.format(
-                            "Unsupported data type: %s. "
-                                    + "Only Row and structured types are supported.",
-                            dataType));
+            return ((StructuredType) logicalType)
+                    .getAttributes().stream()
+                            .map(StructuredType.StructuredAttribute::getName)
+                            .collect(Collectors.toList());
         }
-
-        return fieldNames;
+        throw new IllegalStateException(
+                String.format(
+                        "Unsupported data type: %s. "
+                                + "Only Row and structured types are supported.",
+                        dataType));
     }
 
     /**
@@ -545,6 +1002,7 @@ public class ProcessTableFunctionTestHarness<OUT> implements AutoCloseable {
         private final Map<String, TableArgumentConfiguration> tableArgs = new HashMap<>();
         private final Map<String, PartitionConfiguration> partitionConfigs = new HashMap<>();
         private final Map<String, StateArgumentConfiguration> stateArgs = new HashMap<>();
+        @Nullable private String onTimeColumnName = null;
 
         private Builder(Class<? extends ProcessTableFunction<OUT>> functionClass) {
             this.functionClass = checkNotNull(functionClass, "functionClass must not be null");
@@ -658,6 +1116,21 @@ public class ProcessTableFunctionTestHarness<OUT> implements AutoCloseable {
         }
 
         // ---------------------------------------------------------------------
+        // Timer & Watermark Configuration
+        // ---------------------------------------------------------------------
+
+        /**
+         * Configures the on-time column name for the function.
+         *
+         * @param columnName The column that carries event time
+         */
+        public Builder<OUT> withOnTimeColumn(String columnName) {
+            checkNotNull(columnName, "columnName must not be null");
+            this.onTimeColumnName = columnName;
+            return this;
+        }
+
+        // ---------------------------------------------------------------------
         // Build
         // ---------------------------------------------------------------------
 
@@ -685,9 +1158,17 @@ public class ProcessTableFunctionTestHarness<OUT> implements AutoCloseable {
 
             FunctionContext functionContext = new FunctionContext(null, classLoader, null);
 
-            Method evalMethod = findEvalMethod();
+            ResolvedMethod<ProcessTableFunction.Context> eval =
+                    ResolvedMethod.of(
+                            findEvalMethod(functionClass), ProcessTableFunction.Context.class);
+            Method onTimerMethod = findOnTimerMethod(functionClass, arguments);
+            ResolvedMethod<ProcessTableFunction.OnTimerContext> onTimer =
+                    onTimerMethod != null
+                            ? ResolvedMethod.of(
+                                    onTimerMethod, ProcessTableFunction.OnTimerContext.class)
+                            : null;
 
-            validateEvalMethodSupported(evalMethod, arguments);
+            validateEvalMethodSupported(eval, arguments);
             validatePartitionConsistency(arguments);
             validateInitialStateKeys(arguments);
 
@@ -713,25 +1194,51 @@ public class ProcessTableFunctionTestHarness<OUT> implements AutoCloseable {
 
             // Extract table arguments for output type derivation
             // SystemTypeInference needs table semantics for pass-through column deduplication
-            List<TableArgumentInfo> tableArgs = ArgumentInfo.filterTableArguments(arguments);
+            List<TableArgumentInfo> tableArgInfos = ArgumentInfo.filterTableArguments(arguments);
 
             // Derive output schema using SystemTypeInference
             DataType derivedOutputType =
                     deriveOutputTypeFromSystemInference(
-                            function, dataTypeFactory, systemTypeInference, tableArgs);
+                            function,
+                            dataTypeFactory,
+                            systemTypeInference,
+                            arguments,
+                            tableArgInfos);
 
             // Create output converter for PTF emissions
             DataStructureConverter<Object, Object> harnessOutputConverter =
                     createPTFOutputConverter(derivedOutputType);
 
+            // Validate onTimeColumn configuration
+            if (onTimeColumnName != null) {
+                boolean foundInAnyTable =
+                        tableArgInfos.stream()
+                                .anyMatch(
+                                        t -> getFieldNames(t.dataType).contains(onTimeColumnName));
+                checkArgument(
+                        foundInAnyTable,
+                        "withOnTimeColumn references column '%s' which does not exist in any "
+                                + "table argument. Available table arguments and their columns: %s",
+                        onTimeColumnName,
+                        tableArgInfos.stream()
+                                .collect(
+                                        Collectors.toMap(
+                                                t -> t.name, t -> getFieldNames(t.dataType))));
+            }
+
+            TestHarnessTimerManager timerManager = new TestHarnessTimerManager();
+
             return new ProcessTableFunctionTestHarness<>(
                     function,
                     functionContext,
-                    evalMethod,
+                    eval,
+                    onTimer,
                     arguments,
                     argumentConverters,
                     harnessOutputConverter,
-                    stateManager);
+                    stateManager,
+                    timerManager,
+                    onTimeColumnName);
         }
 
         /**
@@ -805,7 +1312,7 @@ public class ProcessTableFunctionTestHarness<OUT> implements AutoCloseable {
             }
         }
 
-        private Method findEvalMethod() throws NoSuchMethodException {
+        private static Method findEvalMethod(Class<?> functionClass) throws NoSuchMethodException {
             Method[] methods = functionClass.getMethods();
             Method evalMethod = null;
             int evalMethodCount = 0;
@@ -825,49 +1332,78 @@ public class ProcessTableFunctionTestHarness<OUT> implements AutoCloseable {
                         "Multiple eval() methods found in "
                                 + functionClass.getSimpleName()
                                 + ". ProcessTableFunction must have exactly one eval() method.");
-            } else {
-                return evalMethod;
             }
+
+            return evalMethod;
         }
 
-        /**
-         * Validates that the eval() method doesn't use unsupported features. Temporary, until
-         * context is supported.
-         */
-        private void validateEvalMethodSupported(Method evalMethod, List<ArgumentInfo> arguments) {
-            Parameter[] parameters = evalMethod.getParameters();
+        @Nullable
+        private static Method findOnTimerMethod(
+                Class<?> functionClass, List<ArgumentInfo> arguments) {
+            List<Method> candidates = ExtractionUtils.collectMethods(functionClass, "onTimer");
+            if (candidates.isEmpty()) {
+                return null;
+            }
 
-            for (int i = 0; i < parameters.length; i++) {
-                Parameter param = parameters[i];
-                Class<?> paramType = param.getType();
+            Class<?>[] stateClasses =
+                    ArgumentInfo.filterStateArguments(arguments).stream()
+                            .map(s -> s.dataType.getConversionClass())
+                            .toArray(Class<?>[]::new);
 
-                if (ProcessTableFunction.Context.class.isAssignableFrom(paramType)) {
-                    throw new IllegalStateException(
-                            String.format(
-                                    "ProcessTableFunctionTestHarness does not yet support Context parameters. "
-                                            + "Found Context parameter at position %d in eval() method. ",
-                                    i));
+            // Try with OnTimerContext first, then without — mirrors the code generator
+            Class<?>[] withContext = new Class<?>[stateClasses.length + 1];
+            withContext[0] = ProcessTableFunction.OnTimerContext.class;
+            System.arraycopy(stateClasses, 0, withContext, 1, stateClasses.length);
+
+            for (Class<?>[] signature : new Class<?>[][] {withContext, stateClasses}) {
+                Optional<Method> match =
+                        candidates.stream()
+                                .filter(
+                                        m ->
+                                                ExtractionUtils.isInvokable(
+                                                        ExtractionUtils.Autoboxing.JVM,
+                                                        m,
+                                                        signature))
+                                .findFirst();
+                if (match.isPresent()) {
+                    return match.get();
                 }
             }
 
-            if (parameters.length != arguments.size()) {
+            throw new IllegalStateException(
+                    String.format(
+                            "Found %d onTimer() method(s) in %s but none match the expected "
+                                    + "signature: optional OnTimerContext followed by state entries %s.",
+                            candidates.size(),
+                            functionClass.getSimpleName(),
+                            Arrays.toString(stateClasses)));
+        }
+
+        private void validateEvalMethodSupported(
+                ResolvedMethod<?> eval, List<ArgumentInfo> arguments) {
+            Parameter[] parameters = eval.method.getParameters();
+
+            int expectedParamCount = arguments.size() + (eval.takesContext ? 1 : 0);
+            if (parameters.length != expectedParamCount) {
                 long stateCount = ArgumentInfo.filterStateArguments(arguments).size();
                 long nonStateCount = arguments.size() - stateCount;
                 throw new IllegalStateException(
                         String.format(
                                 "Parameter count mismatch: eval() has %d parameters but expected %d "
-                                        + "(%d state + %d table/scalar arguments). "
+                                        + "(%d state + %d table/scalar arguments%s). "
                                         + "eval() signature: %s. "
                                         + "This may indicate missing @ArgumentHint or @StateHint annotations.",
                                 parameters.length,
-                                arguments.size(),
+                                expectedParamCount,
                                 stateCount,
                                 nonStateCount,
-                                evalMethod));
+                                eval.takesContext ? " + Context" : "",
+                                eval.method));
             }
 
+            int argOffset = eval.takesContext ? 1 : 0;
             for (int i = 0; i < arguments.size(); i++) {
-                Parameter param = parameters[i];
+                Parameter param = parameters[i + argOffset];
                 Class<?> paramType = param.getType();
                 ArgumentInfo arg = arguments.get(i);
 
@@ -880,7 +1416,7 @@ public class ProcessTableFunctionTestHarness<OUT> implements AutoCloseable {
                                         "Type mismatch for scalar argument '%s' at position %d: "
                                                 + "eval() parameter expects %s but provided value is %s",
                                         arg.name,
-                                        i,
+                                        i + argOffset,
                                         paramType.getName(),
                                         value.getClass().getName()));
                     }
@@ -1167,40 +1703,45 @@ public class ProcessTableFunctionTestHarness<OUT> implements AutoCloseable {
         }
 
         /** Creates appropriate StateConverter for the given state data type. */
-        private StateConverter createStateConverter(DataType stateDataType, ClassLoader classLoader)
-                throws Exception {
-            LogicalType logicalType = stateDataType.getLogicalType();
+        private StateConverter createStateConverter(
+                DataType stateDataType, ClassLoader classLoader) {
+            DataType resolvedType =
+                    ListView.class.isAssignableFrom(stateDataType.getConversionClass())
+                                    || MapView.class.isAssignableFrom(
+                                            stateDataType.getConversionClass())
+                            ? stateDataType.getChildren().get(0)
+                            : stateDataType;
+
+            LogicalType logicalType = resolvedType.getLogicalType();
 
             if (logicalType instanceof ArrayType) {
-                ArrayType arrayType = (ArrayType) logicalType;
-                DataType elementType = stateDataType.getChildren().get(0);
+                DataType elementType = resolvedType.getChildren().get(0);
                 DataStructureConverter<Object, Object> elementConverter =
                         DataStructureConverters.getConverter(elementType);
                 elementConverter.open(classLoader);
-                return new ListViewStateConverter(arrayType, elementConverter);
+                return new ListViewStateConverter((ArrayType) logicalType, elementConverter);
             } else if (logicalType instanceof MapType) {
-                MapType mapType = (MapType) logicalType;
-                DataType keyType = stateDataType.getChildren().get(0);
-                DataType valueType = stateDataType.getChildren().get(1);
+                DataType keyType = resolvedType.getChildren().get(0);
+                DataType valueType = resolvedType.getChildren().get(1);
                 DataStructureConverter<Object, Object> keyConverter =
                         DataStructureConverters.getConverter(keyType);
                 DataStructureConverter<Object, Object> valueConverter =
                         DataStructureConverters.getConverter(valueType);
                 keyConverter.open(classLoader);
                 valueConverter.open(classLoader);
-                return new MapViewStateConverter(mapType, keyConverter, valueConverter);
+                return new MapViewStateConverter(
+                        (MapType) logicalType, keyConverter, valueConverter);
             } else if (logicalType instanceof RowType) {
-                RowType rowType = (RowType) logicalType;
                 DataStructureConverter<Object, Object> converter =
-                        DataStructureConverters.getConverter(stateDataType);
+                        DataStructureConverters.getConverter(resolvedType);
                 converter.open(classLoader);
-                return new RowStateConverter(converter, rowType);
+                return new RowStateConverter((RowType) logicalType, converter);
             } else {
                 DataStructureConverter<Object, Object> converter =
-                        DataStructureConverters.getConverter(stateDataType);
+                        DataStructureConverters.getConverter(resolvedType);
                 converter.open(classLoader);
-                Class<?> stateClass = stateDataType.getConversionClass();
-                return new StructuredTypeStateConverter(converter, stateClass);
+                return new StructuredTypeStateConverter(
+                        resolvedType.getConversionClass(), converter);
             }
         }
 
@@ -1389,25 +1930,77 @@ public class ProcessTableFunctionTestHarness<OUT> implements AutoCloseable {
 
         /**
          * Derives the output schema using SystemTypeInference, including field name deduplication.
+         *
+         * <p>SystemTypeInference's staticArgs list includes both user-declared arguments and
+         * system-injected arguments (on_time, uid). The CallContext we build must mirror this full
+         * list positionally — each index maps to a staticArg. User args get their resolved
+         * DataType; system args get placeholder types (DESCRIPTOR for on_time, STRING for uid).
+         * Table semantics are attached at the positions of table arguments so SystemTypeInference
+         * can perform pass-through column deduplication.
          */
         private DataType deriveOutputTypeFromSystemInference(
                 ProcessTableFunction<OUT> function,
                 DataTypeFactory dataTypeFactory,
                 TypeInference systemTypeInference,
-                List<TableArgumentInfo> arguments) {
+                List<ArgumentInfo> allArguments,
+                List<TableArgumentInfo> tableArguments) {
 
-            List<DataType> argumentDataTypes = new ArrayList<>();
-            for (TableArgumentInfo arg : arguments) {
-                argumentDataTypes.add(arg.dataType);
+            List<StaticArgument> staticArgs =
+                    systemTypeInference
+                            .getStaticArguments()
+                            .orElseThrow(
+                                    () ->
+                                            new IllegalStateException(
+                                                    "SystemTypeInference has no static arguments"));
+
+            Map<String, TableArgumentInfo> tableArgsByName = new HashMap<>();
+            for (TableArgumentInfo tableArg : tableArguments) {
+                tableArgsByName.put(tableArg.name, tableArg);
+            }
+            Map<String, ArgumentInfo> allArgsByName = new HashMap<>();
+            for (ArgumentInfo arg : allArguments) {
+                if (arg.name != null) {
+                    allArgsByName.put(arg.name, arg);
+                }
             }
 
+            List<DataType> argumentDataTypes = new ArrayList<>();
             Map<Integer, TableSemantics> tableSemanticsMap = new HashMap<>();
-            for (int i = 0; i < arguments.size(); i++) {
-                TableArgumentInfo arg = arguments.get(i);
-                int[] partitionIndices = getPartitionColumnIndices(arg);
-                TableSemantics semantics =
-                        new TestHarnessTableSemantics(arg.dataType, partitionIndices);
-                tableSemanticsMap.put(i, semantics);
+            int onTimePos = -1;
+
+            for (int i = 0; i < staticArgs.size(); i++) {
+                StaticArgument staticArg = staticArgs.get(i);
+                String argName = staticArg.getName();
+
+                if (SystemTypeInference.PROCESS_TABLE_FUNCTION_ARG_ON_TIME.equals(argName)) {
+                    argumentDataTypes.add(DataTypes.DESCRIPTOR());
+                    onTimePos = i;
+                } else if (SystemTypeInference.PROCESS_TABLE_FUNCTION_ARG_UID.equals(argName)) {
+                    argumentDataTypes.add(DataTypes.STRING());
+                } else {
+                    ArgumentInfo argInfo = allArgsByName.get(argName);
+                    if (argInfo != null) {
+                        argumentDataTypes.add(argInfo.dataType);
+                    } else {
+                        argumentDataTypes.add(DataTypes.NULL());
+                    }
+
+                    TableArgumentInfo tableArg = tableArgsByName.get(argName);
+                    if (tableArg != null) {
+                        int[] partitionIndices = getPartitionColumnIndices(tableArg);
+                        int timeColumnIndex = -1;
+                        if (onTimeColumnName != null) {
+                            int idx = getFieldNames(tableArg.dataType).indexOf(onTimeColumnName);
+                            if (idx >= 0) {
+                                timeColumnIndex = idx;
+                            }
+                        }
+                        tableSemanticsMap.put(
+                                i,
+                                new TestHarnessTableSemantics(
+                                        tableArg.dataType, partitionIndices, timeColumnIndex));
+                    }
+                }
             }
 
             TestHarnessCallContext callContext = new TestHarnessCallContext();
@@ -1416,6 +2009,13 @@ public class ProcessTableFunctionTestHarness<OUT> implements AutoCloseable {
             callContext.functionDefinition = function;
             callContext.tableSemantics = tableSemanticsMap;
             callContext.name = function.getClass().getSimpleName();
+
+            if (onTimePos >= 0 && onTimeColumnName != null) {
+                callContext.argumentValues.put(
+                        onTimePos,
+                        org.apache.flink.types.ColumnList.of(
+                                Collections.singletonList(onTimeColumnName)));
+            }
 
             TypeStrategy outputStrategy = systemTypeInference.getOutputTypeStrategy();
             Optional<DataType> outputTypeOpt = outputStrategy.inferType(callContext);
@@ -1428,31 +2028,6 @@ public class ProcessTableFunctionTestHarness<OUT> implements AutoCloseable {
 
             return outputTypeOpt.get();
         }
-
-        private int[] getPartitionColumnIndices(TableArgumentInfo arg) {
-            if (arg.partitionColumnNames == null || arg.partitionColumnNames.length == 0) {
-                return new int[0];
-            }
-
-            List<String> fieldNames = getFieldNames(arg.dataType);
-
-            int[] indices = new int[arg.partitionColumnNames.length];
-            for (int i = 0; i < arg.partitionColumnNames.length; i++) {
-                String colName = arg.partitionColumnNames[i];
-                int index = fieldNames.indexOf(colName);
-                if (index < 0) {
-                    throw new IllegalStateException(
-                            "Partition column '"
-                                    + colName
-                                    + "' not found in table argument. "
-                                    + "Available fields: "
-                                    + fieldNames);
-                }
-                indices[i] = index;
-            }
-
-            return indices;
-        }
     }
 
     private enum OutputPrependStrategy {
@@ -1462,16 +2037,17 @@ public class ProcessTableFunctionTestHarness<OUT> implements AutoCloseable {
     }
 
     private void handleEvalInvocationException(
-            String contextMessage, Object[] args, InvocationTargetException e) throws Exception {
+            String contextMessage, Object[] methodArgs, InvocationTargetException e)
+            throws Exception {
         Throwable cause = e.getCause();
         StringBuilder details = new StringBuilder();
         details.append(contextMessage);
         details.append("Expected parameter types: ");
-        details.append(Arrays.toString(evalMethod.getParameterTypes()));
+        details.append(Arrays.toString(eval.method.getParameterTypes()));
         details.append("\nActual arguments:\n");
         for (int i = 0; i < arguments.size(); i++) {
             ArgumentInfo arg = arguments.get(i);
-            Object value = args[i];
+            Object value = methodArgs[i];
             details.append(
                     String.format(
                             "  [%d] %s: %s (type: %s)\n",

--- a/flink-table/flink-table-test-utils/src/main/java/org/apache/flink/table/runtime/functions/ResolvedMethod.java
+++ b/flink-table/flink-table-test-utils/src/main/java/org/apache/flink/table/runtime/functions/ResolvedMethod.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.functions;
+
+import org.apache.flink.table.functions.ProcessTableFunction;
+
+import javax.annotation.Nullable;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+/**
+ * A resolved PTF method (eval or onTimer) paired with whether its first parameter accepts a
+ * Context.
+ */
+class ResolvedMethod<T extends ProcessTableFunction.Context> {
+    final Method method;
+    final boolean takesContext;
+
+    static <T extends ProcessTableFunction.Context> ResolvedMethod<T> of(
+            Method method, Class<T> contextClass) {
+        boolean takesContext =
+                method.getParameterTypes().length > 0
+                        && contextClass.isAssignableFrom(method.getParameterTypes()[0]);
+        return new ResolvedMethod<>(method, takesContext);
+    }
+
+    private ResolvedMethod(Method method, boolean takesContext) {
+        this.method = method;
+        this.takesContext = takesContext;
+    }
+
+    void invoke(Object target, @Nullable T context, Object[] methodArgs)
+            throws InvocationTargetException, IllegalAccessException {
+        if (takesContext) {
+            Object[] args = new Object[1 + methodArgs.length];
+            args[0] = context;
+            System.arraycopy(methodArgs, 0, args, 1, methodArgs.length);
+            method.invoke(target, args);
+        } else {
+            method.invoke(target, methodArgs);
+        }
+    }
+}

--- a/flink-table/flink-table-test-utils/src/main/java/org/apache/flink/table/runtime/functions/RowStateConverter.java
+++ b/flink-table/flink-table-test-utils/src/main/java/org/apache/flink/table/runtime/functions/RowStateConverter.java
@@ -30,7 +30,7 @@ class RowStateConverter implements StateConverter {
     private final DataStructureConverter<Object, Object> converter;
     private final RowType rowType;
 
-    RowStateConverter(DataStructureConverter<Object, Object> converter, RowType rowType) {
+    RowStateConverter(RowType rowType, DataStructureConverter<Object, Object> converter) {
         this.converter = converter;
         this.rowType = rowType;
     }

--- a/flink-table/flink-table-test-utils/src/main/java/org/apache/flink/table/runtime/functions/StructuredTypeStateConverter.java
+++ b/flink-table/flink-table-test-utils/src/main/java/org/apache/flink/table/runtime/functions/StructuredTypeStateConverter.java
@@ -33,7 +33,7 @@ class StructuredTypeStateConverter implements StateConverter {
     private final Class<?> pojoClass;
 
     StructuredTypeStateConverter(
-            DataStructureConverter<Object, Object> converter, Class<?> pojoClass) {
+            Class<?> pojoClass, DataStructureConverter<Object, Object> converter) {
         this.converter = converter;
         this.pojoClass = pojoClass;
     }

--- a/flink-table/flink-table-test-utils/src/main/java/org/apache/flink/table/runtime/functions/TestHarnessCallContext.java
+++ b/flink-table/flink-table-test-utils/src/main/java/org/apache/flink/table/runtime/functions/TestHarnessCallContext.java
@@ -26,6 +26,7 @@ import org.apache.flink.table.functions.TableSemantics;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.inference.CallContext;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -40,6 +41,7 @@ class TestHarnessCallContext implements CallContext {
     List<DataType> argumentDataTypes;
     FunctionDefinition functionDefinition;
     Map<Integer, TableSemantics> tableSemantics;
+    Map<Integer, Object> argumentValues = new HashMap<>();
     String name;
 
     @Override
@@ -54,7 +56,7 @@ class TestHarnessCallContext implements CallContext {
 
     @Override
     public boolean isArgumentLiteral(int pos) {
-        return false;
+        return argumentValues.containsKey(pos);
     }
 
     @Override
@@ -63,7 +65,12 @@ class TestHarnessCallContext implements CallContext {
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public <T> Optional<T> getArgumentValue(int pos, Class<T> clazz) {
+        Object value = argumentValues.get(pos);
+        if (value != null && clazz.isInstance(value)) {
+            return Optional.of((T) value);
+        }
         return Optional.empty();
     }
 

--- a/flink-table/flink-table-test-utils/src/main/java/org/apache/flink/table/runtime/functions/TestHarnessTableSemantics.java
+++ b/flink-table/flink-table-test-utils/src/main/java/org/apache/flink/table/runtime/functions/TestHarnessTableSemantics.java
@@ -33,16 +33,25 @@ class TestHarnessTableSemantics implements TableSemantics {
     private final DataType dataType;
     private final int[] partitionByColumns;
     private final List<int[]> upsertKeyColumns;
+    private final int timeColumnIndex;
 
     TestHarnessTableSemantics(DataType dataType, int[] partitionByColumns) {
-        this(dataType, partitionByColumns, Collections.emptyList());
+        this(dataType, partitionByColumns, Collections.emptyList(), -1);
+    }
+
+    TestHarnessTableSemantics(DataType dataType, int[] partitionByColumns, int timeColumnIndex) {
+        this(dataType, partitionByColumns, Collections.emptyList(), timeColumnIndex);
     }
 
     TestHarnessTableSemantics(
-            DataType dataType, int[] partitionByColumns, List<int[]> upsertKeyColumns) {
+            DataType dataType,
+            int[] partitionByColumns,
+            List<int[]> upsertKeyColumns,
+            int timeColumnIndex) {
         this.dataType = dataType;
         this.partitionByColumns = partitionByColumns;
         this.upsertKeyColumns = upsertKeyColumns;
+        this.timeColumnIndex = timeColumnIndex;
     }
 
     @Override
@@ -67,7 +76,7 @@ class TestHarnessTableSemantics implements TableSemantics {
 
     @Override
     public int timeColumn() {
-        return -1;
+        return timeColumnIndex;
     }
 
     @Override

--- a/flink-table/flink-table-test-utils/src/main/java/org/apache/flink/table/runtime/functions/TestHarnessTimerManager.java
+++ b/flink-table/flink-table-test-utils/src/main/java/org/apache/flink/table/runtime/functions/TestHarnessTimerManager.java
@@ -1,0 +1,181 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.functions;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.types.Row;
+import org.apache.flink.util.function.ThrowingConsumer;
+
+import javax.annotation.Nullable;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Timer and watermark manager for {@link ProcessTableFunctionTestHarness}.
+ *
+ * <p>Handles timer registration, clearing, watermark tracking, and determining which timers are
+ * eligible to fire.
+ */
+@Internal
+class TestHarnessTimerManager {
+
+    private final Map<Row, Set<Timer>> pendingTimersByPartition = new HashMap<>();
+    private final List<Timer> firedTimers = new ArrayList<>();
+    private final Map<String, Long> watermarkByTable = new HashMap<>();
+    @Nullable private Long globalWatermark;
+
+    TestHarnessTimerManager() {}
+
+    // -------------------------------------------------------------------------
+    // Watermark
+    // -------------------------------------------------------------------------
+
+    void setTableWatermark(String tableName, long absoluteMillis) {
+        Long current = watermarkByTable.get(tableName);
+        if (current != null && absoluteMillis < current) {
+            throw new IllegalArgumentException(
+                    String.format(
+                            "Cannot move watermark backward for table '%s': current=%d, new=%d",
+                            tableName, current, absoluteMillis));
+        }
+        watermarkByTable.put(tableName, absoluteMillis);
+    }
+
+    void updateGlobalWatermarkAndFireTimers(ThrowingConsumer<Timer, Exception> firer)
+            throws Exception {
+        if (watermarkByTable.isEmpty()) {
+            return;
+        }
+        long newGlobalWatermark = Collections.min(watermarkByTable.values());
+        if (globalWatermark != null && newGlobalWatermark < globalWatermark) {
+            throw new IllegalArgumentException(
+                    String.format(
+                            "Cannot move global watermark backward: current=%d, new=%d",
+                            globalWatermark, newGlobalWatermark));
+        }
+        globalWatermark = newGlobalWatermark;
+        fireEligibleTimers(newGlobalWatermark, firer);
+    }
+
+    @Nullable
+    Long getGlobalWatermark() {
+        return globalWatermark;
+    }
+
+    @Nullable
+    Long getWatermarkForTable(String tableName) {
+        return watermarkByTable.get(tableName);
+    }
+
+    // -------------------------------------------------------------------------
+    // Timer Registration
+    // -------------------------------------------------------------------------
+
+    void register(Row partitionKey, long timestampMillis, @Nullable String name) {
+        Set<Timer> timerSet =
+                pendingTimersByPartition.computeIfAbsent(partitionKey, k -> new HashSet<>());
+
+        if (name != null) {
+            timerSet.removeIf(t -> name.equals(t.name));
+        } else {
+            timerSet.removeIf(t -> t.name == null && t.timestamp == timestampMillis);
+        }
+        timerSet.add(new Timer(timestampMillis, name, partitionKey));
+    }
+
+    void clearByName(Row partitionKey, String name) {
+        Set<Timer> timerSet = pendingTimersByPartition.get(partitionKey);
+        if (timerSet != null) {
+            timerSet.removeIf(t -> name.equals(t.name));
+        }
+    }
+
+    /** Clears unnamed timers matching the given timestamp. Named timers are not affected. */
+    void clearByTimestamp(Row partitionKey, long timestamp) {
+        Set<Timer> timerSet = pendingTimersByPartition.get(partitionKey);
+        if (timerSet != null) {
+            timerSet.removeIf(t -> t.name == null && t.timestamp == timestamp);
+        }
+    }
+
+    void clearAll(Row partitionKey) {
+        pendingTimersByPartition.remove(partitionKey);
+    }
+
+    // -------------------------------------------------------------------------
+    // Timer Introspection
+    // -------------------------------------------------------------------------
+
+    List<Timer> getPendingTimers() {
+        return pendingTimersByPartition.values().stream()
+                .flatMap(Collection::stream)
+                .sorted()
+                .collect(Collectors.toList());
+    }
+
+    List<Timer> getFiredTimers() {
+        return new ArrayList<>(firedTimers);
+    }
+
+    void clearFiredTimers() {
+        firedTimers.clear();
+    }
+
+    // -------------------------------------------------------------------------
+    // Internal
+    // -------------------------------------------------------------------------
+
+    // Loop until no more eligible timers — handles cascading registrations
+    private void fireEligibleTimers(long watermark, ThrowingConsumer<Timer, Exception> firer)
+            throws Exception {
+        while (true) {
+            List<Timer> timersToFire =
+                    pendingTimersByPartition.values().stream()
+                            .flatMap(Collection::stream)
+                            .filter(t -> t.timestamp <= watermark)
+                            .sorted()
+                            .collect(Collectors.toList());
+
+            if (timersToFire.isEmpty()) {
+                break;
+            }
+
+            for (Timer timer : timersToFire) {
+                Set<Timer> timerSet =
+                        pendingTimersByPartition.getOrDefault(
+                                timer.partitionKey, Collections.emptySet());
+
+                if (timerSet.contains(timer)) {
+                    timerSet.remove(timer);
+                    timer.markFired();
+                    firedTimers.add(timer);
+                    firer.accept(timer);
+                }
+            }
+        }
+    }
+}

--- a/flink-table/flink-table-test-utils/src/main/java/org/apache/flink/table/runtime/functions/Timer.java
+++ b/flink-table/flink-table-test-utils/src/main/java/org/apache/flink/table/runtime/functions/Timer.java
@@ -1,0 +1,135 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.functions;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.table.utils.DateTimeUtils;
+import org.apache.flink.types.Row;
+
+import javax.annotation.Nullable;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.util.Objects;
+
+/**
+ * A timer registered by a {@link org.apache.flink.table.functions.ProcessTableFunction} during
+ * testing.
+ */
+@PublicEvolving
+public class Timer implements Comparable<Timer> {
+
+    final long timestamp;
+    @Nullable final String name;
+    final Row partitionKey;
+    private boolean fired;
+
+    Timer(long timestamp, @Nullable String name, Row partitionKey) {
+        this.timestamp = timestamp;
+        this.name = name;
+        this.partitionKey = partitionKey;
+    }
+
+    public long getTimestamp() {
+        return timestamp;
+    }
+
+    @SuppressWarnings("unchecked")
+    public <T> T getTimestampAs(Class<T> timeClass) {
+        if (timeClass == Long.class || timeClass == long.class) {
+            return (T) Long.valueOf(timestamp);
+        } else if (timeClass == Instant.class) {
+            return (T) Instant.ofEpochMilli(timestamp);
+        } else if (timeClass == LocalDateTime.class) {
+            return (T) DateTimeUtils.toLocalDateTime(timestamp);
+        } else if (timeClass == java.sql.Timestamp.class) {
+            return (T) DateTimeUtils.toSQLTimestamp(timestamp);
+        }
+        throw new IllegalArgumentException("Unsupported time type: " + timeClass);
+    }
+
+    @Nullable
+    public String getName() {
+        return name;
+    }
+
+    public Row getKey() {
+        return partitionKey;
+    }
+
+    public boolean hasFired() {
+        return fired;
+    }
+
+    void markFired() {
+        this.fired = true;
+    }
+
+    /**
+     * Comparison of timers is done by timestamp first, then by name (unnamed timers sort after
+     * named ones), then by partition key, for a deterministic firing order.
+     */
+    @Override
+    public int compareTo(Timer other) {
+        int cmp = Long.compare(this.timestamp, other.timestamp);
+        if (cmp != 0) {
+            return cmp;
+        }
+        if (this.name == null && other.name == null) {
+            return this.partitionKey.toString().compareTo(other.partitionKey.toString());
+        }
+        if (this.name == null) {
+            return 1;
+        }
+        if (other.name == null) {
+            return -1;
+        }
+        cmp = this.name.compareTo(other.name);
+        if (cmp != 0) {
+            return cmp;
+        }
+        return this.partitionKey.toString().compareTo(other.partitionKey.toString());
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof Timer)) {
+            return false;
+        }
+        Timer that = (Timer) o;
+        return this.timestamp == that.timestamp
+                && Objects.equals(this.name, that.name)
+                && Objects.equals(this.partitionKey, that.partitionKey);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(timestamp, name, partitionKey);
+    }
+
+    @Override
+    public String toString() {
+        return String.format(
+                "Timer{timestamp=%d, name=%s, key=%s, fired=%s}",
+                timestamp, name != null ? "'" + name + "'" : "null", partitionKey, fired);
+    }
+}

--- a/flink-table/flink-table-test-utils/src/test/java/org/apache/flink/table/runtime/functions/ProcessTableFunctionTestHarnessTest.java
+++ b/flink-table/flink-table-test-utils/src/test/java/org/apache/flink/table/runtime/functions/ProcessTableFunctionTestHarnessTest.java
@@ -23,15 +23,22 @@ import org.apache.flink.table.annotation.ArgumentTrait;
 import org.apache.flink.table.annotation.DataTypeHint;
 import org.apache.flink.table.annotation.StateHint;
 import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.api.TableRuntimeException;
 import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.api.dataview.ListView;
 import org.apache.flink.table.api.dataview.MapView;
+import org.apache.flink.table.connector.ChangelogMode;
 import org.apache.flink.table.functions.ProcessTableFunction;
+import org.apache.flink.table.functions.TableSemantics;
 import org.apache.flink.types.Row;
 import org.apache.flink.types.RowKind;
 
 import org.junit.jupiter.api.Test;
 
+import java.sql.Timestamp;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -196,6 +203,20 @@ class ProcessTableFunctionTestHarnessTest {
         }
     }
 
+    public static class TimedEvent {
+        public String key;
+
+        @DataTypeHint("TIMESTAMP(3)")
+        public LocalDateTime ts;
+
+        public TimedEvent() {}
+
+        public TimedEvent(String key, LocalDateTime ts) {
+            this.key = key;
+            this.ts = ts;
+        }
+    }
+
     /** PTF for testing structured type inputs. */
     @DataTypeHint("ROW<name STRING, age INT>")
     public static class UserPTF extends ProcessTableFunction<Row> {
@@ -304,14 +325,6 @@ class ProcessTableFunctionTestHarnessTest {
     public static class PrimitiveScalarPTF extends ProcessTableFunction<Row> {
         public void eval(int a, int b) {
             collect(Row.of(a + b));
-        }
-    }
-
-    /** PTF with Context parameter - should be rejected by test harness. */
-    @DataTypeHint("ROW<value INT>")
-    public static class PTFWithContext extends ProcessTableFunction<Row> {
-        public void eval(Context ctx, @ArgumentHint(ArgumentTrait.ROW_SEMANTIC_TABLE) Row input) {
-            collect(input);
         }
     }
 
@@ -1195,22 +1208,6 @@ class ProcessTableFunctionTestHarnessTest {
     }
 
     @Test
-    void testContextParameterRejected() {
-        Exception exception =
-                assertThrows(
-                        IllegalStateException.class,
-                        () ->
-                                ProcessTableFunctionTestHarness.ofClass(PTFWithContext.class)
-                                        .withTableArgument("input", DataTypes.of("ROW<value INT>"))
-                                        .build());
-
-        assertThat(exception.getMessage())
-                .contains("does not yet support Context parameters")
-                .contains("Context parameter")
-                .contains("position 0");
-    }
-
-    @Test
     void testSetSemanticMissingPartitionConfigThrows() {
         Exception exception =
                 assertThrows(
@@ -1751,5 +1748,994 @@ class ProcessTableFunctionTestHarnessTest {
                 () -> harness.clearStateForKey("state", Row.of(42)));
 
         harness.close();
+    }
+
+    // -------------------------------------------------------------------------
+    // Timer PTFs
+    // -------------------------------------------------------------------------
+
+    @DataTypeHint("ROW<message STRING>")
+    public static class TimerPTF extends ProcessTableFunction<Row> {
+        public void eval(
+                Context ctx,
+                @ArgumentHint({ArgumentTrait.SET_SEMANTIC_TABLE, ArgumentTrait.REQUIRE_ON_TIME})
+                        Row input) {
+            String name = input.getFieldAs("name");
+            TimeContext<LocalDateTime> timeCtx = ctx.timeContext(LocalDateTime.class);
+            timeCtx.registerOnTime("timeout-" + name, timeCtx.time().plus(Duration.ofSeconds(5)));
+            collect(Row.of("registered-" + name));
+        }
+
+        public void onTimer(OnTimerContext ctx) {
+            collect(Row.of("timer-fired-" + ctx.currentTimer()));
+        }
+    }
+
+    @DataTypeHint("ROW<message STRING>")
+    public static class UnnamedTimerPTF extends ProcessTableFunction<Row> {
+        public void eval(
+                Context ctx,
+                @ArgumentHint({ArgumentTrait.SET_SEMANTIC_TABLE, ArgumentTrait.REQUIRE_ON_TIME})
+                        Row input) {
+            TimeContext<Instant> timeCtx = ctx.timeContext(Instant.class);
+            timeCtx.registerOnTime(timeCtx.time().plus(Duration.ofSeconds(5)));
+            collect(Row.of("registered"));
+        }
+
+        public void onTimer(OnTimerContext ctx) {
+            String timerName = ctx.currentTimer();
+            collect(Row.of("fired-unnamed-" + (timerName == null ? "null" : timerName)));
+        }
+    }
+
+    @DataTypeHint("ROW<message STRING>")
+    public static class TimerWithStatePTF extends ProcessTableFunction<Row> {
+        public static class CounterState {
+            public long count = 0L;
+        }
+
+        public void eval(
+                Context ctx,
+                @StateHint CounterState state,
+                @ArgumentHint({ArgumentTrait.SET_SEMANTIC_TABLE, ArgumentTrait.REQUIRE_ON_TIME})
+                        Row input) {
+            state.count++;
+            TimeContext<Long> timeCtx = ctx.timeContext(Long.class);
+            timeCtx.registerOnTime("check", timeCtx.time() + 5000L);
+        }
+
+        public void onTimer(OnTimerContext ctx, @StateHint CounterState state) {
+            collect(Row.of("count=" + state.count));
+        }
+    }
+
+    @DataTypeHint("ROW<message STRING>")
+    public static class PassThroughTimerPTF extends ProcessTableFunction<Row> {
+        public void eval(
+                Context ctx,
+                @ArgumentHint({
+                            ArgumentTrait.SET_SEMANTIC_TABLE,
+                            ArgumentTrait.PASS_COLUMNS_THROUGH,
+                            ArgumentTrait.REQUIRE_ON_TIME
+                        })
+                        Row input) {
+            TimeContext<LocalDateTime> timeCtx = ctx.timeContext(LocalDateTime.class);
+            timeCtx.registerOnTime("timer", timeCtx.time().plus(Duration.ofSeconds(5)));
+            collect(Row.of("registered"));
+        }
+
+        public void onTimer(OnTimerContext ctx) {
+            collect(Row.of("fired"));
+        }
+    }
+
+    @DataTypeHint("ROW<message STRING>")
+    public static class NoOnTimerPTF extends ProcessTableFunction<Row> {
+        public void eval(
+                Context ctx,
+                @ArgumentHint({ArgumentTrait.SET_SEMANTIC_TABLE, ArgumentTrait.REQUIRE_ON_TIME})
+                        Row input) {
+            TimeContext<LocalDateTime> timeCtx = ctx.timeContext(LocalDateTime.class);
+            timeCtx.registerOnTime("timer", timeCtx.time().plus(Duration.ofSeconds(10)));
+            collect(Row.of("registered"));
+        }
+    }
+
+    @DataTypeHint("ROW<message STRING>")
+    public static class MultipleOnTimerPTF extends ProcessTableFunction<Row> {
+        public void eval(
+                Context ctx,
+                @ArgumentHint({ArgumentTrait.SET_SEMANTIC_TABLE, ArgumentTrait.REQUIRE_ON_TIME})
+                        Row input) {
+            TimeContext<LocalDateTime> timeCtx = ctx.timeContext(LocalDateTime.class);
+            timeCtx.registerOnTime("timer", timeCtx.time().plus(Duration.ofSeconds(5)));
+            collect(Row.of("registered"));
+        }
+
+        public void onTimer(OnTimerContext ctx) {
+            collect(Row.of("fired-no-state"));
+        }
+
+        public void onTimer(OnTimerContext ctx, @StateHint String state) {
+            collect(Row.of("fired-with-state"));
+        }
+    }
+
+    @DataTypeHint("ROW<message STRING>")
+    public static class CascadingTimerPTF extends ProcessTableFunction<Row> {
+        public void eval(
+                Context ctx,
+                @ArgumentHint({ArgumentTrait.SET_SEMANTIC_TABLE, ArgumentTrait.REQUIRE_ON_TIME})
+                        Row input) {
+            TimeContext<Timestamp> timeCtx = ctx.timeContext(Timestamp.class);
+            timeCtx.registerOnTime("first", new Timestamp(timeCtx.time().getTime() + 5000));
+            collect(Row.of("eval"));
+        }
+
+        public void onTimer(OnTimerContext ctx) {
+            String name = ctx.currentTimer();
+            collect(Row.of("fired-" + name));
+            if ("first".equals(name)) {
+                TimeContext<Timestamp> timeCtx = ctx.timeContext(Timestamp.class);
+                timeCtx.registerOnTime("second", new Timestamp(timeCtx.time().getTime() - 2000));
+            }
+        }
+    }
+
+    @DataTypeHint("ROW<message STRING>")
+    public static class MultiTableTimerPTF extends ProcessTableFunction<Row> {
+        public void eval(
+                Context ctx,
+                @ArgumentHint({ArgumentTrait.SET_SEMANTIC_TABLE, ArgumentTrait.REQUIRE_ON_TIME})
+                        Row leftTable,
+                @ArgumentHint({ArgumentTrait.SET_SEMANTIC_TABLE, ArgumentTrait.REQUIRE_ON_TIME})
+                        Row rightTable) {
+            if (leftTable != null) {
+                TimeContext<LocalDateTime> timeCtx = ctx.timeContext(LocalDateTime.class);
+                timeCtx.registerOnTime("check", timeCtx.time().plus(Duration.ofSeconds(5)));
+                collect(Row.of("left"));
+            }
+            if (rightTable != null) {
+                collect(Row.of("right"));
+            }
+        }
+
+        public void onTimer(OnTimerContext ctx) {
+            collect(Row.of("timer-fired"));
+        }
+    }
+
+    @DataTypeHint("ROW<message STRING>")
+    public static class ContextClearStatePTF extends ProcessTableFunction<Row> {
+        public static class CounterState {
+            public long count = 0L;
+        }
+
+        public void eval(
+                Context ctx,
+                @StateHint CounterState state,
+                @ArgumentHint({ArgumentTrait.SET_SEMANTIC_TABLE, ArgumentTrait.REQUIRE_ON_TIME})
+                        Row input) {
+            String action = input.getFieldAs("action");
+            if ("increment".equals(action)) {
+                if (state == null) {
+                    state = new CounterState();
+                }
+                state.count++;
+                collect(Row.of("count=" + state.count));
+            } else if ("clear-state".equals(action)) {
+                ctx.clearState("state");
+                collect(Row.of("cleared"));
+            } else if ("clear-all-state".equals(action)) {
+                ctx.clearAllState();
+                collect(Row.of("cleared-all"));
+            } else if ("clear-all".equals(action)) {
+                ctx.clearAll();
+                collect(Row.of("cleared-everything"));
+            } else if ("register-timer".equals(action)) {
+                TimeContext<LocalDateTime> timeCtx = ctx.timeContext(LocalDateTime.class);
+                timeCtx.registerOnTime("t", timeCtx.time().plus(Duration.ofHours(1)));
+                collect(Row.of("timer-registered"));
+            }
+        }
+
+        public void onTimer(OnTimerContext ctx, @StateHint CounterState state) {
+            collect(Row.of("timer-fired"));
+        }
+    }
+
+    @DataTypeHint("ROW<message STRING>")
+    public static class PojoTimerPTF extends ProcessTableFunction<Row> {
+        public void eval(
+                Context ctx,
+                @ArgumentHint({ArgumentTrait.SET_SEMANTIC_TABLE, ArgumentTrait.REQUIRE_ON_TIME})
+                        TimedEvent input) {
+            TimeContext<LocalDateTime> timeCtx = ctx.timeContext(LocalDateTime.class);
+            timeCtx.registerOnTime("check", timeCtx.time().plus(Duration.ofSeconds(5)));
+            collect(Row.of("registered-" + input.key));
+        }
+
+        public void onTimer(OnTimerContext ctx) {
+            collect(Row.of("fired-" + ctx.currentTimer()));
+        }
+    }
+
+    @DataTypeHint("ROW<partitionCols STRING, timeCol INT, changelogMode STRING>")
+    public static class ContextSemanticsIntrospectionPTF extends ProcessTableFunction<Row> {
+        public void eval(
+                Context ctx,
+                @ArgumentHint({ArgumentTrait.SET_SEMANTIC_TABLE, ArgumentTrait.REQUIRE_ON_TIME})
+                        Row input) {
+            TableSemantics semantics = ctx.tableSemanticsFor("input");
+            collect(
+                    Row.of(
+                            java.util.Arrays.toString(semantics.partitionByColumns()),
+                            semantics.timeColumn(),
+                            ctx.getChangelogMode().toString()));
+            TimeContext<LocalDateTime> timeCtx = ctx.timeContext(LocalDateTime.class);
+            timeCtx.registerOnTime("check", timeCtx.time().plus(Duration.ofSeconds(5)));
+        }
+
+        public void onTimer(OnTimerContext ctx) {
+            TableSemantics semantics = ctx.tableSemanticsFor("input");
+            collect(
+                    Row.of(
+                            java.util.Arrays.toString(semantics.partitionByColumns()),
+                            semantics.timeColumn(),
+                            ctx.getChangelogMode().toString()));
+        }
+    }
+
+    @DataTypeHint("ROW<message STRING>")
+    public static class ClearTimerPTF extends ProcessTableFunction<Row> {
+        public void eval(
+                Context ctx,
+                @ArgumentHint({ArgumentTrait.SET_SEMANTIC_TABLE, ArgumentTrait.REQUIRE_ON_TIME})
+                        Row input) {
+            TimeContext<LocalDateTime> timeCtx = ctx.timeContext(LocalDateTime.class);
+            String action = input.getFieldAs("action");
+            if ("register-named".equals(action)) {
+                timeCtx.registerOnTime("myTimer", timeCtx.time().plus(Duration.ofSeconds(5)));
+            } else if ("register-unnamed".equals(action)) {
+                timeCtx.registerOnTime(timeCtx.time().plus(Duration.ofSeconds(5)));
+            } else if ("clear-by-name".equals(action)) {
+                timeCtx.clearTimer("myTimer");
+            } else if ("clear-by-timestamp".equals(action)) {
+                timeCtx.clearTimer(timeCtx.time().plus(Duration.ofSeconds(4)));
+            } else if ("clear-all".equals(action)) {
+                ctx.clearAllTimers();
+            }
+        }
+
+        public void onTimer(OnTimerContext ctx) {
+            collect(
+                    Row.of(
+                            "fired-"
+                                    + (ctx.currentTimer() != null
+                                            ? ctx.currentTimer()
+                                            : "unnamed")));
+        }
+    }
+
+    @DataTypeHint("ROW<message STRING>")
+    public static class WatermarkOnlyTimerPTF extends ProcessTableFunction<Row> {
+        public void eval(Context ctx, @ArgumentHint(ArgumentTrait.SET_SEMANTIC_TABLE) Row input) {
+            TimeContext<Long> timeCtx = ctx.timeContext(Long.class);
+            Long wm = timeCtx.currentWatermark();
+            long timer = wm == null || wm < 0 ? 1 : wm + 1;
+            timeCtx.registerOnTime("t", timer);
+            collect(Row.of("registered"));
+        }
+
+        public void onTimer(OnTimerContext ctx) {
+            collect(Row.of("fired-" + ctx.currentTimer()));
+        }
+    }
+
+    @DataTypeHint("ROW<message STRING>")
+    public static class OnTimePTF extends ProcessTableFunction<Row> {
+        public void eval(
+                Context ctx,
+                @ArgumentHint({ArgumentTrait.SET_SEMANTIC_TABLE, ArgumentTrait.REQUIRE_ON_TIME})
+                        Row input) {
+            String name = input.getFieldAs("name");
+            collect(Row.of("hello-" + name));
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Context Tests
+    // -------------------------------------------------------------------------
+
+    @Test
+    void testPerTableWatermarkTimerFiring() throws Exception {
+        try (ProcessTableFunctionTestHarness<Row> harness =
+                ProcessTableFunctionTestHarness.ofClass(MultiTableTimerPTF.class)
+                        .withTableArgument(
+                                "leftTable", DataTypes.of("ROW<partition STRING, ts TIMESTAMP(3)>"))
+                        .withTableArgument(
+                                "rightTable",
+                                DataTypes.of("ROW<partition STRING, ts TIMESTAMP(3)>"))
+                        .withPartitionBy("leftTable", "partition")
+                        .withPartitionBy("rightTable", "partition")
+                        .withOnTimeColumn("ts")
+                        .build()) {
+
+            // Register a timer at t=5000 via the left table
+            harness.processElementForTable(
+                    "leftTable", Row.of("P1", LocalDateTime.of(2025, 1, 1, 0, 0, 1)));
+            harness.clearOutput();
+
+            // Advance both watermarks, but the right table will not advance enough to trigger the
+            // timer at 6s
+            harness.setWatermarkForTable("rightTable", LocalDateTime.of(2025, 1, 1, 0, 0, 3));
+            harness.setWatermarkForTable("leftTable", LocalDateTime.of(2025, 1, 1, 0, 0, 10));
+            assertThat(harness.getFiredTimers()).isEmpty();
+
+            // Now advance right table past the timer. Global watermark catches up, timer fires
+            harness.setWatermarkForTable("rightTable", LocalDateTime.of(2025, 1, 1, 0, 0, 10));
+            assertThat(harness.getFiredTimers()).hasSize(1);
+            assertThat(harness.getFiredTimers().get(0).getName()).isEqualTo("check");
+            assertThat(harness.getFiredTimers().get(0).getTimestampAs(LocalDateTime.class))
+                    .isEqualTo(LocalDateTime.of(2025, 1, 1, 0, 0, 6));
+            // Both tables' partition keys are prepended (one "P1" per table)
+            assertThat(harness.getOutput())
+                    .containsExactly(
+                            Row.of(
+                                    "P1",
+                                    "P1",
+                                    "timer-fired",
+                                    LocalDateTime.of(2025, 1, 1, 0, 0, 6)));
+        }
+    }
+
+    @Test
+    void testContextClearState() throws Exception {
+        try (ProcessTableFunctionTestHarness<Row> harness =
+                ProcessTableFunctionTestHarness.ofClass(ContextClearStatePTF.class)
+                        .withTableArgument(
+                                "input",
+                                DataTypes.of(
+                                        "ROW<partition STRING, action STRING, ts TIMESTAMP(3)>"))
+                        .withPartitionBy("input", "partition")
+                        .withOnTimeColumn("ts")
+                        .build()) {
+
+            harness.processElement(
+                    Row.of("P1", "increment", LocalDateTime.of(2025, 1, 1, 0, 0, 1)));
+            harness.processElement(
+                    Row.of("P1", "increment", LocalDateTime.of(2025, 1, 1, 0, 0, 2)));
+            assertThat(harness.getOutput())
+                    .containsExactly(
+                            Row.of("P1", "count=1", LocalDateTime.of(2025, 1, 1, 0, 0, 1)),
+                            Row.of("P1", "count=2", LocalDateTime.of(2025, 1, 1, 0, 0, 2)));
+            harness.clearOutput();
+
+            harness.processElement(
+                    Row.of("P1", "clear-state", LocalDateTime.of(2025, 1, 1, 0, 0, 3)));
+            harness.processElement(
+                    Row.of("P1", "increment", LocalDateTime.of(2025, 1, 1, 0, 0, 4)));
+            assertThat(harness.getOutput())
+                    .containsExactly(
+                            Row.of("P1", "cleared", LocalDateTime.of(2025, 1, 1, 0, 0, 3)),
+                            Row.of("P1", "count=1", LocalDateTime.of(2025, 1, 1, 0, 0, 4)));
+        }
+    }
+
+    @Test
+    void testContextClearAllState() throws Exception {
+        try (ProcessTableFunctionTestHarness<Row> harness =
+                ProcessTableFunctionTestHarness.ofClass(ContextClearStatePTF.class)
+                        .withTableArgument(
+                                "input",
+                                DataTypes.of(
+                                        "ROW<partition STRING, action STRING, ts TIMESTAMP(3)>"))
+                        .withPartitionBy("input", "partition")
+                        .withOnTimeColumn("ts")
+                        .build()) {
+
+            harness.processElement(
+                    Row.of("P1", "increment", LocalDateTime.of(2025, 1, 1, 0, 0, 1)));
+            harness.clearOutput();
+
+            harness.processElement(
+                    Row.of("P1", "clear-all-state", LocalDateTime.of(2025, 1, 1, 0, 0, 2)));
+            harness.processElement(
+                    Row.of("P1", "increment", LocalDateTime.of(2025, 1, 1, 0, 0, 3)));
+            assertThat(harness.getOutput())
+                    .containsExactly(
+                            Row.of("P1", "cleared-all", LocalDateTime.of(2025, 1, 1, 0, 0, 2)),
+                            Row.of("P1", "count=1", LocalDateTime.of(2025, 1, 1, 0, 0, 3)));
+        }
+    }
+
+    @Test
+    void testContextClearAll() throws Exception {
+        try (ProcessTableFunctionTestHarness<Row> harness =
+                ProcessTableFunctionTestHarness.ofClass(ContextClearStatePTF.class)
+                        .withTableArgument(
+                                "input",
+                                DataTypes.of(
+                                        "ROW<partition STRING, action STRING, ts TIMESTAMP(3)>"))
+                        .withPartitionBy("input", "partition")
+                        .withOnTimeColumn("ts")
+                        .build()) {
+
+            harness.processElement(
+                    Row.of("P1", "increment", LocalDateTime.of(2025, 1, 1, 0, 0, 1)));
+            harness.processElement(
+                    Row.of("P1", "register-timer", LocalDateTime.of(2025, 1, 1, 0, 0, 2)));
+            assertThat(harness.getPendingTimers()).hasSize(1);
+            assertThat(harness.getPendingTimers().get(0).getName()).isEqualTo("t");
+            harness.clearOutput();
+
+            harness.processElement(
+                    Row.of("P1", "clear-all", LocalDateTime.of(2025, 1, 1, 0, 0, 3)));
+            assertThat(harness.getPendingTimers()).isEmpty();
+
+            harness.processElement(
+                    Row.of("P1", "increment", LocalDateTime.of(2025, 1, 1, 0, 0, 4)));
+            assertThat(harness.getOutput())
+                    .containsExactly(
+                            Row.of(
+                                    "P1",
+                                    "cleared-everything",
+                                    LocalDateTime.of(2025, 1, 1, 0, 0, 3)),
+                            Row.of("P1", "count=1", LocalDateTime.of(2025, 1, 1, 0, 0, 4)));
+        }
+    }
+
+    @Test
+    void testContextTableSemanticsAndChangelogMode() throws Exception {
+        try (ProcessTableFunctionTestHarness<Row> harness =
+                ProcessTableFunctionTestHarness.ofClass(ContextSemanticsIntrospectionPTF.class)
+                        .withTableArgument(
+                                "input", DataTypes.of("ROW<partition STRING, ts TIMESTAMP(3)>"))
+                        .withPartitionBy("input", "partition")
+                        .withOnTimeColumn("ts")
+                        .build()) {
+
+            harness.processElement(Row.of("P1", LocalDateTime.of(2025, 1, 1, 0, 0, 1)));
+
+            assertThat(harness.getOutput()).hasSize(1);
+            Row evalResult = harness.getOutput().get(0);
+            assertThat(evalResult.getFieldAs(0).toString()).isEqualTo("P1");
+            assertThat(evalResult.getFieldAs(1).toString()).isEqualTo("[0]");
+            assertThat((int) evalResult.getFieldAs(2)).isEqualTo(1);
+            assertThat(evalResult.getFieldAs(3).toString())
+                    .isEqualTo(ChangelogMode.insertOnly().toString());
+
+            harness.clearOutput();
+            harness.setWatermark(LocalDateTime.of(2025, 1, 1, 0, 0, 10));
+
+            assertThat(harness.getOutput()).hasSize(1);
+            Row timerResult = harness.getOutput().get(0);
+            assertThat(timerResult.getFieldAs(0).toString()).isEqualTo("P1");
+            assertThat(timerResult.getFieldAs(1).toString()).isEqualTo("[0]");
+            assertThat((int) timerResult.getFieldAs(2)).isEqualTo(1);
+            assertThat(timerResult.getFieldAs(3).toString())
+                    .isEqualTo(ChangelogMode.insertOnly().toString());
+        }
+    }
+
+    @Test
+    void testPojoInputWithOnTimeColumn() throws Exception {
+        try (ProcessTableFunctionTestHarness<Row> harness =
+                ProcessTableFunctionTestHarness.ofClass(PojoTimerPTF.class)
+                        .withTableArgument("input")
+                        .withPartitionBy("input", "key")
+                        .withOnTimeColumn("ts")
+                        .build()) {
+
+            harness.processElement(Row.of("P1", LocalDateTime.of(2025, 1, 1, 0, 0, 1)));
+            assertThat(harness.getOutput())
+                    .containsExactly(
+                            Row.of("P1", "registered-P1", LocalDateTime.of(2025, 1, 1, 0, 0, 1)));
+            assertThat(harness.getPendingTimers()).hasSize(1);
+            harness.clearOutput();
+
+            harness.setWatermark(LocalDateTime.of(2025, 1, 1, 0, 0, 10));
+            assertThat(harness.getFiredTimers()).hasSize(1);
+            assertThat(harness.getOutput())
+                    .containsExactly(
+                            Row.of("P1", "fired-check", LocalDateTime.of(2025, 1, 1, 0, 0, 6)));
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Time / On-Time Column Tests
+    // -------------------------------------------------------------------------
+
+    @Test
+    void testOnTimeColumnAppendedToEvalOutput() throws Exception {
+        try (ProcessTableFunctionTestHarness<Row> harness =
+                ProcessTableFunctionTestHarness.ofClass(OnTimePTF.class)
+                        .withTableArgument(
+                                "input",
+                                DataTypes.of("ROW<partition STRING, name STRING, ts TIMESTAMP(3)>"))
+                        .withPartitionBy("input", "partition")
+                        .withOnTimeColumn("ts")
+                        .build()) {
+
+            harness.processElement(Row.of("P1", "Alice", LocalDateTime.of(2025, 1, 1, 0, 0, 1)));
+            assertThat(harness.getOutput())
+                    .containsExactly(
+                            Row.of("P1", "hello-Alice", LocalDateTime.of(2025, 1, 1, 0, 0, 1)));
+        }
+    }
+
+    @Test
+    void testWatermarkAdvancesWithoutTimers() throws Exception {
+        try (ProcessTableFunctionTestHarness<Row> harness =
+                ProcessTableFunctionTestHarness.ofClass(OnTimePTF.class)
+                        .withTableArgument(
+                                "input",
+                                DataTypes.of("ROW<partition STRING, name STRING, ts TIMESTAMP(3)>"))
+                        .withPartitionBy("input", "partition")
+                        .withOnTimeColumn("ts")
+                        .build()) {
+
+            harness.processElement(Row.of("P1", "Alice", LocalDateTime.of(2025, 1, 1, 0, 0, 1)));
+
+            // Advancing watermark without timers registered should not produce additional output
+            harness.setWatermark(LocalDateTime.of(2025, 1, 1, 0, 0, 10));
+            assertThat(harness.getOutput()).hasSize(1);
+        }
+    }
+
+    @Test
+    void testWatermarkAdvancesWithoutOnTimeColumn() throws Exception {
+        try (ProcessTableFunctionTestHarness<Row> harness =
+                ProcessTableFunctionTestHarness.ofClass(PassthroughPTF.class)
+                        .withTableArgument("input", DataTypes.of("ROW<value INT>"))
+                        .build()) {
+
+            harness.processElement(Row.of(42));
+            harness.setWatermark(LocalDateTime.of(2025, 1, 1, 0, 0, 10));
+            assertThat(harness.getOutput()).containsExactly(Row.of(42));
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Timer Tests
+    // -------------------------------------------------------------------------
+
+    @Test
+    void testNamedTimerRegistrationAndFiring() throws Exception {
+        try (ProcessTableFunctionTestHarness<Row> harness =
+                ProcessTableFunctionTestHarness.ofClass(TimerPTF.class)
+                        .withTableArgument(
+                                "input",
+                                DataTypes.of("ROW<partition STRING, name STRING, ts TIMESTAMP(3)>"))
+                        .withPartitionBy("input", "partition")
+                        .withOnTimeColumn("ts")
+                        .build()) {
+
+            harness.processElement(Row.of("P1", "Alice", LocalDateTime.of(2025, 1, 1, 0, 0, 1)));
+            assertThat(harness.getOutput())
+                    .containsExactly(
+                            Row.of(
+                                    "P1",
+                                    "registered-Alice",
+                                    LocalDateTime.of(2025, 1, 1, 0, 0, 1)));
+            harness.clearOutput();
+
+            assertThat(harness.getPendingTimers()).hasSize(1);
+            Timer timer = harness.getPendingTimers().get(0);
+            assertThat(timer.getName()).isEqualTo("timeout-Alice");
+            assertThat(timer.getTimestampAs(LocalDateTime.class))
+                    .isEqualTo(LocalDateTime.of(2025, 1, 1, 0, 0, 6));
+
+            harness.setWatermark(LocalDateTime.of(2025, 1, 1, 0, 0, 7));
+            assertThat(harness.getOutput())
+                    .containsExactly(
+                            Row.of(
+                                    "P1",
+                                    "timer-fired-timeout-Alice",
+                                    LocalDateTime.of(2025, 1, 1, 0, 0, 6)));
+
+            assertThat(harness.getPendingTimers()).isEmpty();
+            assertThat(harness.getFiredTimers()).hasSize(1);
+            assertThat(harness.getFiredTimers().get(0).getName()).isEqualTo("timeout-Alice");
+            assertThat(harness.getFiredTimers().get(0).getTimestampAs(LocalDateTime.class))
+                    .isEqualTo(LocalDateTime.of(2025, 1, 1, 0, 0, 6));
+        }
+    }
+
+    @Test
+    void testUnnamedTimerFiring() throws Exception {
+        try (ProcessTableFunctionTestHarness<Row> harness =
+                ProcessTableFunctionTestHarness.ofClass(UnnamedTimerPTF.class)
+                        .withTableArgument(
+                                "input", DataTypes.of("ROW<partition STRING, ts TIMESTAMP(3)>"))
+                        .withPartitionBy("input", "partition")
+                        .withOnTimeColumn("ts")
+                        .build()) {
+
+            harness.processElement(Row.of("P1", LocalDateTime.of(2025, 1, 1, 0, 0, 1)));
+            harness.clearOutput();
+
+            harness.setWatermark(Instant.parse("2025-01-01T00:00:07Z"));
+            assertThat(harness.getOutput())
+                    .containsExactly(
+                            Row.of(
+                                    "P1",
+                                    "fired-unnamed-null",
+                                    LocalDateTime.of(2025, 1, 1, 0, 0, 6)));
+        }
+    }
+
+    @Test
+    void testTimerReplacementSemantics() throws Exception {
+        try (ProcessTableFunctionTestHarness<Row> harness =
+                ProcessTableFunctionTestHarness.ofClass(TimerPTF.class)
+                        .withTableArgument(
+                                "input",
+                                DataTypes.of("ROW<partition STRING, name STRING, ts TIMESTAMP(3)>"))
+                        .withPartitionBy("input", "partition")
+                        .withOnTimeColumn("ts")
+                        .build()) {
+
+            // First eval: event at T+1s → timer at T+6s
+            // Second eval: event at T+6s → replaces timer to T+11s
+            harness.processElement(Row.of("P1", "Alice", LocalDateTime.of(2025, 1, 1, 0, 0, 1)));
+            harness.processElement(Row.of("P1", "Alice", LocalDateTime.of(2025, 1, 1, 0, 0, 6)));
+            harness.clearOutput();
+
+            assertThat(harness.getPendingTimers()).hasSize(1);
+            assertThat(harness.getPendingTimers().get(0).getName()).isEqualTo("timeout-Alice");
+            assertThat(harness.getPendingTimers().get(0).getTimestampAs(LocalDateTime.class))
+                    .isEqualTo(LocalDateTime.of(2025, 1, 1, 0, 0, 11));
+
+            // Watermark at T+7s — timer at T+11s should NOT fire
+            harness.setWatermark(LocalDateTime.of(2025, 1, 1, 0, 0, 7));
+            assertThat(harness.getOutput()).isEmpty();
+
+            // Watermark at T+12s — timer at T+11s should fire
+            harness.setWatermark(LocalDateTime.of(2025, 1, 1, 0, 0, 12));
+            assertThat(harness.getOutput())
+                    .containsExactly(
+                            Row.of(
+                                    "P1",
+                                    "timer-fired-timeout-Alice",
+                                    LocalDateTime.of(2025, 1, 1, 0, 0, 11)));
+        }
+    }
+
+    @Test
+    void testMultipleTimersFiringOrder() throws Exception {
+        try (ProcessTableFunctionTestHarness<Row> harness =
+                ProcessTableFunctionTestHarness.ofClass(TimerPTF.class)
+                        .withTableArgument(
+                                "input",
+                                DataTypes.of("ROW<partition STRING, name STRING, ts TIMESTAMP(3)>"))
+                        .withPartitionBy("input", "partition")
+                        .withOnTimeColumn("ts")
+                        .build()) {
+
+            harness.processElement(Row.of("P1", "Charlie", LocalDateTime.of(2025, 1, 1, 0, 0, 5)));
+            harness.processElement(Row.of("P1", "Alice", LocalDateTime.of(2025, 1, 1, 0, 0, 1)));
+            harness.processElement(Row.of("P1", "Bob", LocalDateTime.of(2025, 1, 1, 0, 0, 3)));
+            harness.clearOutput();
+
+            harness.setWatermark(LocalDateTime.of(2025, 1, 1, 0, 0, 11));
+            assertThat(harness.getOutput())
+                    .containsExactly(
+                            Row.of(
+                                    "P1",
+                                    "timer-fired-timeout-Alice",
+                                    LocalDateTime.of(2025, 1, 1, 0, 0, 6)),
+                            Row.of(
+                                    "P1",
+                                    "timer-fired-timeout-Bob",
+                                    LocalDateTime.of(2025, 1, 1, 0, 0, 8)),
+                            Row.of(
+                                    "P1",
+                                    "timer-fired-timeout-Charlie",
+                                    LocalDateTime.of(2025, 1, 1, 0, 0, 10)));
+        }
+    }
+
+    @Test
+    void testStateAccessInOnTimer() throws Exception {
+        try (ProcessTableFunctionTestHarness<Row> harness =
+                ProcessTableFunctionTestHarness.ofClass(TimerWithStatePTF.class)
+                        .withTableArgument(
+                                "input", DataTypes.of("ROW<partition STRING, ts TIMESTAMP(3)>"))
+                        .withPartitionBy("input", "partition")
+                        .withOnTimeColumn("ts")
+                        .build()) {
+
+            harness.processElement(Row.of("P1", LocalDateTime.of(2025, 1, 1, 0, 0, 1)));
+            harness.processElement(Row.of("P1", LocalDateTime.of(2025, 1, 1, 0, 0, 1)));
+            harness.processElement(Row.of("P1", LocalDateTime.of(2025, 1, 1, 0, 0, 1)));
+            harness.processElement(Row.of("P2", LocalDateTime.of(2025, 1, 1, 0, 0, 2)));
+
+            harness.setWatermark(LocalDateTime.of(2025, 1, 1, 0, 0, 8));
+            assertThat(harness.getOutput())
+                    .containsExactly(
+                            Row.of("P1", "count=3", LocalDateTime.of(2025, 1, 1, 0, 0, 6)),
+                            Row.of("P2", "count=1", LocalDateTime.of(2025, 1, 1, 0, 0, 7)));
+
+            assertThat(harness.getFiredTimers(Row.of("P1"))).hasSize(1);
+            assertThat(harness.getFiredTimers(Row.of("P1")).get(0).getName()).isEqualTo("check");
+            assertThat(harness.getFiredTimers(Row.of("P2"))).hasSize(1);
+            assertThat(harness.getFiredTimers(Row.of("P2")).get(0).getName()).isEqualTo("check");
+            assertThat(harness.getPendingTimers(Row.of("P1"))).isEmpty();
+            assertThat(harness.getPendingTimers(Row.of("P2"))).isEmpty();
+        }
+    }
+
+    @Test
+    void testWatermarkCannotMoveBackward() throws Exception {
+        try (ProcessTableFunctionTestHarness<Row> harness =
+                ProcessTableFunctionTestHarness.ofClass(TimerPTF.class)
+                        .withTableArgument(
+                                "input",
+                                DataTypes.of("ROW<partition STRING, name STRING, ts TIMESTAMP(3)>"))
+                        .withPartitionBy("input", "partition")
+                        .withOnTimeColumn("ts")
+                        .build()) {
+
+            harness.setWatermark(LocalDateTime.of(2025, 1, 1, 0, 0, 5));
+            IllegalArgumentException e =
+                    assertThrows(
+                            IllegalArgumentException.class,
+                            () -> harness.setWatermark(LocalDateTime.of(2025, 1, 1, 0, 0, 2)));
+            assertThat(e.getMessage()).contains("Cannot move watermark backward", "input");
+
+            IllegalArgumentException e2 =
+                    assertThrows(
+                            IllegalArgumentException.class,
+                            () ->
+                                    harness.setWatermarkForTable(
+                                            "input", LocalDateTime.of(2025, 1, 1, 0, 0, 2)));
+            assertThat(e2.getMessage()).contains("Cannot move watermark backward", "input");
+        }
+    }
+
+    @Test
+    void testPassThroughWithTimersIsRejected() throws Exception {
+        try (ProcessTableFunctionTestHarness<Row> harness =
+                ProcessTableFunctionTestHarness.ofClass(PassThroughTimerPTF.class)
+                        .withTableArgument(
+                                "input", DataTypes.of("ROW<partition STRING, ts TIMESTAMP(3)>"))
+                        .withPartitionBy("input", "partition")
+                        .withOnTimeColumn("ts")
+                        .build()) {
+
+            TableRuntimeException e =
+                    assertThrows(
+                            TableRuntimeException.class,
+                            () ->
+                                    harness.processElement(
+                                            Row.of("P1", LocalDateTime.of(2025, 1, 1, 0, 0, 1))));
+            assertThat(e.getMessage()).contains("Timers are not supported");
+        }
+    }
+
+    @Test
+    void testNoOnTimerMethodThrows() throws Exception {
+        try (ProcessTableFunctionTestHarness<Row> harness =
+                ProcessTableFunctionTestHarness.ofClass(NoOnTimerPTF.class)
+                        .withTableArgument(
+                                "input", DataTypes.of("ROW<partition STRING, ts TIMESTAMP(3)>"))
+                        .withPartitionBy("input", "partition")
+                        .withOnTimeColumn("ts")
+                        .build()) {
+
+            harness.processElement(Row.of("P1", LocalDateTime.of(2025, 1, 1, 0, 0, 1)));
+
+            IllegalStateException e =
+                    assertThrows(
+                            IllegalStateException.class,
+                            () -> harness.setWatermark(LocalDateTime.of(2025, 1, 1, 0, 1)));
+            assertThat(e.getMessage()).contains("no valid onTimer() method", "NoOnTimerPTF");
+        }
+    }
+
+    @Test
+    void testRequireOnTimeWithoutOnTimeColumnIsRejected() {
+        ValidationException e =
+                assertThrows(
+                        ValidationException.class,
+                        () ->
+                                ProcessTableFunctionTestHarness.ofClass(TimerPTF.class)
+                                        .withTableArgument(
+                                                "input",
+                                                DataTypes.of(
+                                                        "ROW<partition STRING, ts TIMESTAMP(3)>"))
+                                        .withPartitionBy("input", "partition")
+                                        .build());
+        assertThat(e.getMessage()).contains("requires a time attribute", "on_time");
+    }
+
+    @Test
+    void testMultipleOnTimerMethods() throws Exception {
+        try (ProcessTableFunctionTestHarness<Row> harness =
+                ProcessTableFunctionTestHarness.ofClass(MultipleOnTimerPTF.class)
+                        .withTableArgument(
+                                "input", DataTypes.of("ROW<partition STRING, ts TIMESTAMP(3)>"))
+                        .withPartitionBy("input", "partition")
+                        .withOnTimeColumn("ts")
+                        .build()) {
+
+            harness.processElement(Row.of("P1", LocalDateTime.of(2025, 1, 1, 0, 0, 1)));
+            harness.clearOutput();
+
+            harness.setWatermark(LocalDateTime.of(2025, 1, 1, 0, 0, 7));
+            assertThat(harness.getOutput())
+                    .containsExactly(
+                            Row.of("P1", "fired-no-state", LocalDateTime.of(2025, 1, 1, 0, 0, 6)));
+        }
+    }
+
+    @Test
+    void testCascadingTimerFromOnTimer() throws Exception {
+        try (ProcessTableFunctionTestHarness<Row> harness =
+                ProcessTableFunctionTestHarness.ofClass(CascadingTimerPTF.class)
+                        .withTableArgument(
+                                "input", DataTypes.of("ROW<partition STRING, ts TIMESTAMP(3)>"))
+                        .withPartitionBy("input", "partition")
+                        .withOnTimeColumn("ts")
+                        .build()) {
+
+            harness.processElement(Row.of("P1", LocalDateTime.of(2025, 1, 1, 0, 0, 1)));
+            assertThat(harness.getOutput())
+                    .containsExactly(Row.of("P1", "eval", LocalDateTime.of(2025, 1, 1, 0, 0, 1)));
+            harness.clearOutput();
+
+            // "first" fires, registers "second" at 3000ms (past time),
+            // "second" should cascade and fire in the same advance
+            harness.setWatermark(LocalDateTime.of(2025, 1, 1, 0, 0, 7));
+            assertThat(harness.getOutput())
+                    .containsExactly(
+                            Row.of("P1", "fired-first", LocalDateTime.of(2025, 1, 1, 0, 0, 6)),
+                            Row.of("P1", "fired-second", LocalDateTime.of(2025, 1, 1, 0, 0, 4)));
+            assertThat(harness.getPendingTimers()).isEmpty();
+            assertThat(harness.getFiredTimers()).hasSize(2);
+            assertThat(harness.getFiredTimers())
+                    .extracting(Timer::getName)
+                    .containsExactly("first", "second");
+        }
+    }
+
+    @Test
+    void testClearTimerByName() throws Exception {
+        try (ProcessTableFunctionTestHarness<Row> harness =
+                ProcessTableFunctionTestHarness.ofClass(ClearTimerPTF.class)
+                        .withTableArgument(
+                                "input",
+                                DataTypes.of(
+                                        "ROW<partition STRING, action STRING, ts TIMESTAMP(3)>"))
+                        .withPartitionBy("input", "partition")
+                        .withOnTimeColumn("ts")
+                        .build()) {
+
+            harness.processElement(
+                    Row.of("P1", "register-named", LocalDateTime.of(2025, 1, 1, 0, 0, 1)));
+            assertThat(harness.getPendingTimers()).hasSize(1);
+            assertThat(harness.getPendingTimers().get(0).getName()).isEqualTo("myTimer");
+
+            harness.processElement(
+                    Row.of("P1", "clear-by-name", LocalDateTime.of(2025, 1, 1, 0, 0, 2)));
+            assertThat(harness.getPendingTimers()).isEmpty();
+
+            harness.setWatermark(LocalDateTime.of(2025, 1, 1, 0, 1));
+            assertThat(harness.getOutput()).isEmpty();
+        }
+    }
+
+    @Test
+    void testClearTimerByTimestamp() throws Exception {
+        try (ProcessTableFunctionTestHarness<Row> harness =
+                ProcessTableFunctionTestHarness.ofClass(ClearTimerPTF.class)
+                        .withTableArgument(
+                                "input",
+                                DataTypes.of(
+                                        "ROW<partition STRING, action STRING, ts TIMESTAMP(3)>"))
+                        .withPartitionBy("input", "partition")
+                        .withOnTimeColumn("ts")
+                        .build()) {
+
+            harness.processElement(
+                    Row.of("P1", "register-unnamed", LocalDateTime.of(2025, 1, 1, 0, 0, 1)));
+            assertThat(harness.getPendingTimers()).hasSize(1);
+            assertThat(harness.getPendingTimers().get(0).getName()).isNull();
+            assertThat(harness.getPendingTimers().get(0).getTimestampAs(LocalDateTime.class))
+                    .isEqualTo(LocalDateTime.of(2025, 1, 1, 0, 0, 6));
+
+            harness.processElement(
+                    Row.of("P1", "clear-by-timestamp", LocalDateTime.of(2025, 1, 1, 0, 0, 2)));
+            assertThat(harness.getPendingTimers()).isEmpty();
+
+            harness.setWatermark(LocalDateTime.of(2025, 1, 1, 0, 1));
+            assertThat(harness.getOutput()).isEmpty();
+        }
+    }
+
+    @Test
+    void testClearTimerByTimestampDoesNotClearNamedTimers() throws Exception {
+        try (ProcessTableFunctionTestHarness<Row> harness =
+                ProcessTableFunctionTestHarness.ofClass(ClearTimerPTF.class)
+                        .withTableArgument(
+                                "input",
+                                DataTypes.of(
+                                        "ROW<partition STRING, action STRING, ts TIMESTAMP(3)>"))
+                        .withPartitionBy("input", "partition")
+                        .withOnTimeColumn("ts")
+                        .build()) {
+
+            harness.processElement(
+                    Row.of("P1", "register-named", LocalDateTime.of(2025, 1, 1, 0, 0, 1)));
+            assertThat(harness.getPendingTimers()).hasSize(1);
+            assertThat(harness.getPendingTimers().get(0).getName()).isEqualTo("myTimer");
+
+            harness.processElement(
+                    Row.of("P1", "clear-by-timestamp", LocalDateTime.of(2025, 1, 1, 0, 0, 2)));
+            assertThat(harness.getPendingTimers()).hasSize(1);
+            assertThat(harness.getPendingTimers().get(0).getName()).isEqualTo("myTimer");
+
+            harness.setWatermark(LocalDateTime.of(2025, 1, 1, 0, 1));
+            assertThat(harness.getOutput())
+                    .containsExactly(
+                            Row.of("P1", "fired-myTimer", LocalDateTime.of(2025, 1, 1, 0, 0, 6)));
+        }
+    }
+
+    @Test
+    void testClearAllTimers() throws Exception {
+        try (ProcessTableFunctionTestHarness<Row> harness =
+                ProcessTableFunctionTestHarness.ofClass(ClearTimerPTF.class)
+                        .withTableArgument(
+                                "input",
+                                DataTypes.of(
+                                        "ROW<partition STRING, action STRING, ts TIMESTAMP(3)>"))
+                        .withPartitionBy("input", "partition")
+                        .withOnTimeColumn("ts")
+                        .build()) {
+
+            harness.processElement(
+                    Row.of("P1", "register-named", LocalDateTime.of(2025, 1, 1, 0, 0, 1)));
+            harness.processElement(
+                    Row.of("P1", "register-unnamed", LocalDateTime.of(2025, 1, 1, 0, 0, 2)));
+            assertThat(harness.getPendingTimers()).hasSize(2);
+
+            harness.processElement(
+                    Row.of("P1", "clear-all", LocalDateTime.of(2025, 1, 1, 0, 0, 3)));
+            assertThat(harness.getPendingTimers()).isEmpty();
+
+            harness.setWatermark(LocalDateTime.of(2025, 1, 1, 0, 1));
+            assertThat(harness.getOutput()).isEmpty();
+        }
+    }
+
+    @Test
+    void testTimersWithoutOnTimeColumn() throws Exception {
+        try (ProcessTableFunctionTestHarness<Row> harness =
+                ProcessTableFunctionTestHarness.ofClass(WatermarkOnlyTimerPTF.class)
+                        .withTableArgument(
+                                "input", DataTypes.of("ROW<partition STRING, value INT>"))
+                        .withPartitionBy("input", "partition")
+                        .build()) {
+
+            harness.setWatermark(Instant.ofEpochMilli(1000));
+
+            harness.processElement(Row.of("P1", 42));
+            assertThat(harness.getOutput()).containsExactly(Row.of("P1", "registered"));
+            harness.clearOutput();
+
+            assertThat(harness.getPendingTimers()).hasSize(1);
+            assertThat(harness.getPendingTimers().get(0).getName()).isEqualTo("t");
+            assertThat(harness.getPendingTimers().get(0).getTimestamp()).isEqualTo(1001);
+
+            // Advance watermark to fire the timer
+            harness.setWatermark(Instant.ofEpochMilli(1001));
+            assertThat(harness.getFiredTimers()).hasSize(1);
+            assertThat(harness.getFiredTimers().get(0).getName()).isEqualTo("t");
+
+            // Row collected from onTimer should have no on_time column
+            assertThat(harness.getOutput()).containsExactly(Row.of("P1", "fired-t"));
+        }
     }
 }

--- a/flink-table/flink-table-test-utils/src/test/java/org/apache/flink/table/runtime/functions/TestHarnessTimerManagerTest.java
+++ b/flink-table/flink-table-test-utils/src/test/java/org/apache/flink/table/runtime/functions/TestHarnessTimerManagerTest.java
@@ -1,0 +1,369 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.functions;
+
+import org.apache.flink.types.Row;
+import org.apache.flink.util.function.ThrowingConsumer;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class TestHarnessTimerManagerTest {
+
+    private static final Row P1 = Row.of("P1");
+    private static final Row P2 = Row.of("P2");
+
+    private static final ThrowingConsumer<Timer, Exception> NOOP_FIRER = t -> {};
+
+    @Test
+    void testNamedTimerRegistration() {
+        TestHarnessTimerManager manager = new TestHarnessTimerManager();
+
+        manager.register(P1, 1000L, "timer-a");
+        manager.register(P1, 2000L, "timer-b");
+
+        assertThat(manager.getPendingTimers()).hasSize(2);
+    }
+
+    @Test
+    void testNamedTimerReplacementOverwritesTimestamp() throws Exception {
+        TestHarnessTimerManager manager = new TestHarnessTimerManager();
+        List<Timer> fired = new ArrayList<>();
+
+        manager.register(P1, 1000L, "timer-a");
+        manager.register(P1, 3000L, "timer-a");
+
+        assertThat(manager.getPendingTimers()).hasSize(1);
+        assertThat(manager.getPendingTimers().get(0).getTimestamp()).isEqualTo(3000L);
+
+        manager.setTableWatermark("table-a", 2000L);
+        manager.updateGlobalWatermarkAndFireTimers(fired::add);
+        assertThat(fired).isEmpty();
+
+        manager.setTableWatermark("table-a", 3000L);
+        manager.updateGlobalWatermarkAndFireTimers(fired::add);
+        assertThat(fired).hasSize(1);
+        assertThat(fired.get(0).getTimestamp()).isEqualTo(3000L);
+    }
+
+    @Test
+    void testNamedTimerReplacementIsPerPartition() {
+        TestHarnessTimerManager manager = new TestHarnessTimerManager();
+
+        manager.register(P1, 1000L, "timer-a");
+        manager.register(P2, 2000L, "timer-a");
+
+        assertThat(manager.getPendingTimers()).hasSize(2);
+    }
+
+    @Test
+    void testUnnamedTimerRegistration() {
+        TestHarnessTimerManager manager = new TestHarnessTimerManager();
+
+        manager.register(P1, 1000L, null);
+        manager.register(P1, 2000L, null);
+
+        assertThat(manager.getPendingTimers()).hasSize(2);
+    }
+
+    @Test
+    void testUnnamedTimerDeduplicationBySameTimestamp() {
+        TestHarnessTimerManager manager = new TestHarnessTimerManager();
+
+        manager.register(P1, 1000L, null);
+        manager.register(P1, 1000L, null);
+
+        assertThat(manager.getPendingTimers()).hasSize(1);
+    }
+
+    @Test
+    void testUnnamedTimerDeduplicationIsPerPartition() {
+        TestHarnessTimerManager manager = new TestHarnessTimerManager();
+
+        manager.register(P1, 1000L, null);
+        manager.register(P2, 1000L, null);
+
+        assertThat(manager.getPendingTimers()).hasSize(2);
+    }
+
+    @Test
+    void testNamedAndUnnamedTimersAreIndependent() {
+        TestHarnessTimerManager manager = new TestHarnessTimerManager();
+
+        manager.register(P1, 1000L, "timer-a");
+        manager.register(P1, 1000L, null);
+
+        assertThat(manager.getPendingTimers()).hasSize(2);
+    }
+
+    @Test
+    void testGlobalWatermarkIsMinAcrossTables() throws Exception {
+        TestHarnessTimerManager manager = new TestHarnessTimerManager();
+
+        manager.setTableWatermark("table-a", 1000L);
+        manager.setTableWatermark("table-b", 3000L);
+        manager.updateGlobalWatermarkAndFireTimers(NOOP_FIRER);
+
+        assertThat(manager.getGlobalWatermark()).isEqualTo(1000L);
+    }
+
+    @Test
+    void testGlobalWatermarkAdvancesWhenLaggingTableCatchesUp() throws Exception {
+        TestHarnessTimerManager manager = new TestHarnessTimerManager();
+
+        manager.setTableWatermark("table-a", 1000L);
+        manager.setTableWatermark("table-b", 3000L);
+        manager.updateGlobalWatermarkAndFireTimers(NOOP_FIRER);
+        assertThat(manager.getGlobalWatermark()).isEqualTo(1000L);
+
+        manager.setTableWatermark("table-a", 5000L);
+        manager.updateGlobalWatermarkAndFireTimers(NOOP_FIRER);
+        assertThat(manager.getGlobalWatermark()).isEqualTo(3000L);
+    }
+
+    @Test
+    void testPerTableWatermarkCannotMoveBackward() {
+        TestHarnessTimerManager manager = new TestHarnessTimerManager();
+
+        manager.setTableWatermark("table-a", 2000L);
+        assertThrows(
+                IllegalArgumentException.class, () -> manager.setTableWatermark("table-a", 1000L));
+    }
+
+    @Test
+    void testPerTableWatermarkTrackedIndependently() {
+        TestHarnessTimerManager manager = new TestHarnessTimerManager();
+
+        manager.setTableWatermark("table-a", 1000L);
+        manager.setTableWatermark("table-b", 3000L);
+
+        assertThat(manager.getWatermarkForTable("table-a")).isEqualTo(1000L);
+        assertThat(manager.getWatermarkForTable("table-b")).isEqualTo(3000L);
+    }
+
+    @Test
+    void testNewTableCanCauseGlobalWatermarkBackwardError() throws Exception {
+        TestHarnessTimerManager manager = new TestHarnessTimerManager();
+
+        manager.setTableWatermark("table-a", 5000L);
+        manager.updateGlobalWatermarkAndFireTimers(NOOP_FIRER);
+        assertThat(manager.getGlobalWatermark()).isEqualTo(5000L);
+
+        manager.setTableWatermark("table-b", 1000L);
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> manager.updateGlobalWatermarkAndFireTimers(NOOP_FIRER));
+    }
+
+    @Test
+    void testTimerFiresWhenWatermarkAdvancesPastTimestamp() throws Exception {
+        TestHarnessTimerManager manager = new TestHarnessTimerManager();
+        List<Timer> fired = new ArrayList<>();
+
+        manager.register(P1, 1000L, "timer-a");
+        manager.setTableWatermark("table-a", 2000L);
+        manager.updateGlobalWatermarkAndFireTimers(fired::add);
+
+        assertThat(fired).hasSize(1);
+        assertThat(fired.get(0).getName()).isEqualTo("timer-a");
+        assertThat(manager.getPendingTimers()).isEmpty();
+        assertThat(manager.getFiredTimers()).hasSize(1);
+    }
+
+    @Test
+    void testTimerDoesNotFireBeforeWatermark() throws Exception {
+        TestHarnessTimerManager manager = new TestHarnessTimerManager();
+        List<Timer> fired = new ArrayList<>();
+
+        manager.register(P1, 3000L, "timer-a");
+        manager.setTableWatermark("table-a", 2999L);
+        manager.updateGlobalWatermarkAndFireTimers(fired::add);
+
+        assertThat(fired).isEmpty();
+        assertThat(manager.getPendingTimers()).hasSize(1);
+    }
+
+    @Test
+    void testTimerFiresAtExactWatermark() throws Exception {
+        TestHarnessTimerManager manager = new TestHarnessTimerManager();
+        List<Timer> fired = new ArrayList<>();
+
+        manager.register(P1, 2000L, "timer-a");
+        manager.setTableWatermark("table-a", 2000L);
+        manager.updateGlobalWatermarkAndFireTimers(fired::add);
+
+        assertThat(fired).hasSize(1);
+    }
+
+    @Test
+    void testFiringOrderIsDeterministic() throws Exception {
+        TestHarnessTimerManager manager = new TestHarnessTimerManager();
+        List<String> firingOrder = new ArrayList<>();
+
+        manager.register(P1, 2000L, "b-timer");
+        manager.register(P1, 1000L, "c-timer");
+        manager.register(P1, 1000L, "a-timer");
+        manager.register(P2, 1000L, "a-timer");
+
+        manager.setTableWatermark("table-a", 3000L);
+        manager.updateGlobalWatermarkAndFireTimers(
+                t -> firingOrder.add(t.getKey() + ":" + t.getName()));
+
+        assertThat(firingOrder)
+                .containsExactly(
+                        "+I[P1]:a-timer", "+I[P2]:a-timer", "+I[P1]:c-timer", "+I[P1]:b-timer");
+    }
+
+    @Test
+    void testCascadingTimerFiring() throws Exception {
+        TestHarnessTimerManager manager = new TestHarnessTimerManager();
+        List<String> fired = new ArrayList<>();
+
+        manager.register(P1, 1000L, "first");
+        manager.setTableWatermark("table-a", 3000L);
+        manager.updateGlobalWatermarkAndFireTimers(
+                t -> {
+                    fired.add(t.getName());
+                    if ("first".equals(t.getName())) {
+                        manager.register(P1, 2000L, "within");
+                        manager.register(P1, 5000L, "beyond");
+                    }
+                });
+
+        assertThat(fired).containsExactly("first", "within");
+        assertThat(manager.getPendingTimers()).hasSize(1);
+        assertThat(manager.getPendingTimers().get(0).getName()).isEqualTo("beyond");
+        assertThat(manager.getFiredTimers()).hasSize(2);
+    }
+
+    @Test
+    void testTimerClearedDuringFiringCallbackDoesNotFire() throws Exception {
+        TestHarnessTimerManager manager = new TestHarnessTimerManager();
+        List<String> fired = new ArrayList<>();
+
+        manager.register(P1, 1000L, "first");
+        manager.register(P1, 1000L, "second");
+
+        assertThat(manager.getPendingTimers())
+                .hasSize(2)
+                .extracting(Timer::getName)
+                .containsExactlyInAnyOrder("first", "second");
+
+        manager.setTableWatermark("table-a", 2000L);
+        manager.updateGlobalWatermarkAndFireTimers(
+                t -> {
+                    fired.add(t.getName());
+                    if ("first".equals(t.getName())) {
+                        manager.clearByName(P1, "second");
+                    }
+                });
+
+        assertThat(fired).containsExactly("first");
+        assertThat(manager.getPendingTimers()).isEmpty();
+        assertThat(manager.getFiredTimers())
+                .hasSize(1)
+                .extracting(Timer::getName)
+                .containsExactly("first");
+    }
+
+    @Test
+    void testMultiTableTimerOnlyFiresWhenGlobalWatermarkAdvances() throws Exception {
+        TestHarnessTimerManager manager = new TestHarnessTimerManager();
+        List<Timer> fired = new ArrayList<>();
+
+        manager.register(P1, 2000L, "timer-a");
+        manager.setTableWatermark("table-a", 1000L);
+        manager.setTableWatermark("table-b", 500L);
+        manager.updateGlobalWatermarkAndFireTimers(fired::add);
+        assertThat(fired).isEmpty();
+
+        manager.setTableWatermark("table-b", 3000L);
+        manager.updateGlobalWatermarkAndFireTimers(fired::add);
+        assertThat(fired).isEmpty();
+
+        manager.setTableWatermark("table-a", 3000L);
+        manager.updateGlobalWatermarkAndFireTimers(fired::add);
+        assertThat(fired).hasSize(1);
+    }
+
+    @Test
+    void testClearByName() {
+        TestHarnessTimerManager manager = new TestHarnessTimerManager();
+
+        manager.register(P1, 1000L, "timer-a");
+        manager.register(P1, 2000L, "timer-b");
+        manager.clearByName(P1, "timer-a");
+
+        assertThat(manager.getPendingTimers()).hasSize(1);
+        assertThat(manager.getPendingTimers().get(0).getName()).isEqualTo("timer-b");
+    }
+
+    @Test
+    void testClearByTimestampOnlyAffectsUnnamedTimers() {
+        TestHarnessTimerManager manager = new TestHarnessTimerManager();
+
+        manager.register(P1, 1000L, "named");
+        manager.register(P1, 1000L, null);
+        manager.clearByTimestamp(P1, 1000L);
+
+        assertThat(manager.getPendingTimers()).hasSize(1);
+        assertThat(manager.getPendingTimers().get(0).getName()).isEqualTo("named");
+    }
+
+    @Test
+    void testClearAll() {
+        TestHarnessTimerManager manager = new TestHarnessTimerManager();
+
+        manager.register(P1, 1000L, "timer-a");
+        manager.register(P1, 2000L, null);
+        manager.clearAll(P1);
+
+        assertThat(manager.getPendingTimers()).isEmpty();
+    }
+
+    @Test
+    void testClearAllIsPerPartition() {
+        TestHarnessTimerManager manager = new TestHarnessTimerManager();
+
+        manager.register(P1, 1000L, "timer-a");
+        manager.register(P2, 2000L, "timer-b");
+        manager.clearAll(P1);
+
+        assertThat(manager.getPendingTimers()).hasSize(1);
+        assertThat(manager.getPendingTimers().get(0).getKey()).isEqualTo(P2);
+    }
+
+    @Test
+    void testClearFiredTimers() throws Exception {
+        TestHarnessTimerManager manager = new TestHarnessTimerManager();
+
+        manager.register(P1, 1000L, "timer-a");
+        manager.setTableWatermark("table-a", 2000L);
+        manager.updateGlobalWatermarkAndFireTimers(NOOP_FIRER);
+
+        assertThat(manager.getFiredTimers()).hasSize(1);
+        manager.clearFiredTimers();
+        assertThat(manager.getFiredTimers()).isEmpty();
+    }
+}


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

This PR adds support for `Context`, `OnTimerContext`, `TimeContext`, timer registration and firing, watermark management, and `rowtime` support to the PTF Test Harness.

When a PTF registers a timer, the timer is stored in the TimerManager and keyed by the partition row. When the user advances the watermark using
either `setWatermark` or `setWatermarkForTable`, the manager then fires all pending timers below or equal to the watermark in a deterministic order.

I moved per-invocation state stuff into an `InvocationContext` to make separation of concerns a little easier to follow.

Rows emitted from test harness setups that configure an `on_time` column also contain the `rowtime` column, and the PTF rejects at the point of registration if the user tries to register a timer with `PASS_COLUMNS_THROUGH`
enabled (similar to live, per the `PROCESS_INVALID_PASS_THROUGH_TIMERS` test on live.)

Some open questions remain. One is that there's an edge case where if a user's `onTimer` registers a new timer at or before the current watermark, it then fires, and then registers,
then fires, etc. Should there be some sort of max depth check here?

The second is that when defining the on time parameter in SQL, you pass in `DESCRIPTOR(ts)`, but in the harness you just pass in the string name of the column. Would it instead be better to support `withOnTime("DESCRIPTOR(ts)")` to better mirror SQL, rather than `withOnTimeColumn("ts")`?


## Brief change log

- Added support for `Context`, `OnTimerContext`, `TimeContext` in `ProcessTableFunctionTestHarness`
- Added support for timer registration, watermark tracking and timer firing in `ProcessTableFunctionTestHarness`
- Added an `InvocationContext` to capture per-invocation state to simplify the collector logic
- Reworked derriving the output type from the system inference to account for `on_time` and `uid`
- Fixed an issue in `createStateConverter` where the incorrect state converters were being used for Map/List state.


## Verifying this change


This change added tests and can be verified as follows:

- Added tests to `ProcessFunctionTestHarnessesTest` to cover timer firing, watermark advancement and context.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs)

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change the checkbox below to `[X]` followed by the name of the tool, and uncomment the
"Generated-by" line. See the ASF Generative Tooling Guidance for details:
https://www.apache.org/legal/generative-tooling.html

You are responsible for the quality and correctness of every change in this PR
regardless of the tooling used. Low-effort AI-generated PRs will be closed. See
AGENTS.md for the full guidance.
-->

- [x] Yes (please specify the tool below)

2.1.156 (Claude Code)
