### PR TITLE
[hotfix] Fix some typos for connector-base, protobuf, runtime, table-planner and tests modules.

### DIFF
--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/hybrid/HybridSourceReader.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/hybrid/HybridSourceReader.java
@@ -223,7 +223,7 @@ public class HybridSourceReader<T> implements SourceReader<T, HybridSourceSplit>
         try {
             reader = source.createReader(readerContext);
         } catch (Exception e) {
-            throw new RuntimeException("Failed tp create reader", e);
+            throw new RuntimeException("Failed to create reader", e);
         }
         // currentReader must be switched before `addSplits` is called.
         currentSourceIndex = index;

--- a/flink-formats/flink-protobuf/src/main/java/org/apache/flink/formats/protobuf/util/PbSchemaValidationUtils.java
+++ b/flink-formats/flink-protobuf/src/main/java/org/apache/flink/formats/protobuf/util/PbSchemaValidationUtils.java
@@ -83,7 +83,7 @@ public class PbSchemaValidationUtils {
                                 throw new ValidationException(
                                         "Column "
                                                 + rowField.getName()
-                                                + " does not exists in definition of proto class.");
+                                                + " does not exist in definition of proto class.");
                             }
                         });
     }
@@ -160,7 +160,7 @@ public class PbSchemaValidationUtils {
             throw new ValidationException(
                     "Protobuf field type does not match column type, "
                             + fd.getJavaType()
-                            + "(protobuf) is not compatible of "
+                            + "(protobuf) is not compatible with "
                             + logicalTypeRoot);
         }
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/DefaultApplicationStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/DefaultApplicationStore.java
@@ -210,7 +210,7 @@ public class DefaultApplicationStore<R extends ResourceVersion<R>> implements Ap
                         success = true;
                     } catch (StateHandleStore.NotExistException ignored) {
                         LOG.warn(
-                                "{} does not exists in {}.",
+                                "{} does not exist in {}.",
                                 application,
                                 applicationStateHandleStore);
                     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/DefaultExecutionPlanStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/DefaultExecutionPlanStore.java
@@ -235,7 +235,7 @@ public class DefaultExecutionPlanStore<R extends ResourceVersion<R>>
                         success = true;
                     } catch (StateHandleStore.NotExistException ignored) {
                         LOG.warn(
-                                "{} does not exists in {}.",
+                                "{} does not exist in {}.",
                                 executionPlan,
                                 executionPlanStateHandleStore);
                     }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/connectors/DynamicSinkUtils.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/connectors/DynamicSinkUtils.java
@@ -515,7 +515,7 @@ public final class DynamicSinkUtils {
                 && updateInfo.getRowLevelUpdateMode()
                         != SupportsRowLevelUpdate.RowLevelUpdateMode.ALL_ROWS) {
             throw new IllegalArgumentException(
-                    "Unknown update mode:" + updateInfo.getRowLevelUpdateMode());
+                    "Unknown update mode: " + updateInfo.getRowLevelUpdateMode());
         }
         Tuple2<RelNode, int[]> updateRelNodeAndRequireIndices =
                 convertToRowLevelUpdate(
@@ -647,7 +647,7 @@ public final class DynamicSinkUtils {
                     if (!(dynamicTableSource instanceof SupportsReadingMetadata)) {
                         throw new UnsupportedOperationException(
                                 String.format(
-                                        "The table source don't support reading metadata, but the require columns contains the meta columns: %s.",
+                                        "The table source does not support reading metadata, but the required columns contain metadata columns: %s.",
                                         column));
                     }
                     // list what metas the source supports to read
@@ -661,7 +661,7 @@ public final class DynamicSinkUtils {
                     if (!readableMetadata.containsKey(metaCol)) {
                         throw new IllegalArgumentException(
                                 String.format(
-                                        "Expect to read the meta column %s, but the table source for table %s doesn't support read the metadata column."
+                                        "Expected to read metadata column %s, but the table source for table %s does not support it. "
                                                 + "Please make sure the readable metadata for the source contains %s.",
                                         column,
                                         UnresolvedIdentifier.of(
@@ -674,7 +674,7 @@ public final class DynamicSinkUtils {
                     if (!dataType.equals(column.getDataType())) {
                         throw new IllegalArgumentException(
                                 String.format(
-                                        "Un-matched data type: the required column %s has datatype %s, but the data type in readable metadata for the table %s has data type %s. ",
+                                        "Mismatched data type: the required column %s has data type %s, but readable metadata for table %s has data type %s.",
                                         column,
                                         column.getDataType(),
                                         UnresolvedIdentifier.of(

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/spec/IntervalJoinSpec.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/spec/IntervalJoinSpec.java
@@ -28,9 +28,9 @@ import java.util.Objects;
 /**
  * IntervalJoinSpec describes how two tables will be joined in interval join.
  *
- * <p>This class corresponds to {@link org.apache.calcite.rel.core.Join} rel node. the join
- * condition is splitted into two part: WindowBounds and JoinSpec: 1. WindowBounds contains the time
- * range condition. 2. JoinSpec contains rest of the join condition except windowBounds.
+ * <p>This class corresponds to {@link org.apache.calcite.rel.core.Join} rel node. The join
+ * condition is splitted into two parts: WindowBounds and JoinSpec: 1. WindowBounds contains the
+ * time range condition. 2. JoinSpec contains rest of the join condition except windowBounds.
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class IntervalJoinSpec {

--- a/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/GlobalAggregateITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/GlobalAggregateITCase.java
@@ -63,7 +63,7 @@ class GlobalAggregateITCase extends AbstractTestBase {
     /**
      * Source Function that uses updateGlobalAggregate() functionality exposed via
      * StreamingRuntimeContext to validate communication with JobMaster and test both failure and
-     * sucess scenarios.
+     * success scenarios.
      */
     private static class TestSourceFunction extends RichSourceFunction<Integer> {
 


### PR DESCRIPTION


<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

[hotfix] Fix some typos for connector-base, protobuf, runtime, table-planner and tests modules.


## Brief change log

[hotfix] Fix some typos for connector-base, protobuf, runtime, table-planner and tests modules.


## Verifying this change


N.A

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change the checkbox below to `[X]` followed by the name of the tool, and uncomment the
"Generated-by" line. See the ASF Generative Tooling Guidance for details:
https://www.apache.org/legal/generative-tooling.html

You are responsible for the quality and correctness of every change in this PR
regardless of the tooling used. Low-effort AI-generated PRs will be closed. See
AGENTS.md for the full guidance.
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name and Version]
-->
