### PR TITLE
[FLINK-39868][table-runtime] Remove per-row logging from parseUrl and subString

### DIFF
--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/StringFunctionsITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/StringFunctionsITCase.java
@@ -47,6 +47,7 @@ class StringFunctionsITCase extends BuiltInFunctionTestBase {
                         printfTestCases(),
                         startsWithTestCases(),
                         substringTestCases(),
+                        substrTestCases(),
                         translateTestCases(),
                         concatenateTestCases())
                 .flatMap(s -> s);
@@ -757,54 +758,231 @@ class StringFunctionsITCase extends BuiltInFunctionTestBase {
 
     private Stream<TestSetSpec> parseUrlTestCases() {
         return Stream.of(
-                TestSetSpec.forFunction(BuiltInFunctionDefinitions.PARSE_URL)
-                        .onFieldsWithData(
-                                "http://user@flink.apache.org/path?query=1#Ref",
-                                "not a valid url",
-                                null)
-                        .andDataTypes(DataTypes.STRING(), DataTypes.STRING(), DataTypes.STRING())
-                        // normal case
-                        .testResult(
-                                $("f0").parseUrl("HOST"),
-                                "PARSE_URL(f0, 'HOST')",
-                                "flink.apache.org",
-                                DataTypes.STRING())
-                        // malformed url returns null
-                        .testResult(
-                                $("f1").parseUrl("HOST"),
-                                "PARSE_URL(f1, 'HOST')",
-                                null,
-                                DataTypes.STRING())
-                        // null input
-                        .testResult(
-                                $("f2").parseUrl("HOST"),
-                                "PARSE_URL(f2, 'HOST')",
-                                null,
-                                DataTypes.STRING()));
+                parseUrl("http://userinfo@flink.apache.org/path?query=1#Ref")
+                        .part("HOST", "flink.apache.org")
+                        .part("PATH", "/path")
+                        .part("QUERY", "query=1")
+                        .part("REF", "Ref")
+                        .part("PROTOCOL", "http")
+                        .part("FILE", "/path?query=1")
+                        .part("AUTHORITY", "userinfo@flink.apache.org")
+                        .part("USERINFO", "userinfo")
+                        .queryParam("query", "1")
+                        .toSpec(),
+                parseUrl(
+                                "https://use%20r:pas%20s@example.com/dir%20/pa%20th.HTML?query=x%20y&q2=2#Ref%20two")
+                        .part("HOST", "example.com")
+                        .part("PATH", "/dir%20/pa%20th.HTML")
+                        .part("QUERY", "query=x%20y&q2=2")
+                        .part("REF", "Ref%20two")
+                        .part("PROTOCOL", "https")
+                        .part("FILE", "/dir%20/pa%20th.HTML?query=x%20y&q2=2")
+                        .part("AUTHORITY", "use%20r:pas%20s@example.com")
+                        .part("USERINFO", "use%20r:pas%20s")
+                        .queryParam("query", "x%20y")
+                        .queryParam("q2", "2")
+                        .toSpec(),
+                parseUrl("http://user:pass@host")
+                        .part("HOST", "host")
+                        .part("PATH", "")
+                        .part("QUERY", null)
+                        .part("REF", null)
+                        .part("PROTOCOL", "http")
+                        .part("FILE", "")
+                        .part("AUTHORITY", "user:pass@host")
+                        .part("USERINFO", "user:pass")
+                        .queryParam("query", null)
+                        .toSpec(),
+                parseUrl("http://user:pass@host/")
+                        .part("HOST", "host")
+                        .part("PATH", "/")
+                        .part("QUERY", null)
+                        .part("REF", null)
+                        .part("PROTOCOL", "http")
+                        .part("FILE", "/")
+                        .part("AUTHORITY", "user:pass@host")
+                        .part("USERINFO", "user:pass")
+                        .queryParam("query", null)
+                        .toSpec(),
+                parseUrl("http://user:pass@host/?#")
+                        .part("HOST", "host")
+                        .part("PATH", "/")
+                        .part("QUERY", "")
+                        .part("REF", "")
+                        .part("PROTOCOL", "http")
+                        .part("FILE", "/?")
+                        .part("AUTHORITY", "user:pass@host")
+                        .part("USERINFO", "user:pass")
+                        .queryParam("query", null)
+                        .toSpec(),
+                parseUrl("http://user:pass@host/file;param?query;p2")
+                        .part("HOST", "host")
+                        .part("PATH", "/file;param")
+                        .part("QUERY", "query;p2")
+                        .part("REF", null)
+                        .part("PROTOCOL", "http")
+                        .part("FILE", "/file;param?query;p2")
+                        .part("AUTHORITY", "user:pass@host")
+                        .part("USERINFO", "user:pass")
+                        .queryParam("query", null)
+                        .toSpec(),
+                parseUrl("invalid://user:pass@host/file;param?query;p2")
+                        .part("HOST", null)
+                        .part("PATH", null)
+                        .part("QUERY", null)
+                        .part("REF", null)
+                        .part("PROTOCOL", null)
+                        .part("FILE", null)
+                        .part("AUTHORITY", null)
+                        .part("USERINFO", null)
+                        .queryParam("query", null)
+                        .toSpec());
+    }
+
+    private ParseUrlCases parseUrl(String url) {
+        return new ParseUrlCases(url);
+    }
+
+    /** Fluent builder for PARSE_URL specs: one self-describing line per extracted URL part. */
+    private static final class ParseUrlCases {
+        private TestSetSpec spec;
+
+        ParseUrlCases(String url) {
+            spec =
+                    TestSetSpec.forFunction(BuiltInFunctionDefinitions.PARSE_URL, url)
+                            .onFieldsWithData(url)
+                            .andDataTypes(DataTypes.STRING());
+        }
+
+        ParseUrlCases part(String part, String expected) {
+            spec =
+                    spec.testResult(
+                            $("f0").parseUrl(part),
+                            "PARSE_URL(f0, '" + part + "')",
+                            expected,
+                            DataTypes.STRING());
+            return this;
+        }
+
+        ParseUrlCases queryParam(String key, String expected) {
+            spec =
+                    spec.testResult(
+                            $("f0").parseUrl("QUERY", key),
+                            "PARSE_URL(f0, 'QUERY', '" + key + "')",
+                            expected,
+                            DataTypes.STRING());
+            return this;
+        }
+
+        TestSetSpec toSpec() {
+            return spec;
+        }
     }
 
     private Stream<TestSetSpec> substringTestCases() {
         return Stream.of(
                 TestSetSpec.forFunction(BuiltInFunctionDefinitions.SUBSTRING)
-                        .onFieldsWithData("This is a test String.", null)
-                        .andDataTypes(DataTypes.STRING(), DataTypes.STRING())
-                        // normal case
+                        .onFieldsWithData("This is a test String.", 3, -3, 1, "1世3", null)
+                        .andDataTypes(
+                                DataTypes.STRING(),
+                                DataTypes.INT(),
+                                DataTypes.INT(),
+                                DataTypes.INT(),
+                                DataTypes.STRING(),
+                                DataTypes.STRING())
+                        // two-arg form
+                        .testResult(
+                                $("f0").substring(2),
+                                "SUBSTRING(f0, 2)",
+                                "his is a test String.",
+                                DataTypes.STRING())
+                        // three-arg form
                         .testResult(
                                 $("f0").substring(2, 5),
                                 "SUBSTRING(f0, 2, 5)",
                                 "his i",
                                 DataTypes.STRING())
-                        // negative length returns null
                         .testResult(
-                                $("f0").substring(1, -1),
-                                "SUBSTRING(f0, 1, -1)",
-                                null,
+                                $("f0").substring(2, 3),
+                                "SUBSTRING(f0, 2, 3)",
+                                "his",
                                 DataTypes.STRING())
-                        // null input
+                        // start/length from fields
                         .testResult(
-                                $("f1").substring(2),
-                                "SUBSTRING(f1, 2)",
-                                null,
-                                DataTypes.STRING()));
+                                $("f0").substring(1, $("f1")),
+                                "SUBSTRING(f0, 1, f1)",
+                                "Thi",
+                                DataTypes.STRING())
+                        .testResult(
+                                $("f0").substring($("f3"), $("f1")),
+                                "SUBSTRING(f0, f3, f1)",
+                                "Thi",
+                                DataTypes.STRING())
+                        // start with implicit cast from TINYINT
+                        .testResult(
+                                $("f0").substring(lit(1).cast(DataTypes.TINYINT()), $("f1")),
+                                "SUBSTRING(f0, CAST(1 AS TINYINT), f1)",
+                                "Thi",
+                                DataTypes.STRING())
+                        // multibyte characters counted by code point
+                        .testResult(
+                                $("f4").substring(1, 2),
+                                "SUBSTRING(f4, 1, 2)",
+                                "1世",
+                                DataTypes.STRING())
+                        // length past the end is clamped
+                        .testSqlResult(
+                                "SUBSTRING(f0, 2, 100)",
+                                "his is a test String.",
+                                DataTypes.STRING())
+                        // start past the end yields empty
+                        .testSqlResult("SUBSTRING(f0, 100, 10)", "", DataTypes.STRING())
+                        // negative length yields null
+                        .testSqlResult("SUBSTRING(f0, 2, -1)", null, DataTypes.STRING())
+                        .testSqlResult("SUBSTRING(f0, 2, f2)", null, DataTypes.STRING())
+                        // null input yields null
+                        .testSqlResult("SUBSTRING(f5, 2, 3)", null, DataTypes.STRING())
+                        .testSqlResult(
+                                "SUBSTRING(CAST(NULL AS VARCHAR), 2, 3)", null, DataTypes.STRING())
+                        // SQL FROM/FOR syntax
+                        .testSqlResult("SUBSTRING(f0 FROM 2 FOR 1)", "h", DataTypes.STRING())
+                        .testSqlResult(
+                                "SUBSTRING(f0 FROM 2)", "his is a test String.", DataTypes.STRING())
+                        .testSqlResult("SUBSTRING(f0 FROM -2)", "g.", DataTypes.STRING())
+                        .testSqlResult("SUBSTRING(f0 FROM -2 FOR 1)", "g", DataTypes.STRING())
+                        .testSqlResult("SUBSTRING(f0 FROM -2 FOR 0)", "", DataTypes.STRING()));
+    }
+
+    private Stream<TestSetSpec> substrTestCases() {
+        return Stream.of(
+                TestSetSpec.forFunction(BuiltInFunctionDefinitions.SUBSTR)
+                        .onFieldsWithData("This is a test String.", 3, -3, 1, "1世3", null)
+                        .andDataTypes(
+                                DataTypes.STRING(),
+                                DataTypes.INT(),
+                                DataTypes.INT(),
+                                DataTypes.INT(),
+                                DataTypes.STRING(),
+                                DataTypes.STRING())
+                        .testResult(
+                                $("f0").substr(2, 3), "SUBSTR(f0, 2, 3)", "his", DataTypes.STRING())
+                        .testResult(
+                                $("f0").substr(2),
+                                "SUBSTR(f0, 2)",
+                                "his is a test String.",
+                                DataTypes.STRING())
+                        .testSqlResult(
+                                "SUBSTR(f0, 2, 100)", "his is a test String.", DataTypes.STRING())
+                        .testSqlResult("SUBSTR(f0, 100, 10)", "", DataTypes.STRING())
+                        // negative length yields null
+                        .testSqlResult("SUBSTR(f0, 2, -1)", null, DataTypes.STRING())
+                        .testSqlResult("SUBSTR(f0, 2, f2)", null, DataTypes.STRING())
+                        // null input yields null
+                        .testSqlResult("SUBSTR(f5, 2, 3)", null, DataTypes.STRING())
+                        .testSqlResult(
+                                "SUBSTR(CAST(NULL AS VARCHAR), 2, 3)", null, DataTypes.STRING())
+                        .testSqlResult("SUBSTR(f0, f3, f1)", "Thi", DataTypes.STRING())
+                        // multibyte characters counted by code point
+                        .testSqlResult("SUBSTR(f4, 1, 2)", "1世", DataTypes.STRING()));
     }
 }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/StringFunctionsITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/StringFunctionsITCase.java
@@ -41,15 +41,15 @@ class StringFunctionsITCase extends BuiltInFunctionTestBase {
     Stream<TestSetSpec> getTestSetSpecs() {
         return Stream.of(
                         bTrimTestCases(),
+                        concatenateTestCases(),
                         eltTestCases(),
                         endsWithTestCases(),
                         parseUrlTestCases(),
                         printfTestCases(),
                         startsWithTestCases(),
-                        substringTestCases(),
                         substrTestCases(),
-                        translateTestCases(),
-                        concatenateTestCases())
+                        substringTestCases(),
+                        translateTestCases())
                 .flatMap(s -> s);
     }
 

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/StringFunctionsITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/StringFunctionsITCase.java
@@ -43,8 +43,10 @@ class StringFunctionsITCase extends BuiltInFunctionTestBase {
                         bTrimTestCases(),
                         eltTestCases(),
                         endsWithTestCases(),
+                        parseUrlTestCases(),
                         printfTestCases(),
                         startsWithTestCases(),
+                        substringTestCases(),
                         translateTestCases(),
                         concatenateTestCases())
                 .flatMap(s -> s);
@@ -751,5 +753,58 @@ class StringFunctionsITCase extends BuiltInFunctionTestBase {
                                 "TRANSLATE(f0, '3', '5')",
                                 "Invalid input arguments. Expected signatures are:\n"
                                         + "TRANSLATE3(expr <CHARACTER_STRING>, fromStr <CHARACTER_STRING>, toStr <CHARACTER_STRING>)"));
+    }
+
+    private Stream<TestSetSpec> parseUrlTestCases() {
+        return Stream.of(
+                TestSetSpec.forFunction(BuiltInFunctionDefinitions.PARSE_URL)
+                        .onFieldsWithData(
+                                "http://user@flink.apache.org/path?query=1#Ref",
+                                "not a valid url",
+                                null)
+                        .andDataTypes(DataTypes.STRING(), DataTypes.STRING(), DataTypes.STRING())
+                        // normal case
+                        .testResult(
+                                $("f0").parseUrl("HOST"),
+                                "PARSE_URL(f0, 'HOST')",
+                                "flink.apache.org",
+                                DataTypes.STRING())
+                        // malformed url returns null
+                        .testResult(
+                                $("f1").parseUrl("HOST"),
+                                "PARSE_URL(f1, 'HOST')",
+                                null,
+                                DataTypes.STRING())
+                        // null input
+                        .testResult(
+                                $("f2").parseUrl("HOST"),
+                                "PARSE_URL(f2, 'HOST')",
+                                null,
+                                DataTypes.STRING()));
+    }
+
+    private Stream<TestSetSpec> substringTestCases() {
+        return Stream.of(
+                TestSetSpec.forFunction(BuiltInFunctionDefinitions.SUBSTRING)
+                        .onFieldsWithData("This is a test String.", null)
+                        .andDataTypes(DataTypes.STRING(), DataTypes.STRING())
+                        // normal case
+                        .testResult(
+                                $("f0").substring(2, 5),
+                                "SUBSTRING(f0, 2, 5)",
+                                "his i",
+                                DataTypes.STRING())
+                        // negative length returns null
+                        .testResult(
+                                $("f0").substring(1, -1),
+                                "SUBSTRING(f0, 1, -1)",
+                                null,
+                                DataTypes.STRING())
+                        // null input
+                        .testResult(
+                                $("f1").substring(2),
+                                "SUBSTRING(f1, 2)",
+                                null,
+                                DataTypes.STRING()));
     }
 }

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/expressions/ScalarFunctionsTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/expressions/ScalarFunctionsTest.scala
@@ -241,30 +241,6 @@ class ScalarFunctionsTest extends ScalarTypesTestBase {
   }
 
   @Test
-  def testSubstring(): Unit = {
-    testAllApis('f0.substring(2), "SUBSTRING(f0, 2)", "his is a test String.")
-
-    testAllApis('f0.substring(2, 5), "SUBSTRING(f0, 2, 5)", "his i")
-
-    testAllApis('f0.substring(1, 'f7), "SUBSTRING(f0, 1, f7)", "Thi")
-
-    testAllApis(
-      'f0.substring(1.cast(DataTypes.TINYINT), 'f7),
-      "SUBSTRING(f0, CAST(1 AS TINYINT), f7)",
-      "Thi")
-
-    testSqlApi("SUBSTRING(f0 FROM 2 FOR 1)", "h")
-
-    testSqlApi("SUBSTRING(f0 FROM 2)", "his is a test String.")
-
-    testSqlApi("SUBSTRING(f0 FROM -2)", "g.")
-
-    testSqlApi("SUBSTRING(f0 FROM -2 FOR 1)", "g")
-
-    testSqlApi("SUBSTRING(f0 FROM -2 FOR 0)", "")
-  }
-
-  @Test
   def testReplace(): Unit = {
     testAllApis('f0.replace(" ", "_"), "REPLACE(f0, ' ', '_')", "This_is_a_test_String.")
 
@@ -823,23 +799,6 @@ class ScalarFunctionsTest extends ScalarTypesTestBase {
   }
 
   @Test
-  def testSubString(): Unit = {
-    Array("substring", "substr").foreach {
-      substr =>
-        testAllApis('f0.substr(2, 3), s"$substr(f0, 2, 3)", "his")
-        testAllApis('f0.substr(2), s"$substr(f0, 2)", "his is a test String.")
-        testSqlApi(s"$substr(f0, 2, 100)", "his is a test String.")
-        testSqlApi(s"$substr(f0, 100, 10)", "")
-        testSqlApi(s"$substr(f0, 2, -1)", "NULL")
-        testSqlApi(s"$substr(f40, 2, 3)", "NULL")
-        testSqlApi(s"$substr(CAST(null AS VARCHAR), 2, 3)", "NULL")
-        testSqlApi(s"$substr(f0, 2, f14)", "NULL")
-        testSqlApi(s"$substr(f0, f30, f7)", "Thi")
-        testSqlApi(s"$substr(f39, 1, 2)", "1世")
-    }
-  }
-
-  @Test
   def testLPad(): Unit = {
     testSqlApi("lpad(f33,1,'??')", "NULL")
     testSqlApi("lpad(f35, 1, '??')", "a")
@@ -887,127 +846,6 @@ class ScalarFunctionsTest extends ScalarTypesTestBase {
     testSqlApi("rpad('üö',1,'??')", "ü")
     testSqlApi("rpad('abcd', 5, '')", "NULL")
     testAllApis("äää".rpad(13, "12345"), "rpad('äää',13,'12345')", "äää1234512345")
-  }
-
-  @Test
-  def testParseUrl(): Unit = {
-
-    // NOTE: parse_url() requires HOST PATH etc. all capitalized
-    def testUrl(
-        url: String,
-        host: String,
-        path: String,
-        query: String,
-        ref: String,
-        protocol: String,
-        file: String,
-        authority: String,
-        userInfo: String,
-        qv: String): Unit = {
-
-      val parts =
-        Map(
-          "HOST" -> host,
-          "PATH" -> path,
-          "QUERY" -> query,
-          "REF" -> ref,
-          "PROTOCOL" -> protocol,
-          "FILE" -> file,
-          "AUTHORITY" -> authority,
-          "USERINFO" -> userInfo)
-
-      for ((n, v) <- parts) {
-        testAllApis(url.parseUrl(s"$n"), s"parse_url('$url', '$n')", v)
-      }
-
-      testAllApis(url.parseUrl("QUERY", "query"), s"parse_url('$url', 'QUERY', 'query')", qv)
-    }
-
-    testUrl(
-      "http://userinfo@flink.apache.org/path?query=1#Ref",
-      "flink.apache.org",
-      "/path",
-      "query=1",
-      "Ref",
-      "http",
-      "/path?query=1",
-      "userinfo@flink.apache.org",
-      "userinfo",
-      "1"
-    )
-
-    testUrl(
-      "https://use%20r:pas%20s@example.com/dir%20/pa%20th.HTML?query=x%20y&q2=2#Ref%20two",
-      "example.com",
-      "/dir%20/pa%20th.HTML",
-      "query=x%20y&q2=2",
-      "Ref%20two",
-      "https",
-      "/dir%20/pa%20th.HTML?query=x%20y&q2=2",
-      "use%20r:pas%20s@example.com",
-      "use%20r:pas%20s",
-      "x%20y"
-    )
-
-    testUrl(
-      "http://user:pass@host",
-      "host",
-      "",
-      "NULL",
-      "NULL",
-      "http",
-      "",
-      "user:pass@host",
-      "user:pass",
-      "NULL")
-
-    testUrl(
-      "http://user:pass@host/",
-      "host",
-      "/",
-      "NULL",
-      "NULL",
-      "http",
-      "/",
-      "user:pass@host",
-      "user:pass",
-      "NULL")
-
-    testUrl(
-      "http://user:pass@host/?#",
-      "host",
-      "/",
-      "",
-      "",
-      "http",
-      "/?",
-      "user:pass@host",
-      "user:pass",
-      "NULL")
-
-    testUrl(
-      "http://user:pass@host/file;param?query;p2",
-      "host",
-      "/file;param",
-      "query;p2",
-      "NULL",
-      "http",
-      "/file;param?query;p2",
-      "user:pass@host",
-      "user:pass",
-      "NULL")
-
-    testUrl(
-      "invalid://user:pass@host/file;param?query;p2",
-      "NULL",
-      "NULL",
-      "NULL",
-      "NULL",
-      "NULL",
-      "NULL",
-      "NULL",
-      "NULL",
-      "NULL")
   }
 
   @Test

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/SqlFunctionUtils.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/SqlFunctionUtils.java
@@ -603,7 +603,6 @@ public class SqlFunctionUtils {
         try {
             url = URL_CACHE.get(urlStr);
         } catch (Exception e) {
-            LOG.error("Parse URL error: " + urlStr, e);
             return null;
         }
         if ("HOST".equals(partToExtract)) {
@@ -666,16 +665,9 @@ public class SqlFunctionUtils {
 
     public static String subString(String str, long start, long len) {
         if (len < 0) {
-            LOG.error(
-                    "len of 'substring(str, start, len)' must be >= 0 and Int type, but len = {}",
-                    len);
             return null;
         }
         if (len > Integer.MAX_VALUE || start > Integer.MAX_VALUE) {
-            LOG.error(
-                    "len or start of 'substring(str, start, len)' must be Int type, but len = {}, start = {}",
-                    len,
-                    start);
             return null;
         }
         int length = (int) len;


### PR DESCRIPTION
## What is the purpose of the change

Removing hot path error log of the methods parseURL and subString.


## Brief change log

Drop the per-row log calls in SqlFunctionUtils. Both functions already return null on the logged condition, so this is behavior-preserving.

- parseUrl
- subString

No new type strategy. No behavior change.   

## Verifying this change

- Add test to `StringFunctionsITCase`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): on
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change the checkbox below to `[X]` followed by the name of the tool, and uncomment the
"Generated-by" line. See the ASF Generative Tooling Guidance for details:
https://www.apache.org/legal/generative-tooling.html

You are responsible for the quality and correctness of every change in this PR
regardless of the tooling used. Low-effort AI-generated PRs will be closed. See
AGENTS.md for the full guidance.
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name and Version]
-->
