### PR TITLE
[hotfix][ci] Do not run GHA nightly if there is no newer commits since the last run

### DIFF
--- a/.github/workflows/nightly-trigger.yml
+++ b/.github/workflows/nightly-trigger.yml
@@ -21,6 +21,7 @@ name: "Nightly trigger (beta)"
 on:
   schedule:
     - cron: '0 2 * * *'
+  workflow_dispatch:
 
 jobs:
   Trigger:
@@ -39,9 +40,38 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            github.rest.actions.createWorkflowDispatch({
+            const branch = '${{ matrix.branch }}';
+
+            // Resolve the current HEAD of the branch.
+            const { data: branchData } = await github.rest.repos.getBranch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              branch: branch
+            });
+            const currentSha = branchData.commit.sha;
+
+            // Compare SHA from last nightly against current
+            // if it is same, then no need to run nightly for the same SHA again.
+            const { data: runsData } = await github.rest.actions.listWorkflowRuns({
               owner: context.repo.owner,
               repo: context.repo.repo,
               workflow_id: 'nightly.yml',
-              ref: '${{ matrix.branch }}'
-            })
+              branch: branch,
+              per_page: 1
+            });
+            const lastBuiltSha = runsData.workflow_runs[0]?.head_sha;
+
+            // Skipping only the scheduled one if no newer commits.
+            // It is still possible to run manually.
+            if (context.eventName === 'schedule' && lastBuiltSha && lastBuiltSha === currentSha) {
+              core.info(`No new commits on ${branch} since ${currentSha}, skipping scheduled nightly.`);
+              return;
+            }
+
+            core.info(`Triggering nightly on ${branch} at ${currentSha} (last built: ${lastBuiltSha ?? 'none'}).`);
+            await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'nightly.yml',
+              ref: branch
+            });

--- a/.github/workflows/nightly-trigger.yml
+++ b/.github/workflows/nightly-trigger.yml
@@ -59,16 +59,21 @@ jobs:
               branch: branch,
               per_page: 1
             });
-            const lastBuiltSha = runsData.workflow_runs[0]?.head_sha;
+            
+            const lastRun = runsData.workflow_runs[0];
+            const lastBuiltSha = lastRun?.head_sha;
+            const lastConclusion = lastRun?.conclusion;
 
-            // Skipping only the scheduled one if no newer commits.
-            // It is still possible to run manually.
-            if (context.eventName === 'schedule' && lastBuiltSha && lastBuiltSha === currentSha) {
-              core.info(`No new commits on ${branch} since ${currentSha}, skipping scheduled nightly.`);
+            // Skip the scheduled run only if there are no new commits AND the
+            // previous nightly was green. If the last run failed/was cancelled,
+            // re-run even without new commits so failures get retried.
+            // It is still possible to run manually even if the last one was green and no new commits.
+            if (context.eventName === 'schedule' && lastBuiltSha === currentSha && lastConclusion === 'success') {
+              core.info(`No new commits on ${branch} since ${currentSha} and last nightly was green, skipping scheduled nightly.`);
               return;
             }
 
-            core.info(`Triggering nightly on ${branch} at ${currentSha} (last built: ${lastBuiltSha ?? 'none'}).`);
+            core.info(`Triggering nightly on ${branch} at ${currentSha} (last built: ${lastBuiltSha ?? 'none'}, last conclusion: ${lastConclusion ?? 'none'}).`);
             await github.rest.actions.createWorkflowDispatch({
               owner: context.repo.owner,
               repo: context.repo.repo,


### PR DESCRIPTION
## What is the purpose of the change

The PR makes nightly running only if there are new commits since previous run.
If there is no new commits it will not run.
This is will allow to reduce GHA usage since Apache Infra is not happy with current usage


## Brief change log
GHA


## Verifying this change

GHA
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: ( no)
  - The runtime per-record code paths (performance sensitive): ( no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: ( no )
  - The S3 file system connector: ( no)

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable )

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change the checkbox below to `[X]` followed by the name of the tool, and uncomment the
"Generated-by" line. See the ASF Generative Tooling Guidance for details:
https://www.apache.org/legal/generative-tooling.html

You are responsible for the quality and correctness of every change in this PR
regardless of the tooling used. Low-effort AI-generated PRs will be closed. See
AGENTS.md for the full guidance.
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name and Version]
-->
