### PR TITLE
 [FLINK-39882][table] Parser can not parse unparsed polymorphic table functions with several table args

### DIFF
--- a/flink-table/flink-sql-parser/src/main/codegen/templates/Parser.jj
+++ b/flink-table/flink-sql-parser/src/main/codegen/templates/Parser.jj
@@ -1055,6 +1055,9 @@ void AddArg(List<SqlNode> list, ExprContext exprContext) :
 {
     final SqlIdentifier name;
     SqlNode e;
+    final Span s;
+    SqlNodeList partitionList;
+    SqlNodeList orderList;
 }
 {
     (
@@ -1068,6 +1071,17 @@ void AddArg(List<SqlNode> list, ExprContext exprContext) :
         e = LambdaExpression()
     |
         e = Expression(exprContext)
+        // A set-semantics table argument may be a partitioned sub-query, e.g.
+        // "(SELECT ...) PARTITION BY key [ORDER BY ...]".
+        [
+            { s = span(); }
+            <PARTITION> <BY> partitionList = SimpleIdentifierOrList()
+            (
+                orderList = OrderByOfSetSemanticsTable()
+            |   { orderList = SqlNodeList.EMPTY; }
+            )
+            { e = CreateSetSemanticsTableIfNeeded(s, e, partitionList, orderList); }
+        ]
     |
         e = TableParam()
     )

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/stream/sql/ProcessTableFunctionTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/stream/sql/ProcessTableFunctionTest.java
@@ -117,6 +117,15 @@ public class ProcessTableFunctionTest extends TableTestBase {
     }
 
     @Test
+    void testFunctionWithMultipleTableArgs() {
+        util.addTemporarySystemFunction("f", MultiInputFunction.class);
+        util.tableEnv().executeSql("CREATE VIEW v AS SELECT * FROM f("
+                + "in1 => TABLE t PARTITION BY name,"
+                + "in2 => TABLE t PARTITION BY name)");
+        util.verifyRelPlan("SELECT * FROM v");
+    }
+
+    @Test
     void testScalarArgsWithUid() {
         util.addTemporarySystemFunction("f", ScalarArgsFunction.class);
         // argument 'uid' is also reordered

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/stream/sql/ProcessTableFunctionTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/stream/sql/ProcessTableFunctionTest.java
@@ -79,7 +79,7 @@ import static org.apache.flink.table.api.Expressions.row;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Tests for the type inference and planning part of {@link ProcessTableFunction}. */
-public class ProcessTableFunctionTest extends TableTestBase {
+class ProcessTableFunctionTest extends TableTestBase {
 
     private TableTestUtil util;
 
@@ -119,9 +119,11 @@ public class ProcessTableFunctionTest extends TableTestBase {
     @Test
     void testFunctionWithMultipleTableArgs() {
         util.addTemporarySystemFunction("f", MultiInputFunction.class);
-        util.tableEnv().executeSql("CREATE VIEW v AS SELECT * FROM f("
-                + "in1 => TABLE t PARTITION BY name,"
-                + "in2 => TABLE t PARTITION BY name)");
+        util.tableEnv()
+                .executeSql(
+                        "CREATE VIEW v AS SELECT * FROM f("
+                                + "in1 => TABLE t PARTITION BY name,"
+                                + "in2 => TABLE t PARTITION BY name)");
         util.verifyRelPlan("SELECT * FROM v");
     }
 

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/ProcessTableFunctionTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/ProcessTableFunctionTest.xml
@@ -71,6 +71,33 @@ ProcessTableFunction(invocation=[f(DEFAULT(), _UTF-16LE'my-ptf')], uid=[my-ptf],
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testFunctionWithMultipleTableArgs">
+    <Resource name="sql">
+      <![CDATA[SELECT * FROM v]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(name=[$0], name0=[$1], out=[$2])
++- LogicalProject(name=[$0], name0=[$1], out=[$2])
+   +- LogicalTableFunctionScan(invocation=[f(TABLE(#0) PARTITION BY($0), TABLE(#1) PARTITION BY($0), DEFAULT(), DEFAULT())], rowType=[RecordType(VARCHAR(5) name, VARCHAR(5) name0, VARCHAR(2147483647) out)])
+      :- LogicalProject(name=[$0], score=[$1])
+      :  +- LogicalProject(name=[$0], score=[$1])
+      :     +- LogicalValues(tuples=[[{ _UTF-16LE'Bob', 12 }, { _UTF-16LE'Alice', 42 }]])
+      +- LogicalProject(name=[$0], score=[$1])
+         +- LogicalProject(name=[$0], score=[$1])
+            +- LogicalValues(tuples=[[{ _UTF-16LE'Bob', 12 }, { _UTF-16LE'Alice', 42 }]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+ProcessTableFunction(invocation=[f(TABLE(#0) PARTITION BY($0), TABLE(#1) PARTITION BY($0), DEFAULT(), DEFAULT())], uid=[f], select=[name,name0,out], rowType=[RecordType(VARCHAR(5) name, VARCHAR(5) name0, VARCHAR(2147483647) out)])
+:- Exchange(distribution=[hash[name]])
+:  +- Values(tuples=[[{ _UTF-16LE'Bob', 12 }, { _UTF-16LE'Alice', 42 }]])
++- Exchange(distribution=[hash[name]])
+   +- Values(tuples=[[{ _UTF-16LE'Bob', 12 }, { _UTF-16LE'Alice', 42 }]])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testIntervalDayArgs">
     <Resource name="sql">
       <![CDATA[SELECT * FROM f(d => INTERVAL '1' SECOND)]]>

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/utils/TableTestBase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/utils/TableTestBase.scala
@@ -82,7 +82,6 @@ import org.apache.flink.util.jackson.JacksonMapperFactory
 
 import _root_.java.math.{BigDecimal => JBigDecimal}
 import _root_.java.util
-import _root_.scala.collection.JavaConversions._
 import _root_.scala.io.Source
 import org.apache.calcite.avatica.util.TimeUnit
 import org.apache.calcite.rel.RelNode
@@ -1168,7 +1167,7 @@ abstract class TableTestUtilBase(test: TableTestBase, isStreamingMode: Boolean) 
       withDuplicateChanges: Boolean): Unit = {
     val testStmtSet = stmtSet.asInstanceOf[StatementSetImpl[_]]
 
-    val relNodes = testStmtSet.getOperations.map(getPlanner.translateToRel)
+    val relNodes = testStmtSet.getOperations.asScala.map(getPlanner.translateToRel)
     if (relNodes.isEmpty) {
       throw new TableException(
         "No output table have been created yet. " +
@@ -1523,7 +1522,7 @@ case class StreamTableTestUtil(
   def buildStreamProgram(firstProgramNameToRemove: String): Unit = {
     val program = FlinkStreamProgram.buildProgram(tableEnv.getConfig)
     var startRemove = false
-    program.getProgramNames.foreach {
+    program.getProgramNames.asScala.foreach {
       name =>
         if (name.equals(firstProgramNameToRemove)) {
           startRemove = true
@@ -1576,7 +1575,7 @@ case class BatchTableTestUtil(
   def buildBatchProgram(firstProgramNameToRemove: String): Unit = {
     val program = FlinkBatchProgram.buildProgram(tableEnv.getConfig)
     var startRemove = false
-    program.getProgramNames.foreach {
+    program.getProgramNames.asScala.foreach {
       name =>
         if (name.equals(firstProgramNameToRemove)) {
           startRemove = true
@@ -1961,7 +1960,7 @@ object TableTestUtil {
     } else if (file.isHidden) {
       Seq.empty[String]
     } else {
-      Files.readAllLines(Paths.get(file.toURI)).toSeq
+      Files.readAllLines(Paths.get(file.toURI)).asScala
     }
   }
 


### PR DESCRIPTION
## What is the purpose of the change

The problem is that expanded SQL (in case of views or materialized tables) for PTF  with multiple table args (or just one non first table arg) is not able to be parsed by Calcite parser.
The issues is fixed under https://issues.apache.org/jira/browse/CALCITE-7575
here it is a backport 

## Brief change log

Parser.jj

## Verifying this change
the test is included
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: ( no)
  - The runtime per-record code paths (performance sensitive): ( no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: ( no)
  - The S3 file system connector: ( no)

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable )

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change the checkbox below to `[X]` followed by the name of the tool, and uncomment the
"Generated-by" line. See the ASF Generative Tooling Guidance for details:
https://www.apache.org/legal/generative-tooling.html

You are responsible for the quality and correctness of every change in this PR
regardless of the tooling used. Low-effort AI-generated PRs will be closed. See
AGENTS.md for the full guidance.
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name and Version]
-->
