### PR TITLE
[FLINK-38536][tests] Fix data race in FinalizeOnMasterTest and ExecutionGraphFinishTest

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphFinishTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphFinishTest.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.executiongraph;
 
 import org.apache.flink.api.common.JobStatus;
+import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
 import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutorServiceAdapter;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobGraphTestUtils;
@@ -34,12 +35,22 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.function.Supplier;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests the finish behaviour of the {@link ExecutionGraph}. */
 class ExecutionGraphFinishTest {
+
+    /**
+     * Dedicated single-threaded main-thread executor; using forMainThread() here would run the
+     * deployment callbacks on the I/O thread and race the test (FLINK-38536).
+     */
+    @RegisterExtension
+    static final TestExecutorExtension<ScheduledExecutorService> JM_MAIN_THREAD_EXECUTOR_RESOURCE =
+            TestingUtils.jmMainThreadExecutorExtension();
 
     @RegisterExtension
     static final TestExecutorExtension<ScheduledExecutorService> EXECUTOR_RESOURCE =
@@ -47,45 +58,87 @@ class ExecutionGraphFinishTest {
 
     @Test
     void testJobFinishes() throws Exception {
-
         JobGraph jobGraph =
                 JobGraphTestUtils.streamingJobGraph(
                         ExecutionGraphTestUtils.createJobVertex("Task1", 2, NoOpInvokable.class),
                         ExecutionGraphTestUtils.createJobVertex("Task2", 2, NoOpInvokable.class));
 
+        final ComponentMainThreadExecutor mainThreadExecutor =
+                ComponentMainThreadExecutorServiceAdapter.forSingleThreadExecutor(
+                        JM_MAIN_THREAD_EXECUTOR_RESOURCE.getExecutor());
+
         SchedulerBase scheduler =
                 new DefaultSchedulerBuilder(
-                                jobGraph,
-                                ComponentMainThreadExecutorServiceAdapter.forMainThread(),
-                                EXECUTOR_RESOURCE.getExecutor())
+                                jobGraph, mainThreadExecutor, EXECUTOR_RESOURCE.getExecutor())
                         .build();
 
         ExecutionGraph eg = scheduler.getExecutionGraph();
 
-        scheduler.startScheduling();
-        ExecutionGraphTestUtils.switchAllVerticesToRunning(eg);
+        runInMainThread(mainThreadExecutor, scheduler::startScheduling);
+        runInMainThread(
+                mainThreadExecutor, () -> ExecutionGraphTestUtils.switchAllVerticesToRunning(eg));
 
-        Iterator<ExecutionJobVertex> jobVertices = eg.getVerticesTopologically().iterator();
+        final ExecutionJobVertex[] orderedVertices =
+                supplyInMainThread(
+                        mainThreadExecutor,
+                        () -> {
+                            Iterator<ExecutionJobVertex> jobVertices =
+                                    eg.getVerticesTopologically().iterator();
+                            return new ExecutionJobVertex[] {
+                                jobVertices.next(), jobVertices.next()
+                            };
+                        });
+        ExecutionJobVertex sender = orderedVertices[0];
+        ExecutionJobVertex receiver = orderedVertices[1];
 
-        ExecutionJobVertex sender = jobVertices.next();
-        ExecutionJobVertex receiver = jobVertices.next();
-
-        List<ExecutionVertex> senderVertices = Arrays.asList(sender.getTaskVertices());
-        List<ExecutionVertex> receiverVertices = Arrays.asList(receiver.getTaskVertices());
+        List<ExecutionVertex> senderVertices =
+                supplyInMainThread(
+                        mainThreadExecutor, () -> Arrays.asList(sender.getTaskVertices()));
+        List<ExecutionVertex> receiverVertices =
+                supplyInMainThread(
+                        mainThreadExecutor, () -> Arrays.asList(receiver.getTaskVertices()));
 
         // test getNumExecutionVertexFinished
-        senderVertices.get(0).getCurrentExecutionAttempt().markFinished();
-        assertThat(sender.getNumExecutionVertexFinished()).isOne();
-        assertThat(eg.getState()).isEqualTo(JobStatus.RUNNING);
+        runInMainThread(
+                mainThreadExecutor,
+                () -> senderVertices.get(0).getCurrentExecutionAttempt().markFinished());
+        assertThat(supplyInMainThread(mainThreadExecutor, sender::getNumExecutionVertexFinished))
+                .isOne();
+        assertThat(supplyInMainThread(mainThreadExecutor, eg::getState))
+                .isEqualTo(JobStatus.RUNNING);
 
-        senderVertices.get(1).getCurrentExecutionAttempt().markFinished();
-        assertThat(sender.getNumExecutionVertexFinished()).isEqualTo(2);
-        assertThat(eg.getState()).isEqualTo(JobStatus.RUNNING);
+        runInMainThread(
+                mainThreadExecutor,
+                () -> senderVertices.get(1).getCurrentExecutionAttempt().markFinished());
+        assertThat(supplyInMainThread(mainThreadExecutor, sender::getNumExecutionVertexFinished))
+                .isEqualTo(2);
+        assertThat(supplyInMainThread(mainThreadExecutor, eg::getState))
+                .isEqualTo(JobStatus.RUNNING);
 
         // test job finishes
-        receiverVertices.get(0).getCurrentExecutionAttempt().markFinished();
-        receiverVertices.get(1).getCurrentExecutionAttempt().markFinished();
-        assertThat(eg.getNumFinishedVertices()).isEqualTo(4);
-        assertThat(eg.getState()).isEqualTo(JobStatus.FINISHED);
+        runInMainThread(
+                mainThreadExecutor,
+                () -> {
+                    receiverVertices.get(0).getCurrentExecutionAttempt().markFinished();
+                    receiverVertices.get(1).getCurrentExecutionAttempt().markFinished();
+                });
+        assertThat(eg.waitUntilTerminal()).isEqualTo(JobStatus.FINISHED);
+        assertThat(supplyInMainThread(mainThreadExecutor, eg::getNumFinishedVertices)).isEqualTo(4);
+        assertThat(supplyInMainThread(mainThreadExecutor, eg::getState))
+                .isEqualTo(JobStatus.FINISHED);
+    }
+
+    /** Runs the action on the JobManager main thread and blocks until it completes. */
+    private static void runInMainThread(
+            final ComponentMainThreadExecutor mainThreadExecutor, final Runnable action)
+            throws Exception {
+        CompletableFuture.runAsync(action, mainThreadExecutor).get();
+    }
+
+    /** Reads the value on the JobManager main thread and blocks until it is available. */
+    private static <T> T supplyInMainThread(
+            final ComponentMainThreadExecutor mainThreadExecutor, final Supplier<T> supplier)
+            throws Exception {
+        return CompletableFuture.supplyAsync(supplier, mainThreadExecutor).get();
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/FinalizeOnMasterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/FinalizeOnMasterTest.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.executiongraph;
 
 import org.apache.flink.api.common.JobStatus;
+import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
 import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutorServiceAdapter;
 import org.apache.flink.runtime.jobgraph.JobGraphTestUtils;
 import org.apache.flink.runtime.jobgraph.JobVertex;
@@ -30,10 +31,10 @@ import org.apache.flink.testutils.executor.TestExecutorExtension;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.function.Supplier;
 
 import static org.apache.flink.runtime.scheduler.SchedulerTestingUtils.createScheduler;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -47,7 +48,14 @@ import static org.mockito.Mockito.verify;
  * only when the execution graph reaches the successful final state.
  */
 class FinalizeOnMasterTest {
-    private static final Logger LOG = LoggerFactory.getLogger(FinalizeOnMasterTest.class);
+
+    /**
+     * Dedicated single-threaded main-thread executor; using forMainThread() here would run the
+     * deployment callbacks on the I/O thread and race the test (FLINK-38536).
+     */
+    @RegisterExtension
+    static final TestExecutorExtension<ScheduledExecutorService> JM_MAIN_THREAD_EXECUTOR_RESOURCE =
+            TestingUtils.jmMainThreadExecutorExtension();
 
     @RegisterExtension
     static final TestExecutorExtension<ScheduledExecutorService> EXECUTOR_RESOURCE =
@@ -63,31 +71,35 @@ class FinalizeOnMasterTest {
         vertex2.setInvokableClass(NoOpInvokable.class);
         vertex2.setParallelism(2);
 
+        final ComponentMainThreadExecutor mainThreadExecutor =
+                ComponentMainThreadExecutorServiceAdapter.forSingleThreadExecutor(
+                        JM_MAIN_THREAD_EXECUTOR_RESOURCE.getExecutor());
+
         final SchedulerBase scheduler =
                 createScheduler(
                         JobGraphTestUtils.streamingJobGraph(vertex1, vertex2),
-                        ComponentMainThreadExecutorServiceAdapter.forMainThread(),
+                        mainThreadExecutor,
                         EXECUTOR_RESOURCE.getExecutor());
-        scheduler.startScheduling();
 
         final ExecutionGraph eg = scheduler.getExecutionGraph();
-        if (!eg.getState().equals(JobStatus.RUNNING)) {
-            ErrorInfo ei = eg.getFailureInfo();
-            LOG.info("Unexpected state found: Exception as string " + ei.getExceptionAsString());
-            LOG.info("Unexpected state found: ErrorInfo as string " + ei);
-        }
-        assertThat(eg.getState()).isEqualTo(JobStatus.RUNNING);
 
-        ExecutionGraphTestUtils.switchAllVerticesToRunning(eg);
+        runInMainThread(mainThreadExecutor, scheduler::startScheduling);
+        assertThat(supplyInMainThread(mainThreadExecutor, eg::getState))
+                .isEqualTo(JobStatus.RUNNING);
+
+        runInMainThread(
+                mainThreadExecutor, () -> ExecutionGraphTestUtils.switchAllVerticesToRunning(eg));
 
         // move all vertices to finished state
-        ExecutionGraphTestUtils.finishAllVertices(eg);
+        runInMainThread(mainThreadExecutor, () -> ExecutionGraphTestUtils.finishAllVertices(eg));
         assertThat(eg.waitUntilTerminal()).isEqualTo(JobStatus.FINISHED);
 
+        // waitUntilTerminal acts as the barrier, so the assertions below are safe off the main
+        // thread.
         verify(vertex1, times(1)).finalizeOnMaster(any(FinalizeOnMasterContext.class));
         verify(vertex2, times(1)).finalizeOnMaster(any(FinalizeOnMasterContext.class));
 
-        assertThat(eg.getRegisteredExecutions()).isEmpty();
+        assertThat(supplyInMainThread(mainThreadExecutor, eg::getRegisteredExecutions)).isEmpty();
     }
 
     @Test
@@ -96,28 +108,54 @@ class FinalizeOnMasterTest {
         vertex.setInvokableClass(NoOpInvokable.class);
         vertex.setParallelism(1);
 
+        final ComponentMainThreadExecutor mainThreadExecutor =
+                ComponentMainThreadExecutorServiceAdapter.forSingleThreadExecutor(
+                        JM_MAIN_THREAD_EXECUTOR_RESOURCE.getExecutor());
+
         final SchedulerBase scheduler =
                 createScheduler(
                         JobGraphTestUtils.streamingJobGraph(vertex),
-                        ComponentMainThreadExecutorServiceAdapter.forMainThread(),
+                        mainThreadExecutor,
                         EXECUTOR_RESOURCE.getExecutor());
-        scheduler.startScheduling();
 
         final ExecutionGraph eg = scheduler.getExecutionGraph();
 
-        assertThat(eg.getState()).isEqualTo(JobStatus.RUNNING);
+        runInMainThread(mainThreadExecutor, scheduler::startScheduling);
+        assertThat(supplyInMainThread(mainThreadExecutor, eg::getState))
+                .isEqualTo(JobStatus.RUNNING);
 
-        ExecutionGraphTestUtils.switchAllVerticesToRunning(eg);
+        runInMainThread(
+                mainThreadExecutor, () -> ExecutionGraphTestUtils.switchAllVerticesToRunning(eg));
 
         // fail the execution
-        final Execution exec =
-                eg.getJobVertex(vertex.getID()).getTaskVertices()[0].getCurrentExecutionAttempt();
-        exec.fail(new Exception("test"));
+        runInMainThread(
+                mainThreadExecutor,
+                () -> {
+                    final Execution exec =
+                            eg.getJobVertex(vertex.getID())
+                                    .getTaskVertices()[0]
+                                    .getCurrentExecutionAttempt();
+                    exec.fail(new Exception("test"));
+                });
 
         assertThat(eg.waitUntilTerminal()).isEqualTo(JobStatus.FAILED);
 
         verify(vertex, times(0)).finalizeOnMaster(any(FinalizeOnMasterContext.class));
 
-        assertThat(eg.getRegisteredExecutions()).isEmpty();
+        assertThat(supplyInMainThread(mainThreadExecutor, eg::getRegisteredExecutions)).isEmpty();
+    }
+
+    /** Runs the action on the JobManager main thread and blocks until it completes. */
+    private static void runInMainThread(
+            final ComponentMainThreadExecutor mainThreadExecutor, final Runnable action)
+            throws Exception {
+        CompletableFuture.runAsync(action, mainThreadExecutor).get();
+    }
+
+    /** Reads the value on the JobManager main thread and blocks until it is available. */
+    private static <T> T supplyInMainThread(
+            final ComponentMainThreadExecutor mainThreadExecutor, final Supplier<T> supplier)
+            throws Exception {
+        return CompletableFuture.supplyAsync(supplier, mainThreadExecutor).get();
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

This pull request fixes an intermittent CI failure in `FinalizeOnMasterTest`
(reported in [FLINK-38536](https://issues.apache.org/jira/browse/FLINK-38536),
e.g. [build 75697](https://dev.azure.com/apache-flink/apache-flink/_build/results?buildId=75697))
and the same latent data race in its sibling `ExecutionGraphFinishTest`.

The flakiness is a test-harness defect, not a production bug. Both tests wired the
scheduler with `ComponentMainThreadExecutorServiceAdapter.forMainThread()` as the
JobManager main-thread executor while passing a *separate* single-threaded I/O
executor. `forMainThread()` is backed by a `DirectScheduledExecutorService`, whose
`execute()` runs the submitted command **inline on the calling thread** rather than
confining work to one dedicated main thread.

`Execution#deploy()` builds the `TaskDeploymentDescriptor` on the I/O executor via
`CompletableFuture.supplyAsync(..., ioExecutor)` and then composes the continuation
back to the main thread with `thenComposeAsync(..., mainThreadExecutor)`. Because
`forMainThread()` executes inline, those continuations — TDD creation, task
submission, and the deployment-completion handling that can call `markFailed` — ran
on the I/O thread, concurrently with the test thread that was still inside
`startScheduling()` (and, in `ExecutionGraphFinishTest`, subsequently mutating state
via `markFinished()`). This unsynchronized concurrent mutation of the execution graph
produced the two observed signatures:

- `IllegalStateException: BUG: trying to schedule a region which is not in CREATED state`
  (a region's vertices were mutated mid-scheduling), and
- `expected: RUNNING but was: FAILING` (a background deployment callback failed an
  execution and triggered failover).

The async I/O-executor deploy path was introduced recently by
[FLINK-38114](https://issues.apache.org/jira/browse/FLINK-38114) (asynchronous
offloading of `TaskRestore`), which is why these tests started flaking now. The
production scheduling code is unchanged; the fix is confined to the test harness.

## Brief change log

- `FinalizeOnMasterTest`: replace `forMainThread()` with a dedicated single-threaded
  JobManager main-thread executor (`forSingleThreadExecutor` over the existing
  `TestingUtils.jmMainThreadExecutorExtension()`), keeping the separate I/O executor.
  All execution-graph interactions are routed through `runInMainThread` /
  `supplyInMainThread` helpers so the asynchronous deployment callbacks are serialized
  with the test logic instead of racing on the I/O thread. The temporary debug logging
  added under FLINK-38536 by PR #27168 is removed, as the root cause is now fixed.
- `ExecutionGraphFinishTest`: apply the identical remedy to `testJobFinishes()`, which
  shares the same wiring and code path and is therefore exposed to the same race.

No assertion or functional test logic was changed in either test; this is purely a
threading-model fix in the test harness. The change mirrors the pattern already used
by `ExecutionGraphSuspendTest` and `SchedulerTestingUtils`.

## Verifying this change

This change is already covered by the existing tests, which it stabilizes:

- `mvn test -pl flink-runtime -Dtest='FinalizeOnMasterTest,ExecutionGraphFinishTest'`
  passes (3 tests, 0 failures), and `spotless:check` passes.
- The original flake requires the concurrent I/O-thread timing of CI and is not
  reproducible locally in isolation, which is consistent with the diagnosed race; the
  fix removes the cross-thread access entirely rather than widening a timing window.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components),
    Checkpointing, Kubernetes/Yarn, ZooKeeper: no (test-only change)
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable

## AI-assisted contributions

- [X] Yes — generative AI tooling was used (Claude Code, Opus 4.8).

Generated-by: Claude Opus 4.8 (1M context)
