### PR TITLE
[FLINK-39879][tests] Stop CheckpointAcknowledgeFailureITCase hanging on slow CI

### DIFF
--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/CheckpointAcknowledgeFailureITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/CheckpointAcknowledgeFailureITCase.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.state.ValueStateDescriptor;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.MemorySize;
+import org.apache.flink.core.execution.JobClient;
 import org.apache.flink.runtime.checkpoint.CheckpointException;
 import org.apache.flink.runtime.minicluster.MiniCluster;
 import org.apache.flink.runtime.minicluster.RpcServiceSharing;
@@ -39,11 +40,13 @@ import org.apache.flink.util.SerializedThrowable;
 import org.apache.flink.util.TestLogger;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.time.Duration;
 import java.util.Random;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 
 import static org.apache.flink.configuration.CheckpointingOptions.CHECKPOINTING_TIMEOUT;
 import static org.apache.flink.configuration.CheckpointingOptions.CHECKPOINT_STORAGE;
@@ -100,6 +103,7 @@ public class CheckpointAcknowledgeFailureITCase extends TestLogger {
      * reason is exceeding pekko framesize.
      */
     @Test
+    @Timeout(value = 5, unit = TimeUnit.MINUTES)
     void testCheckpointAckFailure(@InjectMiniCluster MiniCluster cluster) throws Exception {
         SharedReference<CompletableFuture<Object>> stateUpdatedFuture =
                 sharedObjects.add(new CompletableFuture<>());
@@ -107,15 +111,32 @@ public class CheckpointAcknowledgeFailureITCase extends TestLogger {
         cfg.set(CHECKPOINTING_TIMEOUT, CHECKPOINT_TIMEOUT);
         final StreamExecutionEnvironment env =
                 StreamExecutionEnvironment.getExecutionEnvironment(cfg);
-        JobID jobID = executeJobAsync(env, stateUpdatedFuture);
-        stateUpdatedFuture.get().join();
+        JobClient jobClient = executeJobAsync(env, stateUpdatedFuture);
+        JobID jobID = jobClient.getJobID();
+
+        // The tiny pekko.ask.timeout that forces the oversized ACK to time out also applies to
+        // every other RPC, so on a slow machine the job can fail before the state is updated and
+        // stateUpdatedFuture would never complete. Propagate a terminal job failure into it so the
+        // wait fails fast with the real cause; @Timeout above is the hard guard against any hang.
+        jobClient
+                .getJobExecutionResult()
+                .whenComplete(
+                        (result, throwable) -> {
+                            if (throwable != null) {
+                                stateUpdatedFuture
+                                        .get()
+                                        .completeExceptionally(
+                                                ExceptionUtils.stripCompletionException(throwable));
+                            }
+                        });
+        stateUpdatedFuture.get().get();
 
         assertThatThrownBy(() -> cluster.triggerCheckpoint(jobID).get())
                 .hasCauseInstanceOf(CheckpointException.class)
                 .matches(CheckpointAcknowledgeFailureITCase::hasAskTimeoutException);
     }
 
-    private static JobID executeJobAsync(
+    private static JobClient executeJobAsync(
             StreamExecutionEnvironment env, SharedReference<CompletableFuture<Object>> stateUpdated)
             throws Exception {
         env.fromSequence(Long.MIN_VALUE, Long.MAX_VALUE)
@@ -140,7 +161,7 @@ public class CheckpointAcknowledgeFailureITCase extends TestLogger {
                             }
                         })
                 .sinkTo(new DiscardingSink<>());
-        return env.executeAsync().getJobID();
+        return env.executeAsync();
     }
 
     private static byte[] buildState() {


### PR DESCRIPTION
## What is the purpose of the change

`CheckpointAcknowledgeFailureITCase.testCheckpointAckFailure` can hang the entire surefire fork on a slow CI machine until the 900s no-output watchdog kills it (observed on `master`, [build 75716](https://dev.azure.com/apache-flink/apache-flink/_build/results?buildId=75716)). The test sets a deliberately tiny `pekko.ask.timeout` so the oversized checkpoint-ACK RPC times out (load-bearing for the `AskTimeoutException` assertion), but that timeout applies to every cluster RPC. On a slow agent an unrelated RPC (e.g. task deployment) can time out and fail the job terminally before the keyed state is updated, so the future the test waits on never completes and the unbounded wait wedges the fork.

This makes the wait fail fast with the real cause and adds a hard timeout so the test can never hang a fork again. It is a test-only stabilization; the assertion is unchanged.

## Brief change log

  - Propagate a terminal job failure into `stateUpdatedFuture` via a `whenComplete` handler on `getJobExecutionResult()` (unwrapping the `CompletionException` to the real cause), so the wait fails fast instead of blocking forever.
  - `executeJobAsync` now returns the `JobClient` so the test can observe job termination.
  - Add `@Timeout(5, MINUTES)` as the hard anti-hang guard (consistent with `ApproximateLocalRecoveryDownstreamITCase` in the same package).

## Verifying this change

This change is a test stabilization of an existing test; the assertion (`triggerCheckpoint(...)` must throw `CheckpointException` caused by `AskTimeoutException`) is unchanged. Verified locally:

  - Happy path passes: `mvn -pl flink-tests -Dtest=CheckpointAcknowledgeFailureITCase test` → `Tests run: 1, Failures: 0`.
  - Fail-fast path: temporarily forcing the ask timeout very low so an unrelated RPC fails the job before the state update — the test now fails fast (~24s) with the job's real `JobExecutionException` instead of hanging until the watchdog kill.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no (test-only change)
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (Claude Opus 4.8 (1M context))

Generated-by: Claude Opus 4.8 (1M context)
