### PR TITLE
[FLINK-39845][BP 2.3][tests] Fix SavepointITCase.testStopWithSavepointFailsOverToSavepoint under AdaptiveScheduler

### DIFF
--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/SavepointITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/SavepointITCase.java
@@ -132,6 +132,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static java.util.concurrent.CompletableFuture.allOf;
+import static org.apache.flink.core.testutils.FlinkAssertions.anyCauseMatches;
 import static org.apache.flink.runtime.testutils.CommonTestUtils.waitForAllTaskRunning;
 import static org.apache.flink.test.util.TestUtils.submitJobAndWaitForResult;
 import static org.apache.flink.test.util.TestUtils.waitUntilAllTasksAreRunning;
@@ -321,11 +322,14 @@ class SavepointITCase {
                             savepointDir.getAbsolutePath(),
                             SavepointFormatType.CANONICAL);
 
+            // The AdaptiveScheduler wraps StopWithSavepointStoppingException in a FlinkException,
+            // so search the whole cause chain rather than only the direct cause.
             assertThatThrownBy(savepointCompleted::get)
                     .isInstanceOf(ExecutionException.class)
-                    .hasCauseInstanceOf(StopWithSavepointStoppingException.class)
-                    .cause()
-                    .hasMessageStartingWith("A savepoint has been created at: ");
+                    .satisfies(
+                            anyCauseMatches(
+                                    StopWithSavepointStoppingException.class,
+                                    "A savepoint has been created at: "));
             assertThat(client.getJobStatus(jobGraph.getJobID()).get())
                     .isIn(JobStatus.FAILED, JobStatus.FAILING);
         } finally {


### PR DESCRIPTION
## What is the purpose of the change

Backport of #28311 (commit c3ec569) to `release-2.3`.

The JUnit5 migration (FLINK-39124, #27667 — also present on `release-2.3`) replaced a cause-chain search in `SavepointITCase.testStopWithSavepointFailsOverToSavepoint` (`ExceptionUtils.assertThrowable` -> `findThrowable`) with a direct-cause assertion (`assertThatThrownBy(...).hasCauseInstanceOf(StopWithSavepointStoppingException.class)`).

Under the AdaptiveScheduler, `StopWithSavepoint.onLeave()` wraps the expected `StopWithSavepointStoppingException` inside a `FlinkException` ("Stop with savepoint operation could not be completed."), so it is no longer the *direct* cause. The default scheduler still exposes it directly, so the test passes there but fails under the adaptive scheduler.

This restores the cause-chain search so the test passes under both schedulers.

## Brief change log

  - Replace the direct-cause assertion in `testStopWithSavepointFailsOverToSavepoint` with `FlinkAssertions.anyCauseMatches(StopWithSavepointStoppingException.class, "A savepoint has been created at: ")`, which searches the whole cause chain (restoring the pre-migration semantics).

(Note: the shared `anyCauseMatches` helper matches the message with `contains` rather than the original `startsWith`. This is safe here because the phrase is the leading text of `StopWithSavepointStoppingException`'s own message, and `anyCauseMatches` binds the class and the message to the same throwable in the chain.)

## Verifying this change

This change is already covered by the existing `SavepointITCase.testStopWithSavepointFailsOverToSavepoint`. The cherry-pick applied cleanly onto `release-2.3` (which carries the same #27667 migration commit), and `FlinkAssertions.anyCauseMatches(Class, String)` is present on the branch.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no (test-only change)
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (Claude Code (Claude Opus 4.8))

Generated-by: Claude Code (Claude Opus 4.8)
