### PR TITLE
[hotfix][javadocs] Fix typos in subpartition, ZooKeeper utils and sink ExecNode comments

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedApproximateSubpartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedApproximateSubpartition.java
@@ -31,7 +31,7 @@ import static org.apache.flink.util.Preconditions.checkState;
 
 /**
  * A pipelined in-memory only subpartition, which allows to reconnect after failure. Only one view
- * is allowed at a time to read teh subpartition.
+ * is allowed at a time to read the subpartition.
  */
 public class PipelinedApproximateSubpartition extends PipelinedSubpartition {
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/ZooKeeperUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/ZooKeeperUtils.java
@@ -730,7 +730,7 @@ public class ZooKeeperUtils {
      * Splits the given ZooKeeper path into its parts.
      *
      * @param path path to split
-     * @return splited path
+     * @return split path
      */
     public static String[] splitZooKeeperPath(String path) {
         return path.split("/");

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecSink.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecSink.java
@@ -111,9 +111,9 @@ import static org.apache.flink.table.api.config.ExecutionConfigOptions.TABLE_EXE
         minStateVersion = FlinkVersion.v1_15)
 // Version 2: Fixed the data type used for creating constraint enforcer and sink upsert
 // materializer. Since this version the sink works correctly with persisted metadata columns.
-// We introduced a new version, because statements that were never rolling back to a value from
-// state could run succesfully. We allow those jobs to be upgraded. Without a new versions such jobs
-// would fail on restore, because the state serializer would differ
+// We introduced a new version, because statements that were never rolling back to a value
+// from state could run successfully. We allow those jobs to be upgraded. Without a new
+// versions such jobs would fail on restore, because the state serializer would differ
 @ExecNodeMetadata(
         name = "stream-exec-sink",
         version = 2,


### PR DESCRIPTION
## What is the purpose of the change

Fixes three typos in code comments / JavaDoc. No functional change:
- `PipelinedApproximateSubpartition`: "read teh subpartition" -> "the"
- `ZooKeeperUtils#splitZooKeeperPath`: "@return splited path" -> "split"
- `StreamExecSink` version comment: "run succesfully" -> "successfully"

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no



---
##### Was generative AI tooling used to co-author this PR?

- [X] Yes — authored with Claude Code (Claude Opus 4.8); reviewed with Codex (GPT-5.5) and Claude Code (claude-fable-5), plus manual human review.

I am responsible for the correctness and quality of every line in this change.

Generated-by: Claude Code (Claude Opus 4.8)
Reviewed-by: Codex (GPT-5.5); Claude Code (claude-fable-5); human review
