### PR TITLE
[FLINK-31244][core] Capture expected IllegalStateException on concurrent free in OffHeapUnsafeMemorySegmentTest

### DIFF
--- a/flink-core/src/test/java/org/apache/flink/core/memory/OffHeapUnsafeMemorySegmentTest.java
+++ b/flink-core/src/test/java/org/apache/flink/core/memory/OffHeapUnsafeMemorySegmentTest.java
@@ -80,8 +80,19 @@ class OffHeapUnsafeMemorySegmentTest extends MemorySegmentTestBase {
         final MemorySegment segment =
                 MemorySegmentFactory.allocateOffHeapUnsafeMemory(10, null, cleaner);
 
-        final Thread t1 = new Thread(segment::free);
-        final Thread t2 = new Thread(segment::free);
+        final Runnable free =
+                () -> {
+                    try {
+                        segment.free();
+                    } catch (IllegalStateException e) {
+                        // The losing thread of the concurrent free() observes the segment as
+                        // already freed; swallow the expected exception so it is not surfaced
+                        // as an uncaught exception polluting the test logs (FLINK-31244).
+                    }
+                };
+
+        final Thread t1 = new Thread(free);
+        final Thread t2 = new Thread(free);
         t1.start();
         t2.start();
         t1.join();


### PR DESCRIPTION
## What is the purpose of the change

Fixes FLINK-31244. `OffHeapUnsafeMemorySegmentTest.testCallCleanerOnceOnConcurrentFree`
starts two threads that both call `segment.free()` on the same `MemorySegment` to
verify the cleaner runs exactly once. When the multiple-free check is enabled
(`-Dflink.tests.check-segment-multiple-free`, which is set in CI), the thread that
loses the race throws `IllegalStateException("MemorySegment can be freed only once!")`.
Because `free()` was used directly as the thread body, that *expected* exception was
raised as an uncaught exception in the worker thread and printed to the CI logs as
noise, e.g.:

```
Exception in thread "Thread-13" java.lang.IllegalStateException: MemorySegment can be freed only once!
```

The test still passed; only the logs were polluted.

## Brief change log

- Wrap the concurrent `segment.free()` call in a `Runnable` that catches the expected
  `IllegalStateException`, so it is no longer surfaced as an uncaught exception. The
  existing assertion that the cleaner ran exactly once is unchanged.

## Verifying this change

This change is a test-only fix and can be verified as follows:

- Before: running `OffHeapUnsafeMemorySegmentTest#testCallCleanerOnceOnConcurrentFree`
  with `-Dflink.tests.check-segment-multiple-free` passes but prints
  `Exception in thread "Thread-N" java.lang.IllegalStateException: MemorySegment can be freed only once!`.
- After: the same run passes with no such exception printed.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no



---
##### Was generative AI tooling used to co-author this PR?

- [X] Yes — authored with Claude Code (Claude Opus 4.8); reviewed with Codex (GPT-5.5) and Claude Code (claude-fable-5), plus manual human review.

I am responsible for the correctness and quality of every line in this change.

Generated-by: Claude Code (Claude Opus 4.8)
Reviewed-by: Codex (GPT-5.5); Claude Code (claude-fable-5); human review
