### PR TITLE
[FLINK-39804][table] Fix nested projection pushdown with non-pushable filters

### DIFF
--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/optimize/program/FlinkBatchProgram.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/optimize/program/FlinkBatchProgram.scala
@@ -245,7 +245,7 @@ object FlinkBatchProgram {
       FlinkHepRuleSetProgramBuilder.newBuilder
         .setHepRulesExecutionType(HEP_RULES_EXECUTION_TYPE.RULE_COLLECTION)
         .setHepMatchOrder(HepMatchOrder.BOTTOM_UP)
-        .add(FlinkBatchRuleSets.PROJECT_RULES)
+        .add(FlinkBatchRuleSets.PROJECT_REWRITE_RULES)
         .build()
     )
 

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/optimize/program/FlinkStreamProgram.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/optimize/program/FlinkStreamProgram.scala
@@ -254,7 +254,7 @@ object FlinkStreamProgram {
       FlinkHepRuleSetProgramBuilder.newBuilder
         .setHepRulesExecutionType(HEP_RULES_EXECUTION_TYPE.RULE_COLLECTION)
         .setHepMatchOrder(HepMatchOrder.BOTTOM_UP)
-        .add(FlinkStreamRuleSets.PROJECT_RULES)
+        .add(FlinkStreamRuleSets.PROJECT_REWRITE_RULES)
         .build()
     )
 

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkBatchRuleSets.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkBatchRuleSets.scala
@@ -24,6 +24,7 @@ import org.apache.flink.table.planner.plan.rules.physical.FlinkExpandConversionR
 import org.apache.flink.table.planner.plan.rules.physical.batch._
 import org.apache.flink.table.planner.plan.rules.physical.common.{PhysicalMLPredictTableFunctionRule, PhysicalVectorSearchTableFunctionRule}
 
+import org.apache.calcite.plan.RelOptRule
 import org.apache.calcite.rel.core.RelFactories
 import org.apache.calcite.rel.logical.{LogicalIntersect, LogicalMinus, LogicalUnion}
 import org.apache.calcite.rel.rules._
@@ -210,10 +211,9 @@ object FlinkBatchRuleSets {
     CoreRules.AGGREGATE_VALUES
   )
 
-  /** RuleSet about project */
-  val PROJECT_RULES: RuleSet = RuleSets.ofList(
+  private def projectRules(projectFilterTranspose: RelOptRule): RuleSet = RuleSets.ofList(
     // push a projection past a filter
-    CoreRules.PROJECT_FILTER_TRANSPOSE,
+    projectFilterTranspose,
     // push a projection to the children of a non semi/anti join
     // push all expressions to handle the time indicator correctly
     new FlinkProjectJoinTransposeRule(
@@ -232,6 +232,13 @@ object FlinkBatchRuleSets {
     // push a projection to the child of a WindowTableFunctionScan
     ProjectWindowTableFunctionTransposeRule.INSTANCE
   )
+
+  /** RuleSet about project for the HEP project rewrite phase. */
+  val PROJECT_REWRITE_RULES: RuleSet =
+    projectRules(CoreRules.PROJECT_FILTER_TRANSPOSE_WHOLE_EXPRESSIONS)
+
+  /** RuleSet about project */
+  val PROJECT_RULES: RuleSet = projectRules(CoreRules.PROJECT_FILTER_TRANSPOSE)
 
   val JOIN_COND_EQUAL_TRANSFER_RULES: RuleSet = RuleSets.ofList(
     (

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkStreamRuleSets.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkStreamRuleSets.scala
@@ -23,6 +23,7 @@ import org.apache.flink.table.planner.plan.rules.physical.FlinkExpandConversionR
 import org.apache.flink.table.planner.plan.rules.physical.common.{PhysicalMLPredictTableFunctionRule, PhysicalVectorSearchTableFunctionRule}
 import org.apache.flink.table.planner.plan.rules.physical.stream._
 
+import org.apache.calcite.plan.RelOptRule
 import org.apache.calcite.rel.core.RelFactories
 import org.apache.calcite.rel.logical.{LogicalIntersect, LogicalMinus, LogicalUnion}
 import org.apache.calcite.rel.rules._
@@ -206,10 +207,9 @@ object FlinkStreamRuleSets {
     CoreRules.AGGREGATE_VALUES
   )
 
-  /** RuleSet about project */
-  val PROJECT_RULES: RuleSet = RuleSets.ofList(
+  private def projectRules(projectFilterTranspose: RelOptRule): RuleSet = RuleSets.ofList(
     // push a projection past a filter
-    CoreRules.PROJECT_FILTER_TRANSPOSE,
+    projectFilterTranspose,
     // push a projection to the children of a non semi/anti join
     // push all expressions to handle the time indicator correctly
     new FlinkProjectJoinTransposeRule(
@@ -230,6 +230,13 @@ object FlinkStreamRuleSets {
     // push a projection to the child of a WindowTableFunctionScan
     ProjectWindowTableFunctionTransposeRule.INSTANCE
   )
+
+  /** RuleSet about project for the HEP project rewrite phase. */
+  val PROJECT_REWRITE_RULES: RuleSet =
+    projectRules(CoreRules.PROJECT_FILTER_TRANSPOSE_WHOLE_EXPRESSIONS)
+
+  /** RuleSet about project */
+  val PROJECT_RULES: RuleSet = projectRules(CoreRules.PROJECT_FILTER_TRANSPOSE)
 
   val JOIN_REORDER_PREPARE_RULES: RuleSet = RuleSets.ofList(
     // merge project to MultiJoin

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/TableSourceTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/TableSourceTest.xml
@@ -103,6 +103,29 @@ Calc(select=[ITEM(result_data_arr, id).value AS EXPR$0, ITEM(result_data_map, 'i
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testNestedProjectWithNonPushableFilter">
+    <Resource name="sql">
+      <![CDATA[
+SELECT id,
+    deepNested.nested1.name AS nestedName
+FROM NestedTable
+WHERE nested.`value` > 0
+      ]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(id=[$0], nestedName=[$1.nested1.name])
++- LogicalFilter(condition=[>($2.value, 0)])
+   +- LogicalTableScan(table=[[default_catalog, default_database, NestedTable]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[id, deepNested_nested1_name AS nestedName], where=[(nested_value > 0)])
++- TableSourceScan(table=[[default_catalog, default_database, NestedTable, filter=[], project=[id, nested_value, deepNested_nested1_name], metadata=[]]], fields=[id, nested_value, deepNested_nested1_name])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testProjectWithoutInputRef">
     <Resource name="sql">
       <![CDATA[SELECT COUNT(1) FROM ProjectableTable]]>

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/TableSourceTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/TableSourceTest.xml
@@ -85,6 +85,29 @@ Calc(select=[id, deepNested_nested1 AS nested1, ((deepNested_nested1.value + dee
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testNestedProjectWithNonPushableFilter">
+    <Resource name="sql">
+      <![CDATA[
+SELECT id,
+    deepNested.nested1.name AS nestedName
+FROM T
+WHERE nested.`value` > 0
+      ]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(id=[$0], nestedName=[$1.nested1.name])
++- LogicalFilter(condition=[>($2.value, 0)])
+   +- LogicalTableScan(table=[[default_catalog, default_database, T]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[id, deepNested_nested1_name AS nestedName], where=[(nested_value > 0)])
++- TableSourceScan(table=[[default_catalog, default_database, T, filter=[], project=[id, nested_value, deepNested_nested1_name], metadata=[]]], fields=[id, nested_value, deepNested_nested1_name])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testNoNestedProjectWithMetadata">
     <Resource name="sql">
       <![CDATA[

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/batch/sql/TableSourceTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/batch/sql/TableSourceTest.scala
@@ -131,6 +131,18 @@ class TableSourceTest extends TableTestBase {
   }
 
   @Test
+  def testNestedProjectWithNonPushableFilter(): Unit = {
+    val sqlQuery =
+      """
+        |SELECT id,
+        |    deepNested.nested1.name AS nestedName
+        |FROM NestedTable
+        |WHERE nested.`value` > 0
+      """.stripMargin
+    util.verifyExecPlan(sqlQuery)
+  }
+
+  @Test
   def testNestProjectWithMetadata(): Unit = {
     val sqlQuery =
       """

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/TableSourceTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/TableSourceTest.scala
@@ -217,6 +217,34 @@ class TableSourceTest extends TableTestBase {
   }
 
   @Test
+  def testNestedProjectWithNonPushableFilter(): Unit = {
+    val ddl =
+      s"""
+         |CREATE TABLE T (
+         |  id int,
+         |  deepNested row<nested1 row<name string, `value` int>,
+         |                 nested2 row<num int, flag boolean>>,
+         |  nested row<name string, `value` int>,
+         |  name string
+         |) WITH (
+         |  'connector' = 'values',
+         |  'nested-projection-supported' = 'true',
+         |  'bounded' = 'false'
+         |)
+       """.stripMargin
+    util.tableEnv.executeSql(ddl)
+
+    val sqlQuery =
+      """
+        |SELECT id,
+        |    deepNested.nested1.name AS nestedName
+        |FROM T
+        |WHERE nested.`value` > 0
+      """.stripMargin
+    util.verifyExecPlan(sqlQuery)
+  }
+
+  @Test
   def testProjectWithoutInputRef(): Unit = {
     val ddl =
       s"""


### PR DESCRIPTION
## What is the purpose of the change

Currently, nested projection pushdown can prune nested fields that are only referenced by a filter which cannot be pushed into the table source. In that case, the rewritten projection may no longer keep the complete filter input, and the final source projection can miss fields that are still required by the filter.

This PR fixes the project rewrite phase to preserve complete filter expressions before nested projection pushdown is derived.


## Brief change log

- Added separate batch and stream project rewrite rule sets that use `PROJECT_FILTER_TRANSPOSE_WHOLE_EXPRESSIONS`.
- Switched the batch and stream project rewrite programs to use the rewrite-specific project rule sets.
- Added batch and stream SQL plan regression coverage for nested projection with a non-pushable filter.

## Verifying this change

This change added tests and can be verified as follows:

- Batch and stream SQL plan tests in `TableSourceTest` for nested projection with a non-pushable filter.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes, Hermes Agent (gpt-5.5, openai-codex)

Generated-by: Hermes Agent (gpt-5.5, openai-codex)
