### PR TITLE
[hotfix][build] Put commas into exclusion groups to avoid commas only

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1015,7 +1015,7 @@ under the License.
 		<profile>
 			<id>enable-adaptive-scheduler</id>
 			<properties>
-				<surefire.excludedGroups.adaptive-scheduler>org.apache.flink.testutils.junit.FailsWithAdaptiveScheduler</surefire.excludedGroups.adaptive-scheduler>
+				<surefire.excludedGroups.adaptive-scheduler>org.apache.flink.testutils.junit.FailsWithAdaptiveScheduler,</surefire.excludedGroups.adaptive-scheduler>
 			</properties>
 			<build>
 				<plugins>
@@ -1026,11 +1026,7 @@ under the License.
 							<systemProperties>
 								<flink.tests.enable-adaptive-scheduler>true</flink.tests.enable-adaptive-scheduler>
 							</systemProperties>
-							<excludedGroups>
-								${surefire.excludedGroups.github-actions},
-								${surefire.excludedGroups.adaptive-scheduler},
-								${surefire.excludedGroups.jdk}
-							</excludedGroups>
+							<excludedGroups>${surefire.excludedGroups.github-actions}${surefire.excludedGroups.adaptive-scheduler}${surefire.excludedGroups.jdk}</excludedGroups>
 						</configuration>
 					</plugin>
 				</plugins>
@@ -1046,11 +1042,7 @@ under the License.
 							<groupId>org.apache.maven.plugins</groupId>
 							<artifactId>maven-surefire-plugin</artifactId>
 							<configuration>
-								<excludedGroups>
-									${surefire.excludedGroups.github-actions},
-									${surefire.excludedGroups.adaptive-scheduler},
-									${surefire.excludedGroups.jdk},
-								</excludedGroups>
+								<excludedGroups>${surefire.excludedGroups.github-actions}${surefire.excludedGroups.adaptive-scheduler}${surefire.excludedGroups.jdk}</excludedGroups>
 							</configuration>
 						</plugin>
 					</plugins>
@@ -1093,7 +1085,7 @@ under the License.
 			</activation>
 
 			<properties>
-				<surefire.excludedGroups.jdk>org.apache.flink.testutils.junit.FailsOnJava17</surefire.excludedGroups.jdk>
+				<surefire.excludedGroups.jdk>org.apache.flink.testutils.junit.FailsOnJava17,</surefire.excludedGroups.jdk>
 			</properties>
 
 			<build>
@@ -1103,11 +1095,7 @@ under the License.
 							<groupId>org.apache.maven.plugins</groupId>
 							<artifactId>maven-surefire-plugin</artifactId>
 							<configuration>
-								<excludedGroups>
-									${surefire.excludedGroups.github-actions},
-									${surefire.excludedGroups.adaptive-scheduler},
-									${surefire.excludedGroups.jdk},
-								</excludedGroups>
+								<excludedGroups>${surefire.excludedGroups.github-actions}${surefire.excludedGroups.adaptive-scheduler}${surefire.excludedGroups.jdk}</excludedGroups>
 							</configuration>
 						</plugin>
 					</plugins>
@@ -1156,11 +1144,7 @@ under the License.
 							<groupId>org.apache.maven.plugins</groupId>
 							<artifactId>maven-surefire-plugin</artifactId>
 							<configuration>
-								<excludedGroups>
-									${surefire.excludedGroups.github-actions},
-									${surefire.excludedGroups.adaptive-scheduler},
-									${surefire.excludedGroups.jdk},
-								</excludedGroups>
+								<excludedGroups>${surefire.excludedGroups.github-actions}${surefire.excludedGroups.adaptive-scheduler}${surefire.excludedGroups.jdk}</excludedGroups>
 							</configuration>
 						</plugin>
 					</plugins>
@@ -1201,7 +1185,7 @@ under the License.
 			</activation>
 
 			<properties>
-				<surefire.excludedGroups.jdk>org.apache.flink.testutils.junit.FailsOnJava25</surefire.excludedGroups.jdk>
+				<surefire.excludedGroups.jdk>org.apache.flink.testutils.junit.FailsOnJava25,</surefire.excludedGroups.jdk>
 			</properties>
 
 			<build>
@@ -1211,11 +1195,7 @@ under the License.
 							<groupId>org.apache.maven.plugins</groupId>
 							<artifactId>maven-surefire-plugin</artifactId>
 							<configuration>
-								<excludedGroups>
-									${surefire.excludedGroups.github-actions},
-									${surefire.excludedGroups.adaptive-scheduler},
-									${surefire.excludedGroups.jdk},
-								</excludedGroups>
+								<excludedGroups>${surefire.excludedGroups.github-actions}${surefire.excludedGroups.adaptive-scheduler}${surefire.excludedGroups.jdk}</excludedGroups>
 							</configuration>
 						</plugin>
 						<plugin>


### PR DESCRIPTION
## What is the purpose of the change

This PR is to fix build with jdk11 (nightly) where exclusions are empty

## Brief change log
pom


## Verifying this change

nightly with java 11
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): ( no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable )

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change the checkbox below to `[X]` followed by the name of the tool, and uncomment the
"Generated-by" line. See the ASF Generative Tooling Guidance for details:
https://www.apache.org/legal/generative-tooling.html

You are responsible for the quality and correctness of every change in this PR
regardless of the tooling used. Low-effort AI-generated PRs will be closed. See
AGENTS.md for the full guidance.
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name and Version]
-->
