### PR TITLE
[FLINK-39900] [forst] Add configuration option for setting the number of ForSt transfer threads

### DIFF
--- a/docs/layouts/shortcodes/generated/expert_forst_section.html
+++ b/docs/layouts/shortcodes/generated/expert_forst_section.html
@@ -24,7 +24,7 @@
             <td><h5>state.backend.forst.checkpoint.transfer.thread.num</h5></td>
             <td style="word-wrap: break-word;">4</td>
             <td>Integer</td>
-            <td>The number of transfer threads used to write or copy files to the state backend.</td>
+            <td>The number of threads used to transfer files during checkpoint (writing or copying files to the checkpoint storage) and restore (transferring state files back to the ForSt working directory). Consider increasing this value when snapshotting or restoring large state. Note that the pool is created per state backend instance. Setting it too high can saturate network bandwidth or trigger rate limiting depending on the remote storage; setting it too low can lead to long checkpoint durations or timeouts for large state. The default value is '4'.</td>
         </tr>
         <tr>
             <td><h5>state.backend.forst.executor.inline-coordinator</h5></td>

--- a/docs/layouts/shortcodes/generated/expert_forst_section.html
+++ b/docs/layouts/shortcodes/generated/expert_forst_section.html
@@ -21,6 +21,12 @@
             <td>When the number of eviction that a block in hot link is moved to cold link reaches this value, the block will be blocked from being promoted to the head of the LRU list. The default value is '3'.</td>
         </tr>
         <tr>
+            <td><h5>state.backend.forst.checkpoint.transfer.thread.num</h5></td>
+            <td style="word-wrap: break-word;">4</td>
+            <td>Integer</td>
+            <td>The number of transfer threads used to write or copy files to the state backend.</td>
+        </tr>
+        <tr>
             <td><h5>state.backend.forst.executor.inline-coordinator</h5></td>
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>

--- a/docs/layouts/shortcodes/generated/forst_configuration.html
+++ b/docs/layouts/shortcodes/generated/forst_configuration.html
@@ -42,7 +42,7 @@
             <td><h5>state.backend.forst.checkpoint.transfer.thread.num</h5></td>
             <td style="word-wrap: break-word;">4</td>
             <td>Integer</td>
-            <td>The number of transfer threads used to write or copy files to the state backend.</td>
+            <td>The number of threads used to transfer files during checkpoint (writing or copying files to the checkpoint storage) and restore (transferring state files back to the ForSt working directory). Consider increasing this value when snapshotting or restoring large state. Note that the pool is created per state backend instance. Setting it too high can saturate network bandwidth or trigger rate limiting depending on the remote storage; setting it too low can lead to long checkpoint durations or timeouts for large state. The default value is '4'.</td>
         </tr>
         <tr>
             <td><h5>state.backend.forst.executor.inline-coordinator</h5></td>

--- a/docs/layouts/shortcodes/generated/forst_configuration.html
+++ b/docs/layouts/shortcodes/generated/forst_configuration.html
@@ -39,6 +39,12 @@
             <td>An upper-bound of the size that can be used for cache. User should specify at least one cache size limit to enable the cache, either this option or the 'state.backend.forst.cache.reserve-size' option. They can be set simultaneously, and in this case, cache will grow if meet the requirements of both two options. The default value is '0 bytes', meaning that this option is disabled. </td>
         </tr>
         <tr>
+            <td><h5>state.backend.forst.checkpoint.transfer.thread.num</h5></td>
+            <td style="word-wrap: break-word;">4</td>
+            <td>Integer</td>
+            <td>The number of transfer threads used to write or copy files to the state backend.</td>
+        </tr>
+        <tr>
             <td><h5>state.backend.forst.executor.inline-coordinator</h5></td>
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>

--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStKeyedStateBackendBuilder.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStKeyedStateBackendBuilder.java
@@ -442,7 +442,7 @@ public class ForStKeyedStateBackendBuilder<K>
             long lastCompletedCheckpointId) {
         ForStStateDataTransfer stateTransfer =
                 new ForStStateDataTransfer(
-                        ForStStateDataTransfer.DEFAULT_THREAD_NUM,
+                        optionsContainer.getDataTransferThreadNum(),
                         optionsContainer.getFileSystem());
 
         if (enableIncrementalCheckpointing) {

--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStOptions.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStOptions.java
@@ -300,4 +300,12 @@ public class ForStOptions {
                                     + " Only valid when '"
                                     + EXECUTOR_WRITE_IO_INLINE.key()
                                     + "' is false.");
+
+    @Documentation.Section(Documentation.Sections.EXPERT_FORST)
+    public static final ConfigOption<Integer> CHECKPOINT_TRANSFER_THREAD_NUM =
+            ConfigOptions.key("state.backend.forst.checkpoint.transfer.thread.num")
+                    .intType()
+                    .defaultValue(4)
+                    .withDescription(
+                            "The number of transfer threads used to write or copy files to the state backend.");
 }

--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStOptions.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStOptions.java
@@ -32,15 +32,11 @@ import static org.apache.flink.state.forst.ForStStateBackend.CHECKPOINT_DIR_AS_P
 import static org.apache.flink.state.forst.ForStStateBackend.LOCAL_DIR_AS_PRIMARY_SHORTCUT;
 import static org.apache.flink.state.forst.ForStStateBackend.PriorityQueueStateType.ForStDB;
 
-/**
- * Configuration options for the ForStStateBackend.
- */
+/** Configuration options for the ForStStateBackend. */
 @Experimental
 public class ForStOptions {
 
-    /**
-     * The local directory (on the TaskManager) where ForSt puts some meta files.
-     */
+    /** The local directory (on the TaskManager) where ForSt puts some meta files. */
     @Documentation.Section(Documentation.Sections.EXPERT_FORST)
     public static final ConfigOption<String> LOCAL_DIRECTORIES =
             ConfigOptions.key("state.backend.forst.local-dir")
@@ -56,9 +52,7 @@ public class ForStOptions {
                                                             .key()))
                                     .build());
 
-    /**
-     * The remote directory where ForSt puts its SST files.
-     */
+    /** The remote directory where ForSt puts its SST files. */
     @Documentation.Section(Documentation.Sections.STATE_BACKEND_FORST)
     public static final ConfigOption<String> PRIMARY_DIRECTORY =
             ConfigOptions.key("state.backend.forst.primary-dir")
@@ -162,9 +156,7 @@ public class ForStOptions {
                                     + "from being promoted to the head of the LRU list. "
                                     + "The default value is '3'.");
 
-    /**
-     * The options factory class for ForSt to create DBOptions and ColumnFamilyOptions.
-     */
+    /** The options factory class for ForSt to create DBOptions and ColumnFamilyOptions. */
     @Documentation.Section(Documentation.Sections.EXPERT_FORST)
     public static final ConfigOption<String> OPTIONS_FACTORY =
             ConfigOptions.key("state.backend.forst.options-factory")
@@ -245,21 +237,17 @@ public class ForStOptions {
                                             + "This option only has an effect when '%s' or '%s' are configured.",
                                     USE_MANAGED_MEMORY.key(), FIX_PER_SLOT_MEMORY_SIZE.key()));
 
-    /**
-     * Choice of timer service implementation.
-     */
+    /** Choice of timer service implementation. */
     @Documentation.Section(Documentation.Sections.STATE_BACKEND_FORST)
     public static final ConfigOption<ForStStateBackend.PriorityQueueStateType>
             TIMER_SERVICE_FACTORY =
-            ConfigOptions.key("state.backend.forst.timer-service.factory")
-                    .enumType(ForStStateBackend.PriorityQueueStateType.class)
-                    .defaultValue(ForStDB)
-                    .withDescription(
-                            "This determines the factory for timer service state implementation.");
+                    ConfigOptions.key("state.backend.forst.timer-service.factory")
+                            .enumType(ForStStateBackend.PriorityQueueStateType.class)
+                            .defaultValue(ForStDB)
+                            .withDescription(
+                                    "This determines the factory for timer service state implementation.");
 
-    /**
-     * The cache size per key-group for ForSt timer service factory implementation.
-     */
+    /** The cache size per key-group for ForSt timer service factory implementation. */
     @Documentation.Section(Documentation.Sections.STATE_BACKEND_FORST)
     public static final ConfigOption<Integer> FORST_TIMER_SERVICE_FACTORY_CACHE_SIZE =
             ConfigOptions.key("state.backend.forst.timer-service.cache-size")

--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStOptions.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStOptions.java
@@ -32,11 +32,15 @@ import static org.apache.flink.state.forst.ForStStateBackend.CHECKPOINT_DIR_AS_P
 import static org.apache.flink.state.forst.ForStStateBackend.LOCAL_DIR_AS_PRIMARY_SHORTCUT;
 import static org.apache.flink.state.forst.ForStStateBackend.PriorityQueueStateType.ForStDB;
 
-/** Configuration options for the ForStStateBackend. */
+/**
+ * Configuration options for the ForStStateBackend.
+ */
 @Experimental
 public class ForStOptions {
 
-    /** The local directory (on the TaskManager) where ForSt puts some meta files. */
+    /**
+     * The local directory (on the TaskManager) where ForSt puts some meta files.
+     */
     @Documentation.Section(Documentation.Sections.EXPERT_FORST)
     public static final ConfigOption<String> LOCAL_DIRECTORIES =
             ConfigOptions.key("state.backend.forst.local-dir")
@@ -52,7 +56,9 @@ public class ForStOptions {
                                                             .key()))
                                     .build());
 
-    /** The remote directory where ForSt puts its SST files. */
+    /**
+     * The remote directory where ForSt puts its SST files.
+     */
     @Documentation.Section(Documentation.Sections.STATE_BACKEND_FORST)
     public static final ConfigOption<String> PRIMARY_DIRECTORY =
             ConfigOptions.key("state.backend.forst.primary-dir")
@@ -156,7 +162,9 @@ public class ForStOptions {
                                     + "from being promoted to the head of the LRU list. "
                                     + "The default value is '3'.");
 
-    /** The options factory class for ForSt to create DBOptions and ColumnFamilyOptions. */
+    /**
+     * The options factory class for ForSt to create DBOptions and ColumnFamilyOptions.
+     */
     @Documentation.Section(Documentation.Sections.EXPERT_FORST)
     public static final ConfigOption<String> OPTIONS_FACTORY =
             ConfigOptions.key("state.backend.forst.options-factory")
@@ -237,17 +245,21 @@ public class ForStOptions {
                                             + "This option only has an effect when '%s' or '%s' are configured.",
                                     USE_MANAGED_MEMORY.key(), FIX_PER_SLOT_MEMORY_SIZE.key()));
 
-    /** Choice of timer service implementation. */
+    /**
+     * Choice of timer service implementation.
+     */
     @Documentation.Section(Documentation.Sections.STATE_BACKEND_FORST)
     public static final ConfigOption<ForStStateBackend.PriorityQueueStateType>
             TIMER_SERVICE_FACTORY =
-                    ConfigOptions.key("state.backend.forst.timer-service.factory")
-                            .enumType(ForStStateBackend.PriorityQueueStateType.class)
-                            .defaultValue(ForStDB)
-                            .withDescription(
-                                    "This determines the factory for timer service state implementation.");
+            ConfigOptions.key("state.backend.forst.timer-service.factory")
+                    .enumType(ForStStateBackend.PriorityQueueStateType.class)
+                    .defaultValue(ForStDB)
+                    .withDescription(
+                            "This determines the factory for timer service state implementation.");
 
-    /** The cache size per key-group for ForSt timer service factory implementation. */
+    /**
+     * The cache size per key-group for ForSt timer service factory implementation.
+     */
     @Documentation.Section(Documentation.Sections.STATE_BACKEND_FORST)
     public static final ConfigOption<Integer> FORST_TIMER_SERVICE_FACTORY_CACHE_SIZE =
             ConfigOptions.key("state.backend.forst.timer-service.cache-size")
@@ -307,5 +319,12 @@ public class ForStOptions {
                     .intType()
                     .defaultValue(4)
                     .withDescription(
-                            "The number of transfer threads used to write or copy files to the state backend.");
+                            "The number of threads used to transfer files during checkpoint (writing or copying "
+                                    + "files to the checkpoint storage) and restore (transferring state files back to "
+                                    + "the ForSt working directory). Consider increasing this value when snapshotting or "
+                                    + "restoring large state. Note that the pool is created per state backend instance. "
+                                    + "Setting it too high can saturate network bandwidth or trigger rate limiting depending "
+                                    + "on the remote storage; setting it too low can lead to long checkpoint durations "
+                                    + "or timeouts for large state. "
+                                    + "The default value is '4'.");
 }

--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStResourceContainer.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStResourceContainer.java
@@ -324,6 +324,10 @@ public final class ForStResourceContainer implements AutoCloseable {
         return configuration.get(ForStOptions.EXECUTOR_WRITE_IO_PARALLELISM);
     }
 
+    public int getDataTransferThreadNum() {
+        return configuration.get(ForStOptions.CHECKPOINT_TRANSFER_THREAD_NUM);
+    }
+
     /**
      * Prepare local and remote directories.
      *

--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/datatransfer/ForStStateDataTransfer.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/datatransfer/ForStStateDataTransfer.java
@@ -64,9 +64,6 @@ import static org.apache.flink.util.concurrent.Executors.newDirectExecutorServic
 public class ForStStateDataTransfer implements Closeable {
     private static final Logger LOG = LoggerFactory.getLogger(ForStStateDataTransfer.class);
 
-    // TODO: Add ConfigOption replace this field after ForSt checkpoint implementation stable
-    public static final int DEFAULT_THREAD_NUM = 4;
-
     protected final ExecutorService executorService;
 
     @Nullable private final ForStFlinkFileSystem forStFs;

--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/restore/ForStIncrementalRestoreOperation.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/restore/ForStIncrementalRestoreOperation.java
@@ -265,7 +265,7 @@ public class ForStIncrementalRestoreOperation<K> implements ForStRestoreOperatio
     private void transferAllStateHandles(List<StateHandleTransferSpec> specs) throws Exception {
         try (ForStStateDataTransfer transfer =
                 new ForStStateDataTransfer(
-                        ForStStateDataTransfer.DEFAULT_THREAD_NUM,
+                        optionsContainer.getDataTransferThreadNum(),
                         optionsContainer.getFileSystem())) {
             transfer.transferAllStateDataToDirectory(
                     optionsContainer.getPathContainer(),

--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/sync/ForStSyncKeyedStateBackendBuilder.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/sync/ForStSyncKeyedStateBackendBuilder.java
@@ -465,7 +465,7 @@ public class ForStSyncKeyedStateBackendBuilder<K> extends AbstractKeyedStateBack
 
         ForStStateDataTransfer stateTransfer =
                 new ForStStateDataTransfer(
-                        ForStStateDataTransfer.DEFAULT_THREAD_NUM,
+                        optionsContainer.getDataTransferThreadNum(),
                         optionsContainer.getFileSystem());
 
         if (enableIncrementalCheckpointing) {

--- a/flink-state-backends/flink-statebackend-forst/src/test/java/org/apache/flink/state/forst/ForStStateBackendConfigTest.java
+++ b/flink-state-backends/flink-statebackend-forst/src/test/java/org/apache/flink/state/forst/ForStStateBackendConfigTest.java
@@ -82,13 +82,10 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-/**
- * Tests for configuring the ForSt State Backend.
- */
+/** Tests for configuring the ForSt State Backend. */
 public class ForStStateBackendConfigTest {
 
-    @Rule
-    public final TemporaryFolder tempFolder = new TemporaryFolder();
+    @Rule public final TemporaryFolder tempFolder = new TemporaryFolder();
 
     // ------------------------------------------------------------------------
     //  default values
@@ -101,7 +98,7 @@ public class ForStStateBackendConfigTest {
         // set the environment variable 'log.file' with the Flink log file location
         System.setProperty("log.file", logFile.getPath());
         try (ForStResourceContainer container =
-                     backend.createOptionsAndResourceContainer(new Path(tempFolder.toString()))) {
+                backend.createOptionsAndResourceContainer(new Path(tempFolder.toString()))) {
             assertEquals(
                     ForStConfigurableOptions.LOG_LEVEL.defaultValue(),
                     container.getDbOptions().infoLogLevel());
@@ -116,8 +113,8 @@ public class ForStStateBackendConfigTest {
             longInstanceBasePath.append("/append-for-long-path");
         }
         try (ForStResourceContainer container =
-                     backend.createOptionsAndResourceContainer(
-                             new Path(longInstanceBasePath.toString()))) {
+                backend.createOptionsAndResourceContainer(
+                        new Path(longInstanceBasePath.toString()))) {
             assertTrue(container.getDbOptions().dbLogDir().isEmpty());
         } finally {
             logFile.delete();
@@ -128,9 +125,7 @@ public class ForStStateBackendConfigTest {
     //  ForSt local file directory
     // ------------------------------------------------------------------------
 
-    /**
-     * This test checks the behavior for basic setting of local DB directories.
-     */
+    /** This test checks the behavior for basic setting of local DB directories. */
     @Test
     public void testSetDbPath() throws Exception {
         final ForStStateBackend forStStateBackend = new ForStStateBackend();
@@ -141,14 +136,14 @@ public class ForStStateBackendConfigTest {
         assertNull(forStStateBackend.getLocalDbStoragePaths());
 
         forStStateBackend.setLocalDbStoragePath(testDir1);
-        assertArrayEquals(new String[]{testDir1}, forStStateBackend.getLocalDbStoragePaths());
+        assertArrayEquals(new String[] {testDir1}, forStStateBackend.getLocalDbStoragePaths());
 
         forStStateBackend.setLocalDbStoragePath(null);
         assertNull(forStStateBackend.getLocalDbStoragePaths());
 
         forStStateBackend.setLocalDbStoragePaths(testDir1, testDir2);
         assertArrayEquals(
-                new String[]{testDir1, testDir2}, forStStateBackend.getLocalDbStoragePaths());
+                new String[] {testDir1, testDir2}, forStStateBackend.getLocalDbStoragePaths());
 
         final MockEnvironment env = getMockEnvironment(tempFolder.newFolder());
         final ForStKeyedStateBackend<Integer> keyedBackend =
@@ -174,7 +169,7 @@ public class ForStStateBackendConfigTest {
         final MockEnvironment env = getMockEnvironment(tempFolder.newFolder());
         ForStStateBackend forStStateBackend = new ForStStateBackend();
         CompressionType[] compressionTypes = {
-                CompressionType.NO_COMPRESSION, CompressionType.SNAPPY_COMPRESSION
+            CompressionType.NO_COMPRESSION, CompressionType.SNAPPY_COMPRESSION
         };
         Configuration conf = new Configuration();
         conf.set(
@@ -256,18 +251,14 @@ public class ForStStateBackendConfigTest {
         }
     }
 
-    /**
-     * Validates that empty arguments for the local DB path are invalid.
-     */
+    /** Validates that empty arguments for the local DB path are invalid. */
     @Test(expected = IllegalArgumentException.class)
     public void testSetEmptyPaths() throws Exception {
         ForStStateBackend forStStateBackend = new ForStStateBackend();
         forStStateBackend.setLocalDbStoragePaths();
     }
 
-    /**
-     * Validates that schemes other than 'file:/' are not allowed.
-     */
+    /** Validates that schemes other than 'file:/' are not allowed. */
     @Test(expected = IllegalArgumentException.class)
     public void testNonFileSchemePath() throws Exception {
         ForStStateBackend forStStateBackend = new ForStStateBackend();
@@ -535,15 +526,15 @@ public class ForStStateBackendConfigTest {
                     ForStConfigurableOptions.COMPACT_FILTER_PERIODIC_COMPACTION_TIME.key(), "1h");
 
             try (ForStResourceContainer optionsContainer =
-                         new ForStResourceContainer(
-                                 configuration,
-                                 null,
-                                 null,
-                                 ForStPathContainer.empty(),
-                                 null,
-                                 null,
-                                 null,
-                                 false)) {
+                    new ForStResourceContainer(
+                            configuration,
+                            null,
+                            null,
+                            ForStPathContainer.empty(),
+                            null,
+                            null,
+                            null,
+                            false)) {
 
                 DBOptions dbOptions = optionsContainer.getDbOptions();
                 assertEquals(-1, dbOptions.maxOpenFiles());
@@ -592,7 +583,7 @@ public class ForStStateBackendConfigTest {
         assertTrue(forStStateBackend.getForStOptions() instanceof TestOptionsFactory);
 
         try (ForStResourceContainer optionsContainer =
-                     forStStateBackend.createOptionsAndResourceContainer(null)) {
+                forStStateBackend.createOptionsAndResourceContainer(null)) {
             DBOptions dbOptions = optionsContainer.getDbOptions();
             assertEquals(4, dbOptions.maxBackgroundJobs());
         }
@@ -616,7 +607,7 @@ public class ForStStateBackendConfigTest {
                 });
 
         try (ForStResourceContainer optionsContainer =
-                     forStStateBackend.createOptionsAndResourceContainer(null)) {
+                forStStateBackend.createOptionsAndResourceContainer(null)) {
             ColumnFamilyOptions colCreated = optionsContainer.getColumnOptions();
             assertEquals(CompactionStyle.FIFO, colCreated.compactionStyle());
         }
@@ -627,15 +618,15 @@ public class ForStStateBackendConfigTest {
         Configuration configuration = new Configuration();
         configuration.set(ForStConfigurableOptions.COMPACTION_STYLE, CompactionStyle.UNIVERSAL);
         try (final ForStResourceContainer optionsContainer =
-                     new ForStResourceContainer(
-                             configuration,
-                             null,
-                             null,
-                             ForStPathContainer.empty(),
-                             null,
-                             null,
-                             null,
-                             false)) {
+                new ForStResourceContainer(
+                        configuration,
+                        null,
+                        null,
+                        ForStPathContainer.empty(),
+                        null,
+                        null,
+                        null,
+                        false)) {
 
             final ColumnFamilyOptions columnFamilyOptions = optionsContainer.getColumnOptions();
             assertNotNull(columnFamilyOptions);
@@ -643,15 +634,15 @@ public class ForStStateBackendConfigTest {
         }
 
         try (final ForStResourceContainer optionsContainer =
-                     new ForStResourceContainer(
-                             new Configuration(),
-                             null,
-                             null,
-                             ForStPathContainer.empty(),
-                             null,
-                             null,
-                             null,
-                             false)) {
+                new ForStResourceContainer(
+                        new Configuration(),
+                        null,
+                        null,
+                        ForStPathContainer.empty(),
+                        null,
+                        null,
+                        null,
+                        false)) {
 
             final ColumnFamilyOptions columnFamilyOptions = optionsContainer.getColumnOptions();
             assertNotNull(columnFamilyOptions);
@@ -678,7 +669,7 @@ public class ForStStateBackendConfigTest {
                 };
 
         try (final ForStResourceContainer optionsContainer =
-                     new ForStResourceContainer(optionsFactory)) {
+                new ForStResourceContainer(optionsFactory)) {
 
             final ColumnFamilyOptions columnFamilyOptions = optionsContainer.getColumnOptions();
             assertNotNull(columnFamilyOptions);
@@ -697,9 +688,9 @@ public class ForStStateBackendConfigTest {
         original.setForStOptions(optionsFactory);
 
         final String[] localDirs =
-                new String[]{
-                        tempFolder.newFolder().getAbsolutePath(),
-                        tempFolder.newFolder().getAbsolutePath()
+                new String[] {
+                    tempFolder.newFolder().getAbsolutePath(),
+                    tempFolder.newFolder().getAbsolutePath()
                 };
         original.setLocalDbStoragePaths(localDirs);
 
@@ -822,7 +813,7 @@ public class ForStStateBackendConfigTest {
                 ForStConfigurableOptions.COMPACT_FILTER_PERIODIC_COMPACTION_TIME.key(), "1d");
         forStStateBackend = forStStateBackend.configure(configuration, getClass().getClassLoader());
         try (ForStResourceContainer resourceContainer =
-                     forStStateBackend.createOptionsAndResourceContainer(null)) {
+                forStStateBackend.createOptionsAndResourceContainer(null)) {
             assertEquals(Duration.ofDays(1), resourceContainer.getPeriodicCompactionTime());
         }
     }
@@ -835,7 +826,7 @@ public class ForStStateBackendConfigTest {
                 ForStConfigurableOptions.COMPACT_FILTER_QUERY_TIME_AFTER_NUM_ENTRIES.key(), "100");
         forStStateBackend = forStStateBackend.configure(configuration, getClass().getClassLoader());
         try (ForStResourceContainer resourceContainer =
-                     forStStateBackend.createOptionsAndResourceContainer(null)) {
+                forStStateBackend.createOptionsAndResourceContainer(null)) {
             assertEquals(100L, resourceContainer.getQueryTimeAfterNumEntries().longValue());
         }
     }
@@ -898,9 +889,7 @@ public class ForStStateBackendConfigTest {
         }
     }
 
-    /**
-     * An implementation of options factory for testing.
-     */
+    /** An implementation of options factory for testing. */
     public static class TestOptionsFactory implements ConfigurableForStOptionsFactory {
         public static final ConfigOption<Integer> BACKGROUND_JOBS_OPTION =
                 ConfigOptions.key("my.custom.forst.backgroundJobs").intType().defaultValue(2);

--- a/flink-state-backends/flink-statebackend-forst/src/test/java/org/apache/flink/state/forst/ForStStateBackendConfigTest.java
+++ b/flink-state-backends/flink-statebackend-forst/src/test/java/org/apache/flink/state/forst/ForStStateBackendConfigTest.java
@@ -82,10 +82,13 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-/** Tests for configuring the ForSt State Backend. */
+/**
+ * Tests for configuring the ForSt State Backend.
+ */
 public class ForStStateBackendConfigTest {
 
-    @Rule public final TemporaryFolder tempFolder = new TemporaryFolder();
+    @Rule
+    public final TemporaryFolder tempFolder = new TemporaryFolder();
 
     // ------------------------------------------------------------------------
     //  default values
@@ -98,7 +101,7 @@ public class ForStStateBackendConfigTest {
         // set the environment variable 'log.file' with the Flink log file location
         System.setProperty("log.file", logFile.getPath());
         try (ForStResourceContainer container =
-                backend.createOptionsAndResourceContainer(new Path(tempFolder.toString()))) {
+                     backend.createOptionsAndResourceContainer(new Path(tempFolder.toString()))) {
             assertEquals(
                     ForStConfigurableOptions.LOG_LEVEL.defaultValue(),
                     container.getDbOptions().infoLogLevel());
@@ -113,8 +116,8 @@ public class ForStStateBackendConfigTest {
             longInstanceBasePath.append("/append-for-long-path");
         }
         try (ForStResourceContainer container =
-                backend.createOptionsAndResourceContainer(
-                        new Path(longInstanceBasePath.toString()))) {
+                     backend.createOptionsAndResourceContainer(
+                             new Path(longInstanceBasePath.toString()))) {
             assertTrue(container.getDbOptions().dbLogDir().isEmpty());
         } finally {
             logFile.delete();
@@ -125,7 +128,9 @@ public class ForStStateBackendConfigTest {
     //  ForSt local file directory
     // ------------------------------------------------------------------------
 
-    /** This test checks the behavior for basic setting of local DB directories. */
+    /**
+     * This test checks the behavior for basic setting of local DB directories.
+     */
     @Test
     public void testSetDbPath() throws Exception {
         final ForStStateBackend forStStateBackend = new ForStStateBackend();
@@ -136,14 +141,14 @@ public class ForStStateBackendConfigTest {
         assertNull(forStStateBackend.getLocalDbStoragePaths());
 
         forStStateBackend.setLocalDbStoragePath(testDir1);
-        assertArrayEquals(new String[] {testDir1}, forStStateBackend.getLocalDbStoragePaths());
+        assertArrayEquals(new String[]{testDir1}, forStStateBackend.getLocalDbStoragePaths());
 
         forStStateBackend.setLocalDbStoragePath(null);
         assertNull(forStStateBackend.getLocalDbStoragePaths());
 
         forStStateBackend.setLocalDbStoragePaths(testDir1, testDir2);
         assertArrayEquals(
-                new String[] {testDir1, testDir2}, forStStateBackend.getLocalDbStoragePaths());
+                new String[]{testDir1, testDir2}, forStStateBackend.getLocalDbStoragePaths());
 
         final MockEnvironment env = getMockEnvironment(tempFolder.newFolder());
         final ForStKeyedStateBackend<Integer> keyedBackend =
@@ -169,7 +174,7 @@ public class ForStStateBackendConfigTest {
         final MockEnvironment env = getMockEnvironment(tempFolder.newFolder());
         ForStStateBackend forStStateBackend = new ForStStateBackend();
         CompressionType[] compressionTypes = {
-            CompressionType.NO_COMPRESSION, CompressionType.SNAPPY_COMPRESSION
+                CompressionType.NO_COMPRESSION, CompressionType.SNAPPY_COMPRESSION
         };
         Configuration conf = new Configuration();
         conf.set(
@@ -251,14 +256,18 @@ public class ForStStateBackendConfigTest {
         }
     }
 
-    /** Validates that empty arguments for the local DB path are invalid. */
+    /**
+     * Validates that empty arguments for the local DB path are invalid.
+     */
     @Test(expected = IllegalArgumentException.class)
     public void testSetEmptyPaths() throws Exception {
         ForStStateBackend forStStateBackend = new ForStStateBackend();
         forStStateBackend.setLocalDbStoragePaths();
     }
 
-    /** Validates that schemes other than 'file:/' are not allowed. */
+    /**
+     * Validates that schemes other than 'file:/' are not allowed.
+     */
     @Test(expected = IllegalArgumentException.class)
     public void testNonFileSchemePath() throws Exception {
         ForStStateBackend forStStateBackend = new ForStStateBackend();
@@ -526,15 +535,15 @@ public class ForStStateBackendConfigTest {
                     ForStConfigurableOptions.COMPACT_FILTER_PERIODIC_COMPACTION_TIME.key(), "1h");
 
             try (ForStResourceContainer optionsContainer =
-                    new ForStResourceContainer(
-                            configuration,
-                            null,
-                            null,
-                            ForStPathContainer.empty(),
-                            null,
-                            null,
-                            null,
-                            false)) {
+                         new ForStResourceContainer(
+                                 configuration,
+                                 null,
+                                 null,
+                                 ForStPathContainer.empty(),
+                                 null,
+                                 null,
+                                 null,
+                                 false)) {
 
                 DBOptions dbOptions = optionsContainer.getDbOptions();
                 assertEquals(-1, dbOptions.maxOpenFiles());
@@ -583,7 +592,7 @@ public class ForStStateBackendConfigTest {
         assertTrue(forStStateBackend.getForStOptions() instanceof TestOptionsFactory);
 
         try (ForStResourceContainer optionsContainer =
-                forStStateBackend.createOptionsAndResourceContainer(null)) {
+                     forStStateBackend.createOptionsAndResourceContainer(null)) {
             DBOptions dbOptions = optionsContainer.getDbOptions();
             assertEquals(4, dbOptions.maxBackgroundJobs());
         }
@@ -607,7 +616,7 @@ public class ForStStateBackendConfigTest {
                 });
 
         try (ForStResourceContainer optionsContainer =
-                forStStateBackend.createOptionsAndResourceContainer(null)) {
+                     forStStateBackend.createOptionsAndResourceContainer(null)) {
             ColumnFamilyOptions colCreated = optionsContainer.getColumnOptions();
             assertEquals(CompactionStyle.FIFO, colCreated.compactionStyle());
         }
@@ -618,15 +627,15 @@ public class ForStStateBackendConfigTest {
         Configuration configuration = new Configuration();
         configuration.set(ForStConfigurableOptions.COMPACTION_STYLE, CompactionStyle.UNIVERSAL);
         try (final ForStResourceContainer optionsContainer =
-                new ForStResourceContainer(
-                        configuration,
-                        null,
-                        null,
-                        ForStPathContainer.empty(),
-                        null,
-                        null,
-                        null,
-                        false)) {
+                     new ForStResourceContainer(
+                             configuration,
+                             null,
+                             null,
+                             ForStPathContainer.empty(),
+                             null,
+                             null,
+                             null,
+                             false)) {
 
             final ColumnFamilyOptions columnFamilyOptions = optionsContainer.getColumnOptions();
             assertNotNull(columnFamilyOptions);
@@ -634,15 +643,15 @@ public class ForStStateBackendConfigTest {
         }
 
         try (final ForStResourceContainer optionsContainer =
-                new ForStResourceContainer(
-                        new Configuration(),
-                        null,
-                        null,
-                        ForStPathContainer.empty(),
-                        null,
-                        null,
-                        null,
-                        false)) {
+                     new ForStResourceContainer(
+                             new Configuration(),
+                             null,
+                             null,
+                             ForStPathContainer.empty(),
+                             null,
+                             null,
+                             null,
+                             false)) {
 
             final ColumnFamilyOptions columnFamilyOptions = optionsContainer.getColumnOptions();
             assertNotNull(columnFamilyOptions);
@@ -669,7 +678,7 @@ public class ForStStateBackendConfigTest {
                 };
 
         try (final ForStResourceContainer optionsContainer =
-                new ForStResourceContainer(optionsFactory)) {
+                     new ForStResourceContainer(optionsFactory)) {
 
             final ColumnFamilyOptions columnFamilyOptions = optionsContainer.getColumnOptions();
             assertNotNull(columnFamilyOptions);
@@ -688,9 +697,9 @@ public class ForStStateBackendConfigTest {
         original.setForStOptions(optionsFactory);
 
         final String[] localDirs =
-                new String[] {
-                    tempFolder.newFolder().getAbsolutePath(),
-                    tempFolder.newFolder().getAbsolutePath()
+                new String[]{
+                        tempFolder.newFolder().getAbsolutePath(),
+                        tempFolder.newFolder().getAbsolutePath()
                 };
         original.setLocalDbStoragePaths(localDirs);
 
@@ -813,7 +822,7 @@ public class ForStStateBackendConfigTest {
                 ForStConfigurableOptions.COMPACT_FILTER_PERIODIC_COMPACTION_TIME.key(), "1d");
         forStStateBackend = forStStateBackend.configure(configuration, getClass().getClassLoader());
         try (ForStResourceContainer resourceContainer =
-                forStStateBackend.createOptionsAndResourceContainer(null)) {
+                     forStStateBackend.createOptionsAndResourceContainer(null)) {
             assertEquals(Duration.ofDays(1), resourceContainer.getPeriodicCompactionTime());
         }
     }
@@ -826,8 +835,22 @@ public class ForStStateBackendConfigTest {
                 ForStConfigurableOptions.COMPACT_FILTER_QUERY_TIME_AFTER_NUM_ENTRIES.key(), "100");
         forStStateBackend = forStStateBackend.configure(configuration, getClass().getClassLoader());
         try (ForStResourceContainer resourceContainer =
-                forStStateBackend.createOptionsAndResourceContainer(null)) {
+                     forStStateBackend.createOptionsAndResourceContainer(null)) {
             assertEquals(100L, resourceContainer.getQueryTimeAfterNumEntries().longValue());
+        }
+    }
+
+    @Test
+    public void testConfigureCheckpointTransferThreadNumber() throws Exception {
+        ForStStateBackend forStStateBackend = new ForStStateBackend();
+        Configuration configuration = new Configuration();
+        configuration.setString(
+                ForStOptions.CHECKPOINT_TRANSFER_THREAD_NUM.key(), "10");
+        forStStateBackend = forStStateBackend.configure(configuration, getClass().getClassLoader());
+
+        try (ForStResourceContainer resourceContainer =
+                     forStStateBackend.createOptionsAndResourceContainer(null)) {
+            assertEquals(10, resourceContainer.getDataTransferThreadNum());
         }
     }
 
@@ -875,7 +898,9 @@ public class ForStStateBackendConfigTest {
         }
     }
 
-    /** An implementation of options factory for testing. */
+    /**
+     * An implementation of options factory for testing.
+     */
     public static class TestOptionsFactory implements ConfigurableForStOptionsFactory {
         public static final ConfigOption<Integer> BACKGROUND_JOBS_OPTION =
                 ConfigOptions.key("my.custom.forst.backgroundJobs").intType().defaultValue(2);

--- a/flink-state-backends/flink-statebackend-forst/src/test/java/org/apache/flink/state/forst/ForStStateBackendConfigTest.java
+++ b/flink-state-backends/flink-statebackend-forst/src/test/java/org/apache/flink/state/forst/ForStStateBackendConfigTest.java
@@ -835,12 +835,11 @@ public class ForStStateBackendConfigTest {
     public void testConfigureCheckpointTransferThreadNumber() throws Exception {
         ForStStateBackend forStStateBackend = new ForStStateBackend();
         Configuration configuration = new Configuration();
-        configuration.setString(
-                ForStOptions.CHECKPOINT_TRANSFER_THREAD_NUM.key(), "10");
+        configuration.setString(ForStOptions.CHECKPOINT_TRANSFER_THREAD_NUM.key(), "10");
         forStStateBackend = forStStateBackend.configure(configuration, getClass().getClassLoader());
 
         try (ForStResourceContainer resourceContainer =
-                     forStStateBackend.createOptionsAndResourceContainer(null)) {
+                forStStateBackend.createOptionsAndResourceContainer(null)) {
             assertEquals(10, resourceContainer.getDataTransferThreadNum());
         }
     }

--- a/flink-state-backends/flink-statebackend-forst/src/test/java/org/apache/flink/state/forst/snapshot/ForStIncrementalSnapshotStrategyTest.java
+++ b/flink-state-backends/flink-statebackend-forst/src/test/java/org/apache/flink/state/forst/snapshot/ForStIncrementalSnapshotStrategyTest.java
@@ -199,7 +199,7 @@ class ForStIncrementalSnapshotStrategyTest {
                 CompositeKeySerializationUtils.computeRequiredBytesInKeyGroupPrefix(2),
                 UUID.randomUUID(),
                 new TreeMap<>(),
-                new ForStStateDataTransfer(5),
+                new ForStStateDataTransfer(4),
                 -1);
     }
 
@@ -231,7 +231,7 @@ class ForStIncrementalSnapshotStrategyTest {
                 new KeyGroupRange(0, 1),
                 CompositeKeySerializationUtils.computeRequiredBytesInKeyGroupPrefix(2),
                 UUID.randomUUID(),
-                new ForStStateDataTransfer(5));
+                new ForStStateDataTransfer(4));
     }
 
     private FsCheckpointStreamFactory createFsCheckpointStreamFactory() throws IOException {

--- a/flink-state-backends/flink-statebackend-forst/src/test/java/org/apache/flink/state/forst/snapshot/ForStIncrementalSnapshotStrategyTest.java
+++ b/flink-state-backends/flink-statebackend-forst/src/test/java/org/apache/flink/state/forst/snapshot/ForStIncrementalSnapshotStrategyTest.java
@@ -200,7 +200,8 @@ class ForStIncrementalSnapshotStrategyTest {
                 CompositeKeySerializationUtils.computeRequiredBytesInKeyGroupPrefix(2),
                 UUID.randomUUID(),
                 new TreeMap<>(),
-                new ForStStateDataTransfer(ForStOptions.CHECKPOINT_TRANSFER_THREAD_NUM.defaultValue()),
+                new ForStStateDataTransfer(
+                        ForStOptions.CHECKPOINT_TRANSFER_THREAD_NUM.defaultValue()),
                 -1);
     }
 
@@ -232,7 +233,8 @@ class ForStIncrementalSnapshotStrategyTest {
                 new KeyGroupRange(0, 1),
                 CompositeKeySerializationUtils.computeRequiredBytesInKeyGroupPrefix(2),
                 UUID.randomUUID(),
-                new ForStStateDataTransfer(ForStOptions.CHECKPOINT_TRANSFER_THREAD_NUM.defaultValue()));
+                new ForStStateDataTransfer(
+                        ForStOptions.CHECKPOINT_TRANSFER_THREAD_NUM.defaultValue()));
     }
 
     private FsCheckpointStreamFactory createFsCheckpointStreamFactory() throws IOException {

--- a/flink-state-backends/flink-statebackend-forst/src/test/java/org/apache/flink/state/forst/snapshot/ForStIncrementalSnapshotStrategyTest.java
+++ b/flink-state-backends/flink-statebackend-forst/src/test/java/org/apache/flink/state/forst/snapshot/ForStIncrementalSnapshotStrategyTest.java
@@ -199,7 +199,7 @@ class ForStIncrementalSnapshotStrategyTest {
                 CompositeKeySerializationUtils.computeRequiredBytesInKeyGroupPrefix(2),
                 UUID.randomUUID(),
                 new TreeMap<>(),
-                new ForStStateDataTransfer(4),
+                new ForStStateDataTransfer(ForStOptions.CHECKPOINT_TRANSFER_THREAD_NUM.defaultValue()),
                 -1);
     }
 

--- a/flink-state-backends/flink-statebackend-forst/src/test/java/org/apache/flink/state/forst/snapshot/ForStIncrementalSnapshotStrategyTest.java
+++ b/flink-state-backends/flink-statebackend-forst/src/test/java/org/apache/flink/state/forst/snapshot/ForStIncrementalSnapshotStrategyTest.java
@@ -33,6 +33,7 @@ import org.apache.flink.runtime.state.filesystem.FsCheckpointStreamFactory;
 import org.apache.flink.runtime.state.v2.RegisteredKeyValueStateBackendMetaInfo;
 import org.apache.flink.state.forst.ForStExtension;
 import org.apache.flink.state.forst.ForStOperationUtils;
+import org.apache.flink.state.forst.ForStOptions;
 import org.apache.flink.state.forst.datatransfer.ForStStateDataTransfer;
 import org.apache.flink.testutils.junit.utils.TempDirUtils;
 
@@ -231,7 +232,7 @@ class ForStIncrementalSnapshotStrategyTest {
                 new KeyGroupRange(0, 1),
                 CompositeKeySerializationUtils.computeRequiredBytesInKeyGroupPrefix(2),
                 UUID.randomUUID(),
-                new ForStStateDataTransfer(4));
+                new ForStStateDataTransfer(ForStOptions.CHECKPOINT_TRANSFER_THREAD_NUM.defaultValue()));
     }
 
     private FsCheckpointStreamFactory createFsCheckpointStreamFactory() throws IOException {

--- a/flink-state-backends/flink-statebackend-forst/src/test/java/org/apache/flink/state/forst/snapshot/ForStIncrementalSnapshotStrategyTest.java
+++ b/flink-state-backends/flink-statebackend-forst/src/test/java/org/apache/flink/state/forst/snapshot/ForStIncrementalSnapshotStrategyTest.java
@@ -199,7 +199,7 @@ class ForStIncrementalSnapshotStrategyTest {
                 CompositeKeySerializationUtils.computeRequiredBytesInKeyGroupPrefix(2),
                 UUID.randomUUID(),
                 new TreeMap<>(),
-                new ForStStateDataTransfer(ForStStateDataTransfer.DEFAULT_THREAD_NUM),
+                new ForStStateDataTransfer(5),
                 -1);
     }
 
@@ -231,7 +231,7 @@ class ForStIncrementalSnapshotStrategyTest {
                 new KeyGroupRange(0, 1),
                 CompositeKeySerializationUtils.computeRequiredBytesInKeyGroupPrefix(2),
                 UUID.randomUUID(),
-                new ForStStateDataTransfer(ForStStateDataTransfer.DEFAULT_THREAD_NUM));
+                new ForStStateDataTransfer(5));
     }
 
     private FsCheckpointStreamFactory createFsCheckpointStreamFactory() throws IOException {


### PR DESCRIPTION
## What is the purpose of the change

Currently the number of threads used by the `ForStStateDataTransfer` class is hardcoded to 4. This PR proposes a new `state.backend.forst.checkpoint.transfer.thread.num` configuration option that allows for providing a custom thread number value.

## Brief change log
- Added a new `state.backend.forst.checkpoint.transfer.thread.num` config option
- Updated the `ForStResourceContainer` with a getter to return this option value
- Updated `ForStStateDataTransfer` to provide the new config option value instead of the hardcoded default of 4
- Removed the hardcoded default



## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: / no
  - The serializers: no 
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented?  Documentation has been added using the existing `ConfigOption` class
