### PR TITLE
[FLINK-39901][ci] Remove obsolete github-actions Maven profile that broke all JDK 11 nightly runs

### DIFF
--- a/.github/workflows/template.flink-ci.yml
+++ b/.github/workflows/template.flink-ci.yml
@@ -285,7 +285,7 @@ jobs:
           DOCKER_HOST: unix:///var/run/docker.sock
         timeout-minutes: ${{ fromJSON(env.GHA_JOB_TIMEOUT) }}
         run: |
-          runuser -u flink -- bash -c '${{ inputs.environment }} PROFILE="$PROFILE -Pgithub-actions" ./tools/azure-pipelines/uploading_watchdog.sh \
+          runuser -u flink -- bash -c '${{ inputs.environment }} ./tools/azure-pipelines/uploading_watchdog.sh \
               ./tools/ci/test_controller.sh ${{ matrix.module }}'
 
       - name: "Post-build Disk Info"
@@ -430,7 +430,7 @@ jobs:
           IT_CASE_S3_SECRET_KEY: ${{ secrets.s3_secret_key }}
         timeout-minutes: ${{ fromJSON(env.GHA_JOB_TIMEOUT) }}
         run: |
-          ${{ inputs.environment }} FLINK_DIR=`pwd`/build-target PROFILE="$PROFILE -Pgithub-actions" ./tools/azure-pipelines/uploading_watchdog.sh \
+          ${{ inputs.environment }} FLINK_DIR=`pwd`/build-target ./tools/azure-pipelines/uploading_watchdog.sh \
             flink-end-to-end-tests/run-nightly-tests.sh ${{ matrix.group }}
 
       - name: "Upload Logs"

--- a/pom.xml
+++ b/pom.xml
@@ -211,7 +211,6 @@ under the License.
 		     of entries in the form '[-]{2}add-[opens|exports]=<module>/<package>=ALL-UNNAMED'.-->
 		<surefire.module.config/>
 
-		<surefire.excludedGroups.github-actions/>
 		<surefire.excludedGroups.adaptive-scheduler/>
 		<surefire.excludedGroups.jdk/>
 
@@ -1027,34 +1026,12 @@ under the License.
 								<flink.tests.enable-adaptive-scheduler>true</flink.tests.enable-adaptive-scheduler>
 							</systemProperties>
 							<excludedGroups>
-								${surefire.excludedGroups.github-actions},
 								${surefire.excludedGroups.adaptive-scheduler},
 								${surefire.excludedGroups.jdk}
 							</excludedGroups>
 						</configuration>
 					</plugin>
 				</plugins>
-			</build>
-		</profile>
-
-		<profile>
-			<id>github-actions</id>
-			<build>
-				<pluginManagement>
-					<plugins>
-						<plugin>
-							<groupId>org.apache.maven.plugins</groupId>
-							<artifactId>maven-surefire-plugin</artifactId>
-							<configuration>
-								<excludedGroups>
-									${surefire.excludedGroups.github-actions},
-									${surefire.excludedGroups.adaptive-scheduler},
-									${surefire.excludedGroups.jdk},
-								</excludedGroups>
-							</configuration>
-						</plugin>
-					</plugins>
-				</pluginManagement>
 			</build>
 		</profile>
 
@@ -1104,9 +1081,8 @@ under the License.
 							<artifactId>maven-surefire-plugin</artifactId>
 							<configuration>
 								<excludedGroups>
-									${surefire.excludedGroups.github-actions},
 									${surefire.excludedGroups.adaptive-scheduler},
-									${surefire.excludedGroups.jdk},
+									${surefire.excludedGroups.jdk}
 								</excludedGroups>
 							</configuration>
 						</plugin>
@@ -1140,31 +1116,6 @@ under the License.
 						</configuration>
 					</plugin>
 				</plugins>
-			</build>
-		</profile>
-
-		<profile>
-			<id>java21</id>
-			<activation>
-				<jdk>[21,)</jdk>
-			</activation>
-
-			<build>
-				<pluginManagement>
-					<plugins>
-						<plugin>
-							<groupId>org.apache.maven.plugins</groupId>
-							<artifactId>maven-surefire-plugin</artifactId>
-							<configuration>
-								<excludedGroups>
-									${surefire.excludedGroups.github-actions},
-									${surefire.excludedGroups.adaptive-scheduler},
-									${surefire.excludedGroups.jdk},
-								</excludedGroups>
-							</configuration>
-						</plugin>
-					</plugins>
-				</pluginManagement>
 			</build>
 		</profile>
 
@@ -1212,9 +1163,8 @@ under the License.
 							<artifactId>maven-surefire-plugin</artifactId>
 							<configuration>
 								<excludedGroups>
-									${surefire.excludedGroups.github-actions},
 									${surefire.excludedGroups.adaptive-scheduler},
-									${surefire.excludedGroups.jdk},
+									${surefire.excludedGroups.jdk}
 								</excludedGroups>
 							</configuration>
 						</plugin>


### PR DESCRIPTION
## What is the purpose of the change

Every GitHub Actions nightly run on master since 2026-05-27 deterministically fails all five `Java 11 / Test (module: …)` jobs plus the Java 11 E2E groups 1 and 4 with:

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-surefire-plugin:3.2.2:test (default-test) on project flink-tests:
org.junit.platform.commons.PreconditionViolationException: list of tag expressions must not be null or empty
```

Since FLINK-33903 removed the `FailsInGHAContainerWithRootUser` group (and all tests tagged with it), the `github-actions` profile no longer excludes anything; it only composes `<excludedGroups>` out of three placeholder properties. After FLINK-39750 dropped `FailsOnJava11`, all three placeholders resolve to the empty string on JDK 11 (the `java17` profile, which provides the only remaining non-empty value, is not active there). Surefire then passes a blank tag list to JUnit, which fails every module before running a single test. Only GitHub Actions passes `-Pgithub-actions`, which is why Azure CI is unaffected. First broken nightly: run 26488072578 (2026-05-27); the May 26 nightly did not show this signature yet.

This PR removes the dead profile, the two `-Pgithub-actions` flags in the workflow template, and the `java21` profile whose only content was a surefire block identical to the one in the always-co-active `java17` profile. After this change, every remaining `<excludedGroups>` block lives in a profile that defines at least one non-empty group property of its own, so the blank composition cannot recur when another `FailsOnJavaX` tag is dropped (note: `FailsOnJava17` currently has no remaining usages either).

## Brief change log

  - Remove the `github-actions` Maven profile and the `surefire.excludedGroups.github-actions` property/placeholders from `pom.xml`
  - Remove the redundant `java21` profile (its surefire configuration was identical to the `java17` profile, which is active on every JDK >= 17)
  - Stop passing `-Pgithub-actions` in the test and e2e steps of `.github/workflows/template.flink-ci.yml`

## Verifying this change

This change is a code cleanup of the Maven/CI configuration, verified manually:

  - Reproduced the nightly failure locally on the unmodified pom with `mvn test -pl flink-metrics/flink-metrics-core -am -P 'github-actions,!java17' -Dtest=MeterViewTest` (simulates the JDK 11 leg where neither `java17` nor any group property is set) — fails with the exact `PreconditionViolationException` from CI
  - Same scenario on this branch (`-P '!java17'`) runs the tests: `Tests run: 4, Failures: 0, BUILD SUCCESS`
  - On JDK >= 17 the effective surefire configuration still resolves to `<excludedGroups>, org.apache.flink.testutils.junit.FailsOnJava17</excludedGroups>` (verified via `mvn -X`), so JDK-version-based exclusion is unchanged
  - The next nightly runs after merging should no longer fail the `Java 11 / Test` modules and Java 11 E2E groups deterministically

Master-only: release branches do not contain FLINK-39750 and still use `FailsInGHAContainerWithRootUser`, so this must not be backported as-is.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (Claude Code)

Generated-by: Claude Code (Fable 5)
