### PR TITLE
[FLINK-39884][ci] Run free_disk_space.sh in the GitHub Actions e2e jobs

### DIFF
--- a/.github/actions/job_init/action.yml
+++ b/.github/actions/job_init/action.yml
@@ -34,6 +34,10 @@ inputs:
     description: "Specifies the directory to which the code should be moved to (needed for containerized runs; not setting this parameter will omit moving the checkout)."
     required: false
     default: ""
+  free_disk_space:
+    description: "Runs tools/azure-pipelines/free_disk_space.sh to remove unneeded pre-installed software from the runner (only works for jobs that run directly on the host, not in a container)."
+    required: false
+    default: "false"
 runs:
   using: "composite"
   steps:
@@ -48,7 +52,13 @@ runs:
       shell: bash
       run: df -h
 
+    - name: "Free up disk space"
+      if: ${{ inputs.free_disk_space == 'true' }}
+      shell: bash
+      run: ./tools/azure-pipelines/free_disk_space.sh
+
     - name: "Delete unused binaries"
+      if: ${{ inputs.free_disk_space != 'true' }}
       shell: bash
       run: |
         # inspired by https://github.com/easimon/maximize-build-space

--- a/.github/workflows/template.flink-ci.yml
+++ b/.github/workflows/template.flink-ci.yml
@@ -357,6 +357,9 @@ jobs:
         with:
           jdk_version: ${{ inputs.jdk_version }}
           maven_repo_folder: ${{ env.MAVEN_REPO_FOLDER }}
+          # the e2e tests download and generate more than 17GB of files; the e2e job runs
+          # directly on the host (not in a container), so the runner's disk can be cleaned up
+          free_disk_space: "true"
 
       - name: "Setup python"
         uses: actions/setup-python@v6


### PR DESCRIPTION
## What is the purpose of the change

Follow-up to FLINK-39884, which extended `tools/azure-pipelines/free_disk_space.sh` to free roughly 34GB on the CI machines. That cleanup so far only runs on Azure; the GitHub Actions `job_init` action only removes the Android SDK, CodeQL and .NET.

The GHA e2e jobs run directly on the ubuntu-24.04 runner (not in the CI container) and download/generate more than 17GB of files, so they benefit from the same cleanup as the Azure e2e jobs on the identical runner image.

## Brief change log

  - Add an opt-in `free_disk_space` input to `.github/actions/job_init` that runs `tools/azure-pipelines/free_disk_space.sh` instead of the smaller inline cleanup
  - Enable it for the e2e jobs in `.github/workflows/template.flink-ci.yml`

The input is opt-in because the compile/packaging/test jobs run inside the CI container, where the runner's disk cannot be cleaned up (the existing inline cleanup remains in place for them).

## Verifying this change

This change is a CI configuration change without test coverage. The existing `df -h` steps before/after `job_init` will show the reclaimed space (~30GB expected) in the e2e job logs of the next runs. The script preserves `/opt/hostedtoolcache/Python` and the JDKs under `/usr/lib/jvm`, which the subsequent `setup-python` and `JAVA_HOME_<version>_X64` steps rely on; the Docker image prune happens before the e2e job loads its cached testcontainers images.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (Claude Code)

Generated-by: Claude Code (Fable 5)