### PR TITLE
[FLINK-39879][tests] Avoid deploy RPC timeout in CheckpointAcknowledgeFailureITCase

### DIFF
--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/CheckpointAcknowledgeFailureITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/CheckpointAcknowledgeFailureITCase.java
@@ -68,8 +68,11 @@ public class CheckpointAcknowledgeFailureITCase extends TestLogger {
     // let all the state go via checkpoint ACK RPC to exceed frame size limit
     private static final MemorySize IN_MEM_STATE_THRESHOLD = new MemorySize(STATE_SIZE * 2);
 
-    // let pekko time out checkpoint ACK
-    private static final Duration ASK_TIMEOUT = Duration.ofMillis(250);
+    // The oversized checkpoint ACK exceeds the pekko frame size, so it can never be delivered and
+    // always surfaces as an AskTimeoutException; this ask timeout only controls how quickly that
+    // surfaces, not whether the ACK fails. Because it is the cluster-wide RPC timeout it also
+    // covers task deployment, so keep it large enough that deployment does not time out on slow CI.
+    private static final Duration ASK_TIMEOUT = Duration.ofSeconds(1);
     // do NOT let flink time out the checkpoint
     private static final Duration CHECKPOINT_TIMEOUT = ASK_TIMEOUT.multipliedBy(1000);
 


### PR DESCRIPTION
## What is the purpose of the change

`CheckpointAcknowledgeFailureITCase.testCheckpointAckFailure` still fails on slow CI after the hang fix. The 250 ms `pekko.ask.timeout` set by the test is load-bearing (it forces the oversized checkpoint ACK to time out, which the test asserts on), but it is the cluster-wide RPC timeout and therefore also governs task deployment. On a slow machine the deployment ask itself exceeds 250 ms, so the job fails (recovery suppressed by `NoRestartBackoffTimeStrategy`) before the keyed state is updated.

## Brief change log

  - Raise `ASK_TIMEOUT` from 250 ms to 1 s. `CHECKPOINT_TIMEOUT` stays `ASK_TIMEOUT * 1000`, so the oversized ACK is still what times out and the `AskTimeoutException` assertion is unchanged, while task deployment gets headroom on slow CI.

## Verifying this change

This change is already covered by the existing `testCheckpointAckFailure` assertion (the `AskTimeoutException` check is unchanged); it only removes a slow-CI deploy-timeout flake. Verified by running the test repeatedly locally.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (Claude Opus 4.8 (1M context))

Generated-by: Claude Opus 4.8 (1M context)
