### PR TITLE
[FLINK-39902][tests] Fix race in RescaleTimelineITCase.testRescaleTerminatedByJobFinished

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/timeline/RescaleTimelineITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/timeline/RescaleTimelineITCase.java
@@ -276,11 +276,19 @@ class RescaleTimelineITCase {
 
         waitForVertexParallelismReachedAndJobRunning(jobGraph, JOB_VERTEX_ID, PARALLELISM);
 
+        assumeThat(enabledRescaleHistory(configuration)).isTrue();
+
         updateJobResourceRequirements(miniCluster, jobGraph, 1, PARALLELISM * 2);
+
+        // The upper bound (PARALLELISM * 2) exceeds the available slots, so this rescale is only
+        // recorded in the history without changing the parallelism. Wait until it is recorded
+        // before unblocking, otherwise on a slow machine the task can finish first and the size-2
+        // condition below times out.
+        waitUntilConditionWithTimeout(
+                () -> getRescaleHistory(miniCluster, jobGraph).size() == 2, 10000);
 
         OnceBlockingNoOpInvokable.unblock();
 
-        assumeThat(enabledRescaleHistory(configuration)).isTrue();
         waitUntilConditionWithTimeout(
                 () -> {
                     List<Rescale> rescaleHistory = getRescaleHistory(miniCluster, jobGraph);


### PR DESCRIPTION
## What is the purpose of the change

`RescaleTimelineITCase.testRescaleTerminatedByJobFinished` is flaky on slow CI. The test requests an upscale to a parallelism that exceeds the available slots, so the rescale never changes the running parallelism and is only observable as a recorded history entry. It then unblocks the no-op task immediately, racing the scheduler recording that second rescale: on a slow machine the job finishes before the rescale is recorded, the history stays at size 1, and the size-2 wait times out.

## Brief change log

  - Wait until the second rescale has been recorded (history size 2) before unblocking the task, so the in-progress rescale resolves to `JOB_FINISHED` once the job finishes.
  - Move the `assumeThat(enabledRescaleHistory(...))` skip ahead of the requirement update so the disabled-history variant skips cleanly.

## Verifying this change

Existing assertions are unchanged; the fix only enforces the ordering the sibling tests already get. Verified by running `testRescaleTerminatedByJobFinished` repeatedly in a loop locally without failure.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (Claude Opus 4.8 (1M context))

Generated-by: Claude Opus 4.8 (1M context)
