### PR TITLE
[FLINK-39903][tests] Fix race in RescaleTimelineITCase.testRescaleTerminatedByResourceRequirementsUpdated

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/timeline/RescaleTimelineITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/timeline/RescaleTimelineITCase.java
@@ -384,6 +384,49 @@ class RescaleTimelineITCase {
 
     @TestTemplate
     void testRescaleTerminatedByResourceRequirementsUpdated() throws Exception {
+        // This case only asserts on the recorded rescale history; skip the disabled-history
+        // parameter before the cluster rebuild below so it does not pay for an unused cluster.
+        assumeThat(enabledRescaleHistory(configuration)).isTrue();
+
+        // This test asserts that the second resource-requirements update terminates the in-progress
+        // rescale started by the first update with terminal reason RESOURCE_REQUIREMENTS_UPDATED.
+        // For that to happen the second update must be processed while the first rescale is still
+        // in-progress: AdaptiveScheduler#recordRescaleForNewResourceRequirements only sets the
+        // RESOURCE_REQUIREMENTS_UPDATED reason via RescaleTimeline#updateRescale, which is a no-op
+        // once the current rescale is already terminated (DefaultRescaleTimeline#isIdling).
+        //
+        // The upper bound exceeds the available slots, so the first rescale cannot change the
+        // parallelism. With the short cooldown/stabilization timeouts shared by the other cases the
+        // DefaultStateTransitionManager re-enters its Idling phase and the Idling constructor
+        // terminates that rescale with NO_RESOURCES_OR_PARALLELISMS_CHANGE (a legitimate terminal
+        // reason for an in-progress rescale that cannot change parallelism). That termination is
+        // driven by wall-clock timers that start the moment the first rescale is recorded, so no
+        // amount of waiting between the two updates can guarantee the second update wins the race;
+        // waiting only consumes the same budget. Widening cooldown and stabilization for this case
+        // is therefore the only deterministic test-side fix: it keeps the in-progress rescale alive
+        // far longer than the single synchronous RPC round trip between the two updates.
+        //
+        // Rebuild the shared fixture cluster in place rather than starting a second one on top of
+        // it, so only one cluster is ever running and the @AfterEach teardown still applies. 60s is
+        // an intentionally generous bound (the suite already uses second-scale guards for slow CI);
+        // the test completes as soon as the second update lands, so a large value has no cost.
+        miniClusterResource.after();
+        final Configuration testConfiguration = new Configuration(configuration);
+        testConfiguration.set(
+                JobManagerOptions.SCHEDULER_EXECUTING_COOLDOWN_AFTER_RESCALING,
+                Duration.ofSeconds(60));
+        testConfiguration.set(
+                JobManagerOptions.SCHEDULER_EXECUTING_RESOURCE_STABILIZATION_TIMEOUT,
+                Duration.ofSeconds(60));
+        miniClusterResource =
+                new MiniClusterResource(
+                        new MiniClusterResourceConfiguration.Builder()
+                                .setConfiguration(testConfiguration)
+                                .setNumberSlotsPerTaskManager(NUMBER_SLOTS_PER_TASK_MANAGER)
+                                .setNumberTaskManagers(NUMBER_TASK_MANAGERS)
+                                .build());
+        miniClusterResource.before();
+
         final MiniCluster miniCluster = miniClusterResource.getMiniCluster();
         final JobGraph jobGraph = createBlockingJobGraph(PARALLELISM);
         miniCluster.submitJob(jobGraph).join();


### PR DESCRIPTION
## What is the purpose of the change

`RescaleTimelineITCase.testRescaleTerminatedByResourceRequirementsUpdated` is flaky on slow CI. It asserts that the second `updateJobResourceRequirements` RPC terminates the in-progress rescale started by the first update with terminal reason `RESOURCE_REQUIREMENTS_UPDATED`. That setter is a no-op once the rescale is already terminated. With the short cooldown (100 ms) and resource-stabilization (50 ms) timeouts shared by the parameterized configuration, the `DefaultStateTransitionManager` re-enters Idling and terminates the rescale with `NO_RESOURCES_OR_PARALLELISMS_CHANGE` before the second update is processed on a slow machine, producing the flaky assertion failure. This is a test-side timing assumption, not a product bug.

## Brief change log

  - For this case only, rebuild the fixture cluster in place with widened cooldown/stabilization (60 s) so the in-progress rescale stays alive across the single synchronous RPC round trip between the two updates.
  - The shared parameterized configuration used by the other cases is left untouched; the disabled-history parameter is skipped up front so it does not pay for a cluster rebuild it never asserts on.

## Verifying this change

Existing assertions are unchanged. Verified by running `testRescaleTerminatedByResourceRequirementsUpdated` repeatedly in a loop locally without failure.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (Claude Opus 4.8 (1M context))

Generated-by: Claude Opus 4.8 (1M context)
