### PR TITLE
[FLINK-35012][table] Fix flaky ChangelogNormalizeRestoreTest by adding padding records to prevent mini-batch merging

### DIFF
--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/ChangelogNormalizeTestPrograms.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/ChangelogNormalizeTestPrograms.java
@@ -54,6 +54,7 @@ public class ChangelogNormalizeTestPrograms {
         Row.ofKind(RowKind.UPDATE_BEFORE, "four", 4, "d"),
         Row.ofKind(RowKind.UPDATE_AFTER, "four", 4, "dd"),
         Row.ofKind(RowKind.INSERT, "six", 6, "f"),
+        Row.ofKind(RowKind.DELETE, "seven", 7, "g"),
         Row.ofKind(RowKind.DELETE, "six", 6, "f")
     };
 


### PR DESCRIPTION
## What is the purpose of the change

Fix the flaky `ChangelogNormalizeRestoreTest.testRestore` failure for the `changelog-normalize-source-mini-batch` variant. The test intermittently fails because `INSERT "six"` and `DELETE "six"` can end up in the same mini-batch, causing `addInput` to overwrite the INSERT with the DELETE, resulting in both records being silently dropped.

## Brief change log

- *[ChangelogNormalizeTestPrograms.java]* Added one no-op `DELETE` padding record (`"seven"`) to `AFTER_DATA` to ensure `INSERT "six"` and `DELETE "six"` are always separated into different mini-batches by `CountBundleTrigger(size=2)`, regardless of processing-time watermark timing.

## Verifying this change

This change is a test-only fix. The existing `ChangelogNormalizeRestoreTest.testRestore` test validates correctness. The padding DELETE records target non-existent keys, so they produce no output and do not affect `AFTER_OUTPUT` expectations.

## Does this pull request potentially affect one of the following parts

- Dependencies (does it add or upgrade a dependency): no
- The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
- The serializers: no
- The runtime per-record code paths (performance sensitive): no
- Anything that affects deployment or recovery: JobManager (and its components), Currentity, Coordination, Zookeeper: no
- The S3 file system connector: no

## Documentation

- Does this pull request introduce a new feature? no
- If yes, how is the feature documented? not applicable