### PR TITLE
[FLINK-35276][table] Fix incorrect sort order for floating-point negative zero in generated comparators

### DIFF
--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/GenerateUtils.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/GenerateUtils.scala
@@ -632,7 +632,11 @@ object GenerateUtils {
       val sortUtil =
         classOf[org.apache.flink.table.runtime.operators.sort.SortUtil].getCanonicalName
       s"$sortUtil.compareBinary($leftTerm, $rightTerm)"
-    case TINYINT | SMALLINT | INTEGER | BIGINT | FLOAT | DOUBLE | DATE | TIME_WITHOUT_TIME_ZONE |
+    case FLOAT =>
+      s"Float.compare($leftTerm, $rightTerm)"
+    case DOUBLE =>
+      s"Double.compare($leftTerm, $rightTerm)"
+    case TINYINT | SMALLINT | INTEGER | BIGINT | DATE | TIME_WITHOUT_TIME_ZONE |
         INTERVAL_YEAR_MONTH | INTERVAL_DAY_TIME =>
       s"($leftTerm > $rightTerm ? 1 : $leftTerm < $rightTerm ? -1 : 0)"
     case TIMESTAMP_WITH_TIME_ZONE | MULTISET | MAP | VARIANT | BITMAP =>

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/codegen/SortCodeGeneratorTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/codegen/SortCodeGeneratorTest.java
@@ -119,6 +119,7 @@ class SortCodeGeneratorTest {
 
     private RowType inputType;
     private SortSpec sortSpec;
+    private BinaryRowData[] customTestData;
 
     private static final DataType INT_ROW_TYPE =
             DataTypes.ROW(DataTypes.FIELD("f0", DataTypes.INT())).bridgedTo(Row.class);
@@ -135,6 +136,26 @@ class SortCodeGeneratorTest {
             new RowTypeInfo(new RowTypeInfo(Types.INT))
                     .createComparator(
                             new int[] {0}, new boolean[] {true}, 0, new ExecutionConfig());
+
+    @Test
+    void testFloatNegativeZeroSortKey() throws Exception {
+        inputType =
+                RowType.of(
+                        new TypeInformationRawType<>(Types.INT),
+                        new FloatType(),
+                        new BooleanType());
+        sortSpec =
+                SortSpec.builder()
+                        .addField(0, true, SortUtil.getNullDefaultOrder(true))
+                        .addField(1, true, SortUtil.getNullDefaultOrder(true))
+                        .build();
+        customTestData = buildNegativeZeroFloatTestData();
+        try {
+            testInner();
+        } finally {
+            customTestData = null;
+        }
+    }
 
     @Test
     void testMultiKeys() throws Exception {
@@ -212,7 +233,22 @@ class SortCodeGeneratorTest {
         return row;
     }
 
+    private BinaryRowData[] buildNegativeZeroFloatTestData() {
+        Object[][] values = new Object[3][];
+        values[0] = new Object[] {RawValueData.fromObject(0), RawValueData.fromObject(0)};
+        values[1] = new Object[] {0.0f, -0.0f};
+        values[2] = new Object[] {false, true};
+        BinaryRowData[] result = new BinaryRowData[2];
+        for (int i = 0; i < result.length; i++) {
+            result[i] = row(i, values);
+        }
+        return result;
+    }
+
     private BinaryRowData[] getTestData() {
+        if (customTestData != null) {
+            return customTestData;
+        }
         BinaryRowData[] result = new BinaryRowData[RECORD_NUM];
         Object[][] values = new Object[inputType.getFieldCount()][];
         for (int i = 0; i < inputType.getFieldCount(); i++) {
@@ -477,7 +513,9 @@ class SortCodeGeneratorTest {
 
         List<BinaryRowData> data = Arrays.asList(dataArray.clone());
         List<BinaryRowData> binaryRows = Arrays.asList(dataArray.clone());
-        Collections.shuffle(binaryRows);
+        if (customTestData == null) {
+            Collections.shuffle(binaryRows);
+        }
 
         for (BinaryRowData row : binaryRows) {
             if (!sortBuffer.write(row)) {


### PR DESCRIPTION
## What is the purpose of the change

The generated sort comparator in `GenerateUtils.scala` uses the ternary expression `(a > b ? 1 : a < b ? -1 : 0)` for FLOAT and DOUBLE types, which treats `0.0` and `-0.0` as equal. This causes `SortCodeGeneratorTest.testMultiKeys` to fail intermittently when random test data contains negative zero, because the Java reference sort uses `Float.compare()` / `Double.compare()` which distinguish `+0.0` from `-0.0`.

## Brief change log

- *`GenerateUtils.scala`*: Split FLOAT and DOUBLE out of the integer comparison branch; generate `Float.compare()` / `Double.compare()` calls instead of the ternary expression
- *`SortCodeGeneratorTest.java`*: Add `testFloatNegativeZeroSortKey()` with deterministic `0.0f` / `-0.0f` test data to verify the fix without relying on random seed probability

## Verifying this change

This change added a new test `SortCodeGeneratorTest#testFloatNegativeZeroSortKey` that constructs rows with `0.0f` and `-0.0f` sort keys and asserts the generated comparator produces the same order as the Java reference sort.

The existing `testMultiKeys` (100 random iterations) also covers this path and will no longer flake.

## Does this pull request potentially affect one of the following parts

- Dependencies (does it add or upgrade a dependency): no
- The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
- The serializers: no
- The runtime per-record code paths (performance sensitive): yes — sort comparison is on the per-record path, but `Float.compare()` / `Double.compare()` are JIT intrinsics with negligible overhead compared to the previous ternary expression
- Anything that affects deployment or recovery: no
- The (broadcasting) coordination functionality: no

## Documentation

- Does this pull request introduce a new feature? no
- If not, how is the change documented? Not applicable.