### PR TITLE
[FLINK-35275][table] Fix ArrayContainsFunction using incorrect element type from needle argument

### DIFF
--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CollectionFunctionsITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CollectionFunctionsITCase.java
@@ -175,6 +175,11 @@ class CollectionFunctionsITCase extends BuiltInFunctionTestBase {
                                 true,
                                 DataTypes.BOOLEAN().nullable())
                         .testResult(
+                                $("f4").arrayContains(lit(0, DataTypes.INT().notNull())),
+                                "ARRAY_CONTAINS(f4, 0)",
+                                false,
+                                DataTypes.BOOLEAN().nullable())
+                        .testResult(
                                 $("f5").arrayContains(lit(null, DataTypes.INT())),
                                 "ARRAY_CONTAINS(f5, CAST(NULL AS INT))",
                                 false,
@@ -188,6 +193,10 @@ class CollectionFunctionsITCase extends BuiltInFunctionTestBase {
                                 $("f5").arrayContains(lit(3, DataTypes.INT().notNull())),
                                 "ARRAY_CONTAINS(f5, 3)",
                                 true,
+                                DataTypes.BOOLEAN().notNull())
+                        .testSqlResult(
+                                "ARRAY_CONTAINS(ARRAY[1, NULL], 0)",
+                                false,
                                 DataTypes.BOOLEAN().notNull())
                         // invalid signatures
                         .testSqlValidationError(

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/ArrayContainsFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/ArrayContainsFunction.java
@@ -25,6 +25,7 @@ import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
 import org.apache.flink.table.functions.FunctionContext;
 import org.apache.flink.table.functions.SpecializedFunction.ExpressionEvaluator;
 import org.apache.flink.table.functions.SpecializedFunction.SpecializedContext;
+import org.apache.flink.table.types.CollectionDataType;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.util.FlinkRuntimeException;
 
@@ -44,13 +45,16 @@ public class ArrayContainsFunction extends BuiltInScalarFunction {
 
     public ArrayContainsFunction(SpecializedContext context) {
         super(BuiltInFunctionDefinitions.ARRAY_CONTAINS, context);
+        final DataType elementDataType =
+                ((CollectionDataType) context.getCallContext().getArgumentDataTypes().get(0))
+                        .getElementDataType();
         final DataType needleDataType = context.getCallContext().getArgumentDataTypes().get(1);
-        elementGetter = ArrayData.createElementGetter(needleDataType.getLogicalType());
+        elementGetter = ArrayData.createElementGetter(elementDataType.getLogicalType());
         equalityEvaluator =
                 context.createEvaluator(
                         $("element").isEqual($("needle")),
                         DataTypes.BOOLEAN(),
-                        DataTypes.FIELD("element", needleDataType.notNull().toInternal()),
+                        DataTypes.FIELD("element", elementDataType.notNull().toInternal()),
                         DataTypes.FIELD("needle", needleDataType.notNull().toInternal()));
     }
 


### PR DESCRIPTION
## What is the purpose of the change

`ArrayContainsFunction` incorrectly used the needle (second argument) data type to create the `ElementGetter` and the `equalityEvaluator`'s element field. When the array element type differs from the needle type in nullability (e.g., `ARRAY<INT NULL>` with a `NOT NULL` needle), the element getter reads array data with the wrong type, causing incorrect results or runtime errors.

## Brief change log

- *[ArrayContainsFunction]* Extract the true element type from `CollectionDataType.getElementDataType()` of the first argument (the array) instead of reusing the needle's data type.
- *[ArrayContainsFunction]* Use `elementDataType` for `ArrayData.createElementGetter()` and the `"element"` field of the equality evaluator; keep `needleDataType` only for the `"needle"` field.
- *[CollectionFunctionsITCase]* Add test cases for `ARRAY_CONTAINS` where the array contains NULL elements and the needle is a NOT NULL literal that is not present in the array.

## Verifying this change

This change added tests in `CollectionFunctionsITCase`:

- `ARRAY_CONTAINS(f4, 0)` where `f4 = ARRAY[1, NULL]` → asserts `false` (Table API + SQL)
- `ARRAY_CONTAINS(ARRAY[1, NULL], 0)` → asserts `false` (SQL only, inline array literal)

These tests fail without the fix due to type mismatch in the element getter.

## Does this pull request potentially affect one of the following parts

- Dependencies (does it add or upgrade a dependency): no
- The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
- The serializers: no
- The runtime per-record code paths (performance sensitive): no
- Anything that affects deployment or recovery: no
- The S3 file system connector: no

## Documentation

- Does this pull request introduce a new feature? no
- If not, how is the change documented? Not applicable.