### PR TITLE
[FLINK-39889][table] Thread USING CONNECTION clause into CatalogTable and CreateTableOperation

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/CatalogPropertiesUtil.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/CatalogPropertiesUtil.java
@@ -96,6 +96,9 @@ public final class CatalogPropertiesUtil {
             final Optional<TableDistribution> distribution = resolvedTable.getDistribution();
             distribution.ifPresent(d -> serializeTableDistribution(properties, d));
 
+            final Optional<UnresolvedIdentifier> connection = resolvedTable.getConnection();
+            connection.ifPresent(c -> serializeConnection(properties, c));
+
             properties.putAll(resolvedTable.getOptions());
 
             properties.remove(IS_GENERIC); // reserved option
@@ -251,6 +254,8 @@ public final class CatalogPropertiesUtil {
             final @Nullable TableDistribution distribution =
                     deserializeTableDistribution(properties);
 
+            final @Nullable UnresolvedIdentifier connection = deserializeConnection(properties);
+
             return CatalogTable.newBuilder()
                     .schema(schema)
                     .comment(comment)
@@ -258,6 +263,7 @@ public final class CatalogPropertiesUtil {
                     .distribution(distribution)
                     .options(options)
                     .snapshot(snapshot)
+                    .connection(connection)
                     .build();
         } catch (Exception e) {
             throw new CatalogException("Error in deserializing catalog table.", e);
@@ -445,12 +451,17 @@ public final class CatalogPropertiesUtil {
 
     private static final String DISTRIBUTION_KEYS = compoundKey(DISTRIBUTION, KEYS);
 
+    private static final String CONNECTION = "connection";
+
+    private static final String CONNECTION_IDENTIFIER = compoundKey(CONNECTION, "identifier");
+
     private static Map<String, String> deserializeOptions(Map<String, String> map) {
         return map.entrySet().stream()
                 .filter(
                         e -> {
                             final String key = e.getKey();
                             return !key.startsWith(DISTRIBUTION + SEPARATOR)
+                                    && !key.startsWith(CONNECTION + SEPARATOR)
                                     && !key.startsWith(PARTITION_KEYS + SEPARATOR)
                                     && !key.startsWith(SCHEMA)
                                     && !key.equals(COMMENT)
@@ -650,6 +661,34 @@ public final class CatalogPropertiesUtil {
                 distribution.getBucketKeys().stream()
                         .map(Collections::singletonList)
                         .collect(Collectors.toList()));
+    }
+
+    private static void serializeConnection(
+            Map<String, String> map, UnresolvedIdentifier connection) {
+        final List<String> parts = new ArrayList<>();
+        connection.getCatalogName().ifPresent(parts::add);
+        connection.getDatabaseName().ifPresent(parts::add);
+        parts.add(connection.getObjectName());
+
+        putIndexedProperties(
+                map,
+                CONNECTION_IDENTIFIER,
+                Collections.singletonList(NAME),
+                parts.stream().map(Collections::singletonList).collect(Collectors.toList()));
+    }
+
+    private static UnresolvedIdentifier deserializeConnection(Map<String, String> map) {
+        final List<String> parts = new ArrayList<>();
+        int i = 0;
+        String partKey = compoundKey(CONNECTION_IDENTIFIER, i, NAME);
+        while (map.containsKey(partKey)) {
+            parts.add(getValue(map, partKey));
+            partKey = compoundKey(CONNECTION_IDENTIFIER, ++i, NAME);
+        }
+        if (parts.isEmpty()) {
+            return null;
+        }
+        return UnresolvedIdentifier.of(parts);
     }
 
     private static void serializeResolvedModelSchema(

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/CatalogTable.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/CatalogTable.java
@@ -109,6 +109,14 @@ public interface CatalogTable extends CatalogBaseTable {
         return Optional.empty();
     }
 
+    /**
+     * Returns the identifier of the connection that this table uses if the {@code USING CONNECTION}
+     * clause is defined.
+     */
+    default Optional<UnresolvedIdentifier> getConnection() {
+        return Optional.empty();
+    }
+
     // --------------------------------------------------------------------------------------------
 
     /** Builder for configuring and creating instances of {@link CatalogTable}. */
@@ -120,6 +128,7 @@ public interface CatalogTable extends CatalogBaseTable {
         private Map<String, String> options = Collections.emptyMap();
         private @Nullable Long snapshot;
         private @Nullable TableDistribution distribution;
+        private @Nullable UnresolvedIdentifier connection;
 
         private Builder() {}
 
@@ -154,9 +163,14 @@ public interface CatalogTable extends CatalogBaseTable {
             return this;
         }
 
+        public Builder connection(@Nullable UnresolvedIdentifier connection) {
+            this.connection = connection;
+            return this;
+        }
+
         public CatalogTable build() {
             return new DefaultCatalogTable(
-                    schema, comment, partitionKeys, options, snapshot, distribution);
+                    schema, comment, partitionKeys, options, snapshot, distribution, connection);
         }
     }
 }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/DefaultCatalogTable.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/DefaultCatalogTable.java
@@ -42,6 +42,7 @@ public class DefaultCatalogTable implements CatalogTable {
     private final List<String> partitionKeys;
     private final Map<String, String> options;
     private final @Nullable Long snapshot;
+    private final @Nullable UnresolvedIdentifier connection;
 
     protected DefaultCatalogTable(
             Schema schema,
@@ -58,12 +59,24 @@ public class DefaultCatalogTable implements CatalogTable {
             Map<String, String> options,
             @Nullable Long snapshot,
             @Nullable TableDistribution distribution) {
+        this(schema, comment, partitionKeys, options, snapshot, distribution, null);
+    }
+
+    protected DefaultCatalogTable(
+            Schema schema,
+            @Nullable String comment,
+            List<String> partitionKeys,
+            Map<String, String> options,
+            @Nullable Long snapshot,
+            @Nullable TableDistribution distribution,
+            @Nullable UnresolvedIdentifier connection) {
         this.schema = checkNotNull(schema, "Schema must not be null.");
         this.comment = comment;
         this.partitionKeys = checkNotNull(partitionKeys, "Partition keys must not be null.");
         this.options = checkNotNull(options, "Options must not be null.");
         this.snapshot = snapshot;
         this.distribution = distribution;
+        this.connection = connection;
 
         checkArgument(
                 options.entrySet().stream()
@@ -97,6 +110,11 @@ public class DefaultCatalogTable implements CatalogTable {
     }
 
     @Override
+    public Optional<UnresolvedIdentifier> getConnection() {
+        return Optional.ofNullable(connection);
+    }
+
+    @Override
     public Map<String, String> getOptions() {
         return options;
     }
@@ -109,13 +127,13 @@ public class DefaultCatalogTable implements CatalogTable {
     @Override
     public CatalogBaseTable copy() {
         return new DefaultCatalogTable(
-                schema, comment, partitionKeys, options, snapshot, distribution);
+                schema, comment, partitionKeys, options, snapshot, distribution, connection);
     }
 
     @Override
     public CatalogTable copy(Map<String, String> options) {
         return new DefaultCatalogTable(
-                schema, comment, partitionKeys, options, snapshot, distribution);
+                schema, comment, partitionKeys, options, snapshot, distribution, connection);
     }
 
     @Override
@@ -142,12 +160,14 @@ public class DefaultCatalogTable implements CatalogTable {
                 && Objects.equals(distribution, that.distribution)
                 && partitionKeys.equals(that.partitionKeys)
                 && options.equals(that.options)
-                && Objects.equals(snapshot, that.snapshot);
+                && Objects.equals(snapshot, that.snapshot)
+                && Objects.equals(connection, that.connection);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(schema, comment, distribution, partitionKeys, options, snapshot);
+        return Objects.hash(
+                schema, comment, distribution, partitionKeys, options, snapshot, connection);
     }
 
     @Override
@@ -166,6 +186,8 @@ public class DefaultCatalogTable implements CatalogTable {
                 + ConfigurationUtils.hideSensitiveValues(options, List.of())
                 + ", snapshot="
                 + snapshot
+                + ", connection="
+                + connection
                 + '}';
     }
 }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/ResolvedCatalogTable.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/ResolvedCatalogTable.java
@@ -146,6 +146,11 @@ public final class ResolvedCatalogTable
     }
 
     @Override
+    public Optional<UnresolvedIdentifier> getConnection() {
+        return origin.getConnection();
+    }
+
+    @Override
     public ResolvedCatalogTable copy(Map<String, String> options) {
         return new ResolvedCatalogTable(origin.copy(options), resolvedSchema);
     }

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/catalog/CatalogPropertiesUtilTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/catalog/CatalogPropertiesUtilTest.java
@@ -160,6 +160,13 @@ class CatalogPropertiesUtilTest {
                                 .distribution(rangeDist)
                                 .build(),
                         resolvedSchema),
+                new ResolvedCatalogTable(
+                        CatalogTable.newBuilder()
+                                .schema(schema)
+                                .comment("some comment")
+                                .connection(UnresolvedIdentifier.of("mycat", "mydb", "myconn"))
+                                .build(),
+                        resolvedSchema),
                 new ResolvedCatalogMaterializedTable(
                         CatalogMaterializedTable.newBuilder()
                                 .schema(schema)

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/table/AbstractCreateTableConverter.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/table/AbstractCreateTableConverter.java
@@ -73,6 +73,11 @@ public abstract class AbstractCreateTableConverter<T extends SqlCreateTable>
         final Map<String, String> tableOptions = mergeContext.getMergedTableOptions();
         final TableDistribution distribution =
                 mergeContext.getMergedTableDistribution().orElse(null);
+        final UnresolvedIdentifier connection =
+                sqlCreateTable
+                        .getConnection()
+                        .map(c -> UnresolvedIdentifier.of(c.names))
+                        .orElse(null);
         final String comment = sqlCreateTable.getComment();
         final CatalogTable catalogTable =
                 CatalogTable.newBuilder()
@@ -81,6 +86,7 @@ public abstract class AbstractCreateTableConverter<T extends SqlCreateTable>
                         .distribution(distribution)
                         .options(tableOptions)
                         .partitionKeys(partitionKeys)
+                        .connection(connection)
                         .build();
         return context.getCatalogManager().resolveCatalogTable(catalogTable);
     }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlDdlToOperationConverterTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlDdlToOperationConverterTest.java
@@ -45,6 +45,7 @@ import org.apache.flink.table.catalog.ResolvedSchema;
 import org.apache.flink.table.catalog.TableChange;
 import org.apache.flink.table.catalog.TableDistribution;
 import org.apache.flink.table.catalog.TableDistribution.Kind;
+import org.apache.flink.table.catalog.UnresolvedIdentifier;
 import org.apache.flink.table.catalog.exceptions.DatabaseNotExistException;
 import org.apache.flink.table.catalog.exceptions.FunctionAlreadyExistException;
 import org.apache.flink.table.expressions.DefaultSqlFactory;
@@ -109,6 +110,7 @@ import static org.apache.flink.table.planner.operations.SqlDdlToOperationConvert
 import static org.apache.flink.table.planner.utils.OperationMatchers.entry;
 import static org.apache.flink.table.planner.utils.OperationMatchers.isCreateTableOperation;
 import static org.apache.flink.table.planner.utils.OperationMatchers.partitionedBy;
+import static org.apache.flink.table.planner.utils.OperationMatchers.withConnection;
 import static org.apache.flink.table.planner.utils.OperationMatchers.withDistribution;
 import static org.apache.flink.table.planner.utils.OperationMatchers.withNoDistribution;
 import static org.apache.flink.table.planner.utils.OperationMatchers.withOptions;
@@ -656,6 +658,31 @@ class SqlDdlToOperationConverterTest extends SqlNodeToOperationConversionTestBas
                                         withDistribution(
                                                 TableDistribution.ofUnknown(
                                                         Collections.singletonList("a"), null)))));
+    }
+
+    @Test
+    void testCreateTableWithConnection() {
+        final String sql =
+                "create table derivedTable(\n"
+                        + "  a int\n"
+                        + ")\n"
+                        + "USING CONNECTION mycat.mydb.myconn";
+        Operation operation = parseAndConvert(sql);
+        assertThat(operation)
+                .is(
+                        new HamcrestCondition<>(
+                                isCreateTableOperation(
+                                        withConnection(
+                                                UnresolvedIdentifier.of(
+                                                        "mycat", "mydb", "myconn")))));
+    }
+
+    @Test
+    void testCreateTableWithoutConnection() {
+        final String sql = "create table derivedTable(\n" + "  a int\n" + ")";
+        Operation operation = parseAndConvert(sql);
+        assertThat(operation)
+                .is(new HamcrestCondition<>(isCreateTableOperation(withConnection(null))));
     }
 
     @Test

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlDdlToOperationConverterTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlDdlToOperationConverterTest.java
@@ -110,7 +110,6 @@ import static org.apache.flink.table.planner.operations.SqlDdlToOperationConvert
 import static org.apache.flink.table.planner.utils.OperationMatchers.entry;
 import static org.apache.flink.table.planner.utils.OperationMatchers.isCreateTableOperation;
 import static org.apache.flink.table.planner.utils.OperationMatchers.partitionedBy;
-import static org.apache.flink.table.planner.utils.OperationMatchers.withConnection;
 import static org.apache.flink.table.planner.utils.OperationMatchers.withDistribution;
 import static org.apache.flink.table.planner.utils.OperationMatchers.withNoDistribution;
 import static org.apache.flink.table.planner.utils.OperationMatchers.withOptions;
@@ -663,26 +662,24 @@ class SqlDdlToOperationConverterTest extends SqlNodeToOperationConversionTestBas
     @Test
     void testCreateTableWithConnection() {
         final String sql =
-                "create table derivedTable(\n"
-                        + "  a int\n"
+                "CREATE TABLE derivedTable(\n"
+                        + "  a INT\n"
                         + ")\n"
                         + "USING CONNECTION mycat.mydb.myconn";
         Operation operation = parseAndConvert(sql);
-        assertThat(operation)
-                .is(
-                        new HamcrestCondition<>(
-                                isCreateTableOperation(
-                                        withConnection(
-                                                UnresolvedIdentifier.of(
-                                                        "mycat", "mydb", "myconn")))));
+        assertThat(operation).isInstanceOf(CreateTableOperation.class);
+        CreateTableOperation op = (CreateTableOperation) operation;
+        assertThat(op.getCatalogTable().getConnection())
+                .hasValue(UnresolvedIdentifier.of("mycat", "mydb", "myconn"));
     }
 
     @Test
     void testCreateTableWithoutConnection() {
-        final String sql = "create table derivedTable(\n" + "  a int\n" + ")";
+        final String sql = "CREATE TABLE derivedTable(\n" + "  a INT\n" + ")";
         Operation operation = parseAndConvert(sql);
-        assertThat(operation)
-                .is(new HamcrestCondition<>(isCreateTableOperation(withConnection(null))));
+        assertThat(operation).isInstanceOf(CreateTableOperation.class);
+        CreateTableOperation op = (CreateTableOperation) operation;
+        assertThat(op.getCatalogTable().getConnection()).isEmpty();
     }
 
     @Test

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlDdlToOperationConverterTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlDdlToOperationConverterTest.java
@@ -24,6 +24,7 @@ import org.apache.flink.sql.parser.error.SqlValidateException;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.Schema;
 import org.apache.flink.table.api.SqlDialect;
+import org.apache.flink.table.api.SqlParserException;
 import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.catalog.Catalog;
 import org.apache.flink.table.catalog.CatalogDatabaseImpl;
@@ -90,6 +91,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import javax.annotation.Nullable;
 
@@ -680,6 +682,38 @@ class SqlDdlToOperationConverterTest extends SqlNodeToOperationConversionTestBas
         assertThat(operation).isInstanceOf(CreateTableOperation.class);
         CreateTableOperation op = (CreateTableOperation) operation;
         assertThat(op.getCatalogTable().getConnection()).isEmpty();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"mycat....mydb....myconn", ".", "...", ".2.2."})
+    void testCreateTableWithMalformedConnectionNameFailsToParse(String connectionName) {
+        final String sql = "CREATE TABLE derivedTable(a INT) USING CONNECTION " + connectionName;
+        assertThatThrownBy(() -> parseAndConvert(sql)).isInstanceOf(SqlParserException.class);
+    }
+
+    @Test
+    void testCreateTableWithTooManyConnectionNameParts() {
+        final String sql =
+                "CREATE TABLE derivedTable(a INT) USING CONNECTION mycat.mydb.mygroup.myconn";
+        assertThatThrownBy(() -> parseAndConvert(sql))
+                .isInstanceOf(ValidationException.class)
+                .hasMessageContaining("Object identifier must consist of 1 to 3 parts.");
+    }
+
+    @Test
+    void testCreateTableWithWhitespaceOnlyConnectionNamePart() {
+        final String sql = "CREATE TABLE derivedTable(a INT) USING CONNECTION mycat.`   `.myconn";
+        assertThatThrownBy(() -> parseAndConvert(sql))
+                .isInstanceOf(ValidationException.class)
+                .hasMessageContaining(
+                        "Parts of the object identifier are null or whitespace-only.");
+    }
+
+    @Test
+    void testCreateTableWithUnicodeConnectionName() {
+        final String sql = "CREATE TABLE derivedTable(a INT) USING CONNECTION `😍.😍`";
+        CreateTableOperation op = (CreateTableOperation) parseAndConvert(sql);
+        assertThat(op.getCatalogTable().getConnection()).hasValue(UnresolvedIdentifier.of("😍.😍"));
     }
 
     @Test

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlDdlToOperationConverterTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlDdlToOperationConverterTest.java
@@ -717,6 +717,14 @@ class SqlDdlToOperationConverterTest extends SqlNodeToOperationConversionTestBas
     }
 
     @Test
+    void testCreateTableWithMultibyteConnectionName() {
+        final String sql = "CREATE TABLE derivedTable(a INT) USING CONNECTION `目录`.`Привет`.`café`";
+        CreateTableOperation op = (CreateTableOperation) parseAndConvert(sql);
+        assertThat(op.getCatalogTable().getConnection())
+                .hasValue(UnresolvedIdentifier.of("目录", "Привет", "café"));
+    }
+
+    @Test
     void testCreateTableInvalidDistribution() {
         final String sql =
                 "create table derivedTable(\n" + "  a int\n" + ")\n" + "DISTRIBUTED BY (f3)";

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/utils/OperationMatchers.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/utils/OperationMatchers.java
@@ -20,7 +20,6 @@ package org.apache.flink.table.planner.utils;
 
 import org.apache.flink.table.api.Schema;
 import org.apache.flink.table.catalog.TableDistribution;
-import org.apache.flink.table.catalog.UnresolvedIdentifier;
 import org.apache.flink.table.operations.Operation;
 import org.apache.flink.table.operations.ddl.CreateTableOperation;
 
@@ -142,24 +141,6 @@ public class OperationMatchers {
      */
     public static Matcher<CreateTableOperation> withNoDistribution() {
         return withDistribution(null);
-    }
-
-    /**
-     * Checks that {@link CreateTableOperation} references the given connection identifier from a
-     * {@code USING CONNECTION} clause.
-     *
-     * @see #isCreateTableOperation(Matcher[])
-     */
-    public static Matcher<CreateTableOperation> withConnection(UnresolvedIdentifier connection) {
-        return new FeatureMatcher<CreateTableOperation, Optional<UnresolvedIdentifier>>(
-                equalTo(Optional.ofNullable(connection)),
-                "connection of the derived table",
-                "connection") {
-            @Override
-            protected Optional<UnresolvedIdentifier> featureValueOf(CreateTableOperation actual) {
-                return actual.getCatalogTable().getConnection();
-            }
-        };
     }
 
     /**

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/utils/OperationMatchers.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/utils/OperationMatchers.java
@@ -20,6 +20,7 @@ package org.apache.flink.table.planner.utils;
 
 import org.apache.flink.table.api.Schema;
 import org.apache.flink.table.catalog.TableDistribution;
+import org.apache.flink.table.catalog.UnresolvedIdentifier;
 import org.apache.flink.table.operations.Operation;
 import org.apache.flink.table.operations.ddl.CreateTableOperation;
 
@@ -141,6 +142,24 @@ public class OperationMatchers {
      */
     public static Matcher<CreateTableOperation> withNoDistribution() {
         return withDistribution(null);
+    }
+
+    /**
+     * Checks that {@link CreateTableOperation} references the given connection identifier from a
+     * {@code USING CONNECTION} clause.
+     *
+     * @see #isCreateTableOperation(Matcher[])
+     */
+    public static Matcher<CreateTableOperation> withConnection(UnresolvedIdentifier connection) {
+        return new FeatureMatcher<CreateTableOperation, Optional<UnresolvedIdentifier>>(
+                equalTo(Optional.ofNullable(connection)),
+                "connection of the derived table",
+                "connection") {
+            @Override
+            protected Optional<UnresolvedIdentifier> featureValueOf(CreateTableOperation actual) {
+                return actual.getCatalogTable().getConnection();
+            }
+        };
     }
 
     /**


### PR DESCRIPTION
## What is the purpose of the change

Part of [FLIP-529: Connections in Flink SQL and TableAPI](https://cwiki.apache.org/confluence/display/FLINK/FLIP-529%3A+Connections+in+Flink+SQL+and+TableAPI) (parent: FLINK-38259).

Threads the connection identifier from a parsed `USING CONNECTION` clause in `SqlCreateTable` (added in FLINK-39726) through to `CatalogTable` and the `CreateTableOperation`, mirroring how the optional `distribution` field is wired.

## Brief change log

- Add `Optional<UnresolvedIdentifier> getConnection()` to `CatalogTable` with a `connection()` builder method, and the backing field/accessor in `DefaultCatalogTable` (equals/hashCode/toString/copy updated; existing constructors kept for compatibility).
- Delegate `getConnection()` in `ResolvedCatalogTable`.
- Read `SqlCreateTable.getConnection()` in `AbstractCreateTableConverter` and set it on the built `CatalogTable`, so `CreateTableOperation#getCatalogTable().getConnection()` carries the reference.
- Serialize/deserialize the connection identifier in `CatalogPropertiesUtil` under a reserved `connection.identifier` key, excluded from connector options, so it round-trips through `toProperties`/`fromProperties` and appears in operation summaries.

## Verifying this change

This change added tests and can be verified as follows:

- Added `SqlDdlToOperationConverterTest#testCreateTableWithConnection` / `#testCreateTableWithoutConnection` with a new `OperationMatchers#withConnection` matcher.
- Added a `ResolvedCatalogTable` serde case carrying a connection to `CatalogPropertiesUtilTest#testCatalogTableSerde`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes (`CatalogTable`, `ResolvedCatalogTable` gain an optional getter with a default)
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable (docs will accompany the completed FLIP-529 feature)

---

##### Was generative AI tooling used to co-author this PR?
Yes
