### PR TITLE
[FLINK-38144][state] Fix changelog state backend NPE with null map state values

### DIFF
--- a/flink-core-api/src/main/java/org/apache/flink/api/common/state/MapState.java
+++ b/flink-core-api/src/main/java/org/apache/flink/api/common/state/MapState.java
@@ -35,9 +35,6 @@ import java.util.Map;
  * the current element. That way, the system can handle stream and state partitioning consistently
  * together.
  *
- * <p>The user value could be null, but change log state backend is not compatible with the user
- * value is null, see FLINK-38144 for more details.
- *
  * @param <UK> Type of the keys in the state.
  * @param <UV> Type of the values in the state.
  */

--- a/flink-core-api/src/main/java/org/apache/flink/api/common/state/v2/MapState.java
+++ b/flink-core-api/src/main/java/org/apache/flink/api/common/state/v2/MapState.java
@@ -35,9 +35,6 @@ import java.util.Map;
  * the current element. That way, the system can handle stream and state partitioning consistently
  * together.
  *
- * <p>The user value could be null, but change log state backend is not compatible with the user
- * value is null, see FLINK-38144 for more details.
- *
  * @param <UK> Type of the keys in the state.
  * @param <UV> Type of the values in the state.
  */

--- a/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/ChangelogMapState.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/ChangelogMapState.java
@@ -33,6 +33,7 @@ import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.function.ThrowingConsumer;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Objects;
@@ -77,8 +78,12 @@ class ChangelogMapState<K, N, UK, UV>
             public UV setValue(UV value) {
                 UV oldValue = entry.setValue(value);
                 try {
-                    changeLogger.valueElementAddedOrUpdated(
-                            getWriter(entry.getKey(), entry.getValue()), ns);
+                    if (value == null) {
+                        changeLogger.valueAdded(Collections.singletonMap(entry.getKey(), null), ns);
+                    } else {
+                        changeLogger.valueElementAddedOrUpdated(
+                                getWriter(entry.getKey(), entry.getValue()), ns);
+                    }
                 } catch (IOException e) {
                     ExceptionUtils.rethrow(e);
                 }
@@ -105,7 +110,11 @@ class ChangelogMapState<K, N, UK, UV>
     @Override
     public void put(UK key, UV value) throws Exception {
         delegatedState.put(key, value);
-        changeLogger.valueElementAddedOrUpdated(getWriter(key, value), getCurrentNamespace());
+        if (value == null) {
+            changeLogger.valueAdded(Collections.singletonMap(key, null), getCurrentNamespace());
+        } else {
+            changeLogger.valueElementAddedOrUpdated(getWriter(key, value), getCurrentNamespace());
+        }
     }
 
     @Override

--- a/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/ChangelogDelegateEmbeddedRocksDBStateBackendTest.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/ChangelogDelegateEmbeddedRocksDBStateBackendTest.java
@@ -139,7 +139,6 @@ public class ChangelogDelegateEmbeddedRocksDBStateBackendTest
     // Follow https://issues.apache.org/jira/browse/FLINK-38144
     @Override
     @TestTemplate
-    @Disabled("Currently, ChangelogStateBackend does not support null values for map state")
     public void testMapStateWithNullValue() throws Exception {
         super.testMapStateWithNullValue();
     }

--- a/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/ChangelogDelegateHashMapTest.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/ChangelogDelegateHashMapTest.java
@@ -32,7 +32,6 @@ import org.apache.flink.runtime.state.StateBackend;
 import org.apache.flink.runtime.state.TestTaskStateManager;
 import org.apache.flink.testutils.junit.utils.TempDirUtils;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -115,7 +114,6 @@ public class ChangelogDelegateHashMapTest extends HashMapStateBackendTest {
     // Follow https://issues.apache.org/jira/browse/FLINK-38144
     @Override
     @TestTemplate
-    @Disabled("Currently, ChangelogStateBackend does not support null values for map state")
     public void testMapStateWithNullValue() throws Exception {
         super.testMapStateWithNullValue();
     }


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

ChangelogMapState.put(key, null) and entry.setValue(null) both call getWriter(key, value) which invokes valueSerializer.serialize(null,out) — causing NPE with null-unsafe serializers (IntSerializer, BooleanSerializer, LongSerializer, etc.).


## Brief change log

- Route put(key, null) and entry.setValue(null) through the existing ADD operation path by calling changeLogger.valueAdded(Collections.singletonMap(key, null), ns) instead of getWriter(key, value)
- The ADD path serializes via MapSerializer.serialize() which already has a boolean null-flag protocol
- On restore, MapStateChangeApplier handles ADD by calling mapState.putAll(mapSerializer.deserialize(in)) which correctly reconstructs null values
- Re-enable testMapStateWithNullValue for both changelog delegate test classes
- Remove FLINK-38144 warning javadoc from MapState

## Verifying this change
- Re-enabled ChangelogDelegateEmbeddedRocksDBStateBackendTest#testMapStateWithNullValue
- Re-enabled ChangelogDelegateHashMapTest#testMapStateWithNullValue
- Manually verified with a long-running job: write → checkpoint → savepoint → restore with changelog enabled on both RocksDB and HashMap backends


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change the checkbox below to `[X]` followed by the name of the tool, and uncomment the
"Generated-by" line. See the ASF Generative Tooling Guidance for details:
https://www.apache.org/legal/generative-tooling.html

You are responsible for the quality and correctness of every change in this PR
regardless of the tooling used. Low-effort AI-generated PRs will be closed. See
AGENTS.md for the full guidance.
-->

- [x] Yes (please specify the tool below)
kiro-cli

<!--
Generated-by: [Tool Name and Version]
-->
