### PR TITLE
[FLINK-39910][ci] Update burnett01/rsync-deployments to v8.0.5 for docs workflow

### DIFF
--- a/.github/workflows/docs-legacy.yml
+++ b/.github/workflows/docs-legacy.yml
@@ -84,7 +84,7 @@ jobs:
             bash -c "apt-get update && apt-get install -y rsync && cd /root/flink && ./.github/workflows/docs.sh"
 
       - name: Upload documentation
-        uses: burnett01/rsync-deployments@7659d600d8bdd035bb5cdfba1d4bd0dd4a307ca6 # 8.0.2
+        uses: burnett01/rsync-deployments@66257cad6bfeb2171d3b6bfa6c9a22279dd9c3a1 # 8.0.5
         with:
           switches: --archive --compress --delete --omit-dir-times
           path: docs/target/

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -70,7 +70,7 @@ jobs:
             bash -c "cd /root/flink && ./.github/workflows/docs.sh"
 
       - name: Upload documentation
-        uses: burnett01/rsync-deployments@7659d600d8bdd035bb5cdfba1d4bd0dd4a307ca6 # 8.0.2
+        uses: burnett01/rsync-deployments@66257cad6bfeb2171d3b6bfa6c9a22279dd9c3a1 # 8.0.5
         with:
           switches: --archive --compress --delete
           path: docs/target/
@@ -82,7 +82,7 @@ jobs:
 
       - name: Upload documentation alias
         if: env.flink_alias != ''
-        uses: burnett01/rsync-deployments@7659d600d8bdd035bb5cdfba1d4bd0dd4a307ca6 # 8.0.2
+        uses: burnett01/rsync-deployments@66257cad6bfeb2171d3b6bfa6c9a22279dd9c3a1 # 8.0.5
         with:
           switches: --archive --compress --delete
           path: docs/target/


### PR DESCRIPTION
## What is the purpose of the change

The "Build documentation" GitHub Actions workflow has been failing with `startup_failure` since 2026-05-23. The root cause is that the pinned `burnett01/rsync-deployments@7659d600d8bdd035bb5cdfba1d4bd0dd4a307ca6` (v8.0.3) was removed from the Apache Infrastructure approved actions allowlist on 2026-05-22 by the automated "Remove Expired Refs" workflow. This PR updates the action to the approved v8.0.5 version to unblock the nightly docs builds.

## Brief change log

  - Updated `burnett01/rsync-deployments` from `7659d600d8bdd035bb5cdfba1d4bd0dd4a307ca6` (v8.0.3, expired) to `66257cad6bfeb2171d3b6bfa6c9a22279dd9c3a1` (v8.0.5, approved with no expiry) in `.github/workflows/docs.yml` and `.github/workflows/docs-legacy.yml`

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented?