### PR TITLE
[FLINK-39909][state] Fix heap state backend savepoint NPE with null map state values

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapKeyValueStateIterator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapKeyValueStateIterator.java
@@ -362,7 +362,9 @@ public final class HeapKeyValueStateIterator implements KeyValueStateIterator {
                     compositeKeyBuilder.buildCompositeKeyUserKey(entry.getKey(), userKeySerializer);
             Object userValue = entry.getValue();
             valueOut.writeBoolean(userValue == null);
-            userValueSerializer.serialize(userValue, valueOut);
+            if (userValue != null) {
+                userValueSerializer.serialize(userValue, valueOut);
+            }
             currentValue = valueOut.getCopyOfBuffer();
 
             if (!mapEntries.hasNext()) {

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/MapStateNullValueCheckpointingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/MapStateNullValueCheckpointingITCase.java
@@ -114,6 +114,8 @@ class MapStateNullValueCheckpointingITCase {
 
         StatefulMapper.firstRunFuture = new CompletableFuture<>();
         StatefulMapper.secondRunFuture = new CompletableFuture<>();
+        NullUnsafeStatefulMapper.firstRunFuture = new CompletableFuture<>();
+        NullUnsafeStatefulMapper.secondRunFuture = new CompletableFuture<>();
     }
 
     @AfterEach
@@ -216,6 +218,143 @@ class MapStateNullValueCheckpointingITCase {
         assertThat(restoredState.get("key")).isEqualTo("value");
         assertThat(restoredState.get("null-key")).isNull();
         assertThat(restoredState).containsKey("null-key");
+    }
+
+    /**
+     * Tests that MapState with null values works correctly with null-unsafe serializers (e.g.,
+     * IntSerializer) during checkpoint/savepoint and restore. This verifies the fix in {@link
+     * org.apache.flink.runtime.state.heap.HeapKeyValueStateIterator} which previously would NPE
+     * when serializing null values during savepoint.
+     */
+    @TestTemplate
+    void testMapStateWithNullUnsafeSerializerCheckpointingAndRestore() throws Exception {
+        final String savepointPath = runJobWithNullUnsafeSerializer();
+        assertThat(savepointPath).isNotEmpty();
+        restoreAndVerifyNullUnsafeSerializer(savepointPath);
+    }
+
+    private String runJobWithNullUnsafeSerializer() throws Exception {
+        Configuration conf = new Configuration();
+        conf.set(
+                CheckpointingOptions.CHECKPOINTS_DIRECTORY,
+                TempDirUtils.newFolder(tmpFolder).toURI().toString());
+        conf.set(CheckpointingOptions.EXTERNALIZED_CHECKPOINT_RETENTION, RETAIN_ON_CANCELLATION);
+        conf.set(
+                CheckpointingOptions.SAVEPOINT_DIRECTORY,
+                TempDirUtils.newFolder(tmpFolder).toURI().toString());
+        conf.set(StateBackendOptions.STATE_BACKEND, stateBackend);
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment(conf);
+        env.setParallelism(1);
+
+        env.fromSource(createSource(), WatermarkStrategy.noWatermarks(), "Data Generator Source")
+                .keyBy(v -> 0)
+                .map(new NullUnsafeStatefulMapper(true))
+                .sinkTo(new DiscardingSink<>());
+
+        JobGraph jobGraph = env.getStreamGraph().getJobGraph();
+        MiniCluster miniCluster = cluster.getMiniCluster();
+        miniCluster.submitJob(jobGraph).get();
+
+        JobID jobID = jobGraph.getJobID();
+        NullUnsafeStatefulMapper.firstRunFuture.get(2, TimeUnit.MINUTES);
+
+        if (snapshotType.isLeft()) {
+            cluster.getClusterClient()
+                    .triggerCheckpoint(jobID, snapshotType.left())
+                    .get(2, TimeUnit.MINUTES);
+            String checkpointPath =
+                    CommonTestUtils.getLatestCompletedCheckpointPath(jobID, miniCluster)
+                            .<NoSuchElementException>orElseThrow(
+                                    () ->
+                                            new NoSuchElementException(
+                                                    "No checkpoint was created yet"));
+            cluster.getClusterClient().cancel(jobID);
+            return checkpointPath;
+        } else {
+            return cluster.getClusterClient()
+                    .stopWithSavepoint(jobID, false, null, snapshotType.right())
+                    .get(2, TimeUnit.MINUTES);
+        }
+    }
+
+    private void restoreAndVerifyNullUnsafeSerializer(String savepointPath) throws Exception {
+        Configuration conf = new Configuration();
+        conf.set(
+                CheckpointingOptions.CHECKPOINTS_DIRECTORY,
+                TempDirUtils.newFolder(tmpFolder).toURI().toString());
+        conf.set(
+                CheckpointingOptions.SAVEPOINT_DIRECTORY,
+                TempDirUtils.newFolder(tmpFolder).toURI().toString());
+        conf.set(StateBackendOptions.STATE_BACKEND, stateBackend);
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment(conf);
+        env.setParallelism(1);
+
+        env.fromSource(createSource(), WatermarkStrategy.noWatermarks(), "Data Generator Source")
+                .keyBy(v -> 0)
+                .map(new NullUnsafeStatefulMapper(false))
+                .sinkTo(new DiscardingSink<>());
+
+        JobGraph jobGraph = env.getStreamGraph().getJobGraph();
+        jobGraph.setSavepointRestoreSettings(SavepointRestoreSettings.forPath(savepointPath));
+
+        MiniCluster miniCluster = cluster.getMiniCluster();
+        miniCluster.submitJob(jobGraph).get();
+
+        Map<String, Integer> restoredState =
+                NullUnsafeStatefulMapper.secondRunFuture.get(2, TimeUnit.MINUTES);
+
+        assertThat(restoredState.get("key")).isEqualTo(42);
+        assertThat(restoredState.get("null-key")).isNull();
+        assertThat(restoredState).containsKey("null-key");
+    }
+
+    /**
+     * A stateful mapper using IntSerializer (null-unsafe) for the map state value type. This
+     * exercises the code path where serializers that cannot handle null will fail during
+     * savepoint/checkpoint if the null-handling logic is incorrect.
+     */
+    private static class NullUnsafeStatefulMapper extends RichMapFunction<Long, Long> {
+
+        static CompletableFuture<Void> firstRunFuture;
+        static CompletableFuture<Map<String, Integer>> secondRunFuture;
+
+        private final boolean isFirstRun;
+        private boolean hasPopulated;
+        private transient MapState<String, Integer> mapState;
+
+        NullUnsafeStatefulMapper(boolean isFirstRun) {
+            this.isFirstRun = isFirstRun;
+        }
+
+        @Override
+        public void open(OpenContext context) {
+            MapStateDescriptor<String, Integer> mapStateDescriptor =
+                    new MapStateDescriptor<>(
+                            "map-state-int",
+                            BasicTypeInfo.STRING_TYPE_INFO,
+                            BasicTypeInfo.INT_TYPE_INFO);
+            mapState = getRuntimeContext().getMapState(mapStateDescriptor);
+            hasPopulated = false;
+        }
+
+        @Override
+        public Long map(Long value) throws Exception {
+            if (hasPopulated) {
+                return value;
+            }
+            if (isFirstRun) {
+                mapState.put("key", 42);
+                mapState.put("null-key", null);
+                firstRunFuture.complete(null);
+            } else {
+                Map<String, Integer> restoredState = new HashMap<>();
+                restoredState.put("key", mapState.get("key"));
+                restoredState.put("null-key", mapState.get("null-key"));
+                secondRunFuture.complete(restoredState);
+            }
+            hasPopulated = true;
+            return value;
+        }
     }
 
     private static class StatefulMapper extends RichMapFunction<Long, Long> {


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Found while investigating FLINK-38144. HeapKeyValueStateIterator unconditionally calls userValueSerializer.serialize(userValue, valueOut) after writing the null flag, causing NPE during canonical savepoint when MapState contains null values with null-unsafe serializers (IntSerializer, BooleanSerializer, LongSerializer, etc.).

Same asymmetric pattern fixed for RocksDB/ForSt in #26831 (FLINK-38137). Only affects canonical savepoints — heap checkpoints use MapSerializer.serialize() which handles nulls internally 


## Brief change log

- Skip userValueSerializer.serialize() when value is null in HeapKeyValueStateIterator, matching the deserialization side which already checks the null flag
- Add testMapStateWithNullUnsafeSerializerCheckpointingAndRestore to MapStateNullValueCheckpointingITCase using IntSerializer (null-unsafe) to cover this code path


## Verifying this change

- Added integration test testMapStateWithNullUnsafeSerializerCheckpointingAndRestore — runs across all backends (hashmap, rocksdb, forst) and snapshot types (full checkpoint, incremental checkpoint, canonical savepoint, native savepoint)
- Manually verified with a long-running job using hashmap backend + null map state values + savepoint/restore

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

- Does this pull request introduce a new feature? no

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change the checkbox below to `[X]` followed by the name of the tool, and uncomment the
"Generated-by" line. See the ASF Generative Tooling Guidance for details:
https://www.apache.org/legal/generative-tooling.html

You are responsible for the quality and correctness of every change in this PR
regardless of the tooling used. Low-effort AI-generated PRs will be closed. See
AGENTS.md for the full guidance.
-->

- [x] Yes (please specify the tool below)
kiro-cli
<!--
Generated-by: [Tool Name and Version]
-->
