### PR TITLE
[BP-2.3][FLINK-39145][tests] Skip counters accumulation when state isn't initialized

### DIFF
--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/UnalignedCheckpointTestBase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/UnalignedCheckpointTestBase.java
@@ -1121,10 +1121,13 @@ abstract class UnalignedCheckpointTestBase {
 
         @Override
         public void close() throws Exception {
-            numOutputCounter.add(state.numOutput);
-            outOfOrderCounter.add(state.numOutOfOrderness);
-            duplicatesCounter.add(state.numDuplicates);
-            lostCounter.add(state.numLostValues);
+            // sink task might be cancelled before state was initialized
+            if (state != null) {
+                numOutputCounter.add(state.numOutput);
+                outOfOrderCounter.add(state.numOutOfOrderness);
+                duplicatesCounter.add(state.numDuplicates);
+                lostCounter.add(state.numLostValues);
+            }
             if (getRuntimeContext().getTaskInfo().getIndexOfThisSubtask() == 0) {
                 numFailures.add(getRuntimeContext().getTaskInfo().getAttemptNumber());
             }


### PR DESCRIPTION
## What is the purpose of the change

Backport of FLINK-39145 (master commit `04a31ba953f`) to `release-2.3`.

`UnalignedCheckpointITCase.execute` still fails on `release-2.3` cron builds with the exact failure signature fixed by FLINK-39145 on master (`NoResourceAvailableException: Could not acquire the minimum required resources` after restart attempts are exhausted). Example: [build 75868](https://dev.azure.com/apache-flink/apache-flink/_build/results?buildId=75868&view=logs&j=39d5b1d5-3b41-54dc-6458-1e2ddd1cdcf3&t=115e5c38-6efb-5006-4921-5e2851da71ef) (`test_cron_azure tests`, scheduled build of `release-2.3`).

The fix was only merged to master (2.4.0); this cherry-picks it onto `release-2.3` so the cron builds stop flaking.

## Brief change log

- Clean cherry-pick of `04a31ba953f` (`[FLINK-39145][tests] Skip counters accumulation when state isn't initialized`), no conflicts. Test-only change.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage (it is itself a test stabilization fix, already verified on master).

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable

---

##### Was generative AI tooling used to co-author this PR?
Yes
