### PR TITLE
[FLINK-39914][runtime] Fix flaky TaskDeploymentDescriptorFactoryTest#testHybridVertexFinish caused by async TDD creation

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/deployment/TaskDeploymentDescriptorFactoryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/deployment/TaskDeploymentDescriptorFactoryTest.java
@@ -35,6 +35,7 @@ import org.apache.flink.runtime.executiongraph.ExecutionVertex;
 import org.apache.flink.runtime.executiongraph.IntermediateResult;
 import org.apache.flink.runtime.executiongraph.MarkPartitionFinishedStrategy;
 import org.apache.flink.runtime.executiongraph.TestingDefaultExecutionGraphBuilder;
+import org.apache.flink.runtime.executiongraph.utils.ExecutionUtils;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
 import org.apache.flink.runtime.jobgraph.DistributionPattern;
 import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
@@ -49,6 +50,7 @@ import org.apache.flink.runtime.scheduler.SchedulerBase;
 import org.apache.flink.runtime.shuffle.ShuffleDescriptor;
 import org.apache.flink.testutils.TestingUtils;
 import org.apache.flink.testutils.executor.TestExecutorExtension;
+import org.apache.flink.util.Preconditions;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -58,6 +60,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledExecutorService;
 
 import static org.apache.flink.configuration.JobManagerOptions.HybridPartitionDataConsumeConstraint.ONLY_FINISHED_PRODUCERS;
@@ -221,18 +224,25 @@ class TaskDeploymentDescriptorFactoryTest {
                 ResultPartitionType.HYBRID_FULL);
 
         JobGraph jobGraph = JobGraphTestUtils.batchJobGraph(producer, consumer);
+
         SchedulerBase scheduler =
                 new DefaultSchedulerBuilder(
                                 jobGraph,
-                                ComponentMainThreadExecutorServiceAdapter.forMainThread(),
+                                ComponentMainThreadExecutorServiceAdapter.forSingleThreadExecutor(
+                                        EXECUTOR_RESOURCE.getExecutor()),
                                 EXECUTOR_RESOURCE.getExecutor())
                         .setHybridPartitionDataConsumeConstraint(ONLY_FINISHED_PRODUCERS)
                         .buildAdaptiveBatchJobScheduler();
-        scheduler.startScheduling();
+        CompletableFuture.runAsync(scheduler::startScheduling, EXECUTOR_RESOURCE.getExecutor())
+                .join();
+        // Barrier: ensure the async vertex-initialization action queued inside startScheduling
+        // has completed before we access getTaskVertices().
+        CompletableFuture.runAsync(() -> {}, EXECUTOR_RESOURCE.getExecutor()).join();
         ExecutionGraph executionGraph = scheduler.getExecutionGraph();
-        return Tuple2.of(
-                executionGraph.getJobVertex(producer.getID()),
-                executionGraph.getJobVertex(consumer.getID()));
+        ExecutionJobVertex producerVertex =
+                Preconditions.checkNotNull(executionGraph.getJobVertex(producer.getID()));
+        ExecutionUtils.waitForTaskDeploymentDescriptorsCreation(producerVertex.getTaskVertices());
+        return Tuple2.of(producerVertex, executionGraph.getJobVertex(consumer.getID()));
     }
 
     // ============== Utils ==============


### PR DESCRIPTION
## What is the purpose of the change

Execution.deploy() now creates TaskDeploymentDescriptor asynchronously, which means the IO executor thread calls jobMasterMainThreadExecutor.execute() to hand off the work.

 The problem is that forMainThread() captures the calling thread at the time of its creation and asserts inside execute() that only that same thread can call it.

Since the IO executor thread calls execute() instead, the assertion fires and throws an AssertionError. This error then bubbles up through the CompletableFuture chain, flipping the producer vertex into FAILED state, which causes an IllegalStateException when the consumer vertex tries to read from it.


## Brief change log

Updated buildExecutionGraph() in TaskDeploymentDescriptorFactoryTest to replace forMainThread() with forSingleThreadExecutor() and add proper async handling to accommodate the asynchronous TaskDeploymentDescriptor creation in Execution.deploy().


## Verifying this change

<img width="2626" height="1902" alt="image" src="https://github.com/user-attachments/assets/78dbdeaa-f8f1-4a1f-b60a-a61c13c99553" />

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change the checkbox below to `[X]` followed by the name of the tool, and uncomment the
"Generated-by" line. See the ASF Generative Tooling Guidance for details:
https://www.apache.org/legal/generative-tooling.html

You are responsible for the quality and correctness of every change in this PR
regardless of the tooling used. Low-effort AI-generated PRs will be closed. See
AGENTS.md for the full guidance.
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name and Version]
-->
