### PR TITLE
[FLINK-39915][table] Reject mixing positional and named function arguments

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/calcite/FlinkCalciteSqlValidator.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/calcite/FlinkCalciteSqlValidator.java
@@ -380,6 +380,7 @@ public final class FlinkCalciteSqlValidator extends FlinkSqlParsingValidator {
         }
 
         final SqlBasicCall call = (SqlBasicCall) node;
+        checkNoNamedAndPositionalMixedArgs(call);
 
         // Special case for MODEL
         if (node instanceof SqlExplicitModelCall) {
@@ -430,6 +431,27 @@ public final class FlinkCalciteSqlValidator extends FlinkSqlParsingValidator {
         }
 
         return rewritten;
+    }
+
+    /** Mixing positional and named arguments is not supported and crashes operand permutation. */
+    private static void checkNoNamedAndPositionalMixedArgs(SqlBasicCall call) {
+        if (!(call.getOperator() instanceof SqlFunction)) {
+            return;
+        }
+        final List<SqlNode> operands = call.getOperandList();
+        final boolean anyNamed =
+                operands.stream()
+                        .anyMatch(op -> op != null && op.getKind() == SqlKind.ARGUMENT_ASSIGNMENT);
+        final boolean anyPositional =
+                operands.stream()
+                        .anyMatch(op -> op != null && op.getKind() != SqlKind.ARGUMENT_ASSIGNMENT);
+        if (anyNamed && anyPositional) {
+            throw new ValidationException(
+                    "Cannot mix positional and named arguments when calling function '"
+                            + call.getOperator().getName()
+                            + "'. Use either all positional arguments or all named arguments "
+                            + "(e.g. arg => value).");
+        }
     }
 
     @Override

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/calcite/FlinkCalciteSqlValidatorTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/calcite/FlinkCalciteSqlValidatorTest.java
@@ -18,9 +18,13 @@
 
 package org.apache.flink.table.planner.calcite;
 
+import org.apache.flink.table.annotation.ArgumentHint;
+import org.apache.flink.table.annotation.DataTypeHint;
+import org.apache.flink.table.annotation.FunctionHint;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.Schema;
 import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.functions.ScalarFunction;
 import org.apache.flink.table.planner.utils.PlannerMocks;
 
 import org.junit.jupiter.api.Test;
@@ -141,8 +145,29 @@ class FlinkCalciteSqlValidatorTest {
 
     @Test
     void testMixedPositionalAndNamedArguments() {
-        assertThatThrownBy(() -> plannerMocks.getParser().parse("SELECT myFunc(1, b => 2) FROM t1"))
+        plannerMocks
+                .getFunctionCatalog()
+                .registerTemporarySystemFunction("myFunc", new NamedArgsScalarFunction(), false);
+
+        assertDoesNotThrow(() -> plannerMocks.getParser().parse("SELECT myFunc(1, 2) FROM t1"));
+        assertDoesNotThrow(
+                () -> plannerMocks.getParser().parse("SELECT myFunc(in1 => 1, in2 => 2) FROM t1"));
+        assertThatThrownBy(
+                        () -> plannerMocks.getParser().parse("SELECT myFunc(1, in2 => 2) FROM t1"))
                 .isInstanceOf(ValidationException.class)
                 .hasMessageContaining("Cannot mix positional and named arguments");
+    }
+
+    /** Scalar function with named arguments for the mixed-argument validation test. */
+    public static class NamedArgsScalarFunction extends ScalarFunction {
+        @FunctionHint(
+                output = @DataTypeHint("INT"),
+                arguments = {
+                    @ArgumentHint(name = "in1", type = @DataTypeHint("INT")),
+                    @ArgumentHint(name = "in2", type = @DataTypeHint("INT"))
+                })
+        public Integer eval(Integer in1, Integer in2) {
+            return null;
+        }
     }
 }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/calcite/FlinkCalciteSqlValidatorTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/calcite/FlinkCalciteSqlValidatorTest.java
@@ -138,4 +138,11 @@ class FlinkCalciteSqlValidatorTest {
                 .hasMessageContaining(
                         "UPSERT INTO statement is not supported. Please use INSERT INTO instead.");
     }
+
+    @Test
+    void testMixedPositionalAndNamedArguments() {
+        assertThatThrownBy(() -> plannerMocks.getParser().parse("SELECT myFunc(1, b => 2) FROM t1"))
+                .isInstanceOf(ValidationException.class)
+                .hasMessageContaining("Cannot mix positional and named arguments");
+    }
 }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/stream/sql/ProcessTableFunctionTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/stream/sql/ProcessTableFunctionTest.java
@@ -350,6 +350,11 @@ class ProcessTableFunctionTest extends TableTestBase {
     private static Stream<ErrorSpec> errorSpecs() {
         return Stream.of(
                 ErrorSpec.ofSelect(
+                        "mixed positional and named arguments",
+                        ScalarArgsFunction.class,
+                        "SELECT * FROM f(1, b => true)",
+                        "Cannot mix positional and named arguments when calling function 'f'"),
+                ErrorSpec.ofSelect(
                         "invalid uid",
                         ScalarArgsFunction.class,
                         "SELECT * FROM f(uid => '%', i => 1, b => true)",


### PR DESCRIPTION
## What is the purpose of the change

Calling a function with a mix of positional and named arguments (e.g. `f(TABLE t, op => DESCRIPTOR(x))`) previously failed validation with an internal assertion calcite error. This surfaces a clear ValidationException instead, telling the user to use either all positional or all named arguments.

## Brief change log

- Detect mixed positional and named arguments in FlinkCalciteSqlValidator and throw a ValidationException before operand permutation runs.

## Verifying this change

- FlinkCalciteSqlValidatorTest
- ProcessTableFunctionTest

## Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): (no)
- The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
- The serializers: (no)
- The runtime per-record code paths (performance sensitive): (no)
- Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
- The S3 file system connector: (no)

## Documentation

- Does this pull request introduce a new feature? (no)
- If yes, how is the feature documented? (not applicable)

---

##### Was generative AI tooling used to co-author this PR?

- [x] Yes (please specify the tool below)

2.1.117 (Claude Code) and Opus 4.8