### PR TITLE
[FLINK-37892][tests] Fix spurious TimeoutException in TestUtils#waitUntil for non-monotonic conditions

### DIFF
--- a/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/test/util/TestUtils.java
+++ b/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/test/util/TestUtils.java
@@ -223,12 +223,17 @@ public class TestUtils {
      */
     public static void waitUntil(Supplier<Boolean> condition, Duration timeout, String message)
             throws InterruptedException, TimeoutException {
-        long startTime = System.currentTimeMillis();
-        while (!condition.get() && System.currentTimeMillis() < startTime + timeout.toMillis()) {
+        long deadline = System.currentTimeMillis() + timeout.toMillis();
+        while (true) {
+            // Latch the result so that a condition that is satisfied once does not fail the
+            // wait if it becomes false again before a re-evaluation.
+            if (condition.get()) {
+                return;
+            }
+            if (System.currentTimeMillis() >= deadline) {
+                throw new TimeoutException(message);
+            }
             Thread.sleep(1);
-        }
-        if (!condition.get()) {
-            throw new TimeoutException(message);
         }
     }
 

--- a/flink-test-utils-parent/flink-test-utils/src/test/java/org/apache/flink/test/util/TestUtilsTest.java
+++ b/flink-test-utils-parent/flink-test-utils/src/test/java/org/apache/flink/test/util/TestUtilsTest.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.test.util;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Tests for {@link TestUtils}. */
+class TestUtilsTest {
+
+    @Test
+    void testWaitUntilReturnsWhenConditionIsMet() {
+        assertThatCode(() -> TestUtils.waitUntil(() -> true, Duration.ofSeconds(5), "msg"))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void testWaitUntilThrowsOnTimeout() {
+        assertThatThrownBy(() -> TestUtils.waitUntil(() -> false, Duration.ofMillis(50), "msg"))
+                .isInstanceOf(TimeoutException.class)
+                .hasMessage("msg");
+    }
+
+    @Test
+    void testWaitUntilSucceedsForConditionSatisfiedOnlyOnce() {
+        // A non-monotonic condition may become true and then false again. Once it has been
+        // observed as true, waitUntil must return successfully instead of re-evaluating it
+        // and throwing a spurious TimeoutException.
+        final AtomicBoolean firstCall = new AtomicBoolean(true);
+        assertThatCode(
+                        () ->
+                                TestUtils.waitUntil(
+                                        () -> firstCall.getAndSet(false),
+                                        Duration.ofSeconds(5),
+                                        "msg"))
+                .doesNotThrowAnyException();
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

Fixes the failure mode behind [FLINK-37892](https://issues.apache.org/jira/browse/FLINK-37892) (`SplitFetcherManagerTest#testCloseBlockingWaitingForFetcherShutdown` flaking on CI).

`TestUtils#waitUntil` evaluates the condition twice — once in the polling loop and again to decide whether to throw:

```java
while (!condition.get() && System.currentTimeMillis() < startTime + timeout.toMillis()) {
    Thread.sleep(1);
}
if (!condition.get()) {
    throw new TimeoutException(message);
}
```

A non-monotonic condition that is momentarily true and then false again can exit the loop on the first evaluation and fail the second, producing a `TimeoutException` within milliseconds despite a 30s budget. `SplitFetcherManagerTest` passes exactly such a condition (`findThread(THREAD_NAME_PREFIX).size() == 2` — a live thread count that can flicker as fetcher threads start/exit).

The recent nightly failures confirm this mechanically: the test "timed out" after **0.027s / 0.039s** against a 30-second budget ([run 27320852550](https://github.com/apache/flink/actions/runs/27320852550), original + re-run, two different profiles) — impossible for a real timeout, and exactly the signature of the double-evaluation race.

## Brief change log

- Restructure `TestUtils#waitUntil(Supplier, Duration, String)` to evaluate the condition once per iteration and latch the result: a condition observed as true always completes the wait; `TimeoutException` is thrown only when the condition was actually false at the deadline.
- Add `TestUtilsTest` with a regression test whose condition is satisfied exactly once and false afterwards.

## Verifying this change

This change added tests and can be verified as follows:

- `TestUtilsTest#testWaitUntilSucceedsForConditionSatisfiedOnlyOnce` fails against the old implementation with the same spurious `TimeoutException` (in ~0.04s) and passes with the fix.
- `SplitFetcherManagerTest` passes against the fixed utility.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable

---

##### Was generative AI tooling used to co-author this PR?
Yes
