### PR TITLE
[FLINK-39913][table] Improve the error message when a foreground query emits an upsert changelog

### DIFF
--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/optimize/program/FlinkChangelogModeInferenceProgram.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/optimize/program/FlinkChangelogModeInferenceProgram.scala
@@ -117,28 +117,31 @@ class FlinkChangelogModeInferenceProgram extends FlinkOptimizeProgram[StreamOpti
       // Reaching here means no node assignment satisfies the changelog requirements. When the root
       // is a sink that cannot consume the upsert changelog produced by its input, point at the
       // conflict directly. Any other failure falls back to the full annotated plan.
-      val errorMessage =
-        if (
-          rootWithModifyKindSet.isInstanceOf[StreamPhysicalSink]
-          && containsUpdates(rootWithModifyKindSet)
-        ) {
-          val conflict = new StringBuilder(describeChangelog(rootWithModifyKindSet))
-          rootWithModifyKindSet.getInputs.foreach(
-            input => conflict.append("\n  +- ").append(describeChangelog(input)))
-          "Can't generate a valid execution plan for the given query.\n\n" +
-            "There is a changelog mismatch between two operators. One produces an upsert " +
-            "changelog (UPDATE_AFTER without UPDATE_BEFORE). The other requires a retract " +
-            "changelog (UPDATE_BEFORE and UPDATE_AFTER), for example a sink without a primary " +
-            "key. In such cases, ensure that the sink is able to digest upserts where the " +
-            "PRIMARY KEY serves as the upsert key, or make the input produce UPDATE_BEFORE.\n\n" +
-            "The conflict is at:\n" + conflict
-        } else {
-          val plan = FlinkRelOptUtil.toString(rootWithModifyKindSet, withChangelogTraits = true)
-          "Can't generate a valid execution plan for the given query:\n" + plan
-        }
+      val errorMessage = createTargetedErrorMessage(rootWithModifyKindSet)
       throw new TableException(errorMessage)
     } else {
       finalRoot.head
+    }
+  }
+
+  private def createTargetedErrorMessage(rootWithModifyKindSet: StreamPhysicalRel) = {
+    if (
+      rootWithModifyKindSet.isInstanceOf[StreamPhysicalSink]
+      && containsUpdates(rootWithModifyKindSet)
+    ) {
+      val conflict = new StringBuilder(describeChangelog(rootWithModifyKindSet))
+      rootWithModifyKindSet.getInputs.foreach(
+        input => conflict.append("\n  +- ").append(describeChangelog(input)))
+      "Can't generate a valid execution plan for the given query.\n\n" +
+        "There is a changelog mismatch between two operators. One produces an upsert " +
+        "changelog (UPDATE_AFTER without UPDATE_BEFORE). The other requires a retract " +
+        "changelog (UPDATE_BEFORE and UPDATE_AFTER), for example a sink without a primary " +
+        "key. In such cases, ensure that the sink is able to digest upserts where the " +
+        "PRIMARY KEY serves as the upsert key, or make the input produce UPDATE_BEFORE.\n\n" +
+        "The conflict is at:\n" + conflict
+    } else {
+      val plan = FlinkRelOptUtil.toString(rootWithModifyKindSet, withChangelogTraits = true)
+      "Can't generate a valid execution plan for the given query:\n" + plan
     }
   }
 
@@ -1629,7 +1632,10 @@ class FlinkChangelogModeInferenceProgram extends FlinkOptimizeProgram[StreamOpti
     getModifyKindSet(rel).contains(ModifyKind.UPDATE) ||
       rel.getInputs.exists(input => containsUpdates(input))
 
-  /** Renders a node's type and changelog mode, for example "Sink(changelogMode=[NONE])". */
+  /**
+   * Renders a node's type and changelog mode, for example
+   * "Sink(ExpectedChangelogMode=[I,UB,UA,D])".
+   */
   private def describeChangelog(rel: RelNode): String = rel match {
     case sink: StreamPhysicalSink =>
       // A sink's own changelog mode is empty; show the mode it expects from its input instead.

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/optimize/program/FlinkChangelogModeInferenceProgram.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/optimize/program/FlinkChangelogModeInferenceProgram.scala
@@ -1634,14 +1634,14 @@ class FlinkChangelogModeInferenceProgram extends FlinkOptimizeProgram[StreamOpti
 
   /**
    * Renders a node's type and changelog mode, for example
-   * "Sink(ExpectedChangelogMode=[I,UB,UA,D])".
+   * "Sink(expectedChangelogMode=[I,UB,UA,D])".
    */
   private def describeChangelog(rel: RelNode): String = rel match {
     case sink: StreamPhysicalSink =>
       // A sink's own changelog mode is empty; show the mode it expects from its input instead.
       val expected =
         sink.tableSink.getChangelogMode(getModifyKindSet(sink.getInput).toDefaultChangelogMode)
-      s"Sink(ExpectedChangelogMode=[${ChangelogPlanUtils.stringifyChangelogMode(Some(expected))}])"
+      s"Sink(expectedChangelogMode=[${ChangelogPlanUtils.stringifyChangelogMode(Some(expected))}])"
     case streamRel: StreamPhysicalRel =>
       val typeName = rel.getRelTypeName.stripPrefix("StreamPhysical")
       val mode =

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/optimize/program/FlinkChangelogModeInferenceProgram.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/optimize/program/FlinkChangelogModeInferenceProgram.scala
@@ -114,9 +114,24 @@ class FlinkChangelogModeInferenceProgram extends FlinkOptimizeProgram[StreamOpti
 
     // step4: sanity check and return non-empty root
     if (finalRoot.isEmpty) {
-      val plan = FlinkRelOptUtil.toString(root, withChangelogTraits = true)
-      throw new TableException(
-        "Can't generate a valid execution plan for the given query:\n" + plan)
+      val errorMessage =
+        if (containsUpdates(rootWithModifyKindSet)) {
+          // Point at the failing node and its inputs instead of dumping the whole plan.
+          val conflict = new StringBuilder(describeChangelog(rootWithModifyKindSet))
+          rootWithModifyKindSet.getInputs.foreach(
+            input => conflict.append("\n  +- ").append(describeChangelog(input)))
+          "Can't generate a valid execution plan for the given query.\n\n" +
+            "There is a changelog mismatch between two operators. One produces an upsert " +
+            "changelog (UPDATE_AFTER without UPDATE_BEFORE). The other requires a retract " +
+            "changelog (UPDATE_BEFORE and UPDATE_AFTER), for example a sink without a primary " +
+            "key. To resolve it, declare a PRIMARY KEY on the sink, or make the input produce " +
+            "UPDATE_BEFORE.\n\n" +
+            "The conflict is at:\n" + conflict
+        } else {
+          val plan = FlinkRelOptUtil.toString(rootWithModifyKindSet, withChangelogTraits = true)
+          "Can't generate a valid execution plan for the given query:\n" + plan
+        }
+      throw new TableException(errorMessage)
     } else {
       finalRoot.head
     }
@@ -1602,6 +1617,21 @@ class FlinkChangelogModeInferenceProgram extends FlinkOptimizeProgram[StreamOpti
   private def getModifyKindSet(node: RelNode): ModifyKindSet = {
     val modifyKindSetTrait = node.getTraitSet.getTrait(ModifyKindSetTraitDef.INSTANCE)
     modifyKindSetTrait.modifyKindSet
+  }
+
+  /** Whether the node or any node in its input subtree produces UPDATE changes. */
+  private def containsUpdates(rel: RelNode): Boolean =
+    getModifyKindSet(rel).contains(ModifyKind.UPDATE) ||
+      rel.getInputs.exists(input => containsUpdates(input))
+
+  /** Renders a node's type and changelog mode, for example "Sink(changelogMode=[NONE])". */
+  private def describeChangelog(rel: RelNode): String = rel match {
+    case streamRel: StreamPhysicalRel =>
+      val typeName = rel.getRelTypeName.stripPrefix("StreamPhysical")
+      val mode =
+        ChangelogPlanUtils.stringifyChangelogMode(ChangelogPlanUtils.getChangelogMode(streamRel))
+      s"$typeName(changelogMode=[$mode])"
+    case _ => rel.getRelTypeName
   }
 
   private def getDeleteKind(node: RelNode): DeleteKind = {

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/optimize/program/FlinkChangelogModeInferenceProgram.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/optimize/program/FlinkChangelogModeInferenceProgram.scala
@@ -114,9 +114,14 @@ class FlinkChangelogModeInferenceProgram extends FlinkOptimizeProgram[StreamOpti
 
     // step4: sanity check and return non-empty root
     if (finalRoot.isEmpty) {
+      // Reaching here means no node assignment satisfies the changelog requirements. When the root
+      // is a sink that cannot consume the upsert changelog produced by its input, point at the
+      // conflict directly. Any other failure falls back to the full annotated plan.
       val errorMessage =
-        if (containsUpdates(rootWithModifyKindSet)) {
-          // Point at the failing node and its inputs instead of dumping the whole plan.
+        if (
+          rootWithModifyKindSet.isInstanceOf[StreamPhysicalSink]
+          && containsUpdates(rootWithModifyKindSet)
+        ) {
           val conflict = new StringBuilder(describeChangelog(rootWithModifyKindSet))
           rootWithModifyKindSet.getInputs.foreach(
             input => conflict.append("\n  +- ").append(describeChangelog(input)))
@@ -124,8 +129,8 @@ class FlinkChangelogModeInferenceProgram extends FlinkOptimizeProgram[StreamOpti
             "There is a changelog mismatch between two operators. One produces an upsert " +
             "changelog (UPDATE_AFTER without UPDATE_BEFORE). The other requires a retract " +
             "changelog (UPDATE_BEFORE and UPDATE_AFTER), for example a sink without a primary " +
-            "key. To resolve it, declare a PRIMARY KEY on the sink, or make the input produce " +
-            "UPDATE_BEFORE.\n\n" +
+            "key. In such cases, ensure that the sink is able to digest upserts where the " +
+            "PRIMARY KEY serves as the upsert key, or make the input produce UPDATE_BEFORE.\n\n" +
             "The conflict is at:\n" + conflict
         } else {
           val plan = FlinkRelOptUtil.toString(rootWithModifyKindSet, withChangelogTraits = true)
@@ -1626,6 +1631,11 @@ class FlinkChangelogModeInferenceProgram extends FlinkOptimizeProgram[StreamOpti
 
   /** Renders a node's type and changelog mode, for example "Sink(changelogMode=[NONE])". */
   private def describeChangelog(rel: RelNode): String = rel match {
+    case sink: StreamPhysicalSink =>
+      // A sink's own changelog mode is empty; show the mode it expects from its input instead.
+      val expected =
+        sink.tableSink.getChangelogMode(getModifyKindSet(sink.getInput).toDefaultChangelogMode)
+      s"Sink(ExpectedChangelogMode=[${ChangelogPlanUtils.stringifyChangelogMode(Some(expected))}])"
     case streamRel: StreamPhysicalRel =>
       val typeName = rel.getRelTypeName.stripPrefix("StreamPhysical")
       val mode =

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/stream/sql/ProcessTableFunctionTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/stream/sql/ProcessTableFunctionTest.java
@@ -521,7 +521,31 @@ class ProcessTableFunctionTest extends TableTestBase {
                         "upsert output into sink without primary key",
                         UpdatingUpsertFunction.class,
                         "INSERT INTO t_no_pk_sink SELECT * FROM f(r => TABLE t_updating PARTITION BY name)",
-                        "declare a PRIMARY KEY on the sink"),
+                        "There is a changelog mismatch between two operators. "
+                                + "One produces an upsert changelog (UPDATE_AFTER without UPDATE_BEFORE). "
+                                + "The other requires a retract changelog (UPDATE_BEFORE and UPDATE_AFTER), for example a sink without a primary key. "
+                                + "In such cases, ensure that the sink is able to digest upserts where the PRIMARY KEY serves as the upsert key, or make the input produce UPDATE_BEFORE.\n\n"
+                                + "The conflict is at:\n"
+                                + "Sink(ExpectedChangelogMode=[I,UB,UA,D])\n"
+                                + "  +- ProcessTableFunction(changelogMode=[I,UA,D])"),
+                ErrorSpec.ofSelect(
+                        "upsert conflict that does not surface at a sink",
+                        UpdatingUpsertFunction.class,
+                        "SELECT name, SUM(`count`) OVER (PARTITION BY name ORDER BY name) "
+                                + "FROM f(r => TABLE t_updating PARTITION BY name)",
+                        "Can't generate a valid execution plan for the given query:\n"),
+                ErrorSpec.ofInsertInto(
+                        "upsert conflict buried below a calc",
+                        UpdatingUpsertFunction.class,
+                        "INSERT INTO t_no_pk_sink SELECT name, name0, `count`, mode "
+                                + "FROM f(r => TABLE t_updating PARTITION BY name) WHERE name0 <> ''",
+                        "There is a changelog mismatch between two operators. "
+                                + "One produces an upsert changelog (UPDATE_AFTER without UPDATE_BEFORE). "
+                                + "The other requires a retract changelog (UPDATE_BEFORE and UPDATE_AFTER), for example a sink without a primary key. "
+                                + "In such cases, ensure that the sink is able to digest upserts where the PRIMARY KEY serves as the upsert key, or make the input produce UPDATE_BEFORE.\n\n"
+                                + "The conflict is at:\n"
+                                + "Sink(ExpectedChangelogMode=[I,UB,UA,D])\n"
+                                + "  +- Calc(changelogMode=[I,UA,D])"),
                 ErrorSpec.ofSelect(
                         "no pass-through for multiple table args",
                         InvalidPassThroughTables.class,

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/stream/sql/ProcessTableFunctionTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/stream/sql/ProcessTableFunctionTest.java
@@ -526,7 +526,7 @@ class ProcessTableFunctionTest extends TableTestBase {
                                 + "The other requires a retract changelog (UPDATE_BEFORE and UPDATE_AFTER), for example a sink without a primary key. "
                                 + "In such cases, ensure that the sink is able to digest upserts where the PRIMARY KEY serves as the upsert key, or make the input produce UPDATE_BEFORE.\n\n"
                                 + "The conflict is at:\n"
-                                + "Sink(ExpectedChangelogMode=[I,UB,UA,D])\n"
+                                + "Sink(expectedChangelogMode=[I,UB,UA,D])\n"
                                 + "  +- ProcessTableFunction(changelogMode=[I,UA,D])"),
                 ErrorSpec.ofSelect(
                         "upsert conflict that does not surface at a sink",
@@ -544,7 +544,7 @@ class ProcessTableFunctionTest extends TableTestBase {
                                 + "The other requires a retract changelog (UPDATE_BEFORE and UPDATE_AFTER), for example a sink without a primary key. "
                                 + "In such cases, ensure that the sink is able to digest upserts where the PRIMARY KEY serves as the upsert key, or make the input produce UPDATE_BEFORE.\n\n"
                                 + "The conflict is at:\n"
-                                + "Sink(ExpectedChangelogMode=[I,UB,UA,D])\n"
+                                + "Sink(expectedChangelogMode=[I,UB,UA,D])\n"
                                 + "  +- Calc(changelogMode=[I,UA,D])"),
                 ErrorSpec.ofSelect(
                         "no pass-through for multiple table args",

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/stream/sql/ProcessTableFunctionTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/stream/sql/ProcessTableFunctionTest.java
@@ -108,6 +108,10 @@ class ProcessTableFunctionTest extends TableTestBase {
                 .executeSql(
                         "CREATE TABLE t_full_delete_sink (`name` STRING PRIMARY KEY NOT ENFORCED, `name0` STRING, `count` BIGINT, `mode` STRING) "
                                 + "WITH ('connector' = 'values')");
+        util.tableEnv()
+                .executeSql(
+                        "CREATE TABLE t_no_pk_sink (`name` STRING, `name0` STRING, `count` BIGINT, `mode` STRING) "
+                                + "WITH ('connector' = 'values', 'sink-insert-only' = 'false')");
     }
 
     @Test
@@ -513,6 +517,11 @@ class ProcessTableFunctionTest extends TableTestBase {
                         "SELECT * FROM f(r => TABLE t_watermarked PARTITION BY name, on_time => DESCRIPTOR(ts))",
                         "Time operations using the `on_time` argument are currently not supported for "
                                 + "PTFs that consume or produce updates."),
+                ErrorSpec.ofInsertInto(
+                        "upsert output into sink without primary key",
+                        UpdatingUpsertFunction.class,
+                        "INSERT INTO t_no_pk_sink SELECT * FROM f(r => TABLE t_updating PARTITION BY name)",
+                        "declare a PRIMARY KEY on the sink"),
                 ErrorSpec.ofSelect(
                         "no pass-through for multiple table args",
                         InvalidPassThroughTables.class,


### PR DESCRIPTION
### What is the purpose of the change                                                                                               
A foreground query (a bare `SELECT` collected through the anonymous result sink, which has no primary key) over a relation that emits an upsert changelog fails with an unhelpful error: Can't generate a valid execution plan for the given query followed by  the optimized plan. A common trigger is `FROM_CHANGELOG` with `PARTITION BY` and an `op_mapping` without `UPDATE_BEFORE`. This change appends actionable guidance to that error. Behavior is unchanged; only the message is improved.              
                                                                                                              
### Brief change log                                                                                                                          
 - `FlinkChangelogModeInferenceProgram`: when the rejected plan involves updates, append guidance explaining the upsert-vs-retract mismatch and the two fixes (declare a `PRIMARY KEY` on the sink, or make the upstream emit `UPDATE_BEFORE`). Gated on `ModifyKind.UPDATE` so unrelated planning failures keep the original message.
 - If there is not mismatch in the foreground sink operator and the other operators changelog mode, the error is produced as before and includes the changelog mode.


### Verifiying the output

Locally setup a test and verified the exception message. The plan now includes the changelog mode of the operators. Before, it was all set to `NONE`.

```
Can't generate a valid execution plan for the given query.

There is a changelog mismatch between two operators. One produces an upsert changelog (UPDATE_AFTER without UPDATE_BEFORE). The other requires a retract changelog (UPDATE_BEFORE and UPDATE_AFTER), for example a sink without a primary key. To resolve it, declare a PRIMARY KEY on the sink, or make the input produce UPDATE_BEFORE.

The conflict is at:
Sink(expectedChangelogMode=[I,UB,UA,D])
  +- ProcessTableFunction(changelogMode=[I,UA,D])
```
### Does this pull request potentially affect one of the following parts:                                                           
                                                                                                                                 
  - Dependencies: no                                                                                                              
   - `@Public(Evolving)` API: no                                                                                                     
   - Serializers: no                                                                                                               
   - Runtime per-record code paths: no                                                                                             
   - Deployment / recovery: no                                                                                                     
   - S3 connector: no                                                                                                              
                                                                                                                                   
   ### Documentation                                                                                                                   
   - New feature: no