### PR TITLE
[FLINK-35562][table-planner] Bound result wait in RestoreTestBase to avoid CI hangs

### DIFF
--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/testutils/RestoreTestBase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/testutils/RestoreTestBase.java
@@ -283,7 +283,9 @@ public abstract class RestoreTestBase implements TableTestProgramRunner {
     }
 
     private void awaitExpectedResults(
-            final TableTestProgram program, final List<CompletableFuture<?>> futures)
+            final TableTestProgram program,
+            final List<CompletableFuture<?>> futures,
+            final boolean ignoreAfter)
             throws Exception {
         try {
             CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]))
@@ -292,11 +294,22 @@ public abstract class RestoreTestBase implements TableTestProgramRunner {
             final StringBuilder message = new StringBuilder();
             message.append("Sink did not produce the expected results within ")
                     .append(RESULT_AWAIT_TIMEOUT_MILLIS)
-                    .append("ms for program '")
+                    .append(" ms for program '")
                     .append(program.id)
                     .append("'.");
             for (SinkTestStep sinkTestStep : program.getSetupSinkTestSteps()) {
+                // Mirror the expected set the observer waits on, so the dump is exact.
+                final List<String> expected =
+                        new ArrayList<>(sinkTestStep.getExpectedBeforeRestoreAsStrings());
+                if (!ignoreAfter) {
+                    expected.addAll(sinkTestStep.getExpectedAfterRestoreAsStrings());
+                }
                 message.append(System.lineSeparator())
+                        .append("Sink '")
+                        .append(sinkTestStep.name)
+                        .append("' expected results: ")
+                        .append(expected)
+                        .append(System.lineSeparator())
                         .append("Sink '")
                         .append(sinkTestStep.name)
                         .append("' actual results: ")
@@ -366,7 +379,7 @@ public abstract class RestoreTestBase implements TableTestProgramRunner {
         compiledPlan.writeToFile(getPlanPath(program, getLatestMetadata()));
 
         final TableResult tableResult = compiledPlan.execute();
-        awaitExpectedResults(program, futures);
+        awaitExpectedResults(program, futures, true);
         final JobClient jobClient = tableResult.getJobClient().get();
         final String savepoint =
                 jobClient
@@ -461,8 +474,11 @@ public abstract class RestoreTestBase implements TableTestProgramRunner {
 
         if (afterRestoreSource == AfterRestoreSource.INFINITE) {
             final TableResult tableResult = compiledPlan.execute();
-            awaitExpectedResults(program, futures);
-            tableResult.getJobClient().get().cancel().get();
+            try {
+                awaitExpectedResults(program, futures, false);
+            } finally {
+                tableResult.getJobClient().get().cancel().get();
+            }
         } else {
             compiledPlan.execute().await();
             for (SinkTestStep sinkTestStep : program.getSetupSinkTestSteps()) {

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/testutils/RestoreTestBase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/testutils/RestoreTestBase.java
@@ -76,6 +76,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -106,6 +108,10 @@ public abstract class RestoreTestBase implements TableTestProgramRunner {
     // This version can be set to generate savepoints for a particular Flink version.
     // By default, the savepoint is generated for the current version in the default directory.
     private static final FlinkVersion FLINK_VERSION = null;
+
+    // Bounds the wait for the expected sink results so a stuck job (e.g. an unlucky
+    // processing-time window split) fails the test instead of hanging the fork.
+    private static final long RESULT_AWAIT_TIMEOUT_MILLIS = TimeUnit.MINUTES.toMillis(5);
     private final Class<? extends ExecNode<?>> execNodeUnderTest;
     private final List<Class<? extends ExecNode<?>>> childExecNodesUnderTest;
     private final AfterRestoreSource afterRestoreSource;
@@ -276,6 +282,30 @@ public abstract class RestoreTestBase implements TableTestProgramRunner {
                 });
     }
 
+    private void awaitExpectedResults(
+            final TableTestProgram program, final List<CompletableFuture<?>> futures)
+            throws Exception {
+        try {
+            CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]))
+                    .get(RESULT_AWAIT_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
+        } catch (TimeoutException e) {
+            final StringBuilder message = new StringBuilder();
+            message.append("Sink did not produce the expected results within ")
+                    .append(RESULT_AWAIT_TIMEOUT_MILLIS)
+                    .append("ms for program '")
+                    .append(program.id)
+                    .append("'.");
+            for (SinkTestStep sinkTestStep : program.getSetupSinkTestSteps()) {
+                message.append(System.lineSeparator())
+                        .append("Sink '")
+                        .append(sinkTestStep.name)
+                        .append("' actual results: ")
+                        .append(getActualResults(sinkTestStep, sinkTestStep.name));
+            }
+            throw new AssertionError(message.toString(), e);
+        }
+    }
+
     /**
      * Execute this test to generate test files. Remember to be using the correct branch when
      * generating the test files.
@@ -336,7 +366,7 @@ public abstract class RestoreTestBase implements TableTestProgramRunner {
         compiledPlan.writeToFile(getPlanPath(program, getLatestMetadata()));
 
         final TableResult tableResult = compiledPlan.execute();
-        CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).get();
+        awaitExpectedResults(program, futures);
         final JobClient jobClient = tableResult.getJobClient().get();
         final String savepoint =
                 jobClient
@@ -431,7 +461,7 @@ public abstract class RestoreTestBase implements TableTestProgramRunner {
 
         if (afterRestoreSource == AfterRestoreSource.INFINITE) {
             final TableResult tableResult = compiledPlan.execute();
-            CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).get();
+            awaitExpectedResults(program, futures);
             tableResult.getJobClient().get().cancel().get();
         } else {
             compiledPlan.execute().await();


### PR DESCRIPTION
## What is the purpose of the change

`RestoreTestBase#testRestore` (INFINITE path) waits without a timeout for the sinks to produce an exact match of the expected results. `PROCTIME()` window boundaries depend on the wall clock, so records can occasionally split across windows differently than when the expected data was captured; the match then never happens and the fork hangs until the CI watchdog kills it after 900s, hiding which test stalled ([build 75906](https://dev.azure.com/apache-flink/apache-flink/_build/results?buildId=75906), thread dump shows the test parked in the unbounded `get()` with the job idle).

This bounds the wait so a residual occurrence fails as a localized, diagnosable test failure. It does not remove the proc-time nondeterminism itself; that is left as follow-up under FLINK-35562/FLINK-34404.

## Brief change log

  - Bound the wait for expected sink results at 5 minutes (`RESULT_AWAIT_TIMEOUT_MILLIS`).
  - On timeout, fail with an `AssertionError` naming the program and each sink's actual results.

Only `WindowTableFunctionProcTimeRestoreTest` (FLINK-35562) and `GroupWindowAggregateProcTimeRestoreTest` (FLINK-34404) use the INFINITE path; both complete in ~20s when healthy. The second call site is inside the `@Disabled` savepoint generator and never runs in CI.

## Verifying this change

This change is already covered by existing tests: `WindowTableFunctionProcTimeRestoreTest`, `GroupWindowAggregateProcTimeRestoreTest`, and `WindowAggregateEventTimeRestoreTest` (FINITE path regression check) all pass. The hang itself is an intermittent CI condition and not reliably reproducible locally.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (Claude Opus 4.8 via Claude Code)

Generated-by: Claude Opus 4.8 (1M context)
