### PR TITLE
[FLINK-39917][tests] Wait for RM disconnect log in JobMasterTriggerSavepointITCase

### DIFF
--- a/flink-tests/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTriggerSavepointITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTriggerSavepointITCase.java
@@ -94,6 +94,9 @@ class JobMasterTriggerSavepointITCase {
 
     private static volatile CountDownLatch triggerCheckpointLatch;
 
+    /** Prefix of the StandaloneResourceManager log line emitted when a JobMaster disconnects. */
+    private static final String DISCONNECT_JOB_MANAGER_LOG_PREFIX = "Disconnect job manager ";
+
     @TempDir protected File temporaryFolder;
 
     @RegisterExtension
@@ -284,7 +287,7 @@ class JobMasterTriggerSavepointITCase {
                 List.of(
                         "Registering job manager .*",
                         "Registered job manager .*",
-                        "Disconnect job manager .*"),
+                        DISCONNECT_JOB_MANAGER_LOG_PREFIX + ".*"),
                 "Registering TaskManager with ResourceID .*");
         assertKeyPresent(
                 MdcUtils.JOB_ID,
@@ -362,6 +365,18 @@ class JobMasterTriggerSavepointITCase {
         clusterClient.cancel(jobGraph.getJobID()).get();
         CommonTestUtils.waitUntilCondition(
                 () -> clusterClient.getJobStatus(jobGraph.getJobID()).get() == JobStatus.CANCELED,
+                600);
+        // The JobMaster disconnects from the ResourceManager asynchronously after CANCELED;
+        // wait for the logged event so verifyJobIdIsLogged does not race it.
+        CommonTestUtils.waitUntilCondition(
+                () ->
+                        standaloneResourceManagerLogging.getEvents().stream()
+                                .anyMatch(
+                                        e ->
+                                                e.getMessage()
+                                                        .getFormattedMessage()
+                                                        .startsWith(
+                                                                DISCONNECT_JOB_MANAGER_LOG_PREFIX)),
                 600);
     }
 


### PR DESCRIPTION
## What is the purpose of the change

`JobMasterTriggerSavepointITCase.testDoNotCancelJobIfSavepointFails` failed in [build 75865](https://dev.azure.com/apache-flink/apache-flink/_build/results?buildId=75865): it asserts that `StandaloneResourceManager` logged `Disconnect job manager .*` right after the job reaches CANCELED, but the JobMaster disconnects from the ResourceManager asynchronously afterwards, so the verification can run before the event is logged.

FLINK-37821 fixed an earlier failure of this test on a different signal; this is a distinct race, tracked in FLINK-39917.

## Brief change log

  - In `waitForDisconnect`, wait until the RM has logged the disconnect event before verifying; what is asserted does not change.
  - The disconnect log prefix is a shared constant used by both the wait predicate and `verifyJobIdIsLogged`'s regex.

## Verifying this change

This change is already covered by existing tests: `JobMasterTriggerSavepointITCase` (4 run, 0 failures).

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (Claude Opus 4.8 via Claude Code)

Generated-by: Claude Opus 4.8 (1M context)
