### PR TITLE
[FLINK-38534][runtime/tests] Fix LocalRecoveryTest racing the async task deployment

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/SchedulerTestingUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/SchedulerTestingUtils.java
@@ -362,6 +362,38 @@ public class SchedulerTestingUtils {
                 RETRY_ATTEMPTS);
     }
 
+    /**
+     * Waits until the task deployment descriptor of every current execution has been created. Call
+     * this before forcing executions into a later state; deployment is rejected once an execution
+     * leaves DEPLOYING.
+     *
+     * <p>Unlike {@code ExecutionUtils#waitForTaskDeploymentDescriptorsCreation}, this may run
+     * concurrently with {@code Execution.deploy()}: executions are observable in DEPLOYING before
+     * the descriptor future is assigned, so the {@code IllegalStateException} thrown while the
+     * future is unset is treated as "not yet ready".
+     *
+     * @param executionGraph the ExecutionGraph to wait for
+     * @throws Exception if the condition is not met within the timeout period
+     */
+    public static void waitForAllTasksDeploymentDescriptorsCreated(
+            final ExecutionGraph executionGraph) throws Exception {
+        for (ExecutionVertex vertex : executionGraph.getAllExecutionVertices()) {
+            waitUntilCondition(
+                    () -> {
+                        try {
+                            vertex.getCurrentExecutionAttempt()
+                                    .getTddCreationDuringDeployFuture()
+                                    .join();
+                            return true;
+                        } catch (IllegalStateException deploymentNotStartedYet) {
+                            return false;
+                        }
+                    },
+                    RETRY_INTERVAL_MILLIS,
+                    RETRY_ATTEMPTS);
+        }
+    }
+
     private static ExecutionJobVertex getJobVertex(
             DefaultScheduler scheduler, JobVertexID jobVertexId) {
         final ExecutionVertexID id = new ExecutionVertexID(jobVertexId, 0);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/LocalRecoveryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/LocalRecoveryTest.java
@@ -56,6 +56,7 @@ import java.util.stream.Collectors;
 import static org.apache.flink.runtime.checkpoint.CheckpointCoordinatorTestingUtils.generateKeyGroupState;
 import static org.apache.flink.runtime.scheduler.SchedulerTestingUtils.acknowledgePendingCheckpoint;
 import static org.apache.flink.runtime.scheduler.SchedulerTestingUtils.setAllExecutionsToRunning;
+import static org.apache.flink.runtime.scheduler.SchedulerTestingUtils.waitForAllTasksDeploymentDescriptorsCreated;
 import static org.apache.flink.runtime.scheduler.SchedulerTestingUtils.waitForAllTasksRunning;
 import static org.apache.flink.runtime.scheduler.SchedulerTestingUtils.waitForCheckpointInProgress;
 import static org.apache.flink.runtime.scheduler.SchedulerTestingUtils.waitForCompletedCheckpoint;
@@ -103,11 +104,6 @@ public class LocalRecoveryTest extends AdaptiveSchedulerTestBase {
 
         // Transition job and all subtasks to RUNNING state.
         waitForJobStatusRunning(scheduler);
-        runInMainThread(() -> setAllExecutionsToRunning(scheduler));
-        // Wait for all task executions to actually reach RUNNING state before triggering
-        // checkpoint.
-        // In slower CI environments, state transitions may not complete immediately, causing
-        // checkpoint triggers to be rejected if tasks are still in DEPLOYING/INITIALIZING state.
         final ExecutionGraph executionGraph =
                 scheduler
                         .getState()
@@ -115,6 +111,16 @@ public class LocalRecoveryTest extends AdaptiveSchedulerTestBase {
                         .map(StateWithExecutionGraph::getExecutionGraph)
                         .orElseThrow(
                                 () -> new IllegalStateException("ExecutionGraph not available"));
+
+        // Forcing RUNNING while the asynchronous descriptor creation is still in flight fails the
+        // deployment and restarts the job, so the checkpoint below would never register.
+        waitForAllTasksDeploymentDescriptorsCreated(executionGraph);
+
+        runInMainThread(() -> setAllExecutionsToRunning(scheduler));
+        // Wait for all task executions to actually reach RUNNING state before triggering
+        // checkpoint.
+        // In slower CI environments, state transitions may not complete immediately, causing
+        // checkpoint triggers to be rejected if tasks are still in DEPLOYING/INITIALIZING state.
         waitForAllTasksRunning(executionGraph);
 
         // Trigger a checkpoint


### PR DESCRIPTION
## What is the purpose of the change

`LocalRecoveryTest.testStateSizeIsConsideredForLocalRecoveryOnRestart` failed in [build 75865](https://dev.azure.com/apache-flink/apache-flink/_build/results?buildId=75865) with `Exhausted retry attempts` from `waitForCheckpointInProgress`. The test forces all executions to RUNNING while the AdaptiveScheduler is still creating task deployment descriptors on an I/O thread; deployment is rejected once the execution leaves DEPLOYING ("execution state has switched to RUNNING during task restore offload"), the job restarts, and the manual checkpoint never registers.

This reuses FLINK-38534: its earlier fix waited for RUNNING *after* the forced transition, which does not prevent this collision. The production `state != DEPLOYING` check is correct; this is a test-only race.

## Brief change log

  - Add `SchedulerTestingUtils#waitForAllTasksDeploymentDescriptorsCreated` and call it in `LocalRecoveryTest` before forcing RUNNING.
  - The helper keys off the descriptor future itself (executions are observable in DEPLOYING before the future is assigned), so it is safe to call concurrently with `Execution.deploy()`; the Javadoc documents when to prefer it over `ExecutionUtils#waitForTaskDeploymentDescriptorsCreation`.

## Verifying this change

This change is already covered by existing tests: `LocalRecoveryTest`, run 5 times consecutively (5/5 pass).

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no (test-only change)
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (Claude Opus 4.8 via Claude Code)

Generated-by: Claude Opus 4.8 (1M context)
