### PR TITLE
[FLINK-39918][tests] Stop operator-restore tests hanging on unexpected job state

### DIFF
--- a/flink-tests/src/test/java/org/apache/flink/test/state/operator/restore/AbstractOperatorRestoreTestBase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/state/operator/restore/AbstractOperatorRestoreTestBase.java
@@ -19,6 +19,7 @@
 package org.apache.flink.test.state.operator.restore;
 
 import org.apache.flink.FlinkVersion;
+import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.api.common.time.Deadline;
 import org.apache.flink.client.program.ClusterClient;
@@ -63,6 +64,7 @@ import java.nio.file.Paths;
 import java.time.Duration;
 import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
@@ -187,15 +189,7 @@ public abstract class AbstractOperatorRestoreTestBase implements MigrationTest {
 
         clusterClient.submitJob(jobToMigrate).get();
 
-        CompletableFuture<JobStatus> jobRunningFuture =
-                FutureUtils.retrySuccessfulWithDelay(
-                        () -> clusterClient.getJobStatus(jobToMigrate.getJobID()),
-                        Duration.ofMillis(50),
-                        deadline,
-                        (jobStatus) -> jobStatus == JobStatus.RUNNING,
-                        scheduledExecutor);
-        assertThat(jobRunningFuture.get(deadline.timeLeft().toMillis(), TimeUnit.MILLISECONDS))
-                .isEqualTo(JobStatus.RUNNING);
+        waitForJobStatus(clusterClient, jobToMigrate.getJobID(), deadline, JobStatus.RUNNING);
 
         // Trigger savepoint
         String savepointPath = null;
@@ -224,15 +218,7 @@ public abstract class AbstractOperatorRestoreTestBase implements MigrationTest {
 
         assertThat(savepointPath).as("Could not take savepoint.").isNotNull();
 
-        CompletableFuture<JobStatus> jobCanceledFuture =
-                FutureUtils.retrySuccessfulWithDelay(
-                        () -> clusterClient.getJobStatus(jobToMigrate.getJobID()),
-                        Duration.ofMillis(50),
-                        deadline,
-                        (jobStatus) -> jobStatus == JobStatus.CANCELED,
-                        scheduledExecutor);
-        assertThat(jobCanceledFuture.get(deadline.timeLeft().toMillis(), TimeUnit.MILLISECONDS))
-                .isEqualTo(JobStatus.CANCELED);
+        waitForJobStatus(clusterClient, jobToMigrate.getJobID(), deadline, JobStatus.CANCELED);
 
         return savepointPath;
     }
@@ -247,15 +233,43 @@ public abstract class AbstractOperatorRestoreTestBase implements MigrationTest {
 
         clusterClient.submitJob(jobToRestore).get();
 
-        CompletableFuture<JobStatus> jobStatusFuture =
+        waitForJobStatus(clusterClient, jobToRestore.getJobID(), deadline, JobStatus.FINISHED);
+    }
+
+    /**
+     * Waits until the job reaches {@code targetStatus}, failing fast if the job reaches a globally
+     * terminal state that is not the target (for example {@code FAILED} when waiting for {@code
+     * FINISHED}) instead of retrying until the deadline.
+     */
+    private void waitForJobStatus(
+            ClusterClient<?> clusterClient, JobID jobId, Deadline deadline, JobStatus targetStatus)
+            throws Exception {
+        final CompletableFuture<JobStatus> statusFuture =
                 FutureUtils.retrySuccessfulWithDelay(
-                        () -> clusterClient.getJobStatus(jobToRestore.getJobID()),
+                        () ->
+                                clusterClient
+                                        .getJobStatus(jobId)
+                                        .thenApply(
+                                                jobStatus -> {
+                                                    if (jobStatus != targetStatus
+                                                            && jobStatus
+                                                                    .isGloballyTerminalState()) {
+                                                        throw new CompletionException(
+                                                                new IllegalStateException(
+                                                                        String.format(
+                                                                                "Job %s reached terminal state %s while waiting for %s.",
+                                                                                jobId,
+                                                                                jobStatus,
+                                                                                targetStatus)));
+                                                    }
+                                                    return jobStatus;
+                                                }),
                         Duration.ofMillis(50),
                         deadline,
-                        (jobStatus) -> jobStatus == JobStatus.FINISHED,
+                        jobStatus -> jobStatus == targetStatus,
                         scheduledExecutor);
-        assertThat(jobStatusFuture.get(deadline.timeLeft().toMillis(), TimeUnit.MILLISECONDS))
-                .isEqualTo(JobStatus.FINISHED);
+        assertThat(statusFuture.get(deadline.timeLeft().toMillis(), TimeUnit.MILLISECONDS))
+                .isEqualTo(targetStatus);
     }
 
     private JobGraph createJobGraph(ExecutionMode mode) {


### PR DESCRIPTION
## What is the purpose of the change

`KeyedComplexChainTest` hung in [build 75865](https://dev.azure.com/apache-flink/apache-flink/_build/results?buildId=75865) until the CI watchdog killed the fork after 900s. `AbstractOperatorRestoreTestBase` waits for one specific job status against a ~2.7h deadline; a job that instead reaches another globally terminal state (e.g. FAILED) never matches the predicate, so the fork is killed without a usable error and the actual job failure is lost.

Tracked in FLINK-39918; the historic hang tickets for this test (FLINK-18138, FLINK-12916) are long closed and unrelated.

## Brief change log

  - Replace the three duplicated wait blocks with a shared `waitForJobStatus` helper that fails fast (with the unexpected state, job id, and target) when the job reaches a globally terminal state other than the target.
  - No timeout values are changed and no local `@Timeout` is added; the fail-fast behavior alone prevents the multi-hour spin.

## Verifying this change

This change is already covered by existing tests: `KeyedComplexChainTest` (16 parameterized cases, 0 failures). The shared base also covers the other operator-restore tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no (test-only change)
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (Claude Opus 4.8 via Claude Code)

Generated-by: Claude Opus 4.8 (1M context)
