### PR TITLE
[BP-2.3][FLINK-37892][tests] Fix spurious TimeoutException in TestUtils#waitUntil for non-monotonic conditions

### DIFF
--- a/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/test/util/TestUtils.java
+++ b/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/test/util/TestUtils.java
@@ -223,12 +223,17 @@ public class TestUtils {
      */
     public static void waitUntil(Supplier<Boolean> condition, Duration timeout, String message)
             throws InterruptedException, TimeoutException {
-        long startTime = System.currentTimeMillis();
-        while (!condition.get() && System.currentTimeMillis() < startTime + timeout.toMillis()) {
+        long deadline = System.currentTimeMillis() + timeout.toMillis();
+        while (true) {
+            // Latch the result so that a condition that is satisfied once does not fail the
+            // wait if it becomes false again before a re-evaluation.
+            if (condition.get()) {
+                return;
+            }
+            if (System.currentTimeMillis() >= deadline) {
+                throw new TimeoutException(message);
+            }
             Thread.sleep(1);
-        }
-        if (!condition.get()) {
-            throw new TimeoutException(message);
         }
     }
 

--- a/flink-test-utils-parent/flink-test-utils/src/test/java/org/apache/flink/test/util/TestUtilsTest.java
+++ b/flink-test-utils-parent/flink-test-utils/src/test/java/org/apache/flink/test/util/TestUtilsTest.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.test.util;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Tests for {@link TestUtils}. */
+class TestUtilsTest {
+
+    @Test
+    void testWaitUntilReturnsWhenConditionIsMet() {
+        assertThatCode(() -> TestUtils.waitUntil(() -> true, Duration.ofSeconds(5), "msg"))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void testWaitUntilThrowsOnTimeout() {
+        assertThatThrownBy(() -> TestUtils.waitUntil(() -> false, Duration.ofMillis(50), "msg"))
+                .isInstanceOf(TimeoutException.class)
+                .hasMessage("msg");
+    }
+
+    @Test
+    void testWaitUntilSucceedsForConditionSatisfiedOnlyOnce() {
+        // A non-monotonic condition may become true and then false again. Once it has been
+        // observed as true, waitUntil must return successfully instead of re-evaluating it
+        // and throwing a spurious TimeoutException.
+        final AtomicBoolean firstCall = new AtomicBoolean(true);
+        assertThatCode(
+                        () ->
+                                TestUtils.waitUntil(
+                                        () -> firstCall.getAndSet(false),
+                                        Duration.ofSeconds(5),
+                                        "msg"))
+                .doesNotThrowAnyException();
+    }
+}


### PR DESCRIPTION

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

[BP-2.3][FLINK-37892][tests] Fix spurious TimeoutException in TestUtils#waitUntil for non-monotonic conditions


## Brief change log

[BP-2.3][FLINK-37892][tests] Fix spurious TimeoutException in TestUtils#waitUntil for non-monotonic conditions


## Verifying this change


[BP-2.3][FLINK-37892][tests] Fix spurious TimeoutException in TestUtils#waitUntil for non-monotonic conditions

## Does this pull request potentially affect one of the following parts:

 N.A

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change the checkbox below to `[X]` followed by the name of the tool, and uncomment the
"Generated-by" line. See the ASF Generative Tooling Guidance for details:
https://www.apache.org/legal/generative-tooling.html

You are responsible for the quality and correctness of every change in this PR
regardless of the tooling used. Low-effort AI-generated PRs will be closed. See
AGENTS.md for the full guidance.
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name and Version]
-->
