### PR TITLE
[BP-2.3][FLINK-39917][tests] Wait for RM disconnect log in JobMasterTriggerSavepointITCase

### DIFF
--- a/flink-tests/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTriggerSavepointITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTriggerSavepointITCase.java
@@ -94,6 +94,9 @@ class JobMasterTriggerSavepointITCase {
 
     private static volatile CountDownLatch triggerCheckpointLatch;
 
+    /** Prefix of the StandaloneResourceManager log line emitted when a JobMaster disconnects. */
+    private static final String DISCONNECT_JOB_MANAGER_LOG_PREFIX = "Disconnect job manager ";
+
     @TempDir protected File temporaryFolder;
 
     @RegisterExtension
@@ -284,7 +287,7 @@ class JobMasterTriggerSavepointITCase {
                 List.of(
                         "Registering job manager .*",
                         "Registered job manager .*",
-                        "Disconnect job manager .*"),
+                        DISCONNECT_JOB_MANAGER_LOG_PREFIX + ".*"),
                 "Registering TaskManager with ResourceID .*");
         assertKeyPresent(
                 MdcUtils.JOB_ID,
@@ -362,6 +365,18 @@ class JobMasterTriggerSavepointITCase {
         clusterClient.cancel(jobGraph.getJobID()).get();
         CommonTestUtils.waitUntilCondition(
                 () -> clusterClient.getJobStatus(jobGraph.getJobID()).get() == JobStatus.CANCELED,
+                600);
+        // The JobMaster disconnects from the ResourceManager asynchronously after CANCELED;
+        // wait for the logged event so verifyJobIdIsLogged does not race it.
+        CommonTestUtils.waitUntilCondition(
+                () ->
+                        standaloneResourceManagerLogging.getEvents().stream()
+                                .anyMatch(
+                                        e ->
+                                                e.getMessage()
+                                                        .getFormattedMessage()
+                                                        .startsWith(
+                                                                DISCONNECT_JOB_MANAGER_LOG_PREFIX)),
                 600);
     }
 


### PR DESCRIPTION

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

[BP-2.3][FLINK-39917][tests] Wait for RM disconnect log in JobMasterTriggerSavepointITCase


## Brief change log

[BP-2.3][FLINK-39917][tests] Wait for RM disconnect log in JobMasterTriggerSavepointITCase


## Verifying this change

[BP-2.3][FLINK-39917][tests] Wait for RM disconnect log in JobMasterTriggerSavepointITCase

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change the checkbox below to `[X]` followed by the name of the tool, and uncomment the
"Generated-by" line. See the ASF Generative Tooling Guidance for details:
https://www.apache.org/legal/generative-tooling.html

You are responsible for the quality and correctness of every change in this PR
regardless of the tooling used. Low-effort AI-generated PRs will be closed. See
AGENTS.md for the full guidance.
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name and Version]
-->
