### PR TITLE
[FLINK-39921][runtime/test] Fix the flaky test case ExecutionTimeBasedSlowTaskDetectorTest due to unexepected ComponentMainThreadExecutor setting.

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/concurrent/NoMainThreadCheckComponentMainThreadExecutor.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/concurrent/NoMainThreadCheckComponentMainThreadExecutor.java
@@ -19,8 +19,10 @@
 package org.apache.flink.runtime.concurrent;
 
 import org.apache.flink.runtime.testutils.DirectScheduledExecutorService;
+import org.apache.flink.util.Preconditions;
 
 import java.util.concurrent.Callable;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
@@ -34,7 +36,15 @@ import java.util.concurrent.TimeUnit;
  */
 public class NoMainThreadCheckComponentMainThreadExecutor implements ComponentMainThreadExecutor {
 
-    private final DirectScheduledExecutorService executor = new DirectScheduledExecutorService();
+    private final ScheduledExecutorService executor;
+
+    public NoMainThreadCheckComponentMainThreadExecutor() {
+        this.executor = new DirectScheduledExecutorService();
+    }
+
+    public NoMainThreadCheckComponentMainThreadExecutor(ScheduledExecutorService executor) {
+        this.executor = Preconditions.checkNotNull(executor);
+    }
 
     @Override
     public void assertRunningInMainThread() {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/slowtaskdetector/ExecutionTimeBasedSlowTaskDetectorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/slowtaskdetector/ExecutionTimeBasedSlowTaskDetectorTest.java
@@ -19,9 +19,11 @@
 
 package org.apache.flink.runtime.scheduler.slowtaskdetector;
 
+import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.SlowTaskDetectorOptions;
-import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutorServiceAdapter;
+import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
+import org.apache.flink.runtime.concurrent.NoMainThreadCheckComponentMainThreadExecutor;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.executiongraph.ExecutionGraph;
 import org.apache.flink.runtime.executiongraph.ExecutionGraphTestUtils;
@@ -42,6 +44,7 @@ import org.apache.flink.runtime.util.TestingFatalErrorHandler;
 import org.apache.flink.testutils.TestingUtils;
 import org.apache.flink.testutils.executor.TestExecutorExtension;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -56,6 +59,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.stream.Collectors;
 
 import static org.apache.flink.runtime.executiongraph.ExecutionGraphTestUtils.createNoOpVertex;
+import static org.apache.flink.runtime.testutils.CommonTestUtils.waitUntilCondition;
 import static org.apache.flink.runtime.util.JobVertexConnectionUtils.connectNewDataSetAsInput;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -64,8 +68,16 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 class ExecutionTimeBasedSlowTaskDetectorTest {
 
     @RegisterExtension
-    private static final TestExecutorExtension<ScheduledExecutorService> EXECUTOR_RESOURCE =
+    private static final TestExecutorExtension<ScheduledExecutorService> EXECUTOR_EXTENSION =
             TestingUtils.defaultExecutorExtension();
+
+    private ComponentMainThreadExecutor mainThreadExecutor;
+
+    @BeforeEach
+    void setUp() {
+        mainThreadExecutor =
+                new NoMainThreadCheckComponentMainThreadExecutor(EXECUTOR_EXTENSION.getExecutor());
+    }
 
     @Test
     void testNoFinishedTaskButRatioIsZero() throws Exception {
@@ -90,9 +102,7 @@ class ExecutionTimeBasedSlowTaskDetectorTest {
         // all tasks are in the CREATED state, which is not classified as slow tasks.
         final ExecutionGraph executionGraph =
                 SchedulerTestingUtils.createScheduler(
-                                jobGraph,
-                                ComponentMainThreadExecutorServiceAdapter.forMainThread(),
-                                EXECUTOR_RESOURCE.getExecutor())
+                                jobGraph, mainThreadExecutor, EXECUTOR_EXTENSION.getExecutor())
                         .getExecutionGraph();
 
         final ExecutionTimeBasedSlowTaskDetector slowTaskDetector = createSlowTaskDetector(0, 1, 0);
@@ -222,7 +232,8 @@ class ExecutionTimeBasedSlowTaskDetectorTest {
                 jobVertex1,
                 DistributionPattern.ALL_TO_ALL,
                 ResultPartitionType.BLOCKING);
-        final ExecutionGraph executionGraph = createDynamicExecutionGraph(jobVertex1, jobVertex2);
+        final ExecutionGraph executionGraph =
+                createDynamicExecutionGraphAndSyncInitVerticesInit(jobVertex1, jobVertex2);
 
         final ExecutionTimeBasedSlowTaskDetector slowTaskDetector =
                 createSlowTaskDetector(0.3, 1, 0);
@@ -420,8 +431,7 @@ class ExecutionTimeBasedSlowTaskDetectorTest {
                 slowTasks -> {
                     throw exception;
                 },
-                new ComponentMainThreadExecutorServiceAdapter(
-                        EXECUTOR_RESOURCE.getExecutor(), Thread.currentThread()));
+                mainThreadExecutor);
 
         slowTaskDetector.getScheduledDetectionFuture().get();
         assertThat(fatalErrorHandler.getException()).isEqualTo(exception);
@@ -432,9 +442,7 @@ class ExecutionTimeBasedSlowTaskDetectorTest {
 
         final SchedulerBase scheduler =
                 SchedulerTestingUtils.createScheduler(
-                        jobGraph,
-                        ComponentMainThreadExecutorServiceAdapter.forMainThread(),
-                        EXECUTOR_RESOURCE.getExecutor());
+                        jobGraph, mainThreadExecutor, EXECUTOR_EXTENSION.getExecutor());
 
         final ExecutionGraph executionGraph = scheduler.getExecutionGraph();
 
@@ -444,19 +452,22 @@ class ExecutionTimeBasedSlowTaskDetectorTest {
         return executionGraph;
     }
 
-    private ExecutionGraph createDynamicExecutionGraph(JobVertex... jobVertices) throws Exception {
+    private ExecutionGraph createDynamicExecutionGraphAndSyncInitVerticesInit(
+            JobVertex... jobVertices) throws Exception {
         final JobGraph jobGraph = JobGraphTestUtils.batchJobGraph(jobVertices);
 
         final SchedulerBase scheduler =
                 new DefaultSchedulerBuilder(
-                                jobGraph,
-                                ComponentMainThreadExecutorServiceAdapter.forMainThread(),
-                                EXECUTOR_RESOURCE.getExecutor())
+                                jobGraph, mainThreadExecutor, EXECUTOR_EXTENSION.getExecutor())
                         .buildAdaptiveBatchJobScheduler();
 
         final ExecutionGraph executionGraph = scheduler.getExecutionGraph();
 
         scheduler.startScheduling();
+
+        waitUntilCondition(() -> executionGraph.getState() == JobStatus.RUNNING, 10, 100);
+        Thread.sleep(20L); // Wait for additional time span to be stable.
+
         ExecutionGraphTestUtils.switchAllVerticesToRunning(executionGraph);
 
         return executionGraph;


### PR DESCRIPTION

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

[FLINK-39921][runtime/test] Fix the flaky test case ExecutionTimeBasedSlowTaskDetectorTest due to unexepected ComponentMainThreadExecutor setting.

## Brief change log

[FLINK-39921][runtime/test] Fix the flaky test case ExecutionTimeBasedSlowTaskDetectorTest due to unexepected ComponentMainThreadExecutor setting.

## Verifying this change


Tested locally much times.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change the checkbox below to `[X]` followed by the name of the tool, and uncomment the
"Generated-by" line. See the ASF Generative Tooling Guidance for details:
https://www.apache.org/legal/generative-tooling.html

You are responsible for the quality and correctness of every change in this PR
regardless of the tooling used. Low-effort AI-generated PRs will be closed. See
AGENTS.md for the full guidance.
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name and Version]
-->
