### PR TITLE
[hotfix][tests] Reenable `PeriodicMaterializationManagerTest.testInitialDelay`

### DIFF
--- a/flink-state-backends/flink-statebackend-common/src/test/java/org/apache/flink/state/common/PeriodicMaterializationManagerTest.java
+++ b/flink-state-backends/flink-statebackend-common/src/test/java/org/apache/flink/state/common/PeriodicMaterializationManagerTest.java
@@ -22,6 +22,8 @@ import org.apache.flink.runtime.mailbox.SyncMailboxExecutor;
 import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
 import org.apache.flink.state.common.PeriodicMaterializationManager.MaterializationTarget;
 
+import org.junit.jupiter.api.Test;
+
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.apache.flink.shaded.guava33.com.google.common.collect.Iterators.getOnlyElement;
 import static org.apache.flink.util.concurrent.Executors.newDirectExecutorService;
@@ -30,6 +32,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /** {@link PeriodicMaterializationManager} test. */
 class PeriodicMaterializationManagerTest {
 
+    @Test
     void testInitialDelay() {
         ManuallyTriggeredScheduledExecutorService scheduledExecutorService =
                 new ManuallyTriggeredScheduledExecutorService();


### PR DESCRIPTION

## What is the purpose of the change

The PR reenablbes test which probably was disabled by mistake

## Brief change log
test

## Verifying this change

existing test

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: (no )
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change the checkbox below to `[X]` followed by the name of the tool, and uncomment the
"Generated-by" line. See the ASF Generative Tooling Guidance for details:
https://www.apache.org/legal/generative-tooling.html

You are responsible for the quality and correctness of every change in this PR
regardless of the tooling used. Low-effort AI-generated PRs will be closed. See
AGENTS.md for the full guidance.
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name and Version]
-->
