### PR TITLE
[BP-2.3][FLINK-34921][tests] Stop SystemProcessingTimeServiceTest hanging on timing jitter

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/streaming/runtime/tasks/SystemProcessingTimeServiceTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/streaming/runtime/tasks/SystemProcessingTimeServiceTest.java
@@ -59,20 +59,24 @@ class SystemProcessingTimeServiceTest {
 
         final CountDownLatch countDownLatch = new CountDownLatch(countDown);
 
+        // The service captures its scheduling base internally; a separate clock read in the test
+        // races it, so the expected timestamps are anchored on the first observed one.
+        final AtomicReference<Long> firstTimestamp = new AtomicReference<>();
+
         try {
-            final long initialTimestamp = timer.getCurrentProcessingTime() + initialDelay;
             timer.scheduleAtFixedRate(
                     timestamp -> {
                         try {
+                            firstTimestamp.compareAndSet(null, timestamp);
                             long executionTimes = countDown - countDownLatch.getCount();
                             assertThat(timestamp)
                                     .isCloseTo(
-                                            initialTimestamp + executionTimes * period,
+                                            firstTimestamp.get() + executionTimes * period,
                                             Offset.offset(period));
                             Thread.sleep(executionDelay);
-                        } catch (Error e) {
-                            System.out.println(e.getMessage());
-                            throw new Error(e);
+                        } catch (Throwable e) {
+                            // errorRef is shared with the service's async exception handler.
+                            errorRef.compareAndSet(null, e);
                         }
                         countDownLatch.countDown();
                     },
@@ -107,14 +111,12 @@ class SystemProcessingTimeServiceTest {
         final LastExecutionTimeWrapper lastExecutionTimeWrapper = new LastExecutionTimeWrapper();
 
         try {
-            final long initialTimestamp = timer.getCurrentProcessingTime() + initialDelay;
             timer.scheduleWithFixedDelay(
                     timestamp -> {
                         try {
-                            if (countDownLatch.getCount() == countDown) {
-                                assertThat(timestamp)
-                                        .isCloseTo(initialTimestamp, Offset.offset(period));
-                            } else {
+                            // The first execution has no non-racy reference point; only later
+                            // executions can verify the fixed-delay spacing.
+                            if (countDownLatch.getCount() != countDown) {
                                 assertThat(timestamp)
                                         .isCloseTo(
                                                 lastExecutionTimeWrapper.ts + period,
@@ -122,9 +124,9 @@ class SystemProcessingTimeServiceTest {
                             }
                             Thread.sleep(executionDelay);
                             lastExecutionTimeWrapper.ts = timer.getCurrentProcessingTime();
-                        } catch (Error e) {
-                            System.out.println(e.getMessage());
-                            throw new Error(e);
+                        } catch (Throwable e) {
+                            // errorRef is shared with the service's async exception handler.
+                            errorRef.compareAndSet(null, e);
                         }
                         countDownLatch.countDown();
                     },


### PR DESCRIPTION
## What is the purpose of the change

Backport of #28405 (commit `4acf53ae18e43055029864072f220087b32ac0e5`) to `release-2.3`.

`SystemProcessingTimeServiceTest.testScheduleAtFixedRate` compared scheduled timestamps against a clock read that races the service's internal scheduling base. On a slow machine the failing assertion threw an `Error` out of the callback, which silently stops the periodic task in `ScheduledThreadPoolExecutor`, so the latch never counted down and the test hung into a bare `TimeoutException` that masked the real failure.

## Brief change log

  - Anchor the fixed-rate spacing check on the first observed timestamp instead of a racy second clock read.
  - Record any callback throwable into `errorRef` while still counting down, so a genuine drift fails fast with the real assertion.
  - Remove the fixed-delay first-execution check, which has no non-racy reference point. The fixed-delay spacing checks for later executions are kept.

## Verifying this change

This change is covered by existing tests: `SystemProcessingTimeServiceTest`. Clean cherry-pick from `master`; no conflicts.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (original commit generated by Claude Opus 4.8; backport cherry-pick prepared via Claude Code)

Generated-by: Claude Opus 4.8 (1M context)
