### PR TITLE
[FLINK-39122][table] Reject out-of-range decimal constant arguments

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/TypeInferenceUtil.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/TypeInferenceUtil.java
@@ -22,6 +22,7 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.table.api.TableException;
 import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.catalog.DataTypeFactory;
+import org.apache.flink.table.data.DecimalData;
 import org.apache.flink.table.functions.FunctionDefinition;
 import org.apache.flink.table.functions.ModelSemantics;
 import org.apache.flink.table.functions.TableSemantics;
@@ -29,10 +30,12 @@ import org.apache.flink.table.functions.UserDefinedFunctionHelper;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.inference.utils.CastCallContext;
 import org.apache.flink.table.types.inference.utils.UnknownCallContext;
+import org.apache.flink.table.types.logical.DecimalType;
 import org.apache.flink.table.types.logical.LogicalTypeRoot;
 
 import javax.annotation.Nullable;
 
+import java.math.BigDecimal;
 import java.time.Duration;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -155,9 +158,57 @@ public final class TypeInferenceUtil {
                                 "Invalid argument type at position %d. Data type %s expected but %s passed.",
                                 pos, expectedType, actualType));
             }
+
+            // Beyond type-level castability, a constant DECIMAL literal must also fit the
+            // expected type on the value level.
+            if (throwOnInferInputFailure) {
+                validateDecimalLiteralFitsExpectedType(callContext, pos, expectedType);
+            }
         }
 
         return castCallContext;
+    }
+
+    /**
+     * Validates that a constant {@code DECIMAL} literal argument fits the expected type on the
+     * value level and not only on the type level. For example, {@code 123.456} is implicitly
+     * castable to a {@code DECIMAL(2, 2)} but would otherwise be silently reduced to {@code NULL}
+     * during constant folding instead of raising a type error.
+     *
+     * <p>Only {@code DECIMAL} is covered here; other value-level overflows (e.g. {@code CHAR}
+     * overruns or out-of-range integer literals) are out of scope for this check.
+     */
+    private static void validateDecimalLiteralFitsExpectedType(
+            CallContext callContext, int pos, DataType expectedType) {
+        if (!expectedType.getLogicalType().is(LogicalTypeRoot.DECIMAL)) {
+            return;
+        }
+        final BigDecimal value;
+        try {
+            if (!callContext.isArgumentLiteral(pos)) {
+                return;
+            }
+            // Absent for a NULL literal or a literal that cannot be represented as a BigDecimal.
+            value = callContext.getArgumentValue(pos, BigDecimal.class).orElse(null);
+        } catch (UnsupportedOperationException e) {
+            // Some call contexts (e.g. procedure calls backed by an ExplicitOperatorBinding)
+            // expose only argument types, not values, so the value-level check cannot run here.
+            // Such constants are reduced and validated separately by the caller.
+            return;
+        }
+        if (value == null) {
+            return;
+        }
+        final DecimalType decimalType = (DecimalType) expectedType.getLogicalType();
+        final DecimalData converted =
+                DecimalData.fromBigDecimal(
+                        value, decimalType.getPrecision(), decimalType.getScale());
+        if (converted == null) {
+            throw new ValidationException(
+                    String.format(
+                            "Invalid argument value at position %d. The value '%s' does not fit the expected data type %s.",
+                            pos, value, expectedType));
+        }
     }
 
     /**

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/TypeInferenceUtil.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/TypeInferenceUtil.java
@@ -175,12 +175,16 @@ public final class TypeInferenceUtil {
      * castable to a {@code DECIMAL(2, 2)} but would otherwise be silently reduced to {@code NULL}
      * during constant folding instead of raising a type error.
      *
-     * <p>Only {@code DECIMAL} is covered here; other value-level overflows (e.g. {@code CHAR}
-     * overruns or out-of-range integer literals) are out of scope for this check.
+     * <p>Only a top-level {@code DECIMAL} argument is covered here; other value-level overflows
+     * (e.g. {@code CHAR} overruns or out-of-range integer literals) and a {@code DECIMAL} nested
+     * inside a container type (e.g. {@code ARRAY<DECIMAL(2, 2)>}) are out of scope for this check.
      */
     private static void validateDecimalLiteralFitsExpectedType(
             CallContext callContext, int pos, DataType expectedType) {
-        if (!expectedType.getLogicalType().is(LogicalTypeRoot.DECIMAL)) {
+        if (!(expectedType.getLogicalType() instanceof DecimalType)) {
+            // Some expected types (e.g. a legacy DECIMAL-rooted type backed by
+            // LegacyTypeInformationType for Types.BIG_DEC) report LogicalTypeRoot.DECIMAL without
+            // actually being a DecimalType, so the type-root alone is not a safe cast guard.
             return;
         }
         final BigDecimal value;

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/inference/InputTypeStrategiesTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/inference/InputTypeStrategiesTest.java
@@ -117,6 +117,74 @@ class InputTypeStrategiesTest extends InputTypeStrategiesTestBase {
                         .expectErrorMessage(
                                 "Invalid number of arguments. At least 2 arguments expected but 1 passed."),
 
+                // a constant literal that overflows the expected DECIMAL precision must raise a
+                // type error instead of being silently reduced to NULL
+                TestSpec.forStrategy(
+                                "literal decimal overflowing the expected precision",
+                                explicitSequence(DataTypes.DECIMAL(2, 2)))
+                        .calledWithArgumentTypes(DataTypes.DECIMAL(6, 3))
+                        .calledWithLiteralAt(0, new BigDecimal("123.456"))
+                        .expectErrorMessage(
+                                "The value '123.456' does not fit the expected data type"),
+
+                // a constant literal that only requires scale rounding still fits
+                TestSpec.forStrategy(
+                                "literal decimal rounded within the expected precision",
+                                explicitSequence(DataTypes.DECIMAL(2, 2)))
+                        .calledWithArgumentTypes(DataTypes.DECIMAL(3, 3))
+                        .calledWithLiteralAt(0, new BigDecimal("0.456"))
+                        .expectArgumentTypes(DataTypes.DECIMAL(2, 2)),
+
+                // a constant literal that fits the expected precision is accepted
+                TestSpec.forStrategy(
+                                "literal decimal fitting the expected precision",
+                                explicitSequence(DataTypes.DECIMAL(2, 2)))
+                        .calledWithArgumentTypes(DataTypes.DECIMAL(2, 2))
+                        .calledWithLiteralAt(0, new BigDecimal("0.45"))
+                        .expectArgumentTypes(DataTypes.DECIMAL(2, 2)),
+
+                // a constant literal whose integer part overflows the expected precision is
+                // rejected, also for precisions other than DECIMAL(2, 2)
+                TestSpec.forStrategy(
+                                "literal decimal overflowing the integer digits",
+                                explicitSequence(DataTypes.DECIMAL(5, 2)))
+                        .calledWithArgumentTypes(DataTypes.DECIMAL(6, 2))
+                        .calledWithLiteralAt(0, new BigDecimal("1234.56"))
+                        .expectErrorMessage(
+                                "The value '1234.56' does not fit the expected data type"),
+
+                // a negative constant literal that overflows the expected precision is rejected
+                TestSpec.forStrategy(
+                                "negative literal decimal overflowing the expected precision",
+                                explicitSequence(DataTypes.DECIMAL(4, 2)))
+                        .calledWithArgumentTypes(DataTypes.DECIMAL(5, 2))
+                        .calledWithLiteralAt(0, new BigDecimal("-123.45"))
+                        .expectErrorMessage(
+                                "The value '-123.45' does not fit the expected data type"),
+
+                // a constant literal that fits a larger expected precision is accepted
+                TestSpec.forStrategy(
+                                "literal decimal fitting a larger expected precision",
+                                explicitSequence(DataTypes.DECIMAL(10, 2)))
+                        .calledWithArgumentTypes(DataTypes.DECIMAL(10, 2))
+                        .calledWithLiteralAt(0, new BigDecimal("12345678.90"))
+                        .expectArgumentTypes(DataTypes.DECIMAL(10, 2)),
+
+                // a NULL literal carries no value and must not raise an overflow error
+                TestSpec.forStrategy(
+                                "NULL decimal literal is not range-checked",
+                                explicitSequence(DataTypes.DECIMAL(2, 2)))
+                        .calledWithArgumentTypes(DataTypes.DECIMAL(6, 3))
+                        .calledWithLiteralAt(0)
+                        .expectArgumentTypes(DataTypes.DECIMAL(2, 2)),
+
+                // a non-literal (runtime) decimal argument is not range-checked, only constants are
+                TestSpec.forStrategy(
+                                "non-literal decimal is not range-checked",
+                                explicitSequence(DataTypes.DECIMAL(2, 2)))
+                        .calledWithArgumentTypes(DataTypes.DECIMAL(6, 3))
+                        .expectArgumentTypes(DataTypes.DECIMAL(2, 2)),
+
                 // any type
                 TestSpec.forStrategy(sequence(ANY))
                         .calledWithArgumentTypes(DataTypes.BIGINT())

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/inference/InputTypeStrategiesTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/inference/InputTypeStrategiesTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.types.inference;
 
+import org.apache.flink.api.common.typeinfo.Types;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.inference.strategies.SpecificInputTypeStrategies;
@@ -25,6 +26,7 @@ import org.apache.flink.table.types.logical.LocalZonedTimestampType;
 import org.apache.flink.table.types.logical.LogicalTypeFamily;
 import org.apache.flink.table.types.logical.LogicalTypeRoot;
 import org.apache.flink.table.types.logical.TimestampKind;
+import org.apache.flink.table.types.utils.LegacyTypeInfoDataTypeConverter;
 import org.apache.flink.table.types.utils.TypeConversions;
 
 import java.math.BigDecimal;
@@ -184,6 +186,18 @@ class InputTypeStrategiesTest extends InputTypeStrategiesTestBase {
                                 explicitSequence(DataTypes.DECIMAL(2, 2)))
                         .calledWithArgumentTypes(DataTypes.DECIMAL(6, 3))
                         .expectArgumentTypes(DataTypes.DECIMAL(2, 2)),
+
+                // a legacy DECIMAL-rooted type (e.g. Types.BIG_DEC via
+                // LegacyTypeInfoDataTypeConverter) is not a DecimalType instance; the check must
+                // not attempt to cast it and must not raise a ClassCastException
+                TestSpec.forStrategy(
+                                "literal decimal against a legacy (non-DecimalType) DECIMAL-rooted type",
+                                explicitSequence(
+                                        LegacyTypeInfoDataTypeConverter.toDataType(Types.BIG_DEC)))
+                        .calledWithArgumentTypes(DataTypes.DECIMAL(2, 2))
+                        .calledWithLiteralAt(0, new BigDecimal("0.45"))
+                        .expectArgumentTypes(
+                                LegacyTypeInfoDataTypeConverter.toDataType(Types.BIG_DEC)),
 
                 // any type
                 TestSpec.forStrategy(sequence(ANY))

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/ProcessTableFunctionSemanticTests.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/ProcessTableFunctionSemanticTests.java
@@ -42,6 +42,7 @@ public class ProcessTableFunctionSemanticTests extends SemanticTestBase {
     public List<TableTestProgram> programs() {
         return List.of(
                 ProcessTableFunctionTestPrograms.PROCESS_SCALAR_ARGS,
+                ProcessTableFunctionTestPrograms.PROCESS_SCALAR_DECIMAL_ARG,
                 ProcessTableFunctionTestPrograms.PROCESS_SCALAR_ARGS_TABLE_API,
                 ProcessTableFunctionTestPrograms.PROCESS_ROW_SEMANTIC_TABLE,
                 ProcessTableFunctionTestPrograms.PROCESS_ROW_SEMANTIC_TABLE_TABLE_API,

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/ProcessTableFunctionTestPrograms.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/ProcessTableFunctionTestPrograms.java
@@ -56,6 +56,7 @@ import org.apache.flink.table.planner.plan.nodes.exec.stream.ProcessTableFunctio
 import org.apache.flink.table.planner.plan.nodes.exec.stream.ProcessTableFunctionTestUtils.ScalarArgsFunction;
 import org.apache.flink.table.planner.plan.nodes.exec.stream.ProcessTableFunctionTestUtils.ScalarArgsTimeFunction;
 import org.apache.flink.table.planner.plan.nodes.exec.stream.ProcessTableFunctionTestUtils.ScalarBeforeRowSemanticTablePassThroughFunction;
+import org.apache.flink.table.planner.plan.nodes.exec.stream.ProcessTableFunctionTestUtils.ScalarDecimalArgFunction;
 import org.apache.flink.table.planner.plan.nodes.exec.stream.ProcessTableFunctionTestUtils.SetSemanticTableFullDeletesArgFunction;
 import org.apache.flink.table.planner.plan.nodes.exec.stream.ProcessTableFunctionTestUtils.SetSemanticTableFunction;
 import org.apache.flink.table.planner.plan.nodes.exec.stream.ProcessTableFunctionTestUtils.SetSemanticTableOptionalPartitionFunction;
@@ -116,6 +117,19 @@ public class ProcessTableFunctionTestPrograms {
                                     .build())
                     .runSql(
                             "INSERT INTO sink SELECT * FROM f(i => 42, b => CAST('TRUE' AS BOOLEAN))")
+                    .build();
+
+    public static final TableTestProgram PROCESS_SCALAR_DECIMAL_ARG =
+            TableTestProgram.of(
+                            "process-scalar-decimal-arg",
+                            "a decimal scalar arg that fits the declared precision")
+                    .setupTemporarySystemFunction("f", ScalarDecimalArgFunction.class)
+                    .setupTableSink(
+                            SinkTestStep.newBuilder("sink")
+                                    .addSchema(BASE_SINK_SCHEMA)
+                                    .consumedValues("+I[{0.4}]")
+                                    .build())
+                    .runSql("INSERT INTO sink SELECT * FROM f(0.4)")
                     .build();
 
     public static final TableTestProgram PROCESS_SCALAR_ARGS_TABLE_API =

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/ProcessTableFunctionTestUtils.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/ProcessTableFunctionTestUtils.java
@@ -42,6 +42,7 @@ import org.apache.flink.types.ColumnList;
 import org.apache.flink.types.Row;
 import org.apache.flink.types.RowKind;
 
+import java.math.BigDecimal;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDateTime;
@@ -316,6 +317,13 @@ public class ProcessTableFunctionTestUtils {
     public static class ScalarArgsFunction extends AppendProcessTableFunctionBase {
         public void eval(Integer i, Boolean b) {
             collectObjects(i, b);
+        }
+    }
+
+    /** Testing function. */
+    public static class ScalarDecimalArgFunction extends AppendProcessTableFunctionBase {
+        public void eval(@DataTypeHint("DECIMAL(2, 2)") BigDecimal d) {
+            collectObjects(d);
         }
     }
 

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/stream/sql/ProcessTableFunctionTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/stream/sql/ProcessTableFunctionTest.java
@@ -41,6 +41,7 @@ import org.apache.flink.table.planner.plan.nodes.exec.stream.ProcessTableFunctio
 import org.apache.flink.table.planner.plan.nodes.exec.stream.ProcessTableFunctionTestUtils.RowSemanticTableFunction;
 import org.apache.flink.table.planner.plan.nodes.exec.stream.ProcessTableFunctionTestUtils.RowSemanticTablePassThroughFunction;
 import org.apache.flink.table.planner.plan.nodes.exec.stream.ProcessTableFunctionTestUtils.ScalarArgsFunction;
+import org.apache.flink.table.planner.plan.nodes.exec.stream.ProcessTableFunctionTestUtils.ScalarDecimalArgFunction;
 import org.apache.flink.table.planner.plan.nodes.exec.stream.ProcessTableFunctionTestUtils.SetSemanticTableFunction;
 import org.apache.flink.table.planner.plan.nodes.exec.stream.ProcessTableFunctionTestUtils.SetSemanticTablePassThroughFunction;
 import org.apache.flink.table.planner.plan.nodes.exec.stream.ProcessTableFunctionTestUtils.TypedRowSemanticTableFunction;
@@ -62,6 +63,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import javax.annotation.Nullable;
 
+import java.math.BigDecimal;
 import java.util.EnumSet;
 import java.util.Optional;
 import java.util.function.Function;
@@ -580,7 +582,22 @@ class ProcessTableFunctionTest extends TableTestBase {
                         TypedRowSemanticTableFunction.class,
                         env -> env.fromValues(row("Bob", 1.99)).process("f", 1),
                         "Invalid argument value. Argument 'u' expects a typed table, but the provided "
-                                + "table is incompatible and cannot be cast to the target type."));
+                                + "table is incompatible and cannot be cast to the target type."),
+                ErrorSpec.ofTableApi(
+                        "decimal scalar arg that overflows the declared precision",
+                        ScalarDecimalArgFunction.class,
+                        env -> env.fromCall("f", new BigDecimal("123.456")),
+                        "The value '123.456' does not fit the expected data type"),
+                ErrorSpec.ofSelect(
+                        "decimal scalar arg that overflows the declared precision in SQL",
+                        ScalarDecimalArgFunction.class,
+                        "SELECT * FROM f(123.456)",
+                        "The value '123.456' does not fit the expected data type"),
+                ErrorSpec.ofSelect(
+                        "non-decimal numeric constant that overflows the declared precision",
+                        ScalarDecimalArgFunction.class,
+                        "SELECT * FROM f(123)",
+                        "The value '123' does not fit the expected data type"));
     }
 
     /** Testing function. */


### PR DESCRIPTION
## What is the purpose of the change
This pull request addresses FLINK-39122 which is related to invalid precision for decimals resulting unexpected in null values. A constant decimal argument that does not fit the declared type (e.g., `123.456` for a `DECIMAL(2, 2)` parameter) silently produced `NULL` instead of raising a type error. The literal is implicitly castable on the type level but overflows on the value level, so it was previous reduced to `NULL` during constant folding. These changes introduce validation for constant arguments during type inference so the call fails with a `ValidationException` instead of producing silent null values.

## Brief change log
  - Validate that a constant literal argument fits its expected `DECIMAL` type in `TypeInferenceUtil`, throwing a `ValidationException` on overflow.
  - Add unit, plan, and execution tests for the overflow error and for valid (fitting) decimal constants.

## Verifying this change
This change added tests and can be verified as follows:
  - `InputTypeStrategiesTest` — overflow raises an error; fitting/rounding constants are accepted.
  - `ProcessTableFunctionTest` — the Table API (`fromCall`) and SQL paths both raise the error.
  - `ProcessTableFunctionSemanticTests` — a fitting decimal constant flows through end-to-end.

## Does this pull request potentially affect one of the following parts:
  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: **no**
  - The S3 file system connector: **no**

## Documentation
- Does this pull request introduce a new feature? **no**

## Generative AI
- Was generative AI tooling used to co-author this PR? **yes** (Claude Code via Opus 4.8)

## Reviewer(s) Requested
@twalthr (original reporter)