### PR TITLE
[FLINK-39893][metrics] Respect non-monotonic counters in OpenTelemetry reporter

### DIFF
--- a/flink-metrics/flink-metrics-otel/src/main/java/org/apache/flink/metrics/otel/OpenTelemetryMetricAdapter.java
+++ b/flink-metrics/flink-metrics-otel/src/main/java/org/apache/flink/metrics/otel/OpenTelemetryMetricAdapter.java
@@ -63,15 +63,7 @@ class OpenTelemetryMetricAdapter {
             Long previousCount,
             MetricMetadata metricMetadata) {
         long delta = count - previousCount;
-        if (delta < 0) {
-            LOG.warn(
-                    "Non-monotonic counter {}: current count {} is less than previous count {}",
-                    metricMetadata.getName(),
-                    count,
-                    previousCount);
-            return Optional.empty();
-        }
-        Boolean isMonotonic = true;
+        Boolean isMonotonic = false;
         return Optional.of(
                 ImmutableMetricData.createLongSum(
                         collectionMetadata.getOtelResource(),

--- a/flink-metrics/flink-metrics-otel/src/test/java/org/apache/flink/metrics/otel/OpenTelemetryMetricAdapterTest.java
+++ b/flink-metrics/flink-metrics-otel/src/test/java/org/apache/flink/metrics/otel/OpenTelemetryMetricAdapterTest.java
@@ -65,7 +65,7 @@ public class OpenTelemetryMetricAdapterTest {
         assertThat(metricData.get().getName()).isEqualTo("foo.bar.count");
         assertThat(metricData.get().getLongSumData().getAggregationTemporality())
                 .isEqualTo(AggregationTemporality.DELTA);
-        assertThat(metricData.get().getLongSumData().isMonotonic()).isEqualTo(true);
+        assertThat(metricData.get().getLongSumData().isMonotonic()).isFalse();
         assertThat(metricData.get().getType()).isEqualTo(MetricDataType.LONG_SUM);
         assertThat(metricData.get().getLongSumData().getPoints().size()).isEqualTo(1);
         LongPointData data = metricData.get().getLongSumData().getPoints().iterator().next();
@@ -75,6 +75,21 @@ public class OpenTelemetryMetricAdapterTest {
         assertThat(metricData.get().getLongGaugeData()).isEqualTo(ImmutableGaugeData.empty());
         assertThat(metricData.get().getDoubleGaugeData()).isEqualTo(ImmutableGaugeData.empty());
         assertThat(metricData.get().getHistogramData()).isEqualTo(ImmutableHistogramData.empty());
+    }
+
+    @Test
+    public void testCounterNonMonotonicDelta() {
+        Optional<MetricData> metricData =
+                OpenTelemetryMetricAdapter.convertCounter(
+                        METADATA, 40L, 50L, new MetricMetadata("foo.bar.count", VARIABLES));
+
+        assertThat(metricData).isPresent();
+        assertThat(metricData.get().getLongSumData().getAggregationTemporality())
+                .isEqualTo(AggregationTemporality.DELTA);
+        assertThat(metricData.get().getLongSumData().isMonotonic()).isFalse();
+        LongPointData data = metricData.get().getLongSumData().getPoints().iterator().next();
+        assertThat(data.getValue()).isEqualTo(-10L);
+        assertThat(asStringMap(data.getAttributes())).isEqualTo(VARIABLES);
     }
 
     @Test


### PR DESCRIPTION
## What is the purpose of the change

Flink `Counter` values are not guaranteed to be monotonic because counters support `dec()` and `inc()` with negative values. The OpenTelemetry reporter currently drops negative deltas when converting counters, which can lose valid counter updates.

This pull request preserves non-incremental counter deltas by exporting Flink counters as non-monotonic delta sums.

Jira: https://issues.apache.org/jira/browse/FLINK-39893

## Brief change log

- Mark converted OpenTelemetry counter sums as non-monotonic.
- Keep negative counter deltas instead of dropping them.
- Add a regression test for a negative/non-incremental counter delta.

## Verifying this change

This change added tests and can be verified as follows:

- `./mvnw -pl flink-metrics/flink-metrics-otel -Dtest=OpenTelemetryMetricAdapterTest -DskipITs -Dfast test`
- `./mvnw -pl flink-metrics/flink-metrics-otel -Dtest=OpenTelemetryMetricAdapterTest,OpenTelemetryMetricReporterTest -DskipITs -Dfast test`
- `./mvnw -pl flink-metrics/flink-metrics-otel -DskipTests -DskipITs -Dfast -Drat.skip=true spotless:check checkstyle:check`

I also ran the full `flink-metrics-otel` module tests. The non-container unit tests passed, but the module-level run could not complete in this environment because Testcontainers could not find `/var/run/docker.sock` for the OpenTelemetry protocol/container tests.

## Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): no
- The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
- The serializers: no
- The runtime per-record code paths (performance sensitive): no
- Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
- The S3 file system connector: no

## Documentation

- Does this pull request introduce a new feature? no

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: Hermes Agent (OpenAI GPT-5.5)
