### PR TITLE
[FLINK-39935] [table] Allow connectors to override lineage dataset name

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/lineage/TableLineageDatasetImpl.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/lineage/TableLineageDatasetImpl.java
@@ -42,7 +42,10 @@ public class TableLineageDatasetImpl implements TableLineageDataset {
 
     public TableLineageDatasetImpl(
             ContextResolvedTable contextResolvedTable, Optional<LineageDataset> lineageDatasetOpt) {
-        this.name = contextResolvedTable.getIdentifier().asSummaryString();
+        this.name =
+                lineageDatasetOpt
+                        .map(lineageDataset -> lineageDataset.name())
+                        .orElse(contextResolvedTable.getIdentifier().asSummaryString());
         this.namespace =
                 lineageDatasetOpt.map(lineageDataset -> lineageDataset.namespace()).orElse("");
         this.catalogContext =

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/lineage/TableLineageDatasetImpl.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/lineage/TableLineageDatasetImpl.java
@@ -40,6 +40,13 @@ public class TableLineageDatasetImpl implements TableLineageDataset {
     @JsonProperty private ObjectPath objectPath;
     @JsonProperty private Map<String, LineageDatasetFacet> facets;
 
+    /**
+     * Connectors can override the default dataset name and/or namespace by implementing {@link
+     * org.apache.flink.streaming.api.lineage.LineageVertexProvider} on their runtime provider. For
+     * example, for LineageDataset Paimon uses its JDBC catalog-key which is more consistent than
+     * catalog-name to produce {@code <catalog-key>.<db-name>.<table-name>} instead of the default
+     * Flink table identifier which is {@code <catalog-name>.<db-name>.<table-name>}.
+     */
     public TableLineageDatasetImpl(
             ContextResolvedTable contextResolvedTable, Optional<LineageDataset> lineageDatasetOpt) {
         this.name =

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/lineage/TableLineageDatasetImpl.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/lineage/TableLineageDatasetImpl.java
@@ -44,14 +44,15 @@ public class TableLineageDatasetImpl implements TableLineageDataset {
      * Connectors can override the default dataset name and/or namespace by implementing {@link
      * org.apache.flink.streaming.api.lineage.LineageVertexProvider} on their runtime provider. For
      * example, for LineageDataset Paimon uses its JDBC catalog-key which is more consistent than
-     * catalog-name to produce {@code <catalog-key>.<db-name>.<table-name>} instead of the default
-     * Flink table identifier which is {@code <catalog-name>.<db-name>.<table-name>}.
+     * catalog-name to produce "catalog-key.db-name.table-name" instead of the default Flink table
+     * identifier which is "catalog-name.db-name.table-name".
      */
     public TableLineageDatasetImpl(
             ContextResolvedTable contextResolvedTable, Optional<LineageDataset> lineageDatasetOpt) {
         this.name =
                 lineageDatasetOpt
                         .map(lineageDataset -> lineageDataset.name())
+                        .filter(n -> n != null && !n.isEmpty())
                         .orElse(contextResolvedTable.getIdentifier().asSummaryString());
         this.namespace =
                 lineageDatasetOpt.map(lineageDataset -> lineageDataset.namespace()).orElse("");

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/factories/TestValuesRuntimeFunctions.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/factories/TestValuesRuntimeFunctions.java
@@ -440,7 +440,7 @@ public final class TestValuesRuntimeFunctions {
 
         @Override
         public LineageVertex getLineageVertex() {
-            return createLineageVertex(tableName, getNamespace());
+            return createLineageVertex("", getNamespace());
         }
 
         abstract String getNamespace();
@@ -757,7 +757,7 @@ public final class TestValuesRuntimeFunctions {
 
         @Override
         public LineageVertex getLineageVertex() {
-            return createLineageVertex(tableName, LINEAGE_NAMESPACE);
+            return createLineageVertex("", LINEAGE_NAMESPACE);
         }
 
         @Override

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/lineage/TableLineageUtilsTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/lineage/TableLineageUtilsTest.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.table.planner.lineage;
 
+import org.apache.flink.streaming.api.lineage.DefaultLineageDataset;
+import org.apache.flink.streaming.api.lineage.DefaultLineageVertex;
 import org.apache.flink.streaming.api.lineage.LineageDataset;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.Schema;
@@ -114,5 +116,45 @@ class TableLineageUtilsTest {
         TableLineageDatasetImpl tableLineageDataset = (TableLineageDatasetImpl) lineageDataset;
         assertThat(tableLineageDataset.catalogContext().getCatalogName()).isEmpty();
         assertThat(tableLineageDataset.name()).isEqualTo(objectIdentifier.asSummaryString());
+    }
+
+    @Test
+    void testCreateTableLineageDatasetWithConnectorNameOverride() {
+        final ObjectIdentifier objectIdentifier =
+                ObjectIdentifier.of(DEFAULT_CATALOG, "my_db", "my_table");
+        final ContextResolvedTable resolvedTable =
+                ContextResolvedTable.permanent(
+                        objectIdentifier,
+                        CATALOG,
+                        new ResolvedCatalogTable(
+                                CatalogTable.newBuilder()
+                                        .schema(CATALOG_TABLE_SCHEMA)
+                                        .comment("my table")
+                                        .partitionKeys(Collections.emptyList())
+                                        .options(TABLE_OPTIONS)
+                                        .build(),
+                                CATALOG_TABLE_RESOLVED_SCHEMA));
+
+        // Simulate a connector (like Paimon) overriding the dataset name with a custom
+        // catalog-key instead of the Flink catalog-name.
+        DefaultLineageVertex connectorLineageVertex = new DefaultLineageVertex();
+        connectorLineageVertex.addLineageDataset(
+                new DefaultLineageDataset(
+                        "jdbc-catalog-key.my_db.my_table",
+                        "paimon://warehouse",
+                        Collections.emptyMap()));
+
+        LineageDataset lineageDataset =
+                createTableLineageDataset(resolvedTable, Optional.of(connectorLineageVertex));
+        assertThat(lineageDataset).isInstanceOf(TableLineageDatasetImpl.class);
+
+        TableLineageDatasetImpl tableLineageDataset = (TableLineageDatasetImpl) lineageDataset;
+        // name() should use the connector-provided name
+        assertThat(tableLineageDataset.name()).isEqualTo("jdbc-catalog-key.my_db.my_table");
+        // namespace should come from the connector
+        assertThat(tableLineageDataset.namespace()).isEqualTo("paimon://warehouse");
+        // catalogContext should still reflect the Flink catalog
+        assertThat(tableLineageDataset.catalogContext().getCatalogName())
+                .isEqualTo(DEFAULT_CATALOG);
     }
 }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/lineage/TableLineageUtilsTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/lineage/TableLineageUtilsTest.java
@@ -157,4 +157,33 @@ class TableLineageUtilsTest {
         assertThat(tableLineageDataset.catalogContext().getCatalogName())
                 .isEqualTo(DEFAULT_CATALOG);
     }
+
+    @Test
+    void testCreateTableLineageDatasetIgnoresEmptyConnectorName() {
+        final ObjectIdentifier objectIdentifier =
+                ObjectIdentifier.of(DEFAULT_CATALOG, "my_db", "my_table");
+        final ContextResolvedTable resolvedTable =
+                ContextResolvedTable.permanent(
+                        objectIdentifier,
+                        CATALOG,
+                        new ResolvedCatalogTable(
+                                CatalogTable.newBuilder()
+                                        .schema(CATALOG_TABLE_SCHEMA)
+                                        .comment("my table")
+                                        .partitionKeys(Collections.emptyList())
+                                        .options(TABLE_OPTIONS)
+                                        .build(),
+                                CATALOG_TABLE_RESOLVED_SCHEMA));
+
+        // Connector provides a LineageDataset with an empty name — should fall back to identifier.
+        DefaultLineageVertex connectorLineageVertex = new DefaultLineageVertex();
+        connectorLineageVertex.addLineageDataset(
+                new DefaultLineageDataset("", "some://namespace", Collections.emptyMap()));
+
+        LineageDataset lineageDataset =
+                createTableLineageDataset(resolvedTable, Optional.of(connectorLineageVertex));
+        TableLineageDatasetImpl tableLineageDataset = (TableLineageDatasetImpl) lineageDataset;
+
+        assertThat(tableLineageDataset.name()).isEqualTo(objectIdentifier.asSummaryString());
+    }
 }


### PR DESCRIPTION

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change
Previously, `TableLineageDatasetImpl` always used the Flink catalog identifier (contextResolvedTable.getIdentifier().asSummaryString()) as the dataset name. Now it prefers the name provided by the connector's LineageDataset when available, enabling connectors like Paimon to use more stable identifiers (e.g., JDBC catalog-key instead of the logical catalog name registered in Flink).

## Brief change log
- `TableLineageDatasetImpl` now uses the connector-provided `LineageDataset.name()` when present, falling back to the Flink identifier. This is consistent with how `namespace` is already handled in the same class.
- Added a test to verify the connector name override behavior.

## Verifying this change
- Added `testCreateTableLineageDatasetWithConnectorNameOverride` in `TableLineageUtilsTest` which verifies that when a connector provides a `LineageDataset` with a custom name, `TableLineageDatasetImpl.name()` uses the connector-provided name while `catalogContext` still reflects the Flink catalog.
- Existing tests (`testCreateTableLineageDatasetWithCatalog`, `testCreateTableLineageDatasetWithoutCatalog`) verify the fallback path when no connector lineage is provided.

## Does this pull request potentially affect one of the following parts:
- Dependencies (does it add or upgrade a dependency): no
- The public API, i.e., is any changed class annotated with @Public(Evolving): no
- The serializers: no
- The runtime per-record code paths (performance sensitive): no
- Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
- The S3 file system connector: no


## Documentation
  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable)

---

##### Was generative AI tooling used to co-author this PR?
No

