### PR TITLE
[FLINK-39587][runtime-web] Remove eslint cache from web dashboard lint

### DIFF
--- a/flink-runtime-web/web-dashboard/package.json
+++ b/flink-runtime-web/web-dashboard/package.json
@@ -4,8 +4,8 @@
   "scripts": {
     "start": "ng serve",
     "build": "ng build --configuration production --base-href ./",
-    "lint": "eslint --cache \"src/**/*.{ts,html}\" && stylelint \"**/*.less\"",
-    "lint:fix": "eslint --fix --cache \"src/**/*.{ts,html}\" && stylelint \"**/*.less\" --fix",
+    "lint": "eslint \"src/**/*.{ts,html}\" && stylelint \"**/*.less\"",
+    "lint:fix": "eslint --fix \"src/**/*.{ts,html}\" && stylelint \"**/*.less\" --fix",
     "ci-check": "npm run lint && npm run build",
     "proxy": "ng serve --proxy-config proxy.conf.json"
   },

--- a/flink-runtime-web/web-dashboard/src/app/pages/job/exceptions/job-exceptions.component.less
+++ b/flink-runtime-web/web-dashboard/src/app/pages/job/exceptions/job-exceptions.component.less
@@ -53,10 +53,10 @@
 
       nz-tag {
         max-width: 100%;
-        white-space: normal;
-        word-break: break-all;
         height: auto;
         line-height: 1.4;
+        white-space: normal;
+        word-break: break-all;
       }
     }
   }


### PR DESCRIPTION
## What is the purpose of the change

This pull request fixes FLINK-39587 by making the web dashboard lint script run ESLint without the persistent cache. This prevents local repeated lint runs from tolerating stale prettier/template drift that can be hidden by `.eslintcache`; CI already runs on a cold checkout, so the change is not expected to slow CI materially.

Jira: https://issues.apache.org/jira/browse/FLINK-39587

## Brief change log

- Removed `--cache` from the web dashboard `lint` script.
- Removed `--cache` from `lint:fix` so the prescribed auto-fix path also checks/fixes all source files.
- Ran `npm run lint:fix`, which produced one scoped stylelint property-order fix in `job-exceptions.component.less`.
- Re-checked the FLINK-39587 prettier/template drift on current master: the lockfile currently resolves prettier `2.6.2`, which does not produce the 83 HTML comment indentation changes described in the Jira. The bulk HTML reformat and `.git-blame-ignore-revs` entry are therefore deferred until prettier is bumped to 2.7+ / 3.x.

## Verifying this change

This change is already covered by the web dashboard lint/build checks and can be verified as follows:

- `node <script check> package.json lint/lint:fix contain no eslint --cache` (failed before the change, passed after)
- `npm run lint:fix`
- `rm -f .eslintcache && npm run lint`
- `npm run build`
- `git diff --check`

## Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): no
- The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
- The serializers: no
- The runtime per-record code paths (performance sensitive): no
- Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
- The S3 file system connector: no

## Documentation

- Does this pull request introduce a new feature? no

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (Hermes Agent, OpenAI GPT-5.5)

Generated-by: Hermes Agent (OpenAI GPT-5.5)
