### PR TITLE
[FLINK-39572] [python] Hide sensitive process environment values in logs

### DIFF
--- a/flink-python/src/main/java/org/apache/beam/runners/fnexecution/control/DefaultJobBundleFactory.java
+++ b/flink-python/src/main/java/org/apache/beam/runners/fnexecution/control/DefaultJobBundleFactory.java
@@ -17,10 +17,12 @@
  */
 package org.apache.beam.runners.fnexecution.control;
 
+import org.apache.flink.configuration.ConfigurationUtils;
 import org.apache.flink.python.FlinkSlf4jLogWriter;
 
 import org.apache.beam.model.fnexecution.v1.ProvisionApi;
 import org.apache.beam.model.pipeline.v1.RunnerApi.Environment;
+import org.apache.beam.model.pipeline.v1.RunnerApi.ProcessPayload;
 import org.apache.beam.model.pipeline.v1.RunnerApi.StandardEnvironments;
 import org.apache.beam.runners.core.construction.BeamUrns;
 import org.apache.beam.runners.core.construction.Environments;
@@ -57,6 +59,7 @@ import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.options.PortablePipelineOptions;
 import org.apache.beam.sdk.util.NoopLock;
 import org.apache.beam.sdk.values.KV;
+import org.apache.beam.vendor.grpc.v1p60p1.com.google.protobuf.InvalidProtocolBufferException;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.annotations.VisibleForTesting;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.MoreObjects;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Preconditions;
@@ -73,6 +76,7 @@ import org.slf4j.LoggerFactory;
 import javax.annotation.concurrent.ThreadSafe;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.IdentityHashMap;
 import java.util.Map;
 import java.util.Set;
@@ -227,7 +231,7 @@ public class DefaultJobBundleFactory implements JobBundleFactory {
                                         if (refCount > 0) {
                                             LOG.warn(
                                                     "Expiring environment {} with {} remaining bundle references. Taking note to clean it up during shutdown if the references are not removed by then.",
-                                                    notification.getKey(),
+                                                    getEnvironmentForLogging(notification.getKey()),
                                                     refCount);
                                             evictedActiveClients.add(client);
                                         }
@@ -698,7 +702,10 @@ public class DefaultJobBundleFactory implements JobBundleFactory {
                 // the next one will be added via Throwable#addSuppressed.
                 closed = true;
             } catch (Exception e) {
-                LOG.warn("Error cleaning up servers {}", environment.getEnvironment(), e);
+                LOG.warn(
+                        "Error cleaning up servers {}",
+                        getEnvironmentForLogging(environment.getEnvironment()),
+                        e);
             }
             // TODO: Wait for executor shutdown?
         }
@@ -712,11 +719,40 @@ public class DefaultJobBundleFactory implements JobBundleFactory {
             Preconditions.checkState(refCount >= 0, "Reference count must not be negative.");
             if (refCount == 0) {
                 // Close environment after it was removed from cache and all bundles finished.
-                LOG.info("Closing environment {}", environment.getEnvironment());
+                LOG.info(
+                        "Closing environment {}",
+                        getEnvironmentForLogging(environment.getEnvironment()));
                 close();
             }
             return refCount;
         }
+    }
+
+    @VisibleForTesting
+    static String getEnvironmentForLogging(Environment environment) {
+        if (BeamUrns.getUrn(StandardEnvironments.Environments.PROCESS)
+                .equals(environment.getUrn())) {
+            try {
+                ProcessPayload processPayload = ProcessPayload.parseFrom(environment.getPayload());
+                ProcessPayload processPayloadWithHiddenSensitiveValues =
+                        processPayload.toBuilder()
+                                .clearEnv()
+                                .putAllEnv(
+                                        ConfigurationUtils.hideSensitiveValues(
+                                                processPayload.getEnvMap(),
+                                                Collections.emptyList()))
+                                .build();
+                return environment.toBuilder()
+                        .setPayload(processPayloadWithHiddenSensitiveValues.toByteString())
+                        .build()
+                        .toString();
+            } catch (InvalidProtocolBufferException e) {
+                LOG.debug("Could not parse process environment payload for logging.", e);
+                // Fail closed and omit the malformed payload because it may contain sensitive data.
+                return environment.toBuilder().clearPayload().build().toString();
+            }
+        }
+        return environment.toString();
     }
 
     private ServerInfo createServerInfo(JobInfo jobInfo, ServerFactory serverFactory)

--- a/flink-python/src/main/java/org/apache/beam/runners/fnexecution/control/DefaultJobBundleFactory.java
+++ b/flink-python/src/main/java/org/apache/beam/runners/fnexecution/control/DefaultJobBundleFactory.java
@@ -78,6 +78,7 @@ import javax.annotation.concurrent.ThreadSafe;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.IdentityHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
@@ -116,6 +117,7 @@ public class DefaultJobBundleFactory implements JobBundleFactory {
     private final Semaphore availableCachesSemaphore;
     private final LinkedBlockingDeque<EnvironmentCacheAndLock> availableCaches;
     private final boolean loadBalanceBundles;
+    private final ImmutableList<String> additionalSensitiveKeys;
 
     /**
      * Clients which were evicted due to environment expiration but still had pending references.
@@ -125,6 +127,11 @@ public class DefaultJobBundleFactory implements JobBundleFactory {
     private boolean closed;
 
     public static DefaultJobBundleFactory create(JobInfo jobInfo) {
+        return create(jobInfo, Collections.emptyList());
+    }
+
+    public static DefaultJobBundleFactory create(
+            JobInfo jobInfo, List<String> additionalSensitiveKeys) {
         PipelineOptions pipelineOptions =
                 PipelineOptionsTranslation.fromProto(jobInfo.pipelineOptions());
         Map<String, EnvironmentFactory.Provider> environmentFactoryProviderMap =
@@ -137,7 +144,8 @@ public class DefaultJobBundleFactory implements JobBundleFactory {
                         new ExternalEnvironmentFactory.Provider(),
                         Environments.ENVIRONMENT_EMBEDDED, // Non Public urn for testing.
                         new EmbeddedEnvironmentFactory.Provider(pipelineOptions));
-        return new DefaultJobBundleFactory(jobInfo, environmentFactoryProviderMap);
+        return new DefaultJobBundleFactory(
+                jobInfo, environmentFactoryProviderMap, additionalSensitiveKeys);
     }
 
     public static DefaultJobBundleFactory create(
@@ -148,6 +156,13 @@ public class DefaultJobBundleFactory implements JobBundleFactory {
 
     DefaultJobBundleFactory(
             JobInfo jobInfo, Map<String, EnvironmentFactory.Provider> environmentFactoryMap) {
+        this(jobInfo, environmentFactoryMap, Collections.emptyList());
+    }
+
+    DefaultJobBundleFactory(
+            JobInfo jobInfo,
+            Map<String, EnvironmentFactory.Provider> environmentFactoryMap,
+            List<String> additionalSensitiveKeys) {
         IdGenerator stageIdSuffixGenerator = IdGenerators.incrementingLongs();
         this.environmentFactoryProviderMap = environmentFactoryMap;
         this.executor = Executors.newCachedThreadPool();
@@ -155,6 +170,7 @@ public class DefaultJobBundleFactory implements JobBundleFactory {
         this.stageIdGenerator = () -> factoryId + "-" + stageIdSuffixGenerator.getId();
         this.environmentExpirationMillis = getEnvironmentExpirationMillis(jobInfo);
         this.loadBalanceBundles = shouldLoadBalanceBundles(jobInfo);
+        this.additionalSensitiveKeys = ImmutableList.copyOf(additionalSensitiveKeys);
         this.environmentCaches =
                 createEnvironmentCaches(
                         serverFactory -> createServerInfo(jobInfo, serverFactory),
@@ -176,6 +192,7 @@ public class DefaultJobBundleFactory implements JobBundleFactory {
         this.stageIdGenerator = stageIdGenerator;
         this.environmentExpirationMillis = getEnvironmentExpirationMillis(jobInfo);
         this.loadBalanceBundles = shouldLoadBalanceBundles(jobInfo);
+        this.additionalSensitiveKeys = ImmutableList.of();
         this.environmentCaches =
                 createEnvironmentCaches(
                         serverFactory -> serverInfo, getMaxEnvironmentClients(jobInfo));
@@ -231,7 +248,9 @@ public class DefaultJobBundleFactory implements JobBundleFactory {
                                         if (refCount > 0) {
                                             LOG.warn(
                                                     "Expiring environment {} with {} remaining bundle references. Taking note to clean it up during shutdown if the references are not removed by then.",
-                                                    getEnvironmentForLogging(notification.getKey()),
+                                                    getEnvironmentForLogging(
+                                                            notification.getKey(),
+                                                            additionalSensitiveKeys),
                                                     refCount);
                                             evictedActiveClients.add(client);
                                         }
@@ -289,7 +308,8 @@ public class DefaultJobBundleFactory implements JobBundleFactory {
                                         return WrappedSdkHarnessClient.wrapping(
                                                 environmentFactory.createEnvironment(
                                                         environment, workerId),
-                                                serverInfo);
+                                                serverInfo,
+                                                additionalSensitiveKeys);
                                     } catch (Exception e) {
                                         close(serverInfo);
                                         throw e;
@@ -649,24 +669,32 @@ public class DefaultJobBundleFactory implements JobBundleFactory {
         private final RemoteEnvironment environment;
         private final SdkHarnessClient client;
         private final ServerInfo serverInfo;
+        private final ImmutableList<String> additionalSensitiveKeys;
         private final AtomicInteger bundleRefCount = new AtomicInteger();
 
         private boolean closed;
 
         static WrappedSdkHarnessClient wrapping(
-                RemoteEnvironment environment, ServerInfo serverInfo) {
+                RemoteEnvironment environment,
+                ServerInfo serverInfo,
+                List<String> additionalSensitiveKeys) {
             SdkHarnessClient client =
                     SdkHarnessClient.usingFnApiClient(
                             environment.getInstructionRequestHandler(),
                             serverInfo.getDataServer().getService());
-            return new WrappedSdkHarnessClient(environment, client, serverInfo);
+            return new WrappedSdkHarnessClient(
+                    environment, client, serverInfo, additionalSensitiveKeys);
         }
 
         private WrappedSdkHarnessClient(
-                RemoteEnvironment environment, SdkHarnessClient client, ServerInfo serverInfo) {
+                RemoteEnvironment environment,
+                SdkHarnessClient client,
+                ServerInfo serverInfo,
+                List<String> additionalSensitiveKeys) {
             this.environment = environment;
             this.client = client;
             this.serverInfo = serverInfo;
+            this.additionalSensitiveKeys = ImmutableList.copyOf(additionalSensitiveKeys);
             ref();
         }
 
@@ -704,7 +732,8 @@ public class DefaultJobBundleFactory implements JobBundleFactory {
             } catch (Exception e) {
                 LOG.warn(
                         "Error cleaning up servers {}",
-                        getEnvironmentForLogging(environment.getEnvironment()),
+                        getEnvironmentForLogging(
+                                environment.getEnvironment(), additionalSensitiveKeys),
                         e);
             }
             // TODO: Wait for executor shutdown?
@@ -721,7 +750,8 @@ public class DefaultJobBundleFactory implements JobBundleFactory {
                 // Close environment after it was removed from cache and all bundles finished.
                 LOG.info(
                         "Closing environment {}",
-                        getEnvironmentForLogging(environment.getEnvironment()));
+                        getEnvironmentForLogging(
+                                environment.getEnvironment(), additionalSensitiveKeys));
                 close();
             }
             return refCount;
@@ -730,6 +760,12 @@ public class DefaultJobBundleFactory implements JobBundleFactory {
 
     @VisibleForTesting
     static String getEnvironmentForLogging(Environment environment) {
+        return getEnvironmentForLogging(environment, Collections.emptyList());
+    }
+
+    @VisibleForTesting
+    static String getEnvironmentForLogging(
+            Environment environment, List<String> additionalSensitiveKeys) {
         if (BeamUrns.getUrn(StandardEnvironments.Environments.PROCESS)
                 .equals(environment.getUrn())) {
             try {
@@ -740,7 +776,7 @@ public class DefaultJobBundleFactory implements JobBundleFactory {
                                 .putAllEnv(
                                         ConfigurationUtils.hideSensitiveValues(
                                                 processPayload.getEnvMap(),
-                                                Collections.emptyList()))
+                                                additionalSensitiveKeys))
                                 .build();
                 return environment.toBuilder()
                         .setPayload(processPayloadWithHiddenSensitiveValues.toByteString())

--- a/flink-python/src/main/java/org/apache/flink/streaming/api/runners/python/beam/BeamPythonFunctionRunner.java
+++ b/flink-python/src/main/java/org/apache/flink/streaming/api/runners/python/beam/BeamPythonFunctionRunner.java
@@ -24,6 +24,7 @@ import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.configuration.ReadableConfig;
+import org.apache.flink.configuration.SecurityOptions;
 import org.apache.flink.fnexecution.v1.FlinkFnApi;
 import org.apache.flink.python.PythonFunctionRunner;
 import org.apache.flink.python.PythonOptions;
@@ -198,6 +199,8 @@ public abstract class BeamPythonFunctionRunner implements PythonFunctionRunner {
 
     private transient Environment environment;
 
+    private transient List<String> additionalSensitiveKeys = Collections.emptyList();
+
     private transient volatile List<TimerRegistrationAction> unregisteredTimers;
 
     public BeamPythonFunctionRunner(
@@ -238,6 +241,7 @@ public abstract class BeamPythonFunctionRunner implements PythonFunctionRunner {
         this.bundleStarted = false;
         this.resultBuffer = new LinkedBlockingQueue<>();
         this.reusableResultTuple = new Tuple3<>();
+        this.additionalSensitiveKeys = config.get(SecurityOptions.ADDITIONAL_SENSITIVE_KEYS);
 
         stateRequestHandler =
                 getStateRequestHandler(
@@ -678,7 +682,8 @@ public abstract class BeamPythonFunctionRunner implements PythonFunctionRunner {
                             taskName,
                             taskName,
                             environmentManager.createRetrievalToken(),
-                            pipelineOptions));
+                            pipelineOptions),
+                    additionalSensitiveKeys);
         }
     }
 

--- a/flink-python/src/test/java/org/apache/beam/runners/fnexecution/control/DefaultJobBundleFactoryTest.java
+++ b/flink-python/src/test/java/org/apache/beam/runners/fnexecution/control/DefaultJobBundleFactoryTest.java
@@ -27,6 +27,8 @@ import org.apache.beam.runners.core.construction.BeamUrns;
 import org.apache.beam.vendor.grpc.v1p60p1.com.google.protobuf.ByteString;
 import org.junit.jupiter.api.Test;
 
+import java.util.Collections;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for {@link DefaultJobBundleFactory}. */
@@ -58,6 +60,32 @@ class DefaultJobBundleFactoryTest {
                 .contains(GlobalConfiguration.HIDDEN_CONTENT)
                 .doesNotContain("secret-token")
                 .doesNotContain("secret-password");
+    }
+
+    @Test
+    void getEnvironmentForLoggingHidesAdditionalSensitiveProcessEnvironmentVariables() {
+        ProcessPayload processPayload =
+                ProcessPayload.newBuilder()
+                        .setCommand("python")
+                        .putEnv("PATH", "/usr/bin")
+                        .putEnv("CUSTOMER_ID", "secret-customer")
+                        .build();
+        Environment environment =
+                Environment.newBuilder()
+                        .setUrn(BeamUrns.getUrn(StandardEnvironments.Environments.PROCESS))
+                        .setPayload(processPayload.toByteString())
+                        .build();
+
+        String environmentForLogging =
+                DefaultJobBundleFactory.getEnvironmentForLogging(
+                        environment, Collections.singletonList("customer_id"));
+
+        assertThat(environmentForLogging)
+                .contains("PATH")
+                .contains("/usr/bin")
+                .contains("CUSTOMER_ID")
+                .contains(GlobalConfiguration.HIDDEN_CONTENT)
+                .doesNotContain("secret-customer");
     }
 
     @Test

--- a/flink-python/src/test/java/org/apache/beam/runners/fnexecution/control/DefaultJobBundleFactoryTest.java
+++ b/flink-python/src/test/java/org/apache/beam/runners/fnexecution/control/DefaultJobBundleFactoryTest.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.beam.runners.fnexecution.control;
+
+import org.apache.flink.configuration.GlobalConfiguration;
+
+import org.apache.beam.model.pipeline.v1.RunnerApi.Environment;
+import org.apache.beam.model.pipeline.v1.RunnerApi.ProcessPayload;
+import org.apache.beam.model.pipeline.v1.RunnerApi.StandardEnvironments;
+import org.apache.beam.runners.core.construction.BeamUrns;
+import org.apache.beam.vendor.grpc.v1p60p1.com.google.protobuf.ByteString;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link DefaultJobBundleFactory}. */
+class DefaultJobBundleFactoryTest {
+
+    @Test
+    void getEnvironmentForLoggingHidesSensitiveProcessEnvironmentVariables() {
+        ProcessPayload processPayload =
+                ProcessPayload.newBuilder()
+                        .setCommand("python")
+                        .putEnv("PATH", "/usr/bin")
+                        .putEnv("ACCESS_TOKEN", "secret-token")
+                        .putEnv("MY_PASSWORD", "secret-password")
+                        .build();
+        Environment environment =
+                Environment.newBuilder()
+                        .setUrn(BeamUrns.getUrn(StandardEnvironments.Environments.PROCESS))
+                        .setPayload(processPayload.toByteString())
+                        .build();
+
+        String environmentForLogging =
+                DefaultJobBundleFactory.getEnvironmentForLogging(environment);
+
+        assertThat(environmentForLogging)
+                .contains("PATH")
+                .contains("/usr/bin")
+                .contains("ACCESS_TOKEN")
+                .contains("MY_PASSWORD")
+                .contains(GlobalConfiguration.HIDDEN_CONTENT)
+                .doesNotContain("secret-token")
+                .doesNotContain("secret-password");
+    }
+
+    @Test
+    void getEnvironmentForLoggingOmitsMalformedProcessPayload() {
+        Environment environment =
+                Environment.newBuilder()
+                        .setUrn(BeamUrns.getUrn(StandardEnvironments.Environments.PROCESS))
+                        .setPayload(ByteString.copyFromUtf8("secret-token"))
+                        .build();
+
+        String environmentForLogging =
+                DefaultJobBundleFactory.getEnvironmentForLogging(environment);
+
+        assertThat(environmentForLogging).doesNotContain("secret-token").doesNotContain("payload");
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

This pull request fixes FLINK-39572 by avoiding logging sensitive values from Beam PROCESS environment payloads when PyFlink closes or expires Beam runner environments.

Jira: https://issues.apache.org/jira/browse/FLINK-39572

## Brief change log

- Added a logging helper for `DefaultJobBundleFactory` that redacts sensitive PROCESS environment values with Flink's existing `ConfigurationUtils.hideSensitiveValues`.
- Applied the helper to the environment close/cleanup/expiration log messages that previously logged the raw Beam `Environment`.
- Made malformed PROCESS payload logging fail closed by omitting the payload from the logged environment string.
- Added focused regression coverage for normal PROCESS env redaction and malformed payload fallback.

## Verifying this change

This change added tests and can be verified as follows:

- Added `DefaultJobBundleFactoryTest#getEnvironmentForLoggingHidesSensitiveProcessEnvironmentVariables`.
- Added `DefaultJobBundleFactoryTest#getEnvironmentForLoggingOmitsMalformedProcessPayload`.
- Ran `./mvnw -pl flink-python -Dtest=DefaultJobBundleFactoryTest -DfailIfNoTests=false -Dsurefire.failIfNoSpecifiedTests=false -DskipITs test`.
- Ran `./mvnw -pl flink-python -DskipTests -DskipITs -Dfast -Drat.skip=true spotless:check checkstyle:check`.
- Ran `git diff --check`.

## Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): no
- The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
- The serializers: no
- The runtime per-record code paths (performance sensitive): no
- Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
- The S3 file system connector: no

## Documentation

- Does this pull request introduce a new feature? no
- If yes, how is the feature documented? not applicable

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (Hermes Agent / OpenAI GPT-5.5)

Generated-by: Hermes Agent / OpenAI GPT-5.5
