### PR TITLE
[BP-2.0][FLINK-39933][ci] Use flink-ci-docker with jdk25 in ci

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -55,7 +55,7 @@ jobs:
           fi
       - name: Build documentation
         run: |
-          docker run --rm --volume "$PWD:/root/flink" chesnay/flink-ci:java_8_11_17_21_maven_386_jammy bash -c "cd /root/flink && ./.github/workflows/docs.sh"
+          docker run --rm --volume "$PWD:/root/flink" apache/flink-ci-docker:java_8_11_17_21_25_maven_386_jammy bash -c "cd /root/flink && ./.github/workflows/docs.sh"
       - name: Upload documentation
         uses: burnett01/rsync-deployments@5.2
         with:

--- a/.github/workflows/template.flink-ci.yml
+++ b/.github/workflows/template.flink-ci.yml
@@ -72,7 +72,7 @@ jobs:
     name: "Compile"
     runs-on: ubuntu-22.04
     container:
-      image: chesnay/flink-ci:java_8_11_17_21_maven_386_jammy
+      image: apache/flink-ci-docker:java_8_11_17_21_25_maven_386_jammy
       # --init makes the process in the container being started as an init process which will clean up any daemon processes during shutdown
       # --privileged allows writing coredumps in docker (FLINK-16973)
       options: --init --privileged
@@ -128,7 +128,7 @@ jobs:
     needs: compile
     runs-on: ubuntu-22.04
     container:
-      image: chesnay/flink-ci:java_8_11_17_21_maven_386_jammy
+      image: apache/flink-ci-docker:java_8_11_17_21_25_maven_386_jammy
       # --init makes the process in the container being started as an init process which will clean up any daemon processes during shutdown
       # --privileged allows writing coredumps in docker (FLINK-16973)
       options: --init --privileged
@@ -168,7 +168,7 @@ jobs:
     needs: compile
     runs-on: ubuntu-22.04
     container:
-      image: chesnay/flink-ci:java_8_11_17_21_maven_386_jammy
+      image: apache/flink-ci-docker:java_8_11_17_21_25_maven_386_jammy
       # --init makes the process in the container being started as an init process which will clean up any daemon processes during shutdown
       # --privileged allows writing coredumps in docker (FLINK-16973)
       options: --init --privileged

--- a/.github/workflows/template.pre-compile-checks.yml
+++ b/.github/workflows/template.pre-compile-checks.yml
@@ -43,7 +43,7 @@ jobs:
     name: "Basic QA"
     runs-on: ubuntu-22.04
     container:
-      image: chesnay/flink-ci:java_8_11_17_21_maven_386_jammy
+      image: apache/flink-ci-docker:java_8_11_17_21_25_maven_386_jammy
       # --init makes the process in the container being started as an init process which will clean up any daemon processes during shutdown
       # --privileged allows writing coredumps in docker (FLINK-16973)
       options: --init --privileged

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -39,7 +39,7 @@ resources:
   # Container with SSL to have the same environment everywhere.
   # see https://github.com/apache/flink-connector-shared-utils/tree/ci_utils
   - container: flink-build-container
-    image: chesnay/flink-ci:java_8_11_17_21_maven_386_jammy
+    image: apache/flink-ci-docker:java_8_11_17_21_25_maven_386_jammy
     # On AZP provided machines, set this flag to allow writing coredumps in docker
     options: --privileged
 

--- a/tools/azure-pipelines/build-apache-repo.yml
+++ b/tools/azure-pipelines/build-apache-repo.yml
@@ -39,7 +39,7 @@ resources:
   # Container with SSL to have the same environment everywhere.
   # see https://github.com/apache/flink-connector-shared-utils/tree/ci_utils
   - container: flink-build-container
-    image: chesnay/flink-ci:java_8_11_17_21_maven_386_jammy
+    image: apache/flink-ci-docker:java_8_11_17_21_25_maven_386_jammy
 
 variables:
   MAVEN_CACHE_FOLDER: $(Pipeline.Workspace)/.m2/repository


### PR DESCRIPTION
backport of https://github.com/apache/flink/pull/28435

backport will allow to have same docker image in cache => less cache rewrites