### PR TITLE
[FLINK-39921][runtime/tests] Fix the flaky test case ExecutionVertexCancelTest.testSendCancelAndReceiveFail

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionVertexCancelTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionVertexCancelTest.java
@@ -19,8 +19,9 @@
 package org.apache.flink.runtime.executiongraph;
 
 import org.apache.flink.api.common.JobStatus;
-import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutorServiceAdapter;
+import org.apache.flink.runtime.concurrent.NoMainThreadCheckComponentMainThreadExecutor;
 import org.apache.flink.runtime.execution.ExecutionState;
+import org.apache.flink.runtime.executiongraph.utils.ExecutionUtils;
 import org.apache.flink.runtime.executiongraph.utils.SimpleAckingTaskManagerGateway;
 import org.apache.flink.runtime.jobgraph.JobGraphTestUtils;
 import org.apache.flink.runtime.jobmaster.LogicalSlot;
@@ -247,12 +248,14 @@ class ExecutionVertexCancelTest {
         final SchedulerBase scheduler =
                 SchedulerTestingUtils.createScheduler(
                         JobGraphTestUtils.streamingJobGraph(createNoOpVertex(10)),
-                        ComponentMainThreadExecutorServiceAdapter.forMainThread(),
+                        new NoMainThreadCheckComponentMainThreadExecutor(),
                         EXECUTOR_RESOURCE.getExecutor());
         final ExecutionGraph graph = scheduler.getExecutionGraph();
 
         scheduler.startScheduling();
-
+        for (ExecutionVertex ev : graph.getAllExecutionVertices()) {
+            ExecutionUtils.waitForTaskDeploymentDescriptorsCreation(ev);
+        }
         ExecutionGraphTestUtils.switchAllVerticesToRunning(graph);
         assertThat(graph.getState()).isEqualTo(JobStatus.RUNNING);
 


### PR DESCRIPTION
## What is the purpose of the change

ExecutionVertexCancelTest.testSendCancelAndReceiveFail was flaky with the following error:

ExecutionVertexCancelTest.testSendCancelAndReceiveFail:254 » IllegalState
BUG: trying to schedule a region which is not in CREATED state

This has the same root cause as #28398 and #28434. Please refer to those PRs for a detailed explanation.

## Brief change log

- Replace `ComponentMainThreadExecutorServiceAdapter.forMainThread()` with `NoMainThreadCheckComponentMainThreadExecutor` to allow IO threads to call `execute()` without thread assertion failure.
- Add `ExecutionUtils.waitForTaskDeploymentDescriptorsCreation()` after `startScheduling()` to ensure async TDD creation completes before `switchAllVerticesToRunning()` is called.


## Verifying this change

<img width="1260" height="1345" alt="image" src="https://github.com/user-attachments/assets/112fc762-b489-4dba-acf5-d845798b24d9" />


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change the checkbox below to `[X]` followed by the name of the tool, and uncomment the
"Generated-by" line. See the ASF Generative Tooling Guidance for details:
https://www.apache.org/legal/generative-tooling.html

You are responsible for the quality and correctness of every change in this PR
regardless of the tooling used. Low-effort AI-generated PRs will be closed. See
AGENTS.md for the full guidance.
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name and Version]
-->
