### PR TITLE
[FLINK-34195][python] Use python3 as the default Python executable

### DIFF
--- a/docs/layouts/shortcodes/generated/python_configuration.html
+++ b/docs/layouts/shortcodes/generated/python_configuration.html
@@ -16,13 +16,13 @@
         </tr>
         <tr>
             <td><h5>python.client.executable</h5></td>
-            <td style="word-wrap: break-word;">"python"</td>
+            <td style="word-wrap: break-word;">"python3"</td>
             <td>String</td>
             <td>The path of the Python interpreter used to launch the Python process when submitting the Python jobs via "flink run" or compiling the Java/Scala jobs containing Python UDFs. Equivalent to the command line option "-pyclientexec" or the environment variable PYFLINK_CLIENT_EXECUTABLE. The priority is as following: <br />1. the configuration 'python.client.executable' defined in the source code(Only used in Flink Java SQL/Table API job call Python UDF);<br />2. the command line option "-pyclientexec";<br />3. the configuration 'python.client.executable' defined in config.yaml<br />4. the environment variable PYFLINK_CLIENT_EXECUTABLE;</td>
         </tr>
         <tr>
             <td><h5>python.executable</h5></td>
-            <td style="word-wrap: break-word;">"python"</td>
+            <td style="word-wrap: break-word;">"python3"</td>
             <td>String</td>
             <td>Specify the path of the python interpreter used to execute the python UDF worker. The python UDF worker depends on Python 3.9+, Apache Beam (version &gt;= 2.54.0, &lt;= 2.61.0), Pip (version &gt;= 20.3) and SetupTools (version &gt;= 37.0.0). Please ensure that the specified environment meets the above requirements. The option is equivalent to the command line option "-pyexec".</td>
         </tr>

--- a/flink-python/bin/pyflink-shell.sh
+++ b/flink-python/bin/pyflink-shell.sh
@@ -28,7 +28,7 @@ FLINK_CLASSPATH=`constructFlinkClassPath`
 PYTHON_JAR_PATH=`echo "$FLINK_OPT_DIR"/flink-python*.jar`
 
 
-PYFLINK_PYTHON="${PYFLINK_PYTHON:-"python"}"
+PYFLINK_PYTHON="${PYFLINK_PYTHON:-"python3"}"
 
 # So that python can find out Flink's Jars
 export FLINK_BIN_DIR=$FLINK_BIN_DIR

--- a/flink-python/docs/getting_started/installation.rst
+++ b/flink-python/docs/getting_started/installation.rst
@@ -28,35 +28,29 @@ Environment Requirements
 
 .. code-block:: bash
 
-   $ python --version
+   $ python3 --version
    # the version printed here must be 3.9, 3.10, 3.11 or 3.12
 
 Environment Setup
 -----------------
 
 Your system may include multiple Python versions, and thus also include multiple Python binary executables.
-You can run the following ``ls`` command to find out what Python binary executables are available in your system:
+You can run the following command to find out what Python binary executables are available in your system:
 
 .. code-block:: bash
 
-   $ ls /usr/bin/python*
+   $ command -v python3
 
-To satisfy the PyFlink requirement regarding the Python environment version, you can choose to soft link ``python`` to point to your ``python3`` interpreter:
-
-.. code-block:: bash
-
-   ln -s /usr/bin/python3 python
-
-In addition to creating a soft link, you can also choose to create a Python virtual environment (``venv``):
+To satisfy the PyFlink requirement regarding the Python environment version, you can create a Python virtual environment (``venv``):
 
 .. code-block:: bash
 
-   python -m venv myenv
+   python3 -m venv myenv
    source myenv/bin/activate  # On Windows: myenv\Scripts\activate
 
 You can refer to the :flinkdoc:`Deployment Preparation <docs/deployment/resource-providers/standalone/overview/>` documentation page for details on how to achieve that setup.
 
-If you don't want to use a soft link to change the system's ``python`` interpreter point to, you can use the configuration way to specify the Python interpreter.
+If you want to use a different Python interpreter, you can use the configuration way to specify the Python interpreter.
 For specifying the Python interpreter used to compile the jobs, you can refer to the configuration :doc:`../user_guide/configuration`.
 For specifying the Python interpreter used to execute the Python UDF, you can refer to the configuration :doc:`../user_guide/configuration`.
 
@@ -67,7 +61,7 @@ PyFlink is available in `PyPi <https://pypi.org/project/apache-flink/>`_ and can
 
 .. code-block:: bash
 
-   $ python -m pip install apache-flink
+   $ python3 -m pip install apache-flink
 
 You can also build PyFlink from source by following the `development guide <https://flink.apache.org/docs/latest/flinkdev/building/#build-pyflink>`_.
 

--- a/flink-python/docs/user_guide/configuration.rst
+++ b/flink-python/docs/user_guide/configuration.rst
@@ -91,7 +91,7 @@ Python Options
      - String
      - Add python archive files for job. The archive files will be extracted to the working directory of python UDF worker. For each archive file, a target directory is specified. If the target directory name is specified, the archive file will be extracted to a directory with the specified name. Otherwise, the archive file will be extracted to a directory with the same name of the archive file. The files uploaded via this option are accessible via relative path. '#' could be used as the separator of the archive file path and the target directory name. Comma (',') could be used as the separator to specify multiple archive files. This option can be used to upload the virtual environment, the data files used in Python UDF. The data files could be accessed in Python UDF, e.g.: f = open('data/data.txt', 'r'). The option is equivalent to the command line option "-pyarch".
    * - python.client.executable
-     - "python"
+     - "python3"
      - String
      - The path of the Python interpreter used to launch the Python process when submitting the Python jobs via "flink run" or compiling the Java/Scala jobs containing Python UDFs. Equivalent to the command line option "-pyclientexec" or the environment variable PYFLINK_CLIENT_EXECUTABLE. The priority is as following:
        - the configuration 'python.client.executable' defined in the source code(Only used in Flink Java SQL/Table API job call Python UDF);
@@ -99,9 +99,9 @@ Python Options
        - the configuration 'python.client.executable' defined in config.yaml
        - the environment variable PYFLINK_CLIENT_EXECUTABLE;
    * - python.executable
-     - "python"
+     - "python3"
      - String
-     - Specify the path of the python interpreter used to execute the python UDF worker. The python UDF worker depends on Python 3.8+, Apache Beam (version >= 2.54.0, <= 2.61.0), Pip (version >= 20.3) and SetupTools (version >= 37.0.0). Please ensure that the specified environment meets the above requirements. The option is equivalent to the command line option "-pyexec".
+     - Specify the path of the python interpreter used to execute the python UDF worker. The python UDF worker depends on Python 3.9+, Apache Beam (version >= 2.54.0, <= 2.61.0), Pip (version >= 20.3) and SetupTools (version >= 37.0.0). Please ensure that the specified environment meets the above requirements. The option is equivalent to the command line option "-pyexec".
    * - python.execution-mode
      - "process"
      - String

--- a/flink-python/pyflink/bin/pyflink-udf-runner.sh
+++ b/flink-python/pyflink/bin/pyflink-udf-runner.sh
@@ -16,7 +16,7 @@
 #  See the License for the specific language governing permissions and
 # limitations under the License.
 ################################################################################
-python=${python:-python}
+python=${python:-python3}
 
 if [[ "$FLINK_TESTING" = "1" ]]; then
     ACTUAL_FLINK_HOME=`cd $FLINK_HOME; pwd -P`

--- a/flink-python/src/main/java/org/apache/flink/client/python/PythonEnvUtils.java
+++ b/flink-python/src/main/java/org/apache/flink/client/python/PythonEnvUtils.java
@@ -97,7 +97,7 @@ final class PythonEnvUtils {
 
         String archivesDirectory;
 
-        String pythonExec = OperatingSystem.isWindows() ? "python.exe" : "python";
+        String pythonExec = OperatingSystem.isWindows() ? "python.exe" : "python3";
 
         String pythonPath;
 

--- a/flink-python/src/main/java/org/apache/flink/python/PythonOptions.java
+++ b/flink-python/src/main/java/org/apache/flink/python/PythonOptions.java
@@ -156,7 +156,7 @@ public class PythonOptions {
     public static final ConfigOption<String> PYTHON_EXECUTABLE =
             ConfigOptions.key("python.executable")
                     .stringType()
-                    .defaultValue("python")
+                    .defaultValue("python3")
                     .withDescription(
                             "Specify the path of the python interpreter used to execute the python "
                                     + "UDF worker. The python UDF worker depends on Python 3.9+, Apache Beam "
@@ -167,7 +167,7 @@ public class PythonOptions {
     public static final ConfigOption<String> PYTHON_CLIENT_EXECUTABLE =
             ConfigOptions.key("python.client.executable")
                     .stringType()
-                    .defaultValue("python")
+                    .defaultValue("python3")
                     .withDescription(
                             Description.builder()
                                     .text(

--- a/flink-python/src/test/java/org/apache/flink/client/python/PythonEnvUtilsTest.java
+++ b/flink-python/src/test/java/org/apache/flink/client/python/PythonEnvUtilsTest.java
@@ -195,7 +195,7 @@ class PythonEnvUtilsTest {
         if (OperatingSystem.isWindows()) {
             assertThat(env.pythonExec).isEqualTo("python.exe");
         } else {
-            assertThat(env.pythonExec).isEqualTo("python");
+            assertThat(env.pythonExec).isEqualTo("python3");
         }
 
         Map<String, String> systemEnv = new HashMap<>(System.getenv());

--- a/flink-python/src/test/java/org/apache/flink/python/PythonOptionsTest.java
+++ b/flink-python/src/test/java/org/apache/flink/python/PythonOptionsTest.java
@@ -146,6 +146,7 @@ class PythonOptionsTest {
         final Optional<String> defaultPythonExecutable =
                 configuration.getOptional(PythonOptions.PYTHON_EXECUTABLE);
         assertThat(defaultPythonExecutable).isEmpty();
+        assertThat(configuration.get(PythonOptions.PYTHON_EXECUTABLE)).isEqualTo("python3");
 
         final String expectedPythonExecutable = "venv/py37/bin/python";
         configuration.set(PythonOptions.PYTHON_EXECUTABLE, expectedPythonExecutable);
@@ -160,6 +161,7 @@ class PythonOptionsTest {
         final Optional<String> defaultPythonClientExecutable =
                 configuration.getOptional(PythonOptions.PYTHON_CLIENT_EXECUTABLE);
         assertThat(defaultPythonClientExecutable).isEmpty();
+        assertThat(configuration.get(PythonOptions.PYTHON_CLIENT_EXECUTABLE)).isEqualTo("python3");
 
         final String expectedPythonClientExecutable = "tmp_dir/test1.py,tmp_dir/test2.py";
         configuration.set(PythonOptions.PYTHON_CLIENT_EXECUTABLE, expectedPythonClientExecutable);


### PR DESCRIPTION
## What is the purpose of the change

This pull request updates PyFlink's default Python executable from `python` to `python3` on non-Windows environments.

PyFlink requires Python 3.9+, but `python` may resolve to Python 2 or may not exist on systems where Python 3 is installed as `python3`. Using `python3` as the default aligns the runtime defaults, shell script defaults, and documentation with the supported Python versions.

## Brief change log

  - Changed `python.executable` and `python.client.executable` defaults to `python3`.
  - Changed the default Python executable used by `PythonEnvUtils` on non-Windows environments to `python3`.
  - Updated PyFlink shell and UDF runner script defaults to use `python3`.
  - Updated PyFlink installation and configuration docs to prefer `python3`.
  - Added regression coverage for the default option values and `PythonEnvUtils` default environment.

## Verifying this change

  - `bash -n flink-python/bin/pyflink-shell.sh`
  - `bash -n flink-python/pyflink/bin/pyflink-udf-runner.sh`
  - `git diff --check upstream/master...HEAD`
  - `JAVA_HOME=/Library/Java/JavaVirtualMachines/zulu-17.jdk/Contents/Home ./mvnw -U -pl flink-python -am -Dflink.markBundledAsOptional=false -Dtest=PythonEnvUtilsTest,PythonOptionsTest -Dsurefire.failIfNoSpecifiedTests=false -DfailIfNoTests=false -DskipITs -Dfast test`

The Maven reactor build completed successfully across all 66 selected modules. `PythonOptionsTest` ran 12 tests and `PythonEnvUtilsTest` ran 4 tests, with no failures, errors, or skips.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (Codex)

Generated-by: Codex (GPT-5)
