### PR TITLE
[FLINK-39946][runtime] Unaligned checkpoint restore can mis-map union input channel state after reordering UIDed sources

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/streaming/api/graph/AdaptiveGraphManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/api/graph/AdaptiveGraphManager.java
@@ -42,6 +42,7 @@ import org.apache.flink.util.Preconditions;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -430,7 +431,9 @@ public class AdaptiveGraphManager
     private void connectToFinishedUpStreamVertex(JobVertexBuildContext jobVertexBuildContext) {
         Map<Integer, OperatorChainInfo> chainInfos = jobVertexBuildContext.getChainInfosInOrder();
         for (OperatorChainInfo chainInfo : chainInfos.values()) {
-            List<StreamEdge> transitiveInEdges = chainInfo.getTransitiveInEdges();
+            List<StreamEdge> transitiveInEdges =
+                    getTransitiveInEdgesInOrder(
+                            chainInfo.getTransitiveInEdges(), jobVertexBuildContext);
             for (StreamEdge transitiveInEdge : transitiveInEdges) {
                 NonChainedOutput output =
                         intermediateOutputsCaches
@@ -445,6 +448,55 @@ public class AdaptiveGraphManager
                         jobVertexBuildContext);
             }
         }
+    }
+
+    private List<StreamEdge> getTransitiveInEdgesInOrder(
+            List<StreamEdge> transitiveInEdges, JobVertexBuildContext jobVertexBuildContext) {
+        final List<StreamEdge> transitiveInEdgesInOrder =
+                transitiveInEdges.stream()
+                        .sorted(
+                                Comparator.comparing(
+                                        inEdge -> getStartNodeId(inEdge.getSourceId())))
+                        .collect(Collectors.toList());
+        final List<StreamEdge> uidTransitiveInEdges =
+                transitiveInEdgesInOrder.stream()
+                        .filter(this::hasUidBackedUpstream)
+                        .sorted(
+                                Comparator.comparing(
+                                        inEdge ->
+                                                getStartNodeJobVertexId(
+                                                        inEdge, jobVertexBuildContext)))
+                        .collect(Collectors.toList());
+
+        if (uidTransitiveInEdges.size() < 2) {
+            return transitiveInEdgesInOrder;
+        }
+
+        int uidTransitiveInEdgeIndex = 0;
+        for (int transitiveInEdgeIndex = 0;
+                transitiveInEdgeIndex < transitiveInEdgesInOrder.size();
+                transitiveInEdgeIndex++) {
+            if (hasUidBackedUpstream(transitiveInEdgesInOrder.get(transitiveInEdgeIndex))) {
+                transitiveInEdgesInOrder.set(
+                        transitiveInEdgeIndex,
+                        uidTransitiveInEdges.get(uidTransitiveInEdgeIndex++));
+            }
+        }
+        return transitiveInEdgesInOrder;
+    }
+
+    private boolean hasUidBackedUpstream(StreamEdge inEdge) {
+        return streamGraph
+                        .getStreamNode(getStartNodeId(inEdge.getSourceId()))
+                        .getTransformationUID()
+                != null;
+    }
+
+    private JobVertexID getStartNodeJobVertexId(
+            StreamEdge inEdge, JobVertexBuildContext jobVertexBuildContext) {
+        return new JobVertexID(
+                Preconditions.checkNotNull(
+                        jobVertexBuildContext.getHash(getStartNodeId(inEdge.getSourceId()))));
     }
 
     private void recordCreatedJobVerticesInfo(JobVertexBuildContext jobVertexBuildContext) {
@@ -473,11 +525,17 @@ public class AdaptiveGraphManager
         final Map<Integer, OperatorChainInfo> chainEntryPoints =
                 buildAndGetChainEntryPoints(streamNodes, jobVertexBuildContext);
 
+        chainEntryPoints.values().stream()
+                .filter(
+                        chainInfo ->
+                                streamGraph
+                                                .getStreamNode(chainInfo.getStartNodeId())
+                                                .getTransformationUID()
+                                        != null)
+                .forEach(chainInfo -> generateHashesByStreamNodeId(chainInfo.getStartNodeId()));
         final Collection<OperatorChainInfo> initialEntryPoints =
-                chainEntryPoints.entrySet().stream()
-                        .sorted(Map.Entry.comparingByKey())
-                        .map(Map.Entry::getValue)
-                        .collect(Collectors.toList());
+                StreamingJobGraphGenerator.getInitialEntryPoints(
+                        chainEntryPoints.values(), jobVertexBuildContext);
 
         for (OperatorChainInfo info : initialEntryPoints) {
             // We use generateHashesByStreamNodeId to subscribe the visited stream node id and

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/api/graph/AdaptiveGraphManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/api/graph/AdaptiveGraphManager.java
@@ -452,12 +452,7 @@ public class AdaptiveGraphManager
 
     private List<StreamEdge> getTransitiveInEdgesInOrder(
             List<StreamEdge> transitiveInEdges, JobVertexBuildContext jobVertexBuildContext) {
-        final List<StreamEdge> transitiveInEdgesInOrder =
-                transitiveInEdges.stream()
-                        .sorted(
-                                Comparator.comparing(
-                                        inEdge -> getStartNodeId(inEdge.getSourceId())))
-                        .collect(Collectors.toList());
+        final List<StreamEdge> transitiveInEdgesInOrder = new ArrayList<>(transitiveInEdges);
         final List<StreamEdge> uidTransitiveInEdges =
                 transitiveInEdgesInOrder.stream()
                         .filter(this::hasUidBackedUpstream)
@@ -525,14 +520,6 @@ public class AdaptiveGraphManager
         final Map<Integer, OperatorChainInfo> chainEntryPoints =
                 buildAndGetChainEntryPoints(streamNodes, jobVertexBuildContext);
 
-        chainEntryPoints.values().stream()
-                .filter(
-                        chainInfo ->
-                                streamGraph
-                                                .getStreamNode(chainInfo.getStartNodeId())
-                                                .getTransformationUID()
-                                        != null)
-                .forEach(chainInfo -> generateHashesByStreamNodeId(chainInfo.getStartNodeId()));
         final Collection<OperatorChainInfo> initialEntryPoints =
                 StreamingJobGraphGenerator.getInitialEntryPoints(
                         chainEntryPoints.values(), jobVertexBuildContext);

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
@@ -670,8 +670,13 @@ public class StreamingJobGraphGenerator {
 
     private static JobVertexID getStartNodeJobVertexId(
             OperatorChainInfo chainInfo, JobVertexBuildContext jobVertexBuildContext) {
-        return new JobVertexID(
-                checkNotNull(jobVertexBuildContext.getHash(chainInfo.getStartNodeId())));
+        final String transformationUid =
+                checkNotNull(
+                        jobVertexBuildContext
+                                .getStreamGraph()
+                                .getStreamNode(chainInfo.getStartNodeId())
+                                .getTransformationUID());
+        return new JobVertexID(StreamGraphHasherV2.generateUserSpecifiedHash(transformationUid));
     }
 
     public static List<StreamEdge> createChain(

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
@@ -607,10 +607,7 @@ public class StreamingJobGraphGenerator {
         final Map<Integer, OperatorChainInfo> chainEntryPoints =
                 buildChainedInputsAndGetHeadInputs();
         final Collection<OperatorChainInfo> initialEntryPoints =
-                chainEntryPoints.entrySet().stream()
-                        .sorted(Comparator.comparing(Map.Entry::getKey))
-                        .map(Map.Entry::getValue)
-                        .collect(Collectors.toList());
+                getInitialEntryPoints(chainEntryPoints.values(), jobVertexBuildContext);
 
         // iterate over a copy of the values, because this map gets concurrently modified
         for (OperatorChainInfo info : initialEntryPoints) {
@@ -624,6 +621,57 @@ public class StreamingJobGraphGenerator {
                     jobVertexBuildContext,
                     null);
         }
+    }
+
+    static Collection<OperatorChainInfo> getInitialEntryPoints(
+            Collection<OperatorChainInfo> chainEntryPoints,
+            JobVertexBuildContext jobVertexBuildContext) {
+        final List<OperatorChainInfo> initialEntryPoints =
+                chainEntryPoints.stream()
+                        .sorted(Comparator.comparing(OperatorChainInfo::getStartNodeId))
+                        .collect(Collectors.toList());
+        final List<OperatorChainInfo> uidEntryPoints =
+                initialEntryPoints.stream()
+                        .filter(
+                                chainInfo ->
+                                        hasTransformationUid(
+                                                chainInfo, jobVertexBuildContext.getStreamGraph()))
+                        .sorted(
+                                Comparator.comparing(
+                                        chainInfo ->
+                                                getStartNodeJobVertexId(
+                                                        chainInfo, jobVertexBuildContext)))
+                        .collect(Collectors.toList());
+
+        if (uidEntryPoints.size() < 2) {
+            return initialEntryPoints;
+        }
+
+        int uidEntryPointIndex = 0;
+        for (int entryPointIndex = 0;
+                entryPointIndex < initialEntryPoints.size();
+                entryPointIndex++) {
+            if (hasTransformationUid(
+                    initialEntryPoints.get(entryPointIndex),
+                    jobVertexBuildContext.getStreamGraph())) {
+                // Input gates are restored by position, so align source traversal with the stable
+                // JobVertexID for UIDed heads while keeping the other heads in their legacy
+                // positions.
+                initialEntryPoints.set(entryPointIndex, uidEntryPoints.get(uidEntryPointIndex++));
+            }
+        }
+        return initialEntryPoints;
+    }
+
+    private static boolean hasTransformationUid(
+            OperatorChainInfo chainInfo, StreamGraph streamGraph) {
+        return streamGraph.getStreamNode(chainInfo.getStartNodeId()).getTransformationUID() != null;
+    }
+
+    private static JobVertexID getStartNodeJobVertexId(
+            OperatorChainInfo chainInfo, JobVertexBuildContext jobVertexBuildContext) {
+        return new JobVertexID(
+                checkNotNull(jobVertexBuildContext.getHash(chainInfo.getStartNodeId())));
     }
 
     public static List<StreamEdge> createChain(

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/AdaptiveGraphManagerTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/AdaptiveGraphManagerTest.java
@@ -197,6 +197,30 @@ public class AdaptiveGraphManagerTest extends JobGraphGeneratorTestBase {
     }
 
     @Test
+    void testMixedUidAndNonUidSourceIdsMatchStreamingGenerator() {
+        final JobGraph adaptiveJobGraph =
+                generateJobGraphInLazilyMode(createMixedUidAndNonUidUnionStreamGraph());
+        final JobGraph streamingJobGraph =
+                StreamingJobGraphGenerator.createJobGraph(
+                        createMixedUidAndNonUidUnionStreamGraph());
+
+        assertThat(getJobVertex(adaptiveJobGraph, "Source: non-uid-source").getID())
+                .isEqualTo(getJobVertex(streamingJobGraph, "Source: non-uid-source").getID());
+    }
+
+    @Test
+    void testNonUidReconnectKeepsUnionDeclarationOrder() {
+        assertThat(getSinkInputSourceNames(createReverseDeclarationUnionJobGraph(false)))
+                .containsExactly("Source: source-b", "Source: source-a");
+    }
+
+    @Test
+    void testUidHashReconnectKeepsUnionDeclarationOrder() {
+        assertThat(getSinkInputSourceNames(createReverseDeclarationUnionJobGraph(true)))
+                .containsExactly("Source: source-b", "Source: source-a");
+    }
+
+    @Test
     void testSourceChain() {
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
         env.setMaxParallelism(100);
@@ -265,6 +289,73 @@ public class AdaptiveGraphManagerTest extends JobGraphGeneratorTestBase {
         streamGraph2.setDynamic(true);
         JobGraph jobGraph2 = StreamingJobGraphGenerator.createJobGraph(streamGraph2);
         assertThat(isJobGraphEquivalent(jobGraph1, jobGraph2)).isTrue();
+    }
+
+    private static StreamGraph createMixedUidAndNonUidUnionStreamGraph() {
+        final StreamExecutionEnvironment env = StreamExecutionEnvironment.createLocalEnvironment(1);
+        env.disableOperatorChaining();
+
+        final DataStream<Integer> nonUidSource = env.fromData(1).name("non-uid-source");
+        final DataStream<Integer> firstUidSource =
+                env.fromData(2).name("uid-source-a").uid("uid-source-a");
+        final DataStream<Integer> secondUidSource =
+                env.fromData(3).name("uid-source-b").uid("uid-source-b");
+
+        nonUidSource
+                .union(firstUidSource, secondUidSource)
+                .sinkTo(new DiscardingSink<>())
+                .name("sink")
+                .uid("sink");
+
+        return env.getStreamGraph();
+    }
+
+    private static JobGraph createReverseDeclarationUnionJobGraph(boolean withUidHashes) {
+        final StreamExecutionEnvironment env = StreamExecutionEnvironment.createLocalEnvironment(1);
+        env.disableOperatorChaining();
+
+        final DataStream<Integer> sourceA =
+                createUnionSource(
+                        env,
+                        "source-a",
+                        1,
+                        withUidHashes ? "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" : null);
+        final DataStream<Integer> sourceB =
+                createUnionSource(
+                        env,
+                        "source-b",
+                        2,
+                        withUidHashes ? "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" : null);
+
+        sourceB.union(sourceA).sinkTo(new DiscardingSink<>()).name("sink").uid("sink");
+
+        return generateJobGraphInLazilyMode(env.getStreamGraph());
+    }
+
+    private static DataStream<Integer> createUnionSource(
+            StreamExecutionEnvironment env, String name, int value, String uidHash) {
+        if (uidHash == null) {
+            return env.fromData(value).name(name);
+        }
+        return env.fromData(value).name(name).setUidHash(uidHash);
+    }
+
+    private static List<String> getSinkInputSourceNames(JobGraph jobGraph) {
+        final JobVertex sink =
+                jobGraph.getVerticesSortedTopologicallyFromSources().stream()
+                        .filter(jobVertex -> jobVertex.getInputs().size() > 1)
+                        .findFirst()
+                        .orElseThrow(() -> new AssertionError("Expected a multi-input sink"));
+        return sink.getInputs().stream()
+                .map(edge -> edge.getSource().getProducer().getName())
+                .collect(Collectors.toList());
+    }
+
+    private static JobVertex getJobVertex(JobGraph jobGraph, String name) {
+        return jobGraph.getVerticesSortedTopologicallyFromSources().stream()
+                .filter(jobVertex -> jobVertex.getName().equals(name))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("Expected job vertex " + name));
     }
 
     private static JobGraph generateJobGraphInLazilyMode(StreamGraph streamGraph) {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/JobGraphGeneratorTestBase.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/JobGraphGeneratorTestBase.java
@@ -1187,6 +1187,24 @@ abstract class JobGraphGeneratorTestBase {
         }
     }
 
+    @Test
+    void testStableUnionInputOrderWithOperatorUids() {
+        assertThat(getInputSourceNames(getUidUnionJobGraph(false)))
+                .isEqualTo(getInputSourceNames(getUidUnionJobGraph(true)));
+    }
+
+    @Test
+    void testStableUnionInputOrderWithOperatorUidsAndUnrelatedSource() {
+        assertThat(getMultiInputSourceNames(getUidUnionJobGraphWithUnrelatedSource(false)))
+                .isEqualTo(getMultiInputSourceNames(getUidUnionJobGraphWithUnrelatedSource(true)));
+    }
+
+    @Test
+    void testUidHashUnionInputOrderKeepsDeclarationOrder() {
+        assertThat(getInputSourceNames(getUidHashUnionJobGraph()))
+                .containsExactly("Source: source-b", "Source: source-a");
+    }
+
     private JobGraph getUnionJobGraph(StreamExecutionEnvironment env) {
 
         createSource(env, 1)
@@ -1200,6 +1218,87 @@ abstract class JobGraphGeneratorTestBase {
 
     private DataStream<Integer> createSource(StreamExecutionEnvironment env, int index) {
         return env.fromData(index).name("source" + index).map(i -> i).name("map" + index);
+    }
+
+    private JobGraph getUidUnionJobGraph(boolean reverseSources) {
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.createLocalEnvironment(1);
+        env.disableOperatorChaining();
+
+        DataStream<Integer> firstSource =
+                createUidSource(
+                        env, reverseSources ? "source-b" : "source-a", reverseSources ? 2 : 1);
+        DataStream<Integer> secondSource =
+                createUidSource(
+                        env, reverseSources ? "source-a" : "source-b", reverseSources ? 1 : 2);
+
+        firstSource.union(secondSource).sinkTo(new DiscardingSink<>()).name("sink").uid("sink");
+
+        return createJobGraph(env.getStreamGraph());
+    }
+
+    private DataStream<Integer> createUidSource(
+            StreamExecutionEnvironment env, String sourceName, int value) {
+        return env.fromData(value).name(sourceName).uid(sourceName);
+    }
+
+    private JobGraph getUidUnionJobGraphWithUnrelatedSource(boolean reverseSources) {
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.createLocalEnvironment(1);
+        env.disableOperatorChaining();
+
+        env.fromData(0)
+                .name("unrelated-source")
+                .sinkTo(new DiscardingSink<>())
+                .name("unrelated-sink");
+
+        DataStream<Integer> firstSource =
+                createUidSource(
+                        env, reverseSources ? "source-b" : "source-a", reverseSources ? 2 : 1);
+        DataStream<Integer> secondSource =
+                createUidSource(
+                        env, reverseSources ? "source-a" : "source-b", reverseSources ? 1 : 2);
+
+        firstSource.union(secondSource).sinkTo(new DiscardingSink<>()).name("sink").uid("sink");
+
+        return createJobGraph(env.getStreamGraph());
+    }
+
+    private JobGraph getUidHashUnionJobGraph() {
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.createLocalEnvironment(1);
+        env.disableOperatorChaining();
+
+        DataStream<Integer> firstSource =
+                createUidHashSource(env, "source-b", 2, "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
+        DataStream<Integer> secondSource =
+                createUidHashSource(env, "source-a", 1, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+
+        firstSource.union(secondSource).sinkTo(new DiscardingSink<>()).name("sink").uid("sink");
+
+        return createJobGraph(env.getStreamGraph());
+    }
+
+    private DataStream<Integer> createUidHashSource(
+            StreamExecutionEnvironment env, String sourceName, int value, String uidHash) {
+        return env.fromData(value).name(sourceName).setUidHash(uidHash);
+    }
+
+    private List<String> getInputSourceNames(JobGraph jobGraph) {
+        JobVertex jobSink = Iterables.getLast(jobGraph.getVerticesSortedTopologicallyFromSources());
+        return getInputSourceNames(jobSink);
+    }
+
+    private List<String> getMultiInputSourceNames(JobGraph jobGraph) {
+        JobVertex jobSink =
+                jobGraph.getVerticesSortedTopologicallyFromSources().stream()
+                        .filter(jobVertex -> jobVertex.getInputs().size() > 1)
+                        .findFirst()
+                        .orElseThrow(() -> new AssertionError("Expected a multi-input sink"));
+        return getInputSourceNames(jobSink);
+    }
+
+    private List<String> getInputSourceNames(JobVertex jobSink) {
+        return jobSink.getInputs().stream()
+                .map(edge -> edge.getSource().getProducer().getName())
+                .collect(Collectors.toList());
     }
 
     @Test


### PR DESCRIPTION
## What is the purpose of the change

When a Flink job restores from an unaligned checkpoint, input channel state is restored by positional input gate/channel indexes rather than by a stable edge identity.

This can break when a job has multiple source operators feeding a union and the source declarations are reordered between job versions. Even if the source operators have stable UIDs, the generated JobEdge / input gate order can still change because initial source traversal is based on transient stream node ordering. After restore, in-flight channel state from one logical source may be applied to another logical input gate.

The PR makes UID-backed union sources connect in stable UID-derived JobVertexID order, so unaligned checkpoint restore sees the same input-gate positions even if source declaration order changes.


## Brief change log

- Updated job graph generation to order UID-backed union source entry points by stable UID-derived JobVertexID instead of declaration/node-id order.
- Applied the same stable ordering in the adaptive graph reconnect path so lazily created downstream vertices get consistent input-gate order too.
- Preserved legacy ordering for non-UID and uidHash-only source heads.

## Verifying this change


This change added tests and can be verified as follows:

- Added regression coverage that reversed UID-backed union source declaration order produces the same sink input order.
- Added regression coverage for mixed UID-backed union inputs plus an unrelated source.
- Added coverage that uidHash-only union inputs keep declaration order.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? (no)

---

##### Was generative AI tooling used to co-author this PR?

- [x] Yes (please specify the tool below)
codex