### PR TITLE
[FLINK-29984][flink-metrics] Export Prometheus histogram min and max

### DIFF
--- a/docs/content.zh/docs/deployment/metric_reporters.md
+++ b/docs/content.zh/docs/deployment/metric_reporters.md
@@ -199,7 +199,7 @@ Flink 指标类型与 Prometheus 指标类型对应关系如下：
 | --------- |------------|-----------------------------------------|
 | Counter   | Gauge      | Prometheus 的 counter 不支持累加。         |
 | Gauge     | Gauge      | 只支持数字与布尔类型。                      |
-| Histogram | Summary    | 分位数为 .5，.75，.95，.98，.99 和 .999。  |
+| Histogram | Summary    | 分位数为 0.0，.5，.75，.95，.98，.99，.999 和 1.0。  |
 | Meter     | Gauge      | Prometheus 的 gauge 为 meter 的百分比形式。 |
 
 所有的 Flink 运行指标变量（见 [List of all Variables]({{< ref "docs/ops/metrics" >}}#list-of-all-variables)）都会按照 label 形式上报给 Prometheus。

--- a/docs/content/docs/deployment/metric_reporters.md
+++ b/docs/content/docs/deployment/metric_reporters.md
@@ -189,7 +189,7 @@ Flink metric types are mapped to Prometheus metric types as follows:
 | --------- |------------|------------------------------------------|
 | Counter   | Gauge      |Prometheus counters cannot be decremented.|
 | Gauge     | Gauge      |Only numbers and booleans are supported.  |
-| Histogram | Summary    |Quantiles .5, .75, .95, .98, .99 and .999 |
+| Histogram | Summary    |Quantiles 0.0, .5, .75, .95, .98, .99, .999 and 1.0 |
 | Meter     | Gauge      |The gauge exports the meter's rate.       |
 
 All Flink metrics variables (see [List of all Variables]({{< ref "docs/ops/metrics" >}}#list-of-all-variables)) are exported to Prometheus as labels. 

--- a/flink-metrics/flink-metrics-prometheus/src/main/java/org/apache/flink/metrics/prometheus/AbstractPrometheusReporter.java
+++ b/flink-metrics/flink-metrics-prometheus/src/main/java/org/apache/flink/metrics/prometheus/AbstractPrometheusReporter.java
@@ -389,14 +389,28 @@ public abstract class AbstractPrometheusReporter implements MetricReporter {
                             labelValues,
                             histogram.getCount()));
             final HistogramStatistics statistics = histogram.getStatistics();
+            addQuantileSample(labelValues, samples, "0.0", statistics.getMin());
             for (final Double quantile : QUANTILES) {
-                samples.add(
-                        new MetricFamilySamples.Sample(
-                                metricName,
-                                labelNamesWithQuantile,
-                                addToList(labelValues, quantile.toString()),
-                                statistics.getQuantile(quantile)));
+                addQuantileSample(
+                        labelValues,
+                        samples,
+                        quantile.toString(),
+                        statistics.getQuantile(quantile));
             }
+            addQuantileSample(labelValues, samples, "1.0", statistics.getMax());
+        }
+
+        private void addQuantileSample(
+                final List<String> labelValues,
+                final List<MetricFamilySamples.Sample> samples,
+                final String quantile,
+                final double value) {
+            samples.add(
+                    new MetricFamilySamples.Sample(
+                            metricName,
+                            labelNamesWithQuantile,
+                            addToList(labelValues, quantile),
+                            value));
         }
     }
 

--- a/flink-metrics/flink-metrics-prometheus/src/test/java/org/apache/flink/metrics/prometheus/PrometheusReporterTaskScopeTest.java
+++ b/flink-metrics/flink-metrics-prometheus/src/test/java/org/apache/flink/metrics/prometheus/PrometheusReporterTaskScopeTest.java
@@ -155,6 +155,30 @@ class PrometheusReporterTaskScopeTest {
                                     addToArray(LABEL_VALUES_2, "" + quantile)))
                     .isEqualTo(quantile);
         }
+        assertThat(
+                        reporter.registry.getSampleValue(
+                                getLogicalScope(METRIC_NAME),
+                                labelNamesWithQuantile,
+                                addToArray(LABEL_VALUES_1, "0.0")))
+                .isEqualTo(histogram1.getStatistics().getMin());
+        assertThat(
+                        reporter.registry.getSampleValue(
+                                getLogicalScope(METRIC_NAME),
+                                labelNamesWithQuantile,
+                                addToArray(LABEL_VALUES_1, "1.0")))
+                .isEqualTo(histogram1.getStatistics().getMax());
+        assertThat(
+                        reporter.registry.getSampleValue(
+                                getLogicalScope(METRIC_NAME),
+                                labelNamesWithQuantile,
+                                addToArray(LABEL_VALUES_2, "0.0")))
+                .isEqualTo(histogram2.getStatistics().getMin());
+        assertThat(
+                        reporter.registry.getSampleValue(
+                                getLogicalScope(METRIC_NAME),
+                                labelNamesWithQuantile,
+                                addToArray(LABEL_VALUES_2, "1.0")))
+                .isEqualTo(histogram2.getStatistics().getMax());
     }
 
     @Test

--- a/flink-metrics/flink-metrics-prometheus/src/test/java/org/apache/flink/metrics/prometheus/PrometheusReporterTest.java
+++ b/flink-metrics/flink-metrics-prometheus/src/test/java/org/apache/flink/metrics/prometheus/PrometheusReporterTest.java
@@ -151,6 +151,8 @@ class PrometheusReporterTest {
                                     + quantile
                                     + "\n");
         }
+        assertThat(response).contains(summaryName + "{" + DIMENSIONS + ",quantile=\"0.0\",} 7.0\n");
+        assertThat(response).contains(summaryName + "{" + DIMENSIONS + ",quantile=\"1.0\",} 6.0\n");
     }
 
     /**


### PR DESCRIPTION
## What is the purpose of the change

Expose histogram min and max from the Prometheus reporters as summary quantiles `0.0` and `1.0`.

## Brief change log

  - Export histogram min and max from `AbstractPrometheusReporter` as summary quantiles.
  - Cover the new samples in `PrometheusReporterTest` and `PrometheusReporterTaskScopeTest`.
  - Document the additional histogram quantiles in the metric reporter docs.

## Verifying this change

This change added tests and can be verified as follows:

  - `./mvnw -pl flink-metrics/flink-metrics-prometheus -am -DskipITs -Dspotless.check.skip=true -Dcheckstyle.skip=true -Dsurefire.failIfNoSpecifiedTests=false -Dtest=PrometheusReporterTest,PrometheusReporterTaskScopeTest test`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs)

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (Codex (GPT-5))

Generated-by: Codex (GPT-5)