### PR TITLE
[FLINK-39948][planner] Fix compile issue in jdk11 for table-planner

### DIFF
--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdModifiedMonotonicityTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdModifiedMonotonicityTest.scala
@@ -21,7 +21,7 @@ import org.apache.flink.table.planner.plan.`trait`.RelModifiedMonotonicity
 import org.apache.flink.table.planner.plan.nodes.logical.{FlinkLogicalRank, FlinkLogicalTableAggregate}
 import org.apache.flink.table.runtime.operators.rank.{ConstantRankRange, RankType}
 
-import org.apache.calcite.rel.`type`.{RelDataTypeFieldImpl, RelRecordType}
+import org.apache.calcite.rel.`type`.{RelDataTypeField, RelDataTypeFieldImpl, RelRecordType}
 import org.apache.calcite.rel.RelCollations
 import org.apache.calcite.rel.core.JoinRelType
 import org.apache.calcite.rel.hint.RelHint
@@ -35,6 +35,7 @@ import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.Test
 
 import java.util
+import java.util.stream.Collectors
 
 import scala.collection.JavaConverters.seqAsJavaListConverter
 import scala.language.postfixOps
@@ -62,7 +63,10 @@ class FlinkRelMdModifiedMonotonicityTest extends FlinkRelMdHandlerTestBase {
     // project `age` field and corresponding output type
     val projection = java.util.List.of[RexInputRef](relBuilder.field("age"))
     val ageFieldType =
-      inputAgg.getRowType.getFieldList.stream().filter(x => x.getName.equals("age")).toList
+      inputAgg.getRowType.getFieldList
+        .stream()
+        .filter(x => x.getName.equals("age"))
+        .collect(Collectors.toList[RelDataTypeField]())
     val outputType = new RelRecordType(ageFieldType)
 
     // select age from (select id, age, count() from student by id, age) where ...


### PR DESCRIPTION

## What is the purpose of the change

*Fix compile issue in jdk11 for table-planner*

This raised from nightly binary snapshot release 

https://dev.azure.com/apache-flink/apache-flink/_build/results?buildId=76109&view=logs&j=585d8b77-fa33-51bc-8163-03e54ba9ce5b&t=68e20e55-906c-5c49-157c-3005667723c9

```
00:33:33.615 [INFO] Compiling 969 source files to /__w/1/s/flink-table/flink-table-planner/target/test-classes at 1781656413615
00:33:58.194 [ERROR] /__w/1/s/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdModifiedMonotonicityTest.scala:65: error: value toList is not a member of java.util.stream.Stream[org.apache.calcite.rel.type.RelDataTypeField]
00:33:58.194 [ERROR]       inputAgg.getRowType.getFieldList.stream().filter(x => x.getName.equals("age")).toList
00:33:58.194 [ERROR]         
```



## Brief change log

  - *Fix compile issue in jdk11 for table-planner*


## Verifying this change

Manually compile using profile -Pjava11-target

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper:no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable

---

##### Was generative AI tooling used to co-author this PR?

No
