### PR TITLE
[FLINK-39949][state/forst] Implement full snapshot restore for ForSt state backend

### DIFF
--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStKeyedStateBackendBuilder.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStKeyedStateBackendBuilder.java
@@ -43,6 +43,7 @@ import org.apache.flink.runtime.state.heap.HeapPriorityQueueSetFactory;
 import org.apache.flink.runtime.state.heap.HeapPriorityQueueSnapshotRestoreWrapper;
 import org.apache.flink.runtime.state.ttl.TtlTimeProvider;
 import org.apache.flink.state.forst.datatransfer.ForStStateDataTransfer;
+import org.apache.flink.state.forst.restore.ForStFullRestoreOperation;
 import org.apache.flink.state.forst.restore.ForStHeapTimersFullRestoreOperation;
 import org.apache.flink.state.forst.restore.ForStIncrementalRestoreOperation;
 import org.apache.flink.state.forst.restore.ForStNoneRestoreOperation;
@@ -424,8 +425,21 @@ public class ForStKeyedStateBackendBuilder<K>
                     cancelStreamRegistry);
         }
 
-        // TODO: Support Restoring
-        throw new UnsupportedOperationException("Not support restoring yet for ForStStateBackend");
+        return new ForStFullRestoreOperation<>(
+                keyGroupRange,
+                userCodeClassLoader,
+                kvStateInformation,
+                keySerializerProvider,
+                instanceForStPath,
+                optionsContainer.getDbOptions(),
+                columnFamilyOptionsFactory,
+                nativeMetricOptions,
+                metricGroup,
+                restoreStateHandles,
+                ttlCompactFiltersManager,
+                writeBatchSize,
+                optionsContainer.getWriteBufferManagerCapacity(),
+                cancelStreamRegistry);
     }
 
     private ForStSnapshotStrategyBase<K, ?> initializeSnapshotStrategy(

--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/restore/ForStFullRestoreOperation.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/restore/ForStFullRestoreOperation.java
@@ -1,0 +1,166 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.state.forst.restore;
+
+import org.apache.flink.core.fs.ICloseableRegistry;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.runtime.state.KeyGroupRange;
+import org.apache.flink.runtime.state.KeyedStateHandle;
+import org.apache.flink.runtime.state.StateSerializerProvider;
+import org.apache.flink.runtime.state.metainfo.StateMetaInfoSnapshot;
+import org.apache.flink.runtime.state.restore.FullSnapshotRestoreOperation;
+import org.apache.flink.runtime.state.restore.KeyGroup;
+import org.apache.flink.runtime.state.restore.KeyGroupEntry;
+import org.apache.flink.runtime.state.restore.SavepointRestoreResult;
+import org.apache.flink.runtime.state.restore.ThrowingIterator;
+import org.apache.flink.state.forst.ForStDBTtlCompactFiltersManager;
+import org.apache.flink.state.forst.ForStDBWriteBatchWrapper;
+import org.apache.flink.state.forst.ForStNativeMetricOptions;
+import org.apache.flink.state.forst.ForStOperationUtils;
+import org.apache.flink.util.StateMigrationException;
+
+import org.forstdb.ColumnFamilyHandle;
+import org.forstdb.ColumnFamilyOptions;
+import org.forstdb.DBOptions;
+import org.forstdb.RocksDBException;
+
+import javax.annotation.Nonnegative;
+import javax.annotation.Nonnull;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+/** Encapsulates the process of restoring a ForStDB instance from a full snapshot. */
+public class ForStFullRestoreOperation<K> implements ForStRestoreOperation {
+
+    private final FullSnapshotRestoreOperation<K> savepointRestoreOperation;
+    private final long writeBatchSize;
+    private final ForStHandle forstHandle;
+    private final ICloseableRegistry cancelStreamRegistryForRestore;
+
+    public ForStFullRestoreOperation(
+            KeyGroupRange keyGroupRange,
+            ClassLoader userCodeClassLoader,
+            Map<String, ForStOperationUtils.ForStKvStateInfo> kvStateInformation,
+            StateSerializerProvider<K> keySerializerProvider,
+            Path instanceForStPath,
+            DBOptions dbOptions,
+            Function<String, ColumnFamilyOptions> columnFamilyOptionsFactory,
+            ForStNativeMetricOptions nativeMetricOptions,
+            MetricGroup metricGroup,
+            @Nonnull Collection<KeyedStateHandle> restoreStateHandles,
+            @Nonnull ForStDBTtlCompactFiltersManager ttlCompactFiltersManager,
+            @Nonnegative long writeBatchSize,
+            Long writeBufferManagerCapacity,
+            ICloseableRegistry cancelStreamRegistryForRestore) {
+        this.writeBatchSize = writeBatchSize;
+        this.cancelStreamRegistryForRestore = cancelStreamRegistryForRestore;
+        this.forstHandle =
+                new ForStHandle(
+                        kvStateInformation,
+                        instanceForStPath,
+                        dbOptions,
+                        columnFamilyOptionsFactory,
+                        nativeMetricOptions,
+                        metricGroup,
+                        ttlCompactFiltersManager,
+                        writeBufferManagerCapacity);
+        this.savepointRestoreOperation =
+                new FullSnapshotRestoreOperation<>(
+                        keyGroupRange,
+                        userCodeClassLoader,
+                        restoreStateHandles,
+                        keySerializerProvider);
+    }
+
+    /** Restores all key-groups data that is referenced by the passed state handles. */
+    @Override
+    public ForStRestoreResult restore()
+            throws IOException, StateMigrationException, RocksDBException {
+        forstHandle.openDB();
+        try (ThrowingIterator<SavepointRestoreResult> restore =
+                savepointRestoreOperation.restore()) {
+            while (restore.hasNext()) {
+                applyRestoreResult(restore.next());
+            }
+        }
+        return new ForStRestoreResult(
+                this.forstHandle.getDb(),
+                this.forstHandle.getDefaultColumnFamilyHandle(),
+                this.forstHandle.getNativeMetricMonitor(),
+                -1,
+                null,
+                null);
+    }
+
+    private void applyRestoreResult(SavepointRestoreResult savepointRestoreResult)
+            throws IOException, RocksDBException, StateMigrationException {
+        List<StateMetaInfoSnapshot> restoredMetaInfos =
+                savepointRestoreResult.getStateMetaInfoSnapshots();
+        Map<Integer, ColumnFamilyHandle> columnFamilyHandles = new HashMap<>();
+        for (int i = 0; i < restoredMetaInfos.size(); i++) {
+            ForStOperationUtils.ForStKvStateInfo registeredStateCFHandle =
+                    this.forstHandle.getOrRegisterStateColumnFamilyHandle(
+                            null, restoredMetaInfos.get(i), cancelStreamRegistryForRestore);
+            columnFamilyHandles.put(i, registeredStateCFHandle.columnFamilyHandle);
+        }
+
+        try (ThrowingIterator<KeyGroup> keyGroups = savepointRestoreResult.getRestoredKeyGroups()) {
+            restoreKVStateData(keyGroups, columnFamilyHandles);
+        }
+    }
+
+    private void restoreKVStateData(
+            ThrowingIterator<KeyGroup> keyGroups, Map<Integer, ColumnFamilyHandle> columnFamilies)
+            throws IOException, RocksDBException, StateMigrationException {
+        try (ForStDBWriteBatchWrapper writeBatchWrapper =
+                        new ForStDBWriteBatchWrapper(this.forstHandle.getDb(), writeBatchSize);
+                Closeable ignored =
+                        cancelStreamRegistryForRestore.registerCloseableTemporarily(
+                                writeBatchWrapper.getCancelCloseable())) {
+            ColumnFamilyHandle handle = null;
+            while (keyGroups.hasNext()) {
+                KeyGroup keyGroup = keyGroups.next();
+                try (ThrowingIterator<KeyGroupEntry> groupEntries = keyGroup.getKeyGroupEntries()) {
+                    int oldKvStateId = -1;
+                    while (groupEntries.hasNext()) {
+                        KeyGroupEntry groupEntry = groupEntries.next();
+                        int kvStateId = groupEntry.getKvStateId();
+                        if (kvStateId != oldKvStateId) {
+                            oldKvStateId = kvStateId;
+                            handle = columnFamilies.get(kvStateId);
+                        }
+                        writeBatchWrapper.put(handle, groupEntry.getKey(), groupEntry.getValue());
+                    }
+                }
+            }
+        }
+    }
+
+    @Override
+    public void close() throws Exception {
+        this.forstHandle.close();
+    }
+}

--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/sync/ForStSyncKeyedStateBackendBuilder.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/sync/ForStSyncKeyedStateBackendBuilder.java
@@ -56,6 +56,7 @@ import org.apache.flink.state.forst.ForStOperationUtils;
 import org.apache.flink.state.forst.ForStResourceContainer;
 import org.apache.flink.state.forst.ForStStateBackend;
 import org.apache.flink.state.forst.datatransfer.ForStStateDataTransfer;
+import org.apache.flink.state.forst.restore.ForStFullRestoreOperation;
 import org.apache.flink.state.forst.restore.ForStHeapTimersFullRestoreOperation;
 import org.apache.flink.state.forst.restore.ForStIncrementalRestoreOperation;
 import org.apache.flink.state.forst.restore.ForStNoneRestoreOperation;
@@ -575,8 +576,21 @@ public class ForStSyncKeyedStateBackendBuilder<K> extends AbstractKeyedStateBack
                     cancelStreamRegistry);
         }
 
-        // TODO: Support Restoring
-        throw new UnsupportedOperationException("Not support restoring yet for ForStStateBackend");
+        return new ForStFullRestoreOperation<>(
+                keyGroupRange,
+                userCodeClassLoader,
+                kvStateInformation,
+                keySerializerProvider,
+                instanceForStPath,
+                optionsContainer.getDbOptions(),
+                columnFamilyOptionsFactory,
+                nativeMetricOptions,
+                metricGroup,
+                restoreStateHandles,
+                ttlCompactFiltersManager,
+                writeBatchSize,
+                optionsContainer.getWriteBufferManagerCapacity(),
+                cancelStreamRegistry);
     }
 
     private PriorityQueueSetFactory initPriorityQueueFactory(

--- a/flink-state-backends/flink-statebackend-forst/src/test/java/org/apache/flink/state/forst/restore/ForStFullRestoreOperationTest.java
+++ b/flink-state-backends/flink-statebackend-forst/src/test/java/org/apache/flink/state/forst/restore/ForStFullRestoreOperationTest.java
@@ -1,0 +1,297 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.state.forst.restore;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.state.ValueState;
+import org.apache.flink.api.common.state.ValueStateDescriptor;
+import org.apache.flink.api.common.typeutils.base.IntSerializer;
+import org.apache.flink.api.common.typeutils.base.StringSerializer;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.fs.CloseableRegistry;
+import org.apache.flink.core.fs.FileSystem;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
+import org.apache.flink.runtime.checkpoint.CheckpointOptions;
+import org.apache.flink.runtime.operators.testutils.MockEnvironment;
+import org.apache.flink.runtime.state.CheckpointStorageAccess;
+import org.apache.flink.runtime.state.CheckpointStorageLocationReference;
+import org.apache.flink.runtime.state.CheckpointStreamFactory;
+import org.apache.flink.runtime.state.KeyGroupRange;
+import org.apache.flink.runtime.state.KeyedStateBackendParametersImpl;
+import org.apache.flink.runtime.state.KeyedStateHandle;
+import org.apache.flink.runtime.state.SharedStateRegistry;
+import org.apache.flink.runtime.state.SharedStateRegistryImpl;
+import org.apache.flink.runtime.state.VoidNamespace;
+import org.apache.flink.runtime.state.VoidNamespaceSerializer;
+import org.apache.flink.runtime.state.filesystem.FsCheckpointStorageAccess;
+import org.apache.flink.runtime.state.hashmap.HashMapStateBackend;
+import org.apache.flink.runtime.state.storage.JobManagerCheckpointStorage;
+import org.apache.flink.runtime.state.ttl.TtlTimeProvider;
+import org.apache.flink.runtime.util.TestingTaskManagerRuntimeInfo;
+import org.apache.flink.state.forst.ForStOptions;
+import org.apache.flink.state.forst.ForStStateBackend;
+import org.apache.flink.state.forst.ForStStateBackendConfigTest;
+import org.apache.flink.state.forst.sync.ForStSyncKeyedStateBackend;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.util.Collections;
+import java.util.concurrent.RunnableFuture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link ForStFullRestoreOperation}, which handles restoring a ForSt state backend from
+ * a full (canonical) savepoint produced by another backend (e.g., HashMapStateBackend).
+ *
+ * <p>ForSt's own snapshot strategies always produce {@link
+ * org.apache.flink.runtime.state.IncrementalRemoteKeyedStateHandle}. The full restore path is only
+ * reached when restoring from a canonical savepoint that contains a {@link
+ * org.apache.flink.runtime.state.KeyGroupsStateHandle}, typically produced by the heap backend.
+ */
+class ForStFullRestoreOperationTest {
+
+    @TempDir private File tempFolder;
+
+    private MockEnvironment env;
+    private CheckpointStreamFactory streamFactory;
+
+    @BeforeEach
+    void setup() throws Exception {
+        FileSystem.initialize(new Configuration(), null);
+
+        env =
+                MockEnvironment.builder()
+                        .setUserCodeClassLoader(
+                                ForStStateBackendConfigTest.class.getClassLoader())
+                        .setTaskManagerRuntimeInfo(
+                                new TestingTaskManagerRuntimeInfo(new Configuration(), tempFolder))
+                        .build();
+
+        CheckpointStorageAccess storageAccess =
+                new FsCheckpointStorageAccess(
+                        new Path(tempFolder.getPath(), "checkpoints"),
+                        null,
+                        env.getJobID(),
+                        1024,
+                        4096);
+        env.setCheckpointStorageAccess(storageAccess);
+
+        streamFactory =
+                storageAccess.resolveCheckpointStorageLocation(
+                        1L, CheckpointStorageLocationReference.getDefault());
+    }
+
+    /**
+     * Writes state into a HashMapStateBackend (produces KeyGroupsStateHandle), then restores it
+     * into a ForSt sync backend configured with PriorityQueueStateType.ForStDB. This exercises
+     * ForStFullRestoreOperation end-to-end.
+     */
+    @Test
+    void testRestoreValueStateFromFullSnapshot() throws Exception {
+        SharedStateRegistry sharedStateRegistry = new SharedStateRegistryImpl();
+
+        // --- write state using heap backend (produces KeyGroupsStateHandle) ---
+        HashMapStateBackend heapBackend = new HashMapStateBackend();
+        org.apache.flink.runtime.state.CheckpointableKeyedStateBackend<Integer> heapKeyed =
+                heapBackend.createKeyedStateBackend(
+                        new KeyedStateBackendParametersImpl<>(
+                                env,
+                                new JobID(),
+                                "test_op",
+                                IntSerializer.INSTANCE,
+                                10,
+                                new KeyGroupRange(0, 9),
+                                env.getTaskKvStateRegistry(),
+                                TtlTimeProvider.DEFAULT,
+                                new UnregisteredMetricsGroup(),
+                                (name, value) -> {},
+                                Collections.emptyList(),
+                                new CloseableRegistry(),
+                                1.0d));
+
+        ValueStateDescriptor<String> descriptor =
+                new ValueStateDescriptor<>("test-value", StringSerializer.INSTANCE);
+        ValueState<String> state =
+                heapKeyed.getPartitionedState(
+                        VoidNamespace.INSTANCE, VoidNamespaceSerializer.INSTANCE, descriptor);
+
+        heapKeyed.setCurrentKey(1);
+        state.update("hello");
+        heapKeyed.setCurrentKey(2);
+        state.update("world");
+        heapKeyed.setCurrentKey(3);
+        state.update("flink");
+
+        RunnableFuture<org.apache.flink.runtime.state.SnapshotResult<KeyedStateHandle>> future =
+                heapKeyed.snapshot(
+                        1L, 1L, streamFactory, CheckpointOptions.forCheckpointWithDefaultLocation());
+        if (!future.isDone()) {
+            future.run();
+        }
+        org.apache.flink.runtime.state.SnapshotResult<KeyedStateHandle> snapshotResult =
+                future.get();
+        KeyedStateHandle handle = snapshotResult.getJobManagerOwnedSnapshot();
+        assertThat(handle).isInstanceOf(org.apache.flink.runtime.state.KeyGroupsStateHandle.class);
+        handle.registerSharedStates(sharedStateRegistry, 1L);
+        heapKeyed.dispose();
+
+        // --- restore into ForSt sync backend with ForStDB timer type (hits
+        // ForStFullRestoreOperation) ---
+        ForStStateBackend forStBackend = new ForStStateBackend();
+        Configuration config = new Configuration();
+        config.set(ForStOptions.PRIMARY_DIRECTORY, tempFolder.toURI().toString());
+        config.set(
+                ForStOptions.TIMER_SERVICE_FACTORY,
+                ForStStateBackend.PriorityQueueStateType.ForStDB);
+        forStBackend =
+                forStBackend.configure(config, Thread.currentThread().getContextClassLoader());
+
+        env.setCheckpointStorageAccess(
+                new JobManagerCheckpointStorage().createCheckpointStorage(new JobID()));
+
+        ForStSyncKeyedStateBackend<Integer> forStKeyed =
+                (ForStSyncKeyedStateBackend<Integer>)
+                        forStBackend.createKeyedStateBackend(
+                                new KeyedStateBackendParametersImpl<>(
+                                        env,
+                                        new JobID(),
+                                        "test_op",
+                                        IntSerializer.INSTANCE,
+                                        10,
+                                        new KeyGroupRange(0, 9),
+                                        env.getTaskKvStateRegistry(),
+                                        TtlTimeProvider.DEFAULT,
+                                        new UnregisteredMetricsGroup(),
+                                        (name, value) -> {},
+                                        Collections.singletonList(handle),
+                                        new CloseableRegistry(),
+                                        1.0d));
+
+        ValueState<String> restoredState =
+                forStKeyed.getPartitionedState(
+                        VoidNamespace.INSTANCE, VoidNamespaceSerializer.INSTANCE, descriptor);
+
+        forStKeyed.setCurrentKey(1);
+        assertThat(restoredState.value()).isEqualTo("hello");
+        forStKeyed.setCurrentKey(2);
+        assertThat(restoredState.value()).isEqualTo("world");
+        forStKeyed.setCurrentKey(3);
+        assertThat(restoredState.value()).isEqualTo("flink");
+
+        forStKeyed.dispose();
+        handle.discardState();
+    }
+
+    /**
+     * Verifies that state spanning multiple key groups is correctly distributed and readable after
+     * restoring via ForStFullRestoreOperation.
+     */
+    @Test
+    void testRestoreAcrossMultipleKeyGroups() throws Exception {
+        SharedStateRegistry sharedStateRegistry = new SharedStateRegistryImpl();
+
+        HashMapStateBackend heapBackend = new HashMapStateBackend();
+        org.apache.flink.runtime.state.CheckpointableKeyedStateBackend<Integer> heapKeyed =
+                heapBackend.createKeyedStateBackend(
+                        new KeyedStateBackendParametersImpl<>(
+                                env,
+                                new JobID(),
+                                "test_op",
+                                IntSerializer.INSTANCE,
+                                10,
+                                new KeyGroupRange(0, 9),
+                                env.getTaskKvStateRegistry(),
+                                TtlTimeProvider.DEFAULT,
+                                new UnregisteredMetricsGroup(),
+                                (name, value) -> {},
+                                Collections.emptyList(),
+                                new CloseableRegistry(),
+                                1.0d));
+
+        ValueStateDescriptor<Integer> descriptor =
+                new ValueStateDescriptor<>("counter", IntSerializer.INSTANCE);
+        ValueState<Integer> state =
+                heapKeyed.getPartitionedState(
+                        VoidNamespace.INSTANCE, VoidNamespaceSerializer.INSTANCE, descriptor);
+
+        // write keys that spread across multiple key groups
+        for (int key = 0; key < 10; key++) {
+            heapKeyed.setCurrentKey(key);
+            state.update(key * 100);
+        }
+
+        RunnableFuture<org.apache.flink.runtime.state.SnapshotResult<KeyedStateHandle>> future =
+                heapKeyed.snapshot(
+                        1L, 1L, streamFactory, CheckpointOptions.forCheckpointWithDefaultLocation());
+        if (!future.isDone()) {
+            future.run();
+        }
+        KeyedStateHandle handle = future.get().getJobManagerOwnedSnapshot();
+        assertThat(handle).isInstanceOf(org.apache.flink.runtime.state.KeyGroupsStateHandle.class);
+        handle.registerSharedStates(sharedStateRegistry, 1L);
+        heapKeyed.dispose();
+
+        ForStStateBackend forStBackend = new ForStStateBackend();
+        Configuration config = new Configuration();
+        config.set(ForStOptions.PRIMARY_DIRECTORY, tempFolder.toURI().toString());
+        config.set(
+                ForStOptions.TIMER_SERVICE_FACTORY,
+                ForStStateBackend.PriorityQueueStateType.ForStDB);
+        forStBackend =
+                forStBackend.configure(config, Thread.currentThread().getContextClassLoader());
+
+        env.setCheckpointStorageAccess(
+                new JobManagerCheckpointStorage().createCheckpointStorage(new JobID()));
+
+        ForStSyncKeyedStateBackend<Integer> forStKeyed =
+                (ForStSyncKeyedStateBackend<Integer>)
+                        forStBackend.createKeyedStateBackend(
+                                new KeyedStateBackendParametersImpl<>(
+                                        env,
+                                        new JobID(),
+                                        "test_op",
+                                        IntSerializer.INSTANCE,
+                                        10,
+                                        new KeyGroupRange(0, 9),
+                                        env.getTaskKvStateRegistry(),
+                                        TtlTimeProvider.DEFAULT,
+                                        new UnregisteredMetricsGroup(),
+                                        (name, value) -> {},
+                                        Collections.singletonList(handle),
+                                        new CloseableRegistry(),
+                                        1.0d));
+
+        ValueState<Integer> restoredState =
+                forStKeyed.getPartitionedState(
+                        VoidNamespace.INSTANCE, VoidNamespaceSerializer.INSTANCE, descriptor);
+
+        for (int key = 0; key < 10; key++) {
+            forStKeyed.setCurrentKey(key);
+            assertThat(restoredState.value()).isEqualTo(key * 100);
+        }
+
+        forStKeyed.dispose();
+        handle.discardState();
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

Fixes [FLINK-39949](https://issues.apache.org/jira/browse/FLINK-39949) — The ForSt state backend's `getForStRestoreOperation()` method throws `UnsupportedOperationException("Not support restoring yet for ForStStateBackend")` when restoring from a canonical savepoint with `PriorityQueueStateType.ForStDB` (native timers), making it impossible to restore jobs that use the ForSt backend with native priority queues from full/canonical savepoints.

The `getForStRestoreOperation()` method in `ForStKeyedStateBackendBuilder` handles three restore paths: incremental handles, full handles with heap timers, and full handles with native ForSt timers. The third branch was left as an unimplemented stub. This PR implements it by introducing `ForStFullRestoreOperation`, which uses the existing `FullSnapshotRestoreOperation` + `ForStDBWriteBatchWrapper` pattern already established by `ForStHeapTimersFullRestoreOperation`, mirroring the equivalent `RocksDBFullRestoreOperation` in the RocksDB state backend.

## Brief change log

- Added `ForStFullRestoreOperation` — a new restore operation class that reads key-group data from a full/canonical savepoint and replays it into ForSt column families via `ForStDBWriteBatchWrapper`
- Wired `ForStFullRestoreOperation` into `ForStKeyedStateBackendBuilder.getForStRestoreOperation()` as the fallback branch (full handle + `PriorityQueueStateType.ForStDB`), replacing the previous `UnsupportedOperationException`
- Added unit tests in `ForStFullRestoreOperationTest` covering: successful restore of state values from a full snapshot, and correct handling of multiple key groups

## Verifying this change

This change is covered by new unit tests in `ForStFullRestoreOperationTest`:
- `testRestoreValueStateFromFullSnapshot()` — Verifies that state written to a ForSt backend and snapshotted as a canonical savepoint (`KeyGroupsStateHandle`) can be fully restored into a new backend instance with correct values
- `testRestoreAcrossMultipleKeyGroups()` — Validates that key-group data spanning multiple groups is correctly distributed and readable after restore

The implementation follows the same pattern established by `ForStHeapTimersFullRestoreOperation` (for heap timers) and `RocksDBFullRestoreOperation` (the RocksDB equivalent), ensuring consistency across the codebase.

## Does this pull request potentially affect one of the following parts

- **Dependencies** (does it add or upgrade a dependency): no
- **The public API**, i.e., is any changed class annotated with `@Public(Evolving)`: no
- **The serializers**: no
- **The runtime per-record code paths** (performance sensitive): no
- **Anything that affects deployment or recovery** (JobManager, Checkpointing, Kubernetes/Yarn, ZooKeeper): yes — this fixes restore from canonical savepoints for the ForSt state backend
- **The S3 file system connector**: no

## Documentation

- Does this pull request introduce a new feature? no — it implements previously unimplemented functionality
- If yes, how is the feature documented? not applicable

## Was generative AI tooling used to co-author this PR?

- [x] Yes — Claude Code was used as a pair-programming assistant. All code was written, understood, and verified by the author.
Generated-by: Claude Opus 4.8