### PR TITLE
[FLINK-39952][Table SQL/Planner] Fix CallContextMock.isArgumentNull() to correctly handle optional arguments

### DIFF
--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/inference/utils/CallContextMock.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/inference/utils/CallContextMock.java
@@ -72,7 +72,7 @@ public class CallContextMock implements CallContext {
     @Override
     public boolean isArgumentNull(int pos) {
         if (argumentNulls == null || pos >= argumentNulls.size()) {
-        return true;
+            return true;
         }
         return Boolean.TRUE.equals(argumentNulls.get(pos));
     }

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/inference/utils/CallContextMock.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/inference/utils/CallContextMock.java
@@ -66,7 +66,10 @@ public class CallContextMock implements CallContext {
 
     @Override
     public boolean isArgumentLiteral(int pos) {
-        return argumentLiterals.get(pos);
+        if (argumentLiterals == null || pos >= argumentLiterals.size()) {
+            return false;
+        }
+        return Boolean.TRUE.equals(argumentLiterals.get(pos));
     }
 
     @Override
@@ -80,8 +83,11 @@ public class CallContextMock implements CallContext {
     @Override
     @SuppressWarnings("unchecked")
     public <T> Optional<T> getArgumentValue(int pos, Class<T> clazz) {
-        return (Optional<T>)
-                argumentValues.get(pos).filter(v -> clazz.isAssignableFrom(v.getClass()));
+        if (argumentValues == null || pos >= argumentValues.size()) {
+            return Optional.empty();
+        }
+        return (Optional<T>) argumentValues.get(pos)
+                .filter(v -> clazz.isAssignableFrom(v.getClass()));
     }
 
     @Override

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/inference/utils/CallContextMock.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/inference/utils/CallContextMock.java
@@ -86,8 +86,8 @@ public class CallContextMock implements CallContext {
         if (argumentValues == null || pos >= argumentValues.size()) {
             return Optional.empty();
         }
-        return (Optional<T>) argumentValues.get(pos)
-                .filter(v -> clazz.isAssignableFrom(v.getClass()));
+        return (Optional<T>)
+                argumentValues.get(pos).filter(v -> clazz.isAssignableFrom(v.getClass()));
     }
 
     @Override

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/inference/utils/CallContextMock.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/inference/utils/CallContextMock.java
@@ -71,7 +71,10 @@ public class CallContextMock implements CallContext {
 
     @Override
     public boolean isArgumentNull(int pos) {
-        return argumentNulls.get(pos);
+        if (argumentNulls == null || pos >= argumentNulls.size()) {
+        return true;
+        }
+        return Boolean.TRUE.equals(argumentNulls.get(pos));
     }
 
     @Override

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/inference/utils/CallContextMockTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/inference/utils/CallContextMockTest.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.types.inference.utils;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link CallContextMock}. */
+class CallContextMockTest {
+
+    @Test
+    void testIsArgumentLiteralWithOutOfBoundsIndex() {
+        CallContextMock mock = new CallContextMock();
+        mock.argumentLiterals = Collections.singletonList(true);
+
+        assertThat(mock.isArgumentLiteral(0)).isTrue();
+        // Should safely return false instead of throwing IndexOutOfBoundsException
+        assertThat(mock.isArgumentLiteral(1)).isFalse();
+    }
+
+    @Test
+    void testIsArgumentLiteralWithNullList() {
+        CallContextMock mock = new CallContextMock();
+        mock.argumentLiterals = null;
+
+        // Should safely return false instead of throwing NullPointerException
+        assertThat(mock.isArgumentLiteral(0)).isFalse();
+    }
+
+    @Test
+    void testIsArgumentNullWithOutOfBoundsIndex() {
+        CallContextMock mock = new CallContextMock();
+        mock.argumentNulls = Collections.singletonList(false);
+
+        assertThat(mock.isArgumentNull(0)).isFalse();
+        // Should safely return true instead of throwing IndexOutOfBoundsException
+        assertThat(mock.isArgumentNull(1)).isTrue();
+    }
+
+    @Test
+    void testIsArgumentNullWithNullList() {
+        CallContextMock mock = new CallContextMock();
+        mock.argumentNulls = null;
+
+        // Should safely return true instead of throwing NullPointerException
+        assertThat(mock.isArgumentNull(0)).isTrue();
+    }
+
+    @Test
+    void testGetArgumentValueWithOutOfBoundsIndex() {
+        CallContextMock mock = new CallContextMock();
+        mock.argumentValues = Collections.singletonList(Optional.of("value"));
+
+        assertThat(mock.getArgumentValue(0, String.class)).contains("value");
+        // Should safely return Optional.empty() instead of throwing IndexOutOfBoundsException
+        assertThat(mock.getArgumentValue(1, String.class)).isEmpty();
+    }
+
+    @Test
+    void testGetArgumentValueWithNullList() {
+        CallContextMock mock = new CallContextMock();
+        mock.argumentValues = null;
+
+        // Should safely return Optional.empty() instead of throwing NullPointerException
+        assertThat(mock.getArgumentValue(0, String.class)).isEmpty();
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

This pull request fixes CallContextMock to better match the CallContext contract when optional arguments are not provided in test scenarios.
Previously, some methods could access argument metadata and values using direct list lookups, which could lead to IndexOutOfBoundsException when a test declared optional arguments but did not provide corresponding entries. This change makes the mock handle missing optional arguments consistently and safely.

## Brief change log

  - Fixed `isArgumentNull()` to correctly handle missing optional arguments.
  - Added bounds checks when accessing argument metadata and values in `CallContextMock` (including `isArgumentLiteral()` and `getArgumentValue()`).
  - Prevented `IndexOutOfBoundsException` for optional arguments that are not provided.
  - Preserved existing behavior for explicitly supplied arguments.

## Verifying this change

This change is already covered by existing tests.
The affected behavior is exercised through the existing type inference test infrastructure that uses `CallContextMock`, including tests based on `InputTypeStrategiesTestBase`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable

---

##### Was generative AI tooling used to co-author this PR?

- [x] Yes (please specify the tool below)

Generated-by: Claude- Opus 4.7
