### PR TITLE
[FLINK-38614][runtime] Defer EndOfData until final checkpoint committables are emitted

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/streaming/api/operators/EmitsRecordsOnFinalCheckpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/api/operators/EmitsRecordsOnFinalCheckpoint.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.operators;
+
+import org.apache.flink.annotation.Internal;
+
+/**
+ * Marks an operator that emits records to downstream operators while processing the final
+ * checkpoint's {@code notifyCheckpointComplete}, i.e. <em>after</em> {@code endInput}.
+ *
+ * <p>The sink {@code CommitterOperator} forwards the committables of the final checkpoint to a
+ * downstream (global) committer only on {@code notifyCheckpointComplete}. With unaligned
+ * checkpoints those committables can belong to the post-end-of-input final checkpoint. Because the
+ * containing task broadcasts {@code EndOfData} right after {@code endInput} (before that final
+ * {@code notifyCheckpointComplete}), the downstream committer finishes before the records are
+ * delivered and silently drops them (FLINK-38614).
+ *
+ * <p>A task whose operator chain contains such an operator defers broadcasting {@code EndOfData}
+ * downstream until the final checkpoint's records have been emitted.
+ */
+@Internal
+public interface EmitsRecordsOnFinalCheckpoint {
+
+    /**
+     * Whether this operator may emit records downstream on the final checkpoint's {@code
+     * notifyCheckpointComplete}. When {@code true}, the owning task defers its downstream {@code
+     * EndOfData} broadcast until the final checkpoint completes.
+     */
+    boolean emitsRecordsOnFinalCheckpoint();
+}

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/operators/sink/CommitterOperator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/operators/sink/CommitterOperator.java
@@ -35,6 +35,7 @@ import org.apache.flink.streaming.api.connector.sink2.CommittableWithLineage;
 import org.apache.flink.streaming.api.graph.StreamConfig;
 import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
 import org.apache.flink.streaming.api.operators.BoundedOneInput;
+import org.apache.flink.streaming.api.operators.EmitsRecordsOnFinalCheckpoint;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
 import org.apache.flink.streaming.api.operators.Output;
 import org.apache.flink.streaming.api.operators.StreamOperatorParameters;
@@ -65,7 +66,8 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  */
 class CommitterOperator<CommT> extends AbstractStreamOperator<CommittableMessage<CommT>>
         implements OneInputStreamOperator<CommittableMessage<CommT>, CommittableMessage<CommT>>,
-                BoundedOneInput {
+                BoundedOneInput,
+                EmitsRecordsOnFinalCheckpoint {
 
     private final SimpleVersionedSerializer<CommT> committableSerializer;
     private final FunctionWithException<CommitterInitContext, Committer<CommT>, IOException>
@@ -149,10 +151,24 @@ class CommitterOperator<CommT> extends AbstractStreamOperator<CommittableMessage
 
     @Override
     public void endInput() throws Exception {
-        if (!isCheckpointingEnabled || isBatchMode) {
+        if (!hasFinalCheckpoint()) {
             // There will be no final checkpoint, all committables should be committed here
             commitAndEmitCheckpoints(Long.MAX_VALUE);
         }
+    }
+
+    @Override
+    public boolean emitsRecordsOnFinalCheckpoint() {
+        // Committables are forwarded downstream (only when emitDownstream) on the final
+        // checkpoint's
+        // notifyCheckpointComplete, after endInput; see EmitsRecordsOnFinalCheckpoint
+        // (FLINK-38614).
+        return emitDownstream && hasFinalCheckpoint();
+    }
+
+    /** Whether a final checkpoint is taken on shutdown (streaming mode with checkpointing). */
+    private boolean hasFinalCheckpoint() {
+        return isCheckpointingEnabled && !isBatchMode;
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/tasks/OperatorChain.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/tasks/OperatorChain.java
@@ -51,6 +51,7 @@ import org.apache.flink.streaming.api.graph.StreamConfig;
 import org.apache.flink.streaming.api.graph.StreamEdge;
 import org.apache.flink.streaming.api.operators.BoundedMultiInput;
 import org.apache.flink.streaming.api.operators.CountingOutput;
+import org.apache.flink.streaming.api.operators.EmitsRecordsOnFinalCheckpoint;
 import org.apache.flink.streaming.api.operators.Input;
 import org.apache.flink.streaming.api.operators.MultipleInputStreamOperator;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
@@ -386,6 +387,22 @@ public abstract class OperatorChain<OUT, OP extends StreamOperator<OUT>>
         return reverse
                 ? new StreamOperatorWrapper.ReadIterator(tailOperatorWrapper, true)
                 : new StreamOperatorWrapper.ReadIterator(mainOperatorWrapper, false);
+    }
+
+    /**
+     * Whether any operator in the chain emits records downstream while processing the final
+     * checkpoint's {@code notifyCheckpointComplete} (see {@link EmitsRecordsOnFinalCheckpoint}).
+     * The owning task defers broadcasting {@code EndOfData} until then (FLINK-38614).
+     */
+    public boolean emitsRecordsOnFinalCheckpoint() {
+        for (StreamOperatorWrapper<?, ?> operatorWrapper : getAllOperators(false)) {
+            StreamOperator<?> operator = operatorWrapper.getStreamOperator();
+            if (operator instanceof EmitsRecordsOnFinalCheckpoint
+                    && ((EmitsRecordsOnFinalCheckpoint) operator).emitsRecordsOnFinalCheckpoint()) {
+                return true;
+            }
+        }
+        return false;
     }
 
     public Input getFinishedOnRestoreInputOrDefault(Input defaultInput) {

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -311,6 +311,12 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
     private Long finalCheckpointMinId = null;
     private final CompletableFuture<Void> finalCheckpointCompleted = new CompletableFuture<>();
 
+    /**
+     * Non-null when the downstream {@code EndOfData} broadcast has been deferred until the final
+     * checkpoint completes (FLINK-38614); holds the {@link StopMode} to broadcast then.
+     */
+    @Nullable private StopMode deferredEndOfData = null;
+
     private long latestReportCheckpointId = -1;
 
     private long latestAsyncCheckpointStartDelayNanos;
@@ -713,11 +719,31 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
         operatorChain.finishOperators(actionExecutor, mode);
         this.finishedOperators = true;
 
-        for (ResultPartitionWriter partitionWriter : getEnvironment().getAllWriters()) {
-            partitionWriter.notifyEndOfData(mode);
+        if (mode == StopMode.DRAIN && shouldDeferEndOfData()) {
+            // Flushed in notifyCheckpointComplete once the final checkpoint completes
+            // (FLINK-38614).
+            this.deferredEndOfData = mode;
+        } else {
+            broadcastEndOfData(mode);
         }
 
         this.endOfDataReceived = true;
+    }
+
+    private void broadcastEndOfData(StopMode mode) throws IOException {
+        for (ResultPartitionWriter partitionWriter : getEnvironment().getAllWriters()) {
+            partitionWriter.notifyEndOfData(mode);
+        }
+    }
+
+    /**
+     * Whether the downstream {@code EndOfData} broadcast must be deferred until the final
+     * checkpoint completes because an operator in the chain still emits records on that final
+     * {@code notifyCheckpointComplete} (FLINK-38614).
+     */
+    private boolean shouldDeferEndOfData() {
+        return areCheckpointsWithFinishedTasksEnabled()
+                && operatorChain.emitsRecordsOnFinalCheckpoint();
     }
 
     protected void notifyEndOfData() {
@@ -1627,6 +1653,14 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
                     && finalCheckpointMinId != null
                     && checkpointId >= finalCheckpointMinId) {
                 finalCheckpointCompleted.complete(null);
+            }
+            // FLINK-38614: once the final checkpoint has completed (above), its records (e.g. sink
+            // committables) have been emitted by operatorChain.notifyCheckpointComplete, so it is
+            // now safe to broadcast the EndOfData deferred in endData. isDone() gates on the final
+            // checkpoint: an intermediate checkpoint completing keeps EndOfData deferred.
+            if (deferredEndOfData != null && finalCheckpointCompleted.isDone()) {
+                broadcastEndOfData(deferredEndOfData);
+                deferredEndOfData = null;
             }
         }
     }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskDeferredEndOfDataTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskDeferredEndOfDataTest.java
@@ -1,0 +1,184 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.tasks;
+
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.api.common.typeutils.base.StringSerializer;
+import org.apache.flink.configuration.CheckpointingOptions;
+import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
+import org.apache.flink.runtime.checkpoint.CheckpointOptions;
+import org.apache.flink.runtime.io.network.api.EndOfData;
+import org.apache.flink.runtime.io.network.api.StopMode;
+import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
+import org.apache.flink.streaming.api.operators.EmitsRecordsOnFinalCheckpoint;
+import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.util.CompletingCheckpointResponder;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Future;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests that a task whose operator chain emits records on the final checkpoint's {@code
+ * notifyCheckpointComplete} (see {@link EmitsRecordsOnFinalCheckpoint}) defers broadcasting {@code
+ * EndOfData} downstream until those records have been emitted (FLINK-38614).
+ *
+ * <p>The sink {@code CommitterOperator} forwards the final checkpoint's committables to a
+ * downstream (global) committer only on {@code notifyCheckpointComplete}, i.e. after {@code
+ * endInput}. Without the deferral, the task broadcasts {@code EndOfData} right after {@code
+ * endInput} (before that final notification) and the downstream committer finishes before receiving
+ * the committables, silently dropping them.
+ */
+class StreamTaskDeferredEndOfDataTest {
+
+    private static final String MARKER = "emitted-on-final-checkpoint";
+
+    @Test
+    void testEndOfDataDeferredUntilFinalCheckpointRecordsAreEmitted() throws Exception {
+        CompletingCheckpointResponder checkpointResponder = new CompletingCheckpointResponder();
+        try (StreamTaskMailboxTestHarness<String> harness =
+                new StreamTaskMailboxTestHarnessBuilder<>(
+                                OneInputStreamTask::new, BasicTypeInfo.STRING_TYPE_INFO)
+                        .addInput(BasicTypeInfo.STRING_TYPE_INFO, 1)
+                        .setCollectNetworkEvents()
+                        .addJobConfig(
+                                CheckpointingOptions.CHECKPOINTING_INTERVAL, Duration.ofSeconds(1))
+                        .setCheckpointResponder(checkpointResponder)
+                        .setupOperatorChain(new EmitOnFinalCheckpointOperator())
+                        .finishForSingletonOperatorChain(StringSerializer.INSTANCE)
+                        .build()) {
+            checkpointResponder.setHandlers(
+                    harness.streamTask::notifyCheckpointCompleteAsync,
+                    harness.streamTask::notifyCheckpointAbortAsync);
+
+            // Exhaust the input. This drives endData/finishOperators; with the deferral the
+            // downstream EndOfData broadcast is held back.
+            harness.processEvent(new EndOfData(StopMode.DRAIN), 0, 0);
+            harness.processAll();
+
+            // EndOfData must not have been broadcast yet: the operator has not emitted its
+            // final-checkpoint records.
+            assertThat(harness.getOutput()).doesNotContain(new EndOfData(StopMode.DRAIN));
+
+            // The final checkpoint completes; the operator emits its record on
+            // notifyCheckpointComplete and only then is the deferred EndOfData broadcast.
+            CompletableFuture<Boolean> checkpointFuture = triggerCheckpoint(harness, 2L);
+            processMailTillCheckpointSucceeds(harness, checkpointFuture);
+            // Deliver the final checkpoint notification deterministically (rather than relying on
+            // the responder's asynchronous callback): the operator emits its record here and the
+            // deferred EndOfData is then flushed.
+            harness.streamTask.notifyCheckpointCompleteAsync(2L);
+            harness.processAll();
+
+            // The record emitted on the final checkpoint must precede EndOfData downstream.
+            assertThat(harness.getOutput())
+                    .containsSubsequence(new StreamRecord<>(MARKER), new EndOfData(StopMode.DRAIN));
+        }
+    }
+
+    @Test
+    void testDeferredEndOfDataNotFlushedUntilFinalCheckpointCompletes() throws Exception {
+        CompletingCheckpointResponder checkpointResponder = new CompletingCheckpointResponder();
+        // Only the second post-end-of-input checkpoint completes; the first is never notified.
+        checkpointResponder.completeCheckpoints(Collections.singletonList(3L));
+        try (StreamTaskMailboxTestHarness<String> harness =
+                new StreamTaskMailboxTestHarnessBuilder<>(
+                                OneInputStreamTask::new, BasicTypeInfo.STRING_TYPE_INFO)
+                        .addInput(BasicTypeInfo.STRING_TYPE_INFO, 1)
+                        .setCollectNetworkEvents()
+                        .addJobConfig(
+                                CheckpointingOptions.CHECKPOINTING_INTERVAL, Duration.ofSeconds(1))
+                        .setCheckpointResponder(checkpointResponder)
+                        .setupOperatorChain(new EmitOnFinalCheckpointOperator())
+                        .finishForSingletonOperatorChain(StringSerializer.INSTANCE)
+                        .build()) {
+            checkpointResponder.setHandlers(
+                    harness.streamTask::notifyCheckpointCompleteAsync,
+                    harness.streamTask::notifyCheckpointAbortAsync);
+
+            harness.processEvent(new EndOfData(StopMode.DRAIN), 0, 0);
+            harness.processAll();
+
+            // The first post-end-of-input checkpoint is triggered but never completes; EndOfData
+            // and the final-checkpoint record must both stay deferred.
+            triggerCheckpoint(harness, 2L);
+            harness.processAll();
+            assertThat(harness.getOutput())
+                    .doesNotContain(new EndOfData(StopMode.DRAIN), new StreamRecord<>(MARKER));
+
+            // A later checkpoint completes; only then are the record and the deferred EndOfData
+            // emitted, in that order.
+            CompletableFuture<Boolean> completed = triggerCheckpoint(harness, 3L);
+            processMailTillCheckpointSucceeds(harness, completed);
+            // Deliver cp3's notification deterministically; the operator emits its record and the
+            // deferred EndOfData is then flushed (cp2 was never notified, so nothing flushed
+            // above).
+            harness.streamTask.notifyCheckpointCompleteAsync(3L);
+            harness.processAll();
+            assertThat(harness.getOutput())
+                    .containsSubsequence(new StreamRecord<>(MARKER), new EndOfData(StopMode.DRAIN));
+        }
+    }
+
+    private static CompletableFuture<Boolean> triggerCheckpoint(
+            StreamTaskMailboxTestHarness<String> harness, long checkpointId) {
+        harness.getTaskStateManager().getWaitForReportLatch().reset();
+        return harness.getStreamTask()
+                .triggerCheckpointAsync(
+                        new CheckpointMetaData(checkpointId, checkpointId * 1000),
+                        CheckpointOptions.forCheckpointWithDefaultLocation());
+    }
+
+    private static void processMailTillCheckpointSucceeds(
+            StreamTaskMailboxTestHarness<String> harness, Future<Boolean> checkpointFuture)
+            throws Exception {
+        while (!checkpointFuture.isDone()) {
+            harness.processSingleStep();
+        }
+        harness.getTaskStateManager().getWaitForReportLatch().await();
+    }
+
+    /**
+     * Operator that emits a record on the final checkpoint's {@code notifyCheckpointComplete},
+     * mirroring how {@code CommitterOperator} forwards committables downstream.
+     */
+    private static class EmitOnFinalCheckpointOperator extends AbstractStreamOperator<String>
+            implements OneInputStreamOperator<String, String>, EmitsRecordsOnFinalCheckpoint {
+
+        @Override
+        public void processElement(StreamRecord<String> element) {}
+
+        @Override
+        public void notifyCheckpointComplete(long checkpointId) throws Exception {
+            super.notifyCheckpointComplete(checkpointId);
+            output.collect(new StreamRecord<>(MARKER));
+        }
+
+        @Override
+        public boolean emitsRecordsOnFinalCheckpoint() {
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

SinkV2 jobs with a post-commit (global) committer can silently **lose the final checkpoint's committables** — an exactly-once data-loss bug. It surfaced as the intermittently failing `SinkV2ITCase.writerAndCommitterExecuteInStreamingModeWithScaling` (FLINK-38614).

Root cause: the `CommitterOperator` forwards the final checkpoint's committables to the downstream global committer only on `notifyCheckpointComplete`, which (per FLIP-147) runs *after* `endInput`. Committables always exist for the FLIP-147 final checkpoint: `SinkWriterOperator.endInput()` flushes and emits remaining committables tagged `lastKnownCheckpointId + 1`, so records arriving after the last pre-end-of-input barrier land in the final checkpoint even with aligned checkpoints (empirically confirmed: the loss reproduces with `execution.checkpointing.unaligned.enabled=false` pinned, under perturbed thread scheduling, ~1/40 runs; unaligned checkpoints amplify the race to ~30% per run but are not required). Note the sink-internal edges (writer→committer→global committer) are already UC-disabled by FLINK-36287/FLINK-36788; the race exists with those edges aligned. The task broadcasts `EndOfData` right after `endInput` (before that final `notifyCheckpointComplete`), so the downstream global committer finishes consuming its input before the committables arrive and silently drops them.

Today the committer task therefore emits data *after* it broadcast `EndOfData` (and after the downstream acked allDataProcessed) — itself a violation of the end-of-data contract; the loss is its symptom.

This change defers the downstream `EndOfData` broadcast — for tasks whose operator chain emits records on the final checkpoint — until the final checkpoint completes, so those records are delivered before the downstream finishes.

## Brief change log

- New `@Internal` marker interface `EmitsRecordsOnFinalCheckpoint` in `org.apache.flink.streaming.api.operators` (beside `BoundedOneInput`).
- `CommitterOperator` implements it; it returns `true` only when it forwards downstream and a final checkpoint will be taken (streaming + checkpointing). The condition is centralized in `hasFinalCheckpoint()`, shared with `endInput`.
- `StreamTask.endData` defers the downstream `EndOfData` broadcast when checkpoints-after-tasks-finished is enabled and the chain contains such an operator; `StreamTask.notifyCheckpointComplete` flushes the deferred broadcast once the final checkpoint completes.
- Added `StreamTaskDeferredEndOfDataTest`.

Notes for reviewers:
- **Why a marker interface** rather than `instanceof CommitterOperator`: the deferral is a generic task-lifecycle concern, and `StreamTask` should not depend on the sink package. `CommitterOperator` is the only in-tree implementor today.
- **Non-sink tasks are unaffected**: `shouldDeferEndOfData()` short-circuits unless checkpoints-after-finished-tasks is enabled and an operator opts in. `endData` runs once per task, not a per-record path.
- **No new hang**: `afterInvoke` already gates termination on `finalCheckpointCompleted` under the identical condition, so the deferral adds no new termination dependency. The flush is gated on the final checkpoint completing; an uncompleted/aborted checkpoint does not flush, and an early flush is deliberately avoided because it would re-introduce the loss.

## Verifying this change

This change added tests and can be verified as follows:
- `StreamTaskDeferredEndOfDataTest` (new) deterministically verifies (a) the final-checkpoint record is emitted *before* `EndOfData` downstream, and (b) the deferred `EndOfData` is not flushed by an uncompleted/aborted final checkpoint but is flushed (after the record) once a later one completes. Both assertions fail without the fix.
- Existing `StreamTaskFinalCheckpointsTest`, `SinkV2CommitterOperatorTest`, `SinkV2SinkWriterOperatorTest`, `CheckpointAfterAllTasksFinishedITCase`, and `SinkV2ITCase` remain green.
- The end-to-end loss is inherently a cross-task scheduling race (committer task vs global-committer task) and is not deterministically reproducible as a plain ITCase; it was reproduced under controlled scheduling and confirmed fixed. The new unit test guards the single-task invariant the fix establishes (records emitted before `EndOfData`).

This change affects checkpoint/end-of-input coordination in `StreamTask` (FLIP-147), so specialist review from a checkpointing/runtime maintainer is requested.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: yes (end-of-input / final-checkpoint coordination)
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (Claude Opus 4.8)

Generated-by: Claude Opus 4.8

