### PR TITLE
[BP-2.3][FLINK-39936][dist] Add flink-s3-fs-native to flink-dist pom file

### DIFF
--- a/flink-dist/pom.xml
+++ b/flink-dist/pom.xml
@@ -402,6 +402,13 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-s3-fs-native</artifactId>
+			<version>${project.version}</version>
+			<scope>provided</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-oss-fs-hadoop</artifactId>
 			<version>${project.version}</version>
 			<scope>provided</scope>


### PR DESCRIPTION
Backport FLINK-39936 to `release-2.3` branch.