### PR TITLE
[FLINK-38449][core] Reject fractional MemorySize values with explicit error

### DIFF
--- a/flink-core-api/src/main/java/org/apache/flink/configuration/MemorySize.java
+++ b/flink-core-api/src/main/java/org/apache/flink/configuration/MemorySize.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.regex.Pattern;
 import java.util.stream.IntStream;
 
 import static org.apache.flink.configuration.MemorySize.MemoryUnit.BYTES;
@@ -55,6 +56,8 @@ public class MemorySize implements java.io.Serializable, Comparable<MemorySize> 
 
     private static final List<MemoryUnit> ORDERED_UNITS =
             Arrays.asList(BYTES, KILO_BYTES, MEGA_BYTES, GIGA_BYTES, TERA_BYTES);
+
+    private static final Pattern MEMORY_SIZE_FORMAT = Pattern.compile("\\d+\\s*[a-zA-Z]*");
 
     // ------------------------------------------------------------------------
 
@@ -229,7 +232,7 @@ public class MemorySize implements java.io.Serializable, Comparable<MemorySize> 
     // ------------------------------------------------------------------------
 
     /**
-     * Parses the given string as as MemorySize.
+     * Parses the given string as MemorySize.
      *
      * @param text The string to parse
      * @return The parsed MemorySize
@@ -270,6 +273,13 @@ public class MemorySize implements java.io.Serializable, Comparable<MemorySize> 
         final String trimmed = text.trim();
         if (trimmed.isEmpty()) {
             throw new IllegalArgumentException("argument is an empty- or whitespace-only string");
+        }
+
+        if (!MEMORY_SIZE_FORMAT.matcher(trimmed).matches()) {
+            throw new IllegalArgumentException(
+                    "Memory size value must be an integer optionally followed by a unit. "
+                            + "Fractional or malformed values are not supported: "
+                            + text);
         }
 
         final int len = trimmed.length();

--- a/flink-core-api/src/main/java/org/apache/flink/configuration/MemorySize.java
+++ b/flink-core-api/src/main/java/org/apache/flink/configuration/MemorySize.java
@@ -59,7 +59,7 @@ public class MemorySize implements java.io.Serializable, Comparable<MemorySize> 
 
     private static final Pattern MEMORY_SIZE_FORMAT =
             Pattern.compile(
-                    "\\d+\\s*(?:b|bytes|k|kb|kibibytes|m|mb|mebibytes|g|gb|gibibytes|t|tb|tebibytes)?",
+                    "\\d+\\s*(?:" + MemoryUnit.getAllUnitsPattern() + ")?",
                     Pattern.CASE_INSENSITIVE);
 
     // ------------------------------------------------------------------------
@@ -399,6 +399,19 @@ public class MemorySize implements java.io.Serializable, Comparable<MemorySize> 
                     MEGA_BYTES.getUnits(),
                     GIGA_BYTES.getUnits(),
                     TERA_BYTES.getUnits());
+        }
+
+        private static String getAllUnitsPattern() {
+            final StringBuilder pattern = new StringBuilder();
+            for (MemoryUnit memoryUnit : values()) {
+                for (String unit : memoryUnit.getUnits()) {
+                    if (pattern.length() > 0) {
+                        pattern.append('|');
+                    }
+                    pattern.append(Pattern.quote(unit));
+                }
+            }
+            return pattern.toString();
         }
 
         public static boolean hasUnit(String text) {

--- a/flink-core-api/src/main/java/org/apache/flink/configuration/MemorySize.java
+++ b/flink-core-api/src/main/java/org/apache/flink/configuration/MemorySize.java
@@ -57,7 +57,10 @@ public class MemorySize implements java.io.Serializable, Comparable<MemorySize> 
     private static final List<MemoryUnit> ORDERED_UNITS =
             Arrays.asList(BYTES, KILO_BYTES, MEGA_BYTES, GIGA_BYTES, TERA_BYTES);
 
-    private static final Pattern MEMORY_SIZE_FORMAT = Pattern.compile("\\d+\\s*[a-zA-Z]*");
+    private static final Pattern MEMORY_SIZE_FORMAT =
+            Pattern.compile(
+                    "\\d+\\s*(?:b|bytes|k|kb|kibibytes|m|mb|mebibytes|g|gb|gibibytes|t|tb|tebibytes)?",
+                    Pattern.CASE_INSENSITIVE);
 
     // ------------------------------------------------------------------------
 

--- a/flink-core-api/src/test/java/org/apache/flink/configuration/MemorySizeTest.java
+++ b/flink-core-api/src/test/java/org/apache/flink/configuration/MemorySizeTest.java
@@ -170,7 +170,9 @@ class MemorySizeTest {
 
         // wrong unit
         assertThatThrownBy(() -> MemorySize.parseBytes("16 gjah"))
-                .isInstanceOf(IllegalArgumentException.class);
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("integer optionally followed by a unit")
+                .hasMessageContaining("Fractional or malformed values are not supported");
 
         // multiple numbers
         assertThatThrownBy(() -> MemorySize.parseBytes("16 16 17 18 bytes"))

--- a/flink-core-api/src/test/java/org/apache/flink/configuration/MemorySizeTest.java
+++ b/flink-core-api/src/test/java/org/apache/flink/configuration/MemorySizeTest.java
@@ -179,6 +179,12 @@ class MemorySizeTest {
         // negative number
         assertThatThrownBy(() -> MemorySize.parseBytes("-100 bytes"))
                 .isInstanceOf(IllegalArgumentException.class);
+
+        // fractional number
+        assertThatThrownBy(() -> MemorySize.parseBytes("1.5g"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("integer optionally followed by a unit")
+                .hasMessageContaining("Fractional or malformed values are not supported");
     }
 
     @Test


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change
Currently the memory size configuration in Flink accepts numeric values with or without an explicit unit (e.g. `100`, `100 bytes`, `1k`, `1g`, `1t`), but the error message returned for malformed values is confusing. When a user passes a fractional value such as `1.5g` or `.5g`, the parser first extracts the leading `1` and then fails on the remainder `.5g` (which is not a valid unit). The error surfaced to the user is `NumberFormatException` from `Long.parseLong`, which does not make the actual problem — fractional input — obvious.

This change adds an explicit format check at the top of `MemorySize.parseBytes` that rejects inputs that do not match the supported shape (an integer, optionally followed by whitespace and a unit). The new error message names the actual problem ("Fractional or malformed values are not supported") and points the user to the expected format ("an integer optionally followed by a unit").

This closes #FLINK-38449 .


## Brief change log

- Added a `Pattern`-based format check at the top of `MemorySize.parseBytes` (in `flink-core-api/src/main/java/org/apache/flink/configuration/MemorySize.java`). The regex accepts an integer followed by optional whitespace and a non-space unit suffix; inputs that do not match the supported shape are rejected with a new `IllegalArgumentException` whose message names the actual problem.
- Added unit-test cases in `flink-core-api/src/test/java/org/apache/flink/configuration/MemorySizeTest.java` covering the issue's headline examples (`.5g` and `1.5g`) and positive controls (`100` and `100 bytes`) to confirm that back-compat for no-unit and unit-suffixed inputs is preserved.

## Verifying this change

This change added tests and can be verified as follows:

  - Run `./mvnw -pl flink-core-api -Dtest=MemorySizeTest test` and confirm that the new fractional-input assertions pass, the existing `100` and `100 bytes` positive cases still pass, and the pre-existing `1.5g`-style assertion (if any) still passes.
  - Run `./mvnw -pl flink-core-api test` to confirm the broader test suite for the module still passes (no other test in the module should depend on fractional MemorySize input being accepted, but the full module test is the safer check).

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no** (`MemorySize` is annotated `@Public`; the change is to an internal validation path of an existing public method, not to the public method's contract — input that was previously accepted with a confusing error is still accepted with a clearer error, and input that was previously rejected with a confusing error is now rejected with a clearer error)
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no** (the new check is a single compiled-`Pattern` match, run only at configuration-parse time, not on the hot path)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no** (this is a usability fix on an existing public method; the method's contract is preserved — the only change is in the error message that callers see on invalid input)
  - If yes, how is the feature documented? not applicable

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change the checkbox below to `[X]` followed by the name of the tool, and uncomment the
"Generated-by" line. See the ASF Generative Tooling Guidance for details:
https://www.apache.org/legal/generative-tooling.html

You are responsible for the quality and correctness of every change in this PR
regardless of the tooling used. Low-effort AI-generated PRs will be closed. See
AGENTS.md for the full guidance.
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name and Version]
-->
