### PR TITLE
[FLINK-37351][runtime] Ensure writer and committer are colocated for non-pre-commit topologies

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/translators/SinkTransformationTranslator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/translators/SinkTransformationTranslator.java
@@ -88,6 +88,16 @@ public class SinkTransformationTranslator<Input, Output>
 
     private Collection<Integer> translateInternal(
             SinkTransformation<Input, Output> transformation, Context context, boolean batch) {
+
+        Sink<Input> sink = transformation.getSink();
+        // Co-locate the writer and committer if there is no pre-commit topology
+        if (sink instanceof SupportsCommitter && !(sink instanceof SupportsPreCommitTopology)) {
+            if (transformation.getCoLocationGroupKey() == null) {
+                transformation.setCoLocationGroupKey(
+                        "sink-writer-committer-" + transformation.getId());
+            }
+        }
+
         SinkExpander<Input> expander =
                 new SinkExpander<>(
                         transformation.getInputStream(),

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/SinkV2TransformationTranslatorITCase.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/SinkV2TransformationTranslatorITCase.java
@@ -272,6 +272,75 @@ class SinkV2TransformationTranslatorITCase {
         assertThat(dest.getSlotSharingGroup()).isEqualTo(SLOT_SHARE_GROUP);
     }
 
+    @Test
+    void testWriterAndCommitterColocatedWithoutPreCommitTopology() {
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        env.setRuntimeMode(RuntimeExecutionMode.STREAMING);
+        final DataStreamSource<Integer> src = env.fromData(1, 2);
+
+        // Wrap the sink to forcefully hide SupportsPreCommitTopology
+        Sink<Integer> strictNoPreCommitSink = new ColocatedTestSink(sinkWithCommitter());
+
+        sinkTo(src.rebalance(), strictNoPreCommitSink).name(NAME).uid(UID);
+
+        final StreamGraph streamGraph = env.getStreamGraph();
+
+        final StreamNode writerNode = findWriter(streamGraph);
+        final StreamNode committerNode = findCommitter(streamGraph);
+
+        // Writer and committer should be co-located for sinks without pre-commit topology
+        assertThat(writerNode.getCoLocationGroup()).isNotNull();
+        assertThat(committerNode.getCoLocationGroup()).isNotNull();
+        assertThat(writerNode.getCoLocationGroup()).isEqualTo(committerNode.getCoLocationGroup());
+    }
+
+    @Test
+    void testWriterAndCommitterNotColocatedWithPreCommitTopology() {
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        env.setRuntimeMode(RuntimeExecutionMode.STREAMING);
+
+        // Create sink with pre-commit topology
+        Sink<Integer> sinkWithPreCommit =
+                ((TestSinkV2.Builder<Integer, TestSinkV2.Record<Integer>>)
+                                TestSinkV2.<Integer>newBuilder()
+                                        .setCommitter(
+                                                new TestSinkV2.DefaultCommitter<>(),
+                                                TestSinkV2.RecordSerializer::new))
+                        .setWithPreCommitTopology(r -> r)
+                        .build();
+
+        final DataStreamSource<Integer> src = env.fromData(1, 2);
+        sinkTo(src.rebalance(), sinkWithPreCommit).name(NAME).uid(UID);
+
+        final StreamGraph streamGraph = env.getStreamGraph();
+
+        final StreamNode writerNode = findWriter(streamGraph);
+        final StreamNode committerNode = findCommitter(streamGraph);
+
+        // Pre-commit topology sinks should not be co-located
+        assertThat(writerNode.getCoLocationGroup()).isNull();
+        assertThat(committerNode.getCoLocationGroup()).isNull();
+    }
+
+    @Test
+    void testUserSpecifiedCoLocationGroupIsRespected() {
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        final DataStreamSource<Integer> src = env.fromData(1, 2);
+        final DataStreamSink<Integer> dataStreamSink = sinkTo(src, sinkWithCommitter());
+        dataStreamSink.name(NAME);
+
+        // Explicitly set user-specified co-location group
+        dataStreamSink.getTransformation().setCoLocationGroupKey("user-specified-group");
+
+        final StreamGraph streamGraph = env.getStreamGraph();
+        final StreamNode writerNode = findWriter(streamGraph);
+        final StreamNode committerNode = findCommitter(streamGraph);
+
+        // Both writer and sink should have the user-specified co-location group
+        assertThat(writerNode.getCoLocationGroup()).isEqualTo("user-specified-group");
+        assertThat(committerNode.getCoLocationGroup()).isEqualTo("user-specified-group");
+    }
+
     StreamGraph buildGraph(Sink<Integer> sink, RuntimeExecutionMode runtimeExecutionMode) {
         return buildGraph(sink, runtimeExecutionMode, true);
     }
@@ -323,5 +392,45 @@ class SinkV2TransformationTranslatorITCase {
 
     StreamNode findGlobalCommitter(StreamGraph streamGraph) {
         return findNodeName(streamGraph, name -> name.contains("Global Committer"));
+    }
+
+    // Wrapper to strictly hide SupportsPreCommitTopology from the translator
+    private static class ColocatedTestSink
+            implements Sink<Integer>,
+                    org.apache.flink.api.connector.sink2.SupportsCommitter<
+                            TestSinkV2.Record<Integer>> {
+        private final Sink<Integer> baseSink;
+        private final org.apache.flink.api.connector.sink2.SupportsCommitter<
+                        TestSinkV2.Record<Integer>>
+                baseCommitter;
+
+        @SuppressWarnings("unchecked")
+        public ColocatedTestSink(Sink<Integer> baseSink) {
+            this.baseSink = baseSink;
+            this.baseCommitter =
+                    (org.apache.flink.api.connector.sink2.SupportsCommitter<
+                                    TestSinkV2.Record<Integer>>)
+                            baseSink;
+        }
+
+        @Override
+        public org.apache.flink.api.connector.sink2.SinkWriter<Integer> createWriter(
+                org.apache.flink.api.connector.sink2.WriterInitContext context)
+                throws java.io.IOException {
+            return baseSink.createWriter(context);
+        }
+
+        @Override
+        public org.apache.flink.api.connector.sink2.Committer<TestSinkV2.Record<Integer>>
+                createCommitter(org.apache.flink.api.connector.sink2.CommitterInitContext context)
+                        throws java.io.IOException {
+            return baseCommitter.createCommitter(context);
+        }
+
+        @Override
+        public org.apache.flink.core.io.SimpleVersionedSerializer<TestSinkV2.Record<Integer>>
+                getCommittableSerializer() {
+            return baseCommitter.getCommittableSerializer();
+        }
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

This pull request addresses the issue detailed in FLINK-37351, which aims to ensure writer and committer colocation specifically for non-pre-commit topologies. This optimization eliminates unnecessary network hops between the writer and committer, thereby improving overall performance and potentially enabling backchannels (Statefun style). 

*Note: This PR takes over the stale work originally started in PR #27486. It fixes the CI propagation issue from the previous PR by moving the colocation group key assignment to the very beginning of the translation lifecycle (`translateInternal`).*

## Brief change log

  - Assigned a default co-location group key in `SinkTransformationTranslator.translateInternal()` for `SinkTransformation`s where the sink implements `SupportsCommitter` but does NOT implement `SupportsPreCommitTopology`.
  - Setting this early ensures the co-location property propagates correctly to all expanded child transformations (Writer and Committer).
  - Ensured that any user-specified co-location group keys are strictly respected and not overwritten.

## Verifying this change

This change added tests and can be verified as follows:

  - Added `testWriterAndCommitterColocatedWithoutPreCommitTopology` to verify writer/committer colocation is strictly applied for non-pre-commit topologies.
  - Added `testWriterAndCommitterNotColocatedWithPreCommitTopology` to verify sinks with pre-commit topologies bypass this co-location logic.
  - Added `testUserSpecifiedCoLocationGroupIsRespected` to verify that manually defined co-location groups by the user are preserved across the translation pipeline.
  - Verified that all downstream properties (parallelism, slot sharing groups, etc.) propagate seamlessly.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: **yes** *(Modifies task scheduling/colocation for Sinks)*
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no** *(Optimization/Bugfix)*
  - If yes, how is the feature documented? **not applicable**

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change the checkbox below to `[X]` followed by the name of the tool, and uncomment the
"Generated-by" line. See the ASF Generative Tooling Guidance for details:
https://www.apache.org/legal/generative-tooling.html

You are responsible for the quality and correctness of every change in this PR
regardless of the tooling used. Low-effort AI-generated PRs will be closed. See
AGENTS.md for the full guidance.
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name and Version]
-->
