### PR TITLE
[hotfix][table] Fix view comment derived from QueryOperation summary string

### DIFF
--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/QueryOperationCatalogView.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/QueryOperationCatalogView.java
@@ -72,9 +72,7 @@ public final class QueryOperationCatalogView implements CatalogView {
 
     @Override
     public String getComment() {
-        return Optional.ofNullable(originalView)
-                .map(CatalogView::getComment)
-                .orElse("");
+        return Optional.ofNullable(originalView).map(CatalogView::getComment).orElse("");
     }
 
     @Override

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/QueryOperationCatalogView.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/QueryOperationCatalogView.java
@@ -74,7 +74,7 @@ public final class QueryOperationCatalogView implements CatalogView {
     public String getComment() {
         return Optional.ofNullable(originalView)
                 .map(CatalogView::getComment)
-                .orElseGet(queryOperation::asSummaryString);
+                .orElse("");
     }
 
     @Override

--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/api/TableEnvironmentTest.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/api/TableEnvironmentTest.java
@@ -119,6 +119,7 @@ class TableEnvironmentTest {
                 tEnv.getCatalog(catalog).orElseThrow(AssertionError::new).getTable(objectPath);
         assertThat(catalogView).isInstanceOf(CatalogView.class);
         assertThat(catalogView.getUnresolvedSchema()).isEqualTo(TEST_SCHEMA);
+        assertThat(catalogView.getComment()).isEmpty();
     }
 
     @Test


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Views registered through the Table API are backed by a `QueryOperationCatalogView` with no user-provided comment. In that case the fallback is `asSummaryString()`, i.e. a multi-line query-tree string, exposed as the view's comment. This fix aligns the `QueryOperationCatalogView` with other `CatalogBaseTable` implementations, which all return an empty string when no comment is set.


## Brief change log

- `QueryOperationCatalogView#getComment()` now returns an empty string instead of `QueryOperation#asSummaryString()` when there is no underlying comment.
- Added an assertion in `TableEnvironmentTest#testCreateViewFromTable` verifying that a Table API view reports an empty comment.


## Verifying this change

- `TableEnvironmentTest#testCreateViewFromTable` now asserts `catalogView.getComment()` is empty after creating a view via the Table API and reading it back from the catalog.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? n/a

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change the checkbox below to `[X]` followed by the name of the tool, and uncomment the
"Generated-by" line. See the ASF Generative Tooling Guidance for details:
https://www.apache.org/legal/generative-tooling.html

You are responsible for the quality and correctness of every change in this PR
regardless of the tooling used. Low-effort AI-generated PRs will be closed. See
AGENTS.md for the full guidance.
-->

No