### PR TITLE
[hotfix][tests] Fix flaky `SessionRelatedITCase#testTouchSession`

### DIFF
--- a/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/rest/SessionRelatedITCase.java
+++ b/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/rest/SessionRelatedITCase.java
@@ -172,7 +172,7 @@ class SessionRelatedITCase extends RestAPIITCaseBase {
                         sessionMessageParameters,
                         emptyRequestBody);
         future.get();
-        assertThat(session.getLastAccessTime()).isGreaterThan(lastAccessTime);
+        assertThat(session.getLastAccessTime()).isGreaterThanOrEqualTo(lastAccessTime);
     }
 
     @Test


### PR DESCRIPTION
## What is the purpose of the change

The PR is to fix flaky test SessionRelatedITCase which sometimes could contain same last access time
e.g.
```
 [ERROR] org.apache.flink.table.gateway.rest.SessionRelatedITCase.testTouchSession -- Time elapsed: 0.011 s <<< FAILURE!
  java.lang.AssertionError:

  Expecting actual:
    1781849700181L
  to be greater than:
    1781849700181L

      at org.apache.flink.table.gateway.rest.SessionRelatedITCase.testTouchSession(SessionRelatedITCase.java:175)
      at java.base/java.lang.reflect.Method.invoke(Method.java:580)
      at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:387)
      at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1312)
      at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1843)
      at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1808)
      at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:188)
```

## Brief change log

SessionRelatedITCase


## Verifying this change

multiple runs locally

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): ( no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no )
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change the checkbox below to `[X]` followed by the name of the tool, and uncomment the
"Generated-by" line. See the ASF Generative Tooling Guidance for details:
https://www.apache.org/legal/generative-tooling.html

You are responsible for the quality and correctness of every change in this PR
regardless of the tooling used. Low-effort AI-generated PRs will be closed. See
AGENTS.md for the full guidance.
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name and Version]
-->
