### PR TITLE
[hotfix] Replace deprecated procedure syntax for scala

### DIFF
--- a/flink-table/flink-table-api-scala/src/main/scala/org/apache/flink/table/api/runtime/types/KryoTraversableSerializer.scala
+++ b/flink-table/flink-table-api-scala/src/main/scala/org/apache/flink/table/api/runtime/types/KryoTraversableSerializer.scala
@@ -30,7 +30,7 @@ private class KryoTraversableSerializer[T, C <: Traversable[T]](
     override val isImmutable: Boolean = true)(implicit cbf: CanBuildFrom[C, T, C])
   extends Serializer[C] {
 
-  override def write(kser: Kryo, out: Output, obj: C) {
+  override def write(kser: Kryo, out: Output, obj: C): Unit = {
     // Write the size:
     out.writeInt(obj.size, true)
     obj.foreach {

--- a/flink-table/flink-table-api-scala/src/main/scala/org/apache/flink/table/api/typeutils/CaseClassComparator.scala
+++ b/flink-table/flink-table-api-scala/src/main/scala/org/apache/flink/table/api/typeutils/CaseClassComparator.scala
@@ -69,7 +69,7 @@ class CaseClassComparator[T <: Product](
     code
   }
 
-  def setReference(toCompare: T) {
+  def setReference(toCompare: T): Unit = {
     var i = 0
     try {
       while (i < keyPositions.length) {
@@ -126,7 +126,11 @@ class CaseClassComparator[T <: Product](
     0
   }
 
-  def putNormalizedKey(value: T, target: MemorySegment, offsetParam: Int, numBytesParam: Int) {
+  def putNormalizedKey(
+      value: T,
+      target: MemorySegment,
+      offsetParam: Int,
+      numBytesParam: Int): Unit = {
     var numBytes = numBytesParam
     var offset = offsetParam
     var i: Int = 0

--- a/flink-table/flink-table-api-scala/src/main/scala/org/apache/flink/table/api/typeutils/UnitSerializer.scala
+++ b/flink-table/flink-table-api-scala/src/main/scala/org/apache/flink/table/api/typeutils/UnitSerializer.scala
@@ -29,7 +29,7 @@ import java.util.function.Supplier
 @SerialVersionUID(5413377487955047394L)
 class UnitSerializer extends TypeSerializerSingleton[Unit] {
 
-  def isImmutableType(): Boolean = true
+  def isImmutableType: Boolean = true
 
   def createInstance(): Unit = ()
 
@@ -37,9 +37,9 @@ class UnitSerializer extends TypeSerializerSingleton[Unit] {
 
   def copy(from: Unit, reuse: Unit): Unit = ()
 
-  def getLength(): Int = 1
+  def getLength: Int = 1
 
-  def serialize(record: Unit, target: DataOutputView) {
+  def serialize(record: Unit, target: DataOutputView): Unit = {
     target.write(0)
   }
 

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/PushProjectIntoLegacyTableSourceScanRule.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/PushProjectIntoLegacyTableSourceScanRule.scala
@@ -55,7 +55,7 @@ class PushProjectIntoLegacyTableSourceScanRule
     }
   }
 
-  override def onMatch(call: RelOptRuleCall) {
+  override def onMatch(call: RelOptRuleCall): Unit = {
     val project: LogicalProject = call.rel(0)
     val scan: LogicalTableScan = call.rel(1)
 

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/batch/table/validation/AggregateValidationTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/batch/table/validation/AggregateValidationTest.scala
@@ -81,7 +81,7 @@ class AggregateValidationTest extends TableTestBase {
   }
 
   @Test
-  def testInvalidUdAggArgs() {
+  def testInvalidUdAggArgs(): Unit = {
     val util = batchTestUtil()
     val t = util.addTableSource[(Int, Long, String)]("Table3", 'a, 'b, 'c)
 
@@ -93,7 +93,7 @@ class AggregateValidationTest extends TableTestBase {
   }
 
   @Test
-  def testGroupingInvalidUdAggArgs() {
+  def testGroupingInvalidUdAggArgs(): Unit = {
     val util = batchTestUtil()
     val t = util.addTableSource[(Int, Long, String)]("Table3", 'a, 'b, 'c)
 
@@ -108,7 +108,7 @@ class AggregateValidationTest extends TableTestBase {
   }
 
   @Test
-  def testGroupingNestedUdAgg() {
+  def testGroupingNestedUdAgg(): Unit = {
     val util = batchTestUtil()
     val t = util.addTableSource[(Int, Long, String)]("Table3", 'a, 'b, 'c)
 
@@ -123,7 +123,7 @@ class AggregateValidationTest extends TableTestBase {
   }
 
   @Test
-  def testAggregationOnNonExistingFieldJava() {
+  def testAggregationOnNonExistingFieldJava(): Unit = {
     val util = batchTestUtil()
     val t = util.addTableSource[(Int, Long, String)]("Table3", 'a, 'b, 'c)
 
@@ -132,7 +132,7 @@ class AggregateValidationTest extends TableTestBase {
   }
 
   @Test
-  def testNonWorkingAggregationDataTypesJava() {
+  def testNonWorkingAggregationDataTypesJava(): Unit = {
     val util = batchTestUtil()
     val t = util.addTableSource[(Long, String)]("Table2", 'b, 'c)
     // Must fail. Cannot compute SUM aggregate on String field.
@@ -141,7 +141,7 @@ class AggregateValidationTest extends TableTestBase {
   }
 
   @Test
-  def testNoNestedAggregationsJava() {
+  def testNoNestedAggregationsJava(): Unit = {
     val util = batchTestUtil()
     val t = util.addTableSource[(Long, String)]("Table2", 'b, 'c)
     // Must fail. Aggregation on aggregation not allowed.
@@ -150,7 +150,7 @@ class AggregateValidationTest extends TableTestBase {
   }
 
   @Test
-  def testNoDeeplyNestedAggregationsJava() {
+  def testNoDeeplyNestedAggregationsJava(): Unit = {
     val util = batchTestUtil()
     val t = util.addTableSource[(Long, String)]("Table2", 'b, 'c)
     // Must fail. Aggregation on aggregation not allowed.
@@ -160,7 +160,7 @@ class AggregateValidationTest extends TableTestBase {
 
   @Test
   @throws[Exception]
-  def testGroupingOnNonExistentFieldJava() {
+  def testGroupingOnNonExistentFieldJava(): Unit = {
     val util = batchTestUtil()
     val t = util.addTableSource[(Int, Long, String)]("Table3", 'a, 'b, 'c)
 
@@ -170,7 +170,7 @@ class AggregateValidationTest extends TableTestBase {
   }
 
   @Test
-  def testGroupingInvalidSelectionJava() {
+  def testGroupingInvalidSelectionJava(): Unit = {
     val util = batchTestUtil()
     val t = util.addTableSource[(Int, Long, String)]("Table3", 'a, 'b, 'c)
 
@@ -183,7 +183,7 @@ class AggregateValidationTest extends TableTestBase {
   }
 
   @Test
-  def testUnknownUdAggJava() {
+  def testUnknownUdAggJava(): Unit = {
     val util = batchTestUtil()
     val t = util.addTableSource[(Int, Long, String)]("Table3", 'a, 'b, 'c)
 
@@ -193,7 +193,7 @@ class AggregateValidationTest extends TableTestBase {
   }
 
   @Test
-  def testGroupingUnknownUdAggJava() {
+  def testGroupingUnknownUdAggJava(): Unit = {
     val util = batchTestUtil()
     val t = util.addTableSource[(Int, Long, String)]("Table3", 'a, 'b, 'c)
 
@@ -206,7 +206,7 @@ class AggregateValidationTest extends TableTestBase {
   }
 
   @Test
-  def testInvalidUdAggArgsJava() {
+  def testInvalidUdAggArgsJava(): Unit = {
     val util = batchTestUtil()
     val t = util.addTableSource[(Int, Long, String)]("Table3", 'a, 'b, 'c)
 
@@ -219,7 +219,7 @@ class AggregateValidationTest extends TableTestBase {
   }
 
   @Test
-  def testGroupingInvalidUdAggArgsJava() {
+  def testGroupingInvalidUdAggArgsJava(): Unit = {
     val util = batchTestUtil()
     val t = util.addTableSource[(Int, Long, String)]("Table3", 'a, 'b, 'c)
 

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/batch/table/validation/CalcValidationTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/batch/table/validation/CalcValidationTest.scala
@@ -50,7 +50,7 @@ class CalcValidationTest extends TableTestBase {
   }
 
   @Test
-  def testSelectInvalidField() {
+  def testSelectInvalidField(): Unit = {
     val util = batchTestUtil()
     val t = util.addTableSource[(Int, Long, String)]("Table3", 'a, 'b, 'c)
 
@@ -60,7 +60,7 @@ class CalcValidationTest extends TableTestBase {
   }
 
   @Test
-  def testSelectAmbiguousFieldNames() {
+  def testSelectAmbiguousFieldNames(): Unit = {
     val util = batchTestUtil()
     val t = util.addTableSource[(Int, Long, String)]("Table3", 'a, 'b, 'c)
 
@@ -70,7 +70,7 @@ class CalcValidationTest extends TableTestBase {
   }
 
   @Test
-  def testFilterInvalidField() {
+  def testFilterInvalidField(): Unit = {
     val util = batchTestUtil()
     val t = util.addTableSource[(Int, Long, String)]("Table3", 'a, 'b, 'c)
 

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/batch/table/validation/JoinValidationTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/batch/table/validation/JoinValidationTest.scala
@@ -120,7 +120,7 @@ class JoinValidationTest extends TableTestBase {
   }
 
   @Test
-  def testJoinTablesFromDifferentEnvsJava() {
+  def testJoinTablesFromDifferentEnvsJava(): Unit = {
     val settings = EnvironmentSettings.newInstance().inBatchMode().build()
     val tEnv1 = TableEnvironmentImpl.create(settings)
     val tEnv2 = TableEnvironmentImpl.create(settings)

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/schema/TimeIndicatorRelDataTypeTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/schema/TimeIndicatorRelDataTypeTest.scala
@@ -26,7 +26,7 @@ import org.junit.jupiter.api.Test
 class TimeIndicatorRelDataTypeTest {
 
   @Test
-  def testGenerateTypeString() {
+  def testGenerateTypeString(): Unit = {
     val typeFactory = new FlinkTypeFactory(
       classOf[TimeIndicatorRelDataTypeTest].getClassLoader,
       FlinkTypeSystem.INSTANCE)

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/FilterableSourceTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/FilterableSourceTest.scala
@@ -103,7 +103,7 @@ class FilterableSourceTest extends TableTestBase {
   }
 
   @Test
-  def testComputedColumnPushdownAcrossWatermark() {
+  def testComputedColumnPushdownAcrossWatermark(): Unit = {
     val ddl =
       """
         |CREATE TABLE WithWatermark (

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/join/LookupJoinITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/join/LookupJoinITCase.scala
@@ -70,7 +70,7 @@ class LookupJoinITCase extends BatchTestBase {
     rowOf(44, null, "Hello world"))
 
   @BeforeEach
-  override def before() {
+  override def before(): Unit = {
     super.before()
     TestValuesTableFactory.RESOURCE_COUNTER.set(0)
     FullCacheTestInputFormat.OPEN_CLOSED_COUNTER.set(0)

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/table/AggregationITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/table/AggregationITCase.scala
@@ -468,7 +468,7 @@ class Top10 extends AggregateFunction[Array[JTuple2[JInt, JFloat]], Array[JTuple
    * @param revenue
    *   The revenue for the ad
    */
-  def accumulate(acc: Array[JTuple2[JInt, JFloat]], adId: Int, revenue: Float) {
+  def accumulate(acc: Array[JTuple2[JInt, JFloat]], adId: Int, revenue: Float): Unit = {
 
     var i = 9
     var skipped = 0

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/table/CalcITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/table/CalcITCase.scala
@@ -335,7 +335,7 @@ class CalcITCase extends BatchTestBase {
   }
 
   @Test
-  def testUserDefinedScalarFunction() {
+  def testUserDefinedScalarFunction(): Unit = {
     val table = BatchTableEnvUtil.fromElements(tEnv, "a", "b", "c")
     val result = table.select(HashCode($"f0"))
     val results = executeQuery(result)
@@ -344,7 +344,7 @@ class CalcITCase extends BatchTestBase {
   }
 
   @Test
-  def testNumericAutocastInArithmetic() {
+  def testNumericAutocastInArithmetic(): Unit = {
     val table = BatchTableEnvUtil
       .fromElements(tEnv, (1.toByte, 1.toShort, 1, 1L, 1.0f, 1.0d, 1L, 1001.1))
       .select('_1 + 1, '_2 + 1, '_3 + 1L, '_4 + 1.0f, '_5 + 1.0d, '_6 + 1, '_7 + 1.0d, '_8 + '_1)
@@ -355,7 +355,7 @@ class CalcITCase extends BatchTestBase {
   }
 
   @Test
-  def testNumericAutocastInComparison() {
+  def testNumericAutocastInComparison(): Unit = {
     val table = BatchTableEnvUtil
       .fromCollection(
         tEnv,

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/table/JoinITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/table/JoinITCase.scala
@@ -341,7 +341,7 @@ class JoinITCase(miniBatch: MiniBatchMode, mode: StateBackendMode, enableAsyncSt
   }
 
   @TestTemplate
-  def testInnerJoinWithProcTimeAttributeOutput() {
+  def testInnerJoinWithProcTimeAttributeOutput(): Unit = {
 
     val data1 = List(
       (1L, 1, "LEFT:Hi"),
@@ -1588,7 +1588,7 @@ class JoinITCase(miniBatch: MiniBatchMode, mode: StateBackendMode, enableAsyncSt
   }
 
   @TestTemplate
-  def testJoinWithProcTimeAttributeOutput() {
+  def testJoinWithProcTimeAttributeOutput(): Unit = {
 
     val data1 = List(
       (1L, 1, "LEFT:Hi"),

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/utils/StreamTestSink.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/utils/StreamTestSink.scala
@@ -127,7 +127,7 @@ abstract class AbstractExactlyOnceSink[T] extends RichSinkFunction[T] with Check
 }
 
 final class StringSink[T] extends AbstractExactlyOnceSink[T]() {
-  override def invoke(value: T) {
+  override def invoke(value: T): Unit = {
     localResults += value.toString
   }
 

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/utils/UserDefinedAggFunctions.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/utils/UserDefinedAggFunctions.scala
@@ -49,7 +49,7 @@ class Top10 extends AggregateFunction[Array[JTuple2[JInt, JFloat]], Array[JTuple
    * @param value
    *   The value for the ID
    */
-  def accumulate(acc: Array[JTuple2[JInt, JFloat]], id: Int, value: Float) {
+  def accumulate(acc: Array[JTuple2[JInt, JFloat]], id: Int, value: Float): Unit = {
 
     var i = 9
     var skipped = 0

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/utils/UserDefinedTableAggFunctions.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/utils/UserDefinedTableAggFunctions.scala
@@ -88,7 +88,7 @@ class Top3 extends TableAggregateFunction[JTuple2[JInt, JInt], Top3Accum] {
     }
   }
 
-  def accumulate(acc: Top3Accum, v: JInt) {
+  def accumulate(acc: Top3Accum, v: JInt): Unit = {
     if (acc.size == 0) {
       acc.size = 1
       acc.smallest = v
@@ -183,7 +183,7 @@ class Top3WithMapView extends TableAggregateFunction[JTuple2[JInt, JInt], Top3Wi
     }
   }
 
-  def accumulate(acc: Top3WithMapViewAccum, v: Int) {
+  def accumulate(acc: Top3WithMapViewAccum, v: Int): Unit = {
     if (acc.size == 0) {
       acc.size = 1
       acc.smallest = v
@@ -230,11 +230,11 @@ class Top3WithRetractInput
     acc
   }
 
-  def accumulate(acc: Top3WithRetractInputAcc, v: JInt) {
+  def accumulate(acc: Top3WithRetractInputAcc, v: JInt): Unit = {
     acc.data.append(v)
   }
 
-  def retract(acc: Top3WithRetractInputAcc, v: JInt) {
+  def retract(acc: Top3WithRetractInputAcc, v: JInt): Unit = {
     acc.data.remove(acc.data.indexOf(v))
   }
 

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/utils/UserDefinedTableFunctions.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/utils/UserDefinedTableFunctions.scala
@@ -418,7 +418,7 @@ class VarArgsFunc0 extends TableFunction[String] {
 
 @SerialVersionUID(1L)
 class HierarchyTableFunction extends SplittableTableFunction[java.lang.Boolean, Integer] {
-  def eval(user: String) {
+  def eval(user: String): Unit = {
     if (user.contains("#")) {
       val splits = user.split("#")
       val age = splits(1).toInt


### PR DESCRIPTION

## What is the purpose of the change

following https://docs.scala-lang.org/scala3/reference/dropped-features/procedure-syntax.html

## Brief change log

scala methods

## Verifying this change

existing tests

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: (no )
  - The runtime per-record code paths (performance sensitive):(no )
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change the checkbox below to `[X]` followed by the name of the tool, and uncomment the
"Generated-by" line. See the ASF Generative Tooling Guidance for details:
https://www.apache.org/legal/generative-tooling.html

You are responsible for the quality and correctness of every change in this PR
regardless of the tooling used. Low-effort AI-generated PRs will be closed. See
AGENTS.md for the full guidance.
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name and Version]
-->
