### PR TITLE
[FLINK-39923][state] Fix RocksDB Statistics native memory leak

### DIFF
--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/state/rocksdb/RocksDBNativeMetricMonitor.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/state/rocksdb/RocksDBNativeMetricMonitor.java
@@ -22,6 +22,7 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.metrics.Gauge;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.metrics.View;
+import org.apache.flink.util.IOUtils;
 
 import org.rocksdb.ColumnFamilyHandle;
 import org.rocksdb.RocksDB;
@@ -107,7 +108,7 @@ public class RocksDBNativeMetricMonitor implements Closeable {
 
     /** Updates the value of metricView if the reference is still valid. */
     private void setProperty(RocksDBNativePropertyMetricView metricView) {
-        if (metricView.isClosed()) {
+        if (metricView.isClosed() || rocksDB == null) {
             return;
         }
         try {
@@ -126,11 +127,11 @@ public class RocksDBNativeMetricMonitor implements Closeable {
     }
 
     private void setStatistics(RocksDBNativeStatisticsMetricView metricView) {
-        if (metricView.isClosed()) {
+        if (metricView.isClosed() || statistics == null) {
             return;
         }
-        if (statistics != null) {
-            synchronized (lock) {
+        synchronized (lock) {
+            if (statistics != null) {
                 metricView.setValue(statistics.getTickerCount(metricView.tickerType));
             }
         }
@@ -140,6 +141,8 @@ public class RocksDBNativeMetricMonitor implements Closeable {
     public void close() {
         synchronized (lock) {
             rocksDB = null;
+            // Wrapper holds a JNI shared_ptr that leaks without explicit close. See FLINK-39923.
+            IOUtils.closeQuietly(statistics);
             statistics = null;
         }
     }

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/state/rocksdb/restore/RocksDBHandle.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/state/rocksdb/restore/RocksDBHandle.java
@@ -37,6 +37,7 @@ import org.rocksdb.ColumnFamilyOptions;
 import org.rocksdb.DBOptions;
 import org.rocksdb.ExportImportFilesMetaData;
 import org.rocksdb.RocksDB;
+import org.rocksdb.Statistics;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -90,6 +91,8 @@ class RocksDBHandle implements AutoCloseable {
     private RocksDB db;
     private ColumnFamilyHandle defaultColumnFamilyHandle;
     private RocksDBNativeMetricMonitor nativeMetricMonitor;
+    // Released in close() for the partial-init case; on success the monitor closes it.
+    private Statistics statistics;
     private final Long writeBufferManagerCapacity;
 
     protected RocksDBHandle(
@@ -147,12 +150,16 @@ class RocksDBHandle implements AutoCloseable {
                         dbOptions);
         // remove the default column family which is located at the first index
         defaultColumnFamilyHandle = columnFamilyHandles.remove(0);
-        // init native metrics monitor if configured
+
+        if (!nativeMetricOptions.isEnabled()) {
+            return;
+        }
+        // dbOptions.statistics() returns a new Java wrapper around a fresh shared_ptr<Statistics>
+        // aliasing the existing native StatisticsImpl. The original wrapper is closed by
+        // RocksDBResourceContainer (via dbOptions); this one must also be closed. See FLINK-39923.
+        statistics = dbOptions.statistics();
         nativeMetricMonitor =
-                nativeMetricOptions.isEnabled()
-                        ? new RocksDBNativeMetricMonitor(
-                                nativeMetricOptions, metricGroup, db, dbOptions.statistics())
-                        : null;
+                new RocksDBNativeMetricMonitor(nativeMetricOptions, metricGroup, db, statistics);
     }
 
     RocksDbKvStateInfo getOrRegisterStateColumnFamilyHandle(
@@ -306,7 +313,13 @@ class RocksDBHandle implements AutoCloseable {
     @Override
     public void close() throws Exception {
         IOUtils.closeQuietly(defaultColumnFamilyHandle);
-        IOUtils.closeQuietly(nativeMetricMonitor);
+        if (nativeMetricMonitor != null) {
+            // Monitor owns the statistics wrapper.
+            IOUtils.closeQuietly(nativeMetricMonitor);
+        } else {
+            // Monitor construction never completed; release the wrapper directly.
+            IOUtils.closeQuietly(statistics);
+        }
         IOUtils.closeQuietly(db);
         // Making sure the already created column family options will be closed
         columnFamilyDescriptors.forEach((cfd) -> IOUtils.closeQuietly(cfd.getOptions()));


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix `RocksDBNativeMetricMonitor.close()` to invoke `Statistics.close()` instead of just nulling. Also hoist `dbOptions.statistics()` into a local in `RocksDBHandle.loadDb()` so a monitor-constructor failure doesn't orphan the wrapper.

## Why are the changes needed?

Fix memory leak. When any of the 11 RocksDB ticker metrics is enabled, the TaskManager leaks native memory in proportion to the number of keyed state backend rebuilds e.g. during continuously failing and restarting job. 

1. Latent Flink-side bug was introduced in [FLINK-24786](https://issues.apache.org/jira/browse/FLINK-24786) when Statistics object was added without explicit close() on the object. This was latent as it relied on finalize() running to call dispose() and close().
2. rocksdb side finalizer was removed in https://github.com/facebook/rocksdb/commit/99d86252b6514d0fe3b848bd39bda94642c14faf
3. Flink 2.0+ uses frocksdb 8.10.0. Leak started occurring as close is no longer called.

## Verifying this change

Reproduced on `flink:2.2.2`, TaskManager container limited to 4 GB cgroup matching `taskmanager.memory.process.size`. Jobs that throw `NumberFormatException` on every row is submitted with `restart-strategy.fixed-delay.delay=100ms` and all 11 ticker metrics enabled.

| Run | Stats | Outcome |
|---|---|---|
| Unpatched | ON | TM OOMKilled at 4 GB in ~80 s |
| Patched | ON | Ran for 4 minutes, no OOM, anon RSS stayed at around 2GB |

See here for reproduction steps: https://github.com/leekeiabstraction/flink/tree/reproduce-rocksdb-statistics-leak/reproduce-rocksdb-statistics-leak

## Does this PR introduce any user-facing change?

None.