### PR TITLE
[FLINK-39724][python] Support InternalTypeInfo in PyFlink type extraction

### DIFF
--- a/flink-python/pyflink/common/tests/test_typeinfo.py
+++ b/flink-python/pyflink/common/tests/test_typeinfo.py
@@ -17,7 +17,9 @@
 ################################################################################
 
 from pyflink.common.typeinfo import Types, RowTypeInfo, TupleTypeInfo, _from_java_type
+from pyflink.java_gateway import get_gateway
 from pyflink.testing.test_case_utils import PyFlinkTestCase
+from pyflink.util.java_utils import to_jarray
 
 
 class TypeInfoTests(PyFlinkTestCase):
@@ -143,3 +145,21 @@ class TypeInfoTests(PyFlinkTestCase):
         list_type_info = Types.LIST(Types.INT())
         self.assertEqual(list_type_info,
                          _from_java_type(list_type_info.get_java_type_info()))
+
+    def test_internal_type_info(self):
+        # InternalTypeInfo is produced by sources such as CsvReaderFormat. It bridges to
+        # RowData internally, so it must be converted through its logical type back to a
+        # PyFlink type. See FLINK-39724.
+        gateway = get_gateway()
+        JInternalTypeInfo = \
+            gateway.jvm.org.apache.flink.table.runtime.typeutils.InternalTypeInfo
+        JVarCharType = gateway.jvm.org.apache.flink.table.types.logical.VarCharType
+        JDoubleType = gateway.jvm.org.apache.flink.table.types.logical.DoubleType
+        JRowType = gateway.jvm.org.apache.flink.table.types.logical.RowType
+        JLogicalType = gateway.jvm.org.apache.flink.table.types.logical.LogicalType
+
+        j_field_types = to_jarray(JLogicalType, [JVarCharType(), JDoubleType()])
+        j_internal_type_info = JInternalTypeInfo.of(JRowType.of(j_field_types))
+
+        self.assertEqual(Types.ROW([Types.STRING(), Types.DOUBLE()]),
+                         _from_java_type(j_internal_type_info))

--- a/flink-python/pyflink/common/typeinfo.py
+++ b/flink-python/pyflink/common/typeinfo.py
@@ -1115,6 +1115,16 @@ def _from_java_type(j_type_info: JavaObject) -> TypeInformation:
         return ExternalTypeInfo(_from_java_type(
             TypeInfoDataTypeConverter.toLegacyTypeInfo(j_type_info.getDataType())))
 
+    JInternalTypeInfo = gateway.jvm.org.apache.flink.table.runtime.typeutils.InternalTypeInfo
+    if _is_instance_of(j_type_info, JInternalTypeInfo):
+        LogicalTypeDataTypeConverter = \
+            gateway.jvm.org.apache.flink.table.types.utils.LogicalTypeDataTypeConverter
+        TypeInfoDataTypeConverter = \
+            gateway.jvm.org.apache.flink.table.types.utils.LegacyTypeInfoDataTypeConverter
+        return _from_java_type(
+            TypeInfoDataTypeConverter.toLegacyTypeInfo(
+                LogicalTypeDataTypeConverter.toDataType(j_type_info.toLogicalType())))
+
     raise TypeError("The java type info: %s is not supported in PyFlink currently." % j_type_info)
 
 


### PR DESCRIPTION
## What is the purpose of the change

When a PyFlink `DataStream` is produced by sources such as `CsvReaderFormat`, its underlying Java `TypeInformation` is an `InternalTypeInfo` wrapping a `RowData` logical type. The `_from_java_type` helper in `flink-python` did not recognize this class, so calls like `DataStream.get_type()` and `DataStream.assign_timestamps_and_watermarks()` raised `TypeError: The java type info: ... is not supported in PyFlink currently.`, forcing users to insert an identity `map` as a workaround.

## Brief change log

  - `flink-python/pyflink/common/typeinfo.py`: in `_from_java_type`, detect `InternalTypeInfo`, convert it back to its logical type, then run it through `LogicalTypeDataTypeConverter` and `LegacyTypeInfoDataTypeConverter` to obtain a legacy `TypeInformation` that maps to a PyFlink type.

## Verifying this change

This change added a unit test: `test_internal_type_info` in `flink-python/pyflink/common/tests/test_typeinfo.py` builds an `InternalTypeInfo` over a `RowType(VARCHAR, DOUBLE)` and asserts `_from_java_type` round-trips it to `Types.ROW([Types.STRING(), Types.DOUBLE()])`. The test fails on the pre-fix code, which raised `TypeError`.

## Does this pull request potentially affect one of the following parts

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no (the change is confined to the private `_from_java_type` helper in PyFlink)
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no (this runs once during type extraction at stream construction, not per record)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: Claude Code

JIRA: https://issues.apache.org/jira/browse/FLINK-39724