### PR TITLE
[FLINK-39725][python] Apply the Python TimestampAssigner in from_source

### DIFF
--- a/flink-python/pyflink/datastream/stream_execution_environment.py
+++ b/flink-python/pyflink/datastream/stream_execution_environment.py
@@ -767,6 +767,18 @@ class StreamExecutionEnvironment(object):
             j_type_info = type_info.get_java_type_info()
         else:
             j_type_info = None
+        if watermark_strategy._timestamp_assigner is not None:
+            # in case users have specified a custom Python TimestampAssigner, the timestamp
+            # extraction and watermark generation cannot be performed on the Java source. So we
+            # create the source without watermarks first and then apply the watermark strategy
+            # downstream, where the custom Python TimestampAssigner can be executed.
+            j_data_stream = self._j_stream_execution_environment.fromSource(
+                source.get_java_function(),
+                WatermarkStrategy.no_watermarks()._j_watermark_strategy,
+                source_name,
+                j_type_info)
+            return DataStream(j_data_stream=j_data_stream).assign_timestamps_and_watermarks(
+                watermark_strategy)
         j_data_stream = self._j_stream_execution_environment.fromSource(
             source.get_java_function(),
             watermark_strategy._j_watermark_strategy,

--- a/flink-python/pyflink/datastream/tests/test_stream_execution_environment.py
+++ b/flink-python/pyflink/datastream/tests/test_stream_execution_environment.py
@@ -27,12 +27,14 @@ import unittest
 
 from pyflink.common import Configuration, ExecutionConfig
 from pyflink.common.typeinfo import Types
+from pyflink.common.watermark_strategy import WatermarkStrategy, TimestampAssigner
 from pyflink.datastream import (StreamExecutionEnvironment, CheckpointConfig,
                                 CheckpointingMode, SlotSharingGroup)
 from pyflink.datastream.connectors.kafka import FlinkKafkaConsumer
+from pyflink.datastream.connectors.number_seq import NumberSequenceSource
 from pyflink.datastream.execution_mode import RuntimeExecutionMode
 from pyflink.datastream.formats.json import JsonRowDeserializationSchema
-from pyflink.datastream.functions import SourceFunction
+from pyflink.datastream.functions import ProcessFunction, SourceFunction
 from pyflink.datastream.slot_sharing_group import MemorySize
 from pyflink.datastream.tests.test_util import DataStreamTestSinkFunction
 from pyflink.find_flink_home import _find_flink_source_root
@@ -673,6 +675,36 @@ class StreamExecutionEnvironmentTests(PyFlinkTestCase):
         cached_files = self.env._j_stream_execution_environment.getCachedFiles()
         self.assertEqual(cached_files.size(), 1)
         self.assertEqual(cached_files[0].getField(0), 'cache_test')
+
+    def test_from_source_with_timestamp_assigner(self):
+        self.env.set_parallelism(1)
+        self.env.get_config().set_auto_watermark_interval(2000)
+        seq_source = NumberSequenceSource(1, 4)
+
+        class MyTimestampAssigner(TimestampAssigner):
+
+            def extract_timestamp(self, value, record_timestamp) -> int:
+                return value * 1000
+
+        class MyProcessFunction(ProcessFunction):
+
+            def process_element(self, value, ctx):
+                yield "value: {}, timestamp: {}".format(str(value), str(ctx.timestamp()))
+
+        watermark_strategy = WatermarkStrategy.for_monotonous_timestamps() \
+            .with_timestamp_assigner(MyTimestampAssigner())
+        ds = self.env.from_source(seq_source, watermark_strategy, "seq_source",
+                                  type_info=Types.LONG())
+        ds.process(MyProcessFunction(), output_type=Types.STRING()).add_sink(self.test_sink)
+        self.env.execute('test from source with timestamp assigner')
+        results = self.test_sink.get_results()
+        expected = ["value: 1, timestamp: 1000",
+                    "value: 2, timestamp: 2000",
+                    "value: 3, timestamp: 3000",
+                    "value: 4, timestamp: 4000"]
+        results.sort()
+        expected.sort()
+        self.assertEqual(expected, results)
 
     def tearDown(self) -> None:
         self.test_sink.clear()


### PR DESCRIPTION
## What is the purpose of the change

When `StreamExecutionEnvironment.from_source` is called in PyFlink with a `WatermarkStrategy` that carries a custom Python `TimestampAssigner`, the assigner was never invoked. The strategy was passed straight to the Java source operator, which runs timestamp extraction and watermark generation on the JVM side and so ignores the Python assigner entirely.

## Brief change log

  - `flink-python/pyflink/datastream/stream_execution_environment.py`: in `from_source`, when the `WatermarkStrategy` carries a Python `TimestampAssigner` (`watermark_strategy._timestamp_assigner is not None`), create the source with `WatermarkStrategy.no_watermarks()` and then apply the original strategy downstream via `DataStream.assign_timestamps_and_watermarks`, so the Python `TimestampAssigner` is executed. The existing path (no Python assigner) is unchanged.

## Verifying this change

This change added a unit test: `test_from_source_with_timestamp_assigner` in `flink-python/pyflink/datastream/tests/test_stream_execution_environment.py` runs a `NumberSequenceSource` with a `WatermarkStrategy.for_monotonous_timestamps()` and a custom `TimestampAssigner`, then reads `ctx.timestamp()` in a `ProcessFunction` and asserts the timestamps the Python assigner produced (value * 1000). The test fails on the pre-fix code, where the Python assigner is ignored and the timestamp is not set.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no (the change is in PyFlink Python `stream_execution_environment.py`; no Java `@Public(Evolving)` class is touched. It does change the observable behavior of the public PyFlink `from_source` method, as described above, without changing its signature.)
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): yes (only when a Python `TimestampAssigner` is supplied: the fix then routes the stream through a downstream `assign_timestamps_and_watermarks` operator so the assigner runs per record, which is the intended behavior and the existing PyFlink mechanism. The default path, with no Python assigner, is unchanged.)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: Claude Code

JIRA: https://issues.apache.org/jira/browse/FLINK-39725