### PR TITLE
[FLINK-23882][docs] Clarify TIMESTAMP WITH TIME ZONE is not supported by Flink SQL

### DIFF
--- a/docs/content.zh/docs/sql/reference/data-types.md
+++ b/docs/content.zh/docs/sql/reference/data-types.md
@@ -812,6 +812,12 @@ Data type of a timestamp *with* time zone consisting of `year-month-day hour:min
 with up to nanosecond precision and values ranging from `0000-01-01 00:00:00.000000000 +14:59` to
 `9999-12-31 23:59:59.999999999 -14:59`.
 
+{{< hint warning >}}
+`TIMESTAMP WITH TIME ZONE` currently only exists as a logical type and is **not supported** by Flink SQL yet
+(tracked by [FLINK-20869](https://issues.apache.org/jira/browse/FLINK-20869)). If you need to retain time zone
+information, use `TIMESTAMP_LTZ` instead.
+{{< /hint >}}
+
 {{< tabs "timestamps" >}}
 {{< tab "SQL/Java/Scala" >}}
 Compared to the SQL standard, leap seconds (`23:59:60` and `23:59:61`) are not supported as the semantics

--- a/docs/content/docs/sql/reference/data-types.md
+++ b/docs/content/docs/sql/reference/data-types.md
@@ -820,6 +820,12 @@ Data type of a timestamp *with* time zone consisting of `year-month-day hour:min
 with up to nanosecond precision and values ranging from `0000-01-01 00:00:00.000000000 +14:59` to
 `9999-12-31 23:59:59.999999999 -14:59`.
 
+{{< hint warning >}}
+`TIMESTAMP WITH TIME ZONE` currently only exists as a logical type and is **not supported** by Flink SQL yet
+(tracked by [FLINK-20869](https://issues.apache.org/jira/browse/FLINK-20869)). If you need to retain time zone
+information, use `TIMESTAMP_LTZ` instead.
+{{< /hint >}}
+
 {{< tabs "timestamps" >}}
 {{< tab "SQL/Java/Scala" >}}
 Compared to the SQL standard, leap seconds (`23:59:60` and `23:59:61`) are not supported as the semantics


### PR DESCRIPTION
## What is the purpose of the change

The data types reference page documents `TIMESTAMP WITH TIME ZONE` with full declaration syntax (`TIMESTAMP(p) WITH TIME ZONE`), which makes it look like a usable SQL type. In reality the type currently **only exists as a logical type** and is not supported by Flink SQL yet — reading/casting it is unimplemented (tracked by [FLINK-20869](https://issues.apache.org/jira/browse/FLINK-20869)), and the SQL JDBC driver explicitly throws:

> `TIMESTAMP WITH TIME ZONE is not supported, use TIMESTAMP or TIMESTAMP_LTZ instead`

The missing caveat has repeatedly confused users (see [FLINK-23882](https://issues.apache.org/jira/browse/FLINK-23882)), who reach for `TIMESTAMP WITH TIME ZONE` expecting it to work and then hit timestamp-correctness surprises.

## Brief change log

- Add a `{{< hint warning >}}` callout to the `TIMESTAMP WITH TIME ZONE` section of the data types reference stating the type only exists as a logical type, is not supported by Flink SQL yet (linking FLINK-20869), and pointing users to `TIMESTAMP_LTZ` when time zone information must be retained.
- Apply the same note to the Chinese (`content.zh`) mirror of the page.

## Verifying this change

This change is a documentation-only update without test coverage. The claim was verified against the codebase: `FlinkResultSet` rejects `TIMESTAMP_WITH_TIME_ZONE`, and `CastFunctionITCase` leaves the casts unimplemented pending FLINK-20869. The note reuses the `{{< hint warning >}}` shortcode already present elsewhere on the same page.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **docs** (this PR is the doc change)

---
_This documentation change was prepared with AI assistance (Claude Code)._