### PR TITLE
[FLINK-39788][kubernetes] Append .svc suffix to namespaced Kubernetes service hostnames

### DIFF
--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/decorators/ExternalServiceDecorator.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/decorators/ExternalServiceDecorator.java
@@ -60,6 +60,6 @@ public class ExternalServiceDecorator extends AbstractKubernetesStepDecorator {
      * project, so do not delete it.
      */
     public static String getNamespacedExternalServiceName(String clusterId, String namespace) {
-        return getExternalServiceName(clusterId) + "." + namespace;
+        return getExternalServiceName(clusterId) + "." + namespace + ".svc";
     }
 }

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/decorators/InternalServiceDecorator.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/decorators/InternalServiceDecorator.java
@@ -75,6 +75,6 @@ public class InternalServiceDecorator extends AbstractKubernetesStepDecorator {
 
     /** Generate namespaced name of the internal Service. */
     public static String getNamespacedInternalServiceName(String clusterId, String namespace) {
-        return getInternalServiceName(clusterId) + "." + namespace;
+        return getInternalServiceName(clusterId) + "." + namespace + ".svc";
     }
 }

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/utils/KubernetesUtils.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/utils/KubernetesUtils.java
@@ -691,7 +691,7 @@ public class KubernetesUtils {
 
     /** Generate namespaced name of the service. */
     public static String getNamespacedServiceName(Service service) {
-        return service.getMetadata().getName() + "." + service.getMetadata().getNamespace();
+        return service.getMetadata().getName() + "." + service.getMetadata().getNamespace() + ".svc";
     }
 
     private KubernetesUtils() {}

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesClusterDescriptorTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesClusterDescriptorTest.java
@@ -243,7 +243,8 @@ class KubernetesClusterDescriptorTest extends KubernetesClientTestBase {
                         .deployApplicationCluster(clusterSpecification, appConfig)
                         .getClusterClient();
 
-        final String address = CLUSTER_ID + Constants.FLINK_REST_SERVICE_SUFFIX + "." + NAMESPACE;
+        final String address =
+                CLUSTER_ID + Constants.FLINK_REST_SERVICE_SUFFIX + "." + NAMESPACE + ".svc";
         final int port = flinkConfig.get(RestOptions.PORT);
         assertThat(clusterClient.getWebInterfaceURL())
                 .isEqualTo(String.format("http://%s:%d", address, port));


### PR DESCRIPTION
## What is the purpose of the change

When a Flink Session cluster is deployed on Kubernetes, the TaskManager resolves the JobManager RPC endpoint through Pekko using the value returned by `getNamespacedServiceName` (and its related helpers). The current implementation produces a hostname of the form `<service>.<namespace>`, which is not a fully qualified Kubernetes service DNS name and is treated as an opaque host by Pekko. For namespaces whose name begins with a digit (for example `1234-ns`), DNS resolution fails and the TaskManager logs `Actor not found` while trying to connect to the dispatcher (FLINK-39788).

This change appends the `.svc` segment so the namespaced service name becomes the standard Kubernetes service FQDN `<service>.<namespace>.svc`, which resolves correctly regardless of how the namespace name begins.

## Brief change log

  - Append `.svc` to the namespaced service name in `ExternalServiceDecorator.getNamespacedExternalServiceName`, `InternalServiceDecorator.getNamespacedInternalServiceName`, and `KubernetesUtils.getNamespacedServiceName`, so the result is the FQDN `<service>.<namespace>.svc`.
  - Update the expected address in `KubernetesClusterDescriptorTest` to match the new fully qualified host.

## Verifying this change

This change is already covered by existing tests, specifically `KubernetesClusterDescriptorTest.testDeployApplicationClusterWithClusterIP`, whose expected web interface URL is updated to assert the new `<service>.<namespace>.svc` hostname.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: yes (changes the Kubernetes service hostname used for JobManager RPC resolution)
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: Claude Code
