### PR TITLE
[FLINK-23140][docs] Fix SourceFunction documentation link

### DIFF
--- a/docs/content.zh/docs/dev/datastream/overview.md
+++ b/docs/content.zh/docs/dev/datastream/overview.md
@@ -213,7 +213,7 @@ Data Sources
 {{< tabs "8104e62c-db79-40b0-8519-0063e9be791f" >}}
 {{< tab "Java" >}}
 
-Source 是你的程序从中读取其输入的地方。你可以用 `StreamExecutionEnvironment.addSource(sourceFunction)` 将一个 source 关联到你的程序。Flink 自带了许多预先实现的 source functions，不过你仍然可以通过实现 `SourceFunction` 接口编写自定义的非并行 source，也可以通过实现 `ParallelSourceFunction` 接口或者继承 `RichParallelSourceFunction` 类编写自定义的并行 sources。
+Source 是你的程序从中读取其输入的地方。你可以用 `StreamExecutionEnvironment.addSource(sourceFunction)` 将一个 source 关联到你的程序。Flink 自带了许多预先实现的 source functions，不过你仍然可以通过实现 {{< gh_link file="flink-runtime/src/main/java/org/apache/flink/streaming/api/functions/source/legacy/SourceFunction.java" name="SourceFunction" >}} 接口编写自定义的非并行 source，也可以通过实现 `ParallelSourceFunction` 接口或者继承 `RichParallelSourceFunction` 类编写自定义的并行 sources。
 
 通过 `StreamExecutionEnvironment` 可以访问多种预定义的 stream source：
 

--- a/docs/content.zh/docs/dev/datastream/overview.md
+++ b/docs/content.zh/docs/dev/datastream/overview.md
@@ -213,7 +213,7 @@ Data Sources
 {{< tabs "8104e62c-db79-40b0-8519-0063e9be791f" >}}
 {{< tab "Java" >}}
 
-Source 是你的程序从中读取其输入的地方。你可以用 `StreamExecutionEnvironment.addSource(sourceFunction)` 将一个 source 关联到你的程序。Flink 自带了许多预先实现的 source functions，不过你仍然可以通过实现 {{< gh_link file="flink-runtime/src/main/java/org/apache/flink/streaming/api/functions/source/legacy/SourceFunction.java" name="SourceFunction" >}} 接口编写自定义的非并行 source，也可以通过实现 `ParallelSourceFunction` 接口或者继承 `RichParallelSourceFunction` 类编写自定义的并行 sources。
+Source 是你的程序从中读取其输入的地方。你可以用 `StreamExecutionEnvironment.addSource(sourceFunction)` 将一个 source 关联到你的程序。Flink 自带了许多预先实现的 source functions，不过你仍然可以通过实现 {{< gh_link file="flink-runtime/src/main/java/org/apache/flink/streaming/api/functions/source/legacy/SourceFunction.java" name="SourceFunction" >}} 接口编写自定义的非并行 source，也可以通过实现 {{< gh_link file="flink-runtime/src/main/java/org/apache/flink/streaming/api/functions/source/legacy/ParallelSourceFunction.java" name="ParallelSourceFunction" >}} 接口或者继承 {{< gh_link file="flink-runtime/src/main/java/org/apache/flink/streaming/api/functions/source/legacy/RichParallelSourceFunction.java" name="RichParallelSourceFunction" >}} 类编写自定义的并行 sources。
 
 通过 `StreamExecutionEnvironment` 可以访问多种预定义的 stream source：
 

--- a/docs/content/docs/dev/datastream/overview.md
+++ b/docs/content/docs/dev/datastream/overview.md
@@ -263,8 +263,11 @@ Sources are where your program reads its input from. You can attach a source to 
 using `StreamExecutionEnvironment.addSource(sourceFunction)`. Flink comes with a number of pre-implemented
 source functions, but you can always write your own custom sources by implementing the
 {{< gh_link file="flink-runtime/src/main/java/org/apache/flink/streaming/api/functions/source/legacy/SourceFunction.java" name="SourceFunction" >}}
-for non-parallel sources, or by implementing the `ParallelSourceFunction` interface or extending the
-`RichParallelSourceFunction` for parallel sources.
+interface for non-parallel sources, or by implementing the
+{{< gh_link file="flink-runtime/src/main/java/org/apache/flink/streaming/api/functions/source/legacy/ParallelSourceFunction.java" name="ParallelSourceFunction" >}}
+interface or extending the
+{{< gh_link file="flink-runtime/src/main/java/org/apache/flink/streaming/api/functions/source/legacy/RichParallelSourceFunction.java" name="RichParallelSourceFunction" >}}
+class for parallel sources.
 
 There are several predefined stream sources accessible from the `StreamExecutionEnvironment`:
 

--- a/docs/content/docs/dev/datastream/overview.md
+++ b/docs/content/docs/dev/datastream/overview.md
@@ -261,7 +261,8 @@ Data Sources
 
 Sources are where your program reads its input from. You can attach a source to your program by
 using `StreamExecutionEnvironment.addSource(sourceFunction)`. Flink comes with a number of pre-implemented
-source functions, but you can always write your own custom sources by implementing the `SourceFunction`
+source functions, but you can always write your own custom sources by implementing the
+{{< gh_link file="flink-runtime/src/main/java/org/apache/flink/streaming/api/functions/source/legacy/SourceFunction.java" name="SourceFunction" >}}
 for non-parallel sources, or by implementing the `ParallelSourceFunction` interface or extending the
 `RichParallelSourceFunction` for parallel sources.
 


### PR DESCRIPTION
## What is the purpose of the change

This PR fixes the DataStream Data Sources documentation for the legacy source function APIs.

The current documentation mentions `SourceFunction`, `ParallelSourceFunction`, and `RichParallelSourceFunction` together when explaining how users can implement custom sources with `StreamExecutionEnvironment.addSource(...)`. `SourceFunction` was updated to link to the current legacy source package, but the two related APIs in the same sentence were still left as plain code text.

To keep the documentation consistent and easier to navigate, this PR links all three legacy source APIs to their current source files:

- `SourceFunction`
- `ParallelSourceFunction`
- `RichParallelSourceFunction`

The same update is applied to both the English and Chinese DataStream documentation.

This closes FLINK-23140.

## Brief change log

- Updated the English DataStream Data Sources documentation to link all three legacy source function APIs.
- Updated the Chinese DataStream Data Sources documentation with the same set of legacy source API links.
- Kept the change limited to documentation; no runtime code, API behavior, or dependency changes are included.

## Verifying this change

This change is a documentation-only update without new test coverage.

Verified locally with:

- `test -f flink-runtime/src/main/java/org/apache/flink/streaming/api/functions/source/legacy/SourceFunction.java`
- `test -f flink-runtime/src/main/java/org/apache/flink/streaming/api/functions/source/legacy/ParallelSourceFunction.java`
- `test -f flink-runtime/src/main/java/org/apache/flink/streaming/api/functions/source/legacy/RichParallelSourceFunction.java`
- `git diff --check`

The verification confirms that each linked target file exists and that the Markdown diff does not contain whitespace errors.

## Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): no
- The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
- The serializers: no
- The runtime per-record code paths (performance sensitive): no
- Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
- The S3 file system connector: no

## Documentation

- Does this pull request introduce a new feature? no
- If yes, how is the feature documented? not applicable

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (OpenAI Codex)

Generated-by: OpenAI Codex
