### PR TITLE
[FLINK-39769][tests][JUnit5 migration] Module: flink-examples-streaming

### DIFF
--- a/flink-examples/flink-examples-streaming/src/test/java/org/apache/flink/streaming/test/StreamingExamplesITCase.java
+++ b/flink-examples/flink-examples-streaming/src/test/java/org/apache/flink/streaming/test/StreamingExamplesITCase.java
@@ -34,34 +34,24 @@ import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.test.examples.join.WindowJoinData;
 import org.apache.flink.test.testdata.WordCountData;
-import org.apache.flink.test.util.AbstractTestBaseJUnit4;
+import org.apache.flink.test.util.AbstractTestBase;
 
 import org.apache.commons.io.FileUtils;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.io.File;
 import java.nio.file.Files;
-import java.util.Arrays;
-import java.util.Collection;
 
 import static org.apache.flink.test.util.TestBaseUtils.checkLinesAgainstRegexp;
 import static org.apache.flink.test.util.TestBaseUtils.compareResultsByLinesInMemory;
 
 /** Integration test for streaming programs in Java examples. */
-@RunWith(Parameterized.class)
-public class StreamingExamplesITCase extends AbstractTestBaseJUnit4 {
-
-    @Parameterized.Parameter public boolean asyncState;
-
-    @Parameterized.Parameters
-    public static Collection<Boolean> setup() {
-        return Arrays.asList(false, true);
-    }
+class StreamingExamplesITCase extends AbstractTestBase {
 
     @Test
-    public void testWindowJoin() throws Exception {
+    void testWindowJoin() throws Exception {
 
         final String resultPath = Files.createTempDirectory("result-path").toUri().toString();
 
@@ -111,7 +101,7 @@ public class StreamingExamplesITCase extends AbstractTestBaseJUnit4 {
     }
 
     @Test
-    public void testSessionWindowing() throws Exception {
+    void testSessionWindowing() throws Exception {
         final String resultPath = getTempDirPath("result");
         org.apache.flink.streaming.examples.windowing.SessionWindowing.main(
                 new String[] {"--output", resultPath});
@@ -120,8 +110,9 @@ public class StreamingExamplesITCase extends AbstractTestBaseJUnit4 {
         // state here.
     }
 
-    @Test
-    public void testWindowWordCount() throws Exception {
+    @ParameterizedTest(name = "asyncState: {0}")
+    @ValueSource(booleans = {false, true})
+    void testWindowWordCount(boolean asyncState) throws Exception {
         final String windowSize = "25";
         final String slideSize = "15";
         final String textPath = createTempFile("text.txt", WordCountData.TEXT);
@@ -153,8 +144,9 @@ public class StreamingExamplesITCase extends AbstractTestBaseJUnit4 {
         checkLinesAgainstRegexp(resultPath, "^\\([a-z]+,(\\d)+\\)");
     }
 
-    @Test
-    public void testWordCount() throws Exception {
+    @ParameterizedTest(name = "asyncState: {0}")
+    @ValueSource(booleans = {false, true})
+    void testWordCount(boolean asyncState) throws Exception {
         final String textPath = createTempFile("text.txt", WordCountData.TEXT);
         final String resultPath = getTempDirPath("result");
 

--- a/flink-examples/flink-examples-streaming/src/test/java/org/apache/flink/streaming/test/examples/windowing/TopSpeedWindowingExampleITCase.java
+++ b/flink-examples/flink-examples-streaming/src/test/java/org/apache/flink/streaming/test/examples/windowing/TopSpeedWindowingExampleITCase.java
@@ -20,37 +20,37 @@ package org.apache.flink.streaming.test.examples.windowing;
 import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
 import org.apache.flink.streaming.examples.windowing.TopSpeedWindowing;
 import org.apache.flink.streaming.examples.windowing.util.TopSpeedWindowingExampleData;
-import org.apache.flink.test.util.MiniClusterWithClientResource;
+import org.apache.flink.test.junit5.MiniClusterExtension;
 import org.apache.flink.util.FileUtils;
-import org.apache.flink.util.TestLogger;
 
-import org.junit.ClassRule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
 
 import static org.apache.flink.test.util.TestBaseUtils.compareResultsByLinesInMemory;
 
 /** Tests for {@link TopSpeedWindowing}. */
-public class TopSpeedWindowingExampleITCase extends TestLogger {
+class TopSpeedWindowingExampleITCase {
 
-    @ClassRule public static TemporaryFolder temporaryFolder = new TemporaryFolder();
-
-    @ClassRule
-    public static MiniClusterWithClientResource miniClusterResource =
-            new MiniClusterWithClientResource(
+    @RegisterExtension
+    static final MiniClusterExtension MINI_CLUSTER_EXTENSION =
+            new MiniClusterExtension(
                     new MiniClusterResourceConfiguration.Builder()
                             .setNumberTaskManagers(1)
                             .setNumberSlotsPerTaskManager(1)
                             .build());
 
+    @TempDir static File temporaryFolder;
+
     @Test
-    public void testTopSpeedWindowingExampleITCase() throws Exception {
-        File inputFile = temporaryFolder.newFile();
+    void testTopSpeedWindowingExampleITCase() throws Exception {
+        File inputFile = new File(temporaryFolder, "input");
+        inputFile.createNewFile();
         FileUtils.writeFileUtf8(inputFile, TopSpeedWindowingExampleData.CAR_DATA);
 
-        final String resultPath = temporaryFolder.newFolder().toURI().toString();
+        final String resultPath = new File(temporaryFolder, "result").toURI().toString();
 
         TopSpeedWindowing.main(
                 new String[] {

--- a/flink-examples/flink-examples-streaming/src/test/java/org/apache/flink/streaming/test/socket/SocketWindowWordCountITCase.java
+++ b/flink-examples/flink-examples-streaming/src/test/java/org/apache/flink/streaming/test/socket/SocketWindowWordCountITCase.java
@@ -20,12 +20,11 @@ package org.apache.flink.streaming.test.socket;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.streaming.examples.socket.SocketWindowWordCount;
 import org.apache.flink.test.testdata.WordCountData;
-import org.apache.flink.test.util.AbstractTestBaseJUnit4;
+import org.apache.flink.test.util.AbstractTestBase;
 import org.apache.flink.util.NetUtils;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -35,24 +34,15 @@ import java.io.PrintWriter;
 import java.net.InetAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
-import java.util.Arrays;
-import java.util.Collection;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 /** Tests for {@link SocketWindowWordCount}. */
-@RunWith(Parameterized.class)
-public class SocketWindowWordCountITCase extends AbstractTestBaseJUnit4 {
+class SocketWindowWordCountITCase extends AbstractTestBase {
 
-    @Parameterized.Parameter public boolean asyncState;
-
-    @Parameterized.Parameters
-    public static Collection<Boolean> setup() {
-        return Arrays.asList(false, true);
-    }
-
-    @Test
-    public void testJavaProgram() throws Exception {
+    @ParameterizedTest(name = "asyncState: {0}")
+    @ValueSource(booleans = {false, true})
+    void testJavaProgram(boolean asyncState) throws Exception {
         InetAddress localhost = InetAddress.getByName("localhost");
 
         // suppress sysout messages from this example

--- a/flink-examples/flink-examples-streaming/src/test/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
+++ b/flink-examples/flink-examples-streaming/src/test/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
@@ -1,0 +1,17 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+org.apache.flink.util.TestLoggerExtension
+org.apache.flink.util.TestNameProviderExtension


### PR DESCRIPTION
## What is the purpose of the change

Migrate the remaining JUnit 4 tests in `flink-examples/flink-examples-streaming` to JUnit 5 (Jupiter). After this PR the module has zero JUnit 4 imports. Part of the umbrella JUnit 4 → 5 migration.

JIRA: [FLINK-39769](https://issues.apache.org/jira/browse/FLINK-39769) (sub-task of [FLINK-25325](https://issues.apache.org/jira/browse/FLINK-25325))

## Brief change log

Three test classes migrated:

- **`StreamingExamplesITCase`** and **`SocketWindowWordCountITCase`** (parameterized on `asyncState`):
  - `@RunWith(Parameterized.class)` → native JUnit 5 `@ParameterizedTest` + `@ValueSource(booleans = {false, true})`; the boolean arrives as a method argument rather than an injected field.
  - In `StreamingExamplesITCase`, only `testWindowWordCount` and `testWordCount` actually read `asyncState`, so only those are parameterized; `testWindowJoin` and `testSessionWindowing` become plain `@Test` instead of running redundantly under both values.
  - `extends AbstractTestBaseJUnit4` → `extends AbstractTestBase` (the JUnit 5 sibling).
  - `org.junit.Assert.fail` → `org.assertj.core.api.Assertions.fail` (`SocketWindowWordCountITCase`).
- **`TopSpeedWindowingExampleITCase`**:
  - `@ClassRule MiniClusterWithClientResource` → `@RegisterExtension static MiniClusterExtension`.
  - `@ClassRule TemporaryFolder` → `@TempDir static File`; `newFile()`/`newFolder()` → `new File(tempDir, ...)`.
  - Drop `extends TestLogger`; `org.junit.Test` → `org.junit.jupiter.api.Test`.
- Drop `public` on test classes and methods per the Flink JUnit 5 Migration Guide.

No production code is touched.

## Verifying this change

This change is a test-only migration covered by the existing tests it migrates:

```
./mvnw -pl flink-examples/flink-examples-streaming test \
  -Dtest='StreamingExamplesITCase,TopSpeedWindowingExampleITCase,SocketWindowWordCountITCase'
```

Result: **9 tests run, 0 failures, 0 errors, 0 skipped** (`StreamingExamplesITCase` 6, `SocketWindowWordCountITCase` 2, `TopSpeedWindowingExampleITCase` 1).

`StreamingExamplesITCase` runs 6 rather than the previous 8: `testWindowJoin` and `testSessionWindowing` never read `asyncState`, so they no longer execute once per value. No coverage is lost — the dropped runs were identical.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

---

##### Was generative AI tooling used to co-author this PR?

- [x] Yes — Claude Code
