### PR TITLE
[FLINK-20454][formats] Add metadata support for Debezium Avro

### DIFF
--- a/docs/content/docs/connectors/table/formats/debezium.md
+++ b/docs/content/docs/connectors/table/formats/debezium.md
@@ -175,6 +175,8 @@ Available Metadata
 
 The following format metadata can be exposed as read-only (`VIRTUAL`) columns in a table definition.
 
+Both `debezium-json` and `debezium-avro-confluent` formats support the same metadata fields.
+
 <span class="label label-danger">Attention</span> Format metadata fields are only available if the
 corresponding connector forwards format metadata. Currently, only the Kafka connector is able to expose
 metadata fields for its value format.
@@ -235,6 +237,7 @@ metadata fields for its value format.
 The following example shows how to access Debezium metadata fields in Kafka:
 
 ```sql
+-- For debezium-json format
 CREATE TABLE KafkaTable (
   origin_ts TIMESTAMP(3) METADATA FROM 'value.ingestion-timestamp' VIRTUAL,
   event_time TIMESTAMP(3) METADATA FROM 'value.source.timestamp' VIRTUAL,
@@ -252,6 +255,27 @@ CREATE TABLE KafkaTable (
   'properties.group.id' = 'testGroup',
   'scan.startup.mode' = 'earliest-offset',
   'value.format' = 'debezium-json'
+);
+
+-- For debezium-avro-confluent format
+CREATE TABLE KafkaTable (
+  origin_ts TIMESTAMP(3) METADATA FROM 'value.ingestion-timestamp' VIRTUAL,
+  event_time TIMESTAMP(3) METADATA FROM 'value.source.timestamp' VIRTUAL,
+  origin_database STRING METADATA FROM 'value.source.database' VIRTUAL,
+  origin_schema STRING METADATA FROM 'value.source.schema' VIRTUAL,
+  origin_table STRING METADATA FROM 'value.source.table' VIRTUAL,
+  origin_properties MAP<STRING, STRING> METADATA FROM 'value.source.properties' VIRTUAL,
+  user_id BIGINT,
+  item_id BIGINT,
+  behavior STRING
+) WITH (
+  'connector' = 'kafka',
+  'topic' = 'user_behavior',
+  'properties.bootstrap.servers' = 'localhost:9092',
+  'properties.group.id' = 'testGroup',
+  'scan.startup.mode' = 'earliest-offset',
+  'value.format' = 'debezium-avro-confluent',
+  'debezium-avro-confluent.url' = 'http://localhost:8081'
 );
 ```
 

--- a/flink-formats/flink-avro-confluent-registry/src/main/java/org/apache/flink/formats/avro/registry/confluent/debezium/DebeziumAvroDecodingFormat.java
+++ b/flink-formats/flink-avro-confluent-registry/src/main/java/org/apache/flink/formats/avro/registry/confluent/debezium/DebeziumAvroDecodingFormat.java
@@ -249,12 +249,11 @@ public class DebeziumAvroDecodingFormat
     /**
      * Reads a property from the source MAP by key.
      *
-     * <p>The source field contains GenericMapData injected at runtime by {@link
-     * DebeziumAvroDeserializationSchema#convertSourceToMap}. Safe to cast because the runtime type
-     * is guaranteed.
+     * <p>The source field contains GenericMapData injected at runtime. Safe to cast because the
+     * runtime type is guaranteed.
      *
      * @param row the rootRow containing source MapData at pos
-     * @param pos the source field position (4 in Debezium envelope)
+     * @param pos the configured source field position
      * @param key the StringData key to lookup
      * @return the field value, or null if not found
      */

--- a/flink-formats/flink-avro-confluent-registry/src/main/java/org/apache/flink/formats/avro/registry/confluent/debezium/DebeziumAvroDecodingFormat.java
+++ b/flink-formats/flink-avro-confluent-registry/src/main/java/org/apache/flink/formats/avro/registry/confluent/debezium/DebeziumAvroDecodingFormat.java
@@ -1,0 +1,266 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.formats.avro.registry.confluent.debezium;
+
+import org.apache.flink.api.common.serialization.DeserializationSchema;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.formats.avro.registry.confluent.debezium.DebeziumAvroDeserializationSchema.MetadataConverter;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.connector.ChangelogMode;
+import org.apache.flink.table.connector.Projection;
+import org.apache.flink.table.connector.format.DecodingFormat;
+import org.apache.flink.table.connector.format.ProjectableDecodingFormat;
+import org.apache.flink.table.connector.source.DynamicTableSource;
+import org.apache.flink.table.data.GenericMapData;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.utils.DataTypeUtils;
+import org.apache.flink.types.RowKind;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+/** {@link DecodingFormat} for Debezium using Avro encoding. */
+public class DebeziumAvroDecodingFormat
+        implements ProjectableDecodingFormat<DeserializationSchema<RowData>> {
+
+    // ----------------------------------------------------------------------------------------
+    // Mutable attributes
+    // ----------------------------------------------------------------------------------------
+
+    private List<String> metadataKeys;
+
+    // ----------------------------------------------------------------------------------------
+    // Debezium-specific attributes
+    // ----------------------------------------------------------------------------------------
+
+    private final String schemaRegistryURL;
+    private final String schema;
+    private final Map<String, ?> optionalPropertiesMap;
+
+    public DebeziumAvroDecodingFormat(
+            String schemaRegistryURL, String schema, Map<String, ?> optionalPropertiesMap) {
+        this.schemaRegistryURL = schemaRegistryURL;
+        this.schema = schema;
+        this.optionalPropertiesMap = optionalPropertiesMap;
+        this.metadataKeys = Collections.emptyList();
+    }
+
+    @Override
+    public DeserializationSchema<RowData> createRuntimeDecoder(
+            DynamicTableSource.Context context, DataType physicalDataType, int[][] projections) {
+        physicalDataType = Projection.of(projections).project(physicalDataType);
+
+        final List<ReadableMetadata> readableMetadata =
+                metadataKeys.stream()
+                        .map(
+                                k ->
+                                        Stream.of(ReadableMetadata.values())
+                                                .filter(rm -> rm.key.equals(k))
+                                                .findFirst()
+                                                .orElseThrow(IllegalStateException::new))
+                        .collect(Collectors.toList());
+        final List<DataTypes.Field> metadataFields =
+                readableMetadata.stream()
+                        .map(m -> DataTypes.FIELD(m.key, m.dataType))
+                        .collect(Collectors.toList());
+
+        final DataType producedDataType =
+                DataTypeUtils.appendRowFields(physicalDataType, metadataFields);
+        final TypeInformation<RowData> producedTypeInfo =
+                context.createTypeInformation(producedDataType);
+
+        return new DebeziumAvroDeserializationSchema(
+                physicalDataType,
+                readableMetadata,
+                producedTypeInfo,
+                schemaRegistryURL,
+                schema,
+                optionalPropertiesMap);
+    }
+
+    @Override
+    public Map<String, DataType> listReadableMetadata() {
+        final Map<String, DataType> metadataMap = new LinkedHashMap<>();
+        Stream.of(ReadableMetadata.values())
+                .forEachOrdered(m -> metadataMap.put(m.key, m.dataType));
+        return metadataMap;
+    }
+
+    @Override
+    public void applyReadableMetadata(List<String> metadataKeys) {
+        this.metadataKeys = metadataKeys;
+    }
+
+    @Override
+    public ChangelogMode getChangelogMode() {
+        return ChangelogMode.newBuilder()
+                .addContainedKind(RowKind.INSERT)
+                .addContainedKind(RowKind.UPDATE_BEFORE)
+                .addContainedKind(RowKind.UPDATE_AFTER)
+                .addContainedKind(RowKind.DELETE)
+                .build();
+    }
+
+    // ----------------------------------------------------------------------------------------
+    // Metadata handling
+    // ----------------------------------------------------------------------------------------
+
+    /** List of metadata that can be read with this format. */
+    enum ReadableMetadata {
+        INGESTION_TIMESTAMP(
+                "ingestion-timestamp",
+                DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(3).nullable(),
+                DataTypes.FIELD("ts_ms", DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(3)),
+                new MetadataConverter() {
+                    private static final long serialVersionUID = 1L;
+
+                    @Override
+                    public Object convert(GenericRowData row, int unused) {
+                        return row;
+                    }
+                }),
+
+        SOURCE_TIMESTAMP(
+                "source.timestamp",
+                DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(3).nullable(),
+                SOURCE_FIELD,
+                new MetadataConverter() {
+                    private static final long serialVersionUID = 1L;
+
+                    @Override
+                    public Object convert(GenericRowData row, int unused) {
+                        int pos = SOURCE_PROPERTY_POSITION.get("ts_ms");
+                        return row.getField(pos);
+                    }
+                }),
+
+        SOURCE_DATABASE(
+                "source.database",
+                DataTypes.STRING().nullable(),
+                SOURCE_FIELD,
+                new MetadataConverter() {
+                    private static final long serialVersionUID = 1L;
+
+                    @Override
+                    public Object convert(GenericRowData row, int unused) {
+                        int pos = SOURCE_PROPERTY_POSITION.get("db");
+                        return row.getField(pos);
+                    }
+                }),
+
+        SOURCE_SCHEMA(
+                "source.schema",
+                DataTypes.STRING().nullable(),
+                SOURCE_FIELD,
+                new MetadataConverter() {
+                    private static final long serialVersionUID = 1L;
+
+                    @Override
+                    public Object convert(GenericRowData row, int unused) {
+                        int pos = SOURCE_PROPERTY_POSITION.get("schema");
+                        return row.getField(pos);
+                    }
+                }),
+
+        SOURCE_TABLE(
+                "source.table",
+                DataTypes.STRING().nullable(),
+                SOURCE_FIELD,
+                new MetadataConverter() {
+                    private static final long serialVersionUID = 1L;
+
+                    @Override
+                    public Object convert(GenericRowData row, int unused) {
+                        int pos = SOURCE_PROPERTY_POSITION.get("table");
+                        return row.getField(pos);
+                    }
+                }),
+
+        SOURCE_PROPERTIES(
+                "source.properties",
+                // key and value of the map are nullable to make handling easier in queries
+                DataTypes.MAP(DataTypes.STRING().nullable(), DataTypes.STRING().nullable())
+                        .nullable(),
+                SOURCE_FIELD,
+                new MetadataConverter() {
+                    private static final long serialVersionUID = 1L;
+
+                    @Override
+                    public Object convert(GenericRowData row, int unused) {
+                        Map<StringData, StringData> result = new HashMap<>();
+                        for (int i = 0; i < SOURCE_PROPERTY_FIELDS.length; i++) {
+                            Object value = row.getField(i);
+                            result.put(
+                                    StringData.fromString(SOURCE_PROPERTY_FIELDS[i].getName()),
+                                    value == null ? null : StringData.fromString(value.toString()));
+                        }
+                        return new GenericMapData(result);
+                    }
+                });
+
+        final String key;
+        final DataType dataType;
+        final DataTypes.Field requiredAvroField;
+        final MetadataConverter converter;
+
+        ReadableMetadata(
+                String key,
+                DataType dataType,
+                DataTypes.Field requiredAvroField,
+                MetadataConverter converter) {
+            this.key = key;
+            this.dataType = dataType;
+            this.requiredAvroField = requiredAvroField;
+            this.converter = converter;
+        }
+    }
+
+    private static final DataTypes.Field[] SOURCE_PROPERTY_FIELDS = {
+        DataTypes.FIELD("version", DataTypes.STRING()),
+        DataTypes.FIELD("connector", DataTypes.STRING()),
+        DataTypes.FIELD("name", DataTypes.STRING()),
+        DataTypes.FIELD("ts_ms", DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(3).nullable()),
+        DataTypes.FIELD("snapshot", DataTypes.STRING().nullable()),
+        DataTypes.FIELD("db", DataTypes.STRING()),
+        DataTypes.FIELD("sequence", DataTypes.STRING().nullable()),
+        DataTypes.FIELD("schema", DataTypes.STRING().nullable()),
+        DataTypes.FIELD("table", DataTypes.STRING()),
+        DataTypes.FIELD("txId", DataTypes.STRING().nullable()),
+        DataTypes.FIELD("scn", DataTypes.STRING().nullable()),
+        DataTypes.FIELD("commit_scn", DataTypes.STRING().nullable()),
+        DataTypes.FIELD("lcr_position", DataTypes.STRING().nullable())
+    };
+
+    private static final Map<String, Integer> SOURCE_PROPERTY_POSITION =
+            IntStream.range(0, SOURCE_PROPERTY_FIELDS.length)
+                    .boxed()
+                    .collect(Collectors.toMap(i -> SOURCE_PROPERTY_FIELDS[i].getName(), i -> i));
+
+    private static final DataTypes.Field SOURCE_FIELD =
+            DataTypes.FIELD("source", DataTypes.ROW(SOURCE_PROPERTY_FIELDS));
+}

--- a/flink-formats/flink-avro-confluent-registry/src/main/java/org/apache/flink/formats/avro/registry/confluent/debezium/DebeziumAvroDecodingFormat.java
+++ b/flink-formats/flink-avro-confluent-registry/src/main/java/org/apache/flink/formats/avro/registry/confluent/debezium/DebeziumAvroDecodingFormat.java
@@ -31,17 +31,16 @@ import org.apache.flink.table.data.GenericMapData;
 import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.data.TimestampData;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.utils.DataTypeUtils;
 import org.apache.flink.types.RowKind;
 
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 /** {@link DecodingFormat} for Debezium using Avro encoding. */
@@ -130,74 +129,88 @@ public class DebeziumAvroDecodingFormat
     // Metadata handling
     // ----------------------------------------------------------------------------------------
 
+    // StringData keys for reading source metadata from MAP runtime payload.
+    private static final StringData KEY_SOURCE_TIMESTAMP = StringData.fromString("ts_ms");
+    private static final StringData KEY_SOURCE_DATABASE = StringData.fromString("db");
+    private static final StringData KEY_SOURCE_SCHEMA = StringData.fromString("schema");
+    private static final StringData KEY_SOURCE_TABLE = StringData.fromString("table");
+
+    // Keep Avro schema generation stable while source values are read from runtime MapData.
+    private static final DataTypes.Field REQUIRED_SOURCE_AVRO_FIELD =
+            DataTypes.FIELD("source", DataTypes.ROW());
+
     /** List of metadata that can be read with this format. */
     enum ReadableMetadata {
         INGESTION_TIMESTAMP(
                 "ingestion-timestamp",
                 DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(3).nullable(),
-                DataTypes.FIELD("ts_ms", DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(3)),
+                DataTypes.FIELD("ts_ms", DataTypes.BIGINT()),
                 new MetadataConverter() {
                     private static final long serialVersionUID = 1L;
 
                     @Override
-                    public Object convert(GenericRowData row, int unused) {
-                        return row;
+                    public Object convert(GenericRowData row, int pos) {
+                        if (row.isNullAt(pos)) {
+                            return null;
+                        }
+                        return TimestampData.fromEpochMillis(row.getLong(pos));
                     }
                 }),
 
         SOURCE_TIMESTAMP(
                 "source.timestamp",
                 DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(3).nullable(),
-                SOURCE_FIELD,
+                REQUIRED_SOURCE_AVRO_FIELD,
                 new MetadataConverter() {
                     private static final long serialVersionUID = 1L;
 
                     @Override
-                    public Object convert(GenericRowData row, int unused) {
-                        int pos = SOURCE_PROPERTY_POSITION.get("ts_ms");
-                        return row.getField(pos);
+                    public Object convert(GenericRowData row, int pos) {
+                        final StringData timestamp =
+                                (StringData) readProperty(row, pos, KEY_SOURCE_TIMESTAMP);
+                        if (timestamp == null) {
+                            return null;
+                        }
+                        return TimestampData.fromEpochMillis(Long.parseLong(timestamp.toString()));
                     }
                 }),
 
         SOURCE_DATABASE(
                 "source.database",
                 DataTypes.STRING().nullable(),
-                SOURCE_FIELD,
+                REQUIRED_SOURCE_AVRO_FIELD,
                 new MetadataConverter() {
                     private static final long serialVersionUID = 1L;
 
                     @Override
-                    public Object convert(GenericRowData row, int unused) {
-                        int pos = SOURCE_PROPERTY_POSITION.get("db");
-                        return row.getField(pos);
+                    public Object convert(GenericRowData row, int pos) {
+                        return readProperty(row, pos, KEY_SOURCE_DATABASE);
                     }
                 }),
 
         SOURCE_SCHEMA(
                 "source.schema",
                 DataTypes.STRING().nullable(),
-                SOURCE_FIELD,
+                REQUIRED_SOURCE_AVRO_FIELD,
                 new MetadataConverter() {
                     private static final long serialVersionUID = 1L;
 
                     @Override
-                    public Object convert(GenericRowData row, int unused) {
-                        int pos = SOURCE_PROPERTY_POSITION.get("schema");
-                        return row.getField(pos);
+                    public Object convert(GenericRowData row, int pos) {
+                        return readProperty(row, pos, KEY_SOURCE_SCHEMA);
                     }
                 }),
 
         SOURCE_TABLE(
                 "source.table",
                 DataTypes.STRING().nullable(),
-                SOURCE_FIELD,
+                REQUIRED_SOURCE_AVRO_FIELD,
                 new MetadataConverter() {
                     private static final long serialVersionUID = 1L;
 
                     @Override
-                    public Object convert(GenericRowData row, int unused) {
-                        int pos = SOURCE_PROPERTY_POSITION.get("table");
-                        return row.getField(pos);
+                    public Object convert(GenericRowData row, int pos) {
+                        return readProperty(row, pos, KEY_SOURCE_TABLE);
                     }
                 }),
 
@@ -206,20 +219,13 @@ public class DebeziumAvroDecodingFormat
                 // key and value of the map are nullable to make handling easier in queries
                 DataTypes.MAP(DataTypes.STRING().nullable(), DataTypes.STRING().nullable())
                         .nullable(),
-                SOURCE_FIELD,
+                REQUIRED_SOURCE_AVRO_FIELD,
                 new MetadataConverter() {
                     private static final long serialVersionUID = 1L;
 
                     @Override
-                    public Object convert(GenericRowData row, int unused) {
-                        Map<StringData, StringData> result = new HashMap<>();
-                        for (int i = 0; i < SOURCE_PROPERTY_FIELDS.length; i++) {
-                            Object value = row.getField(i);
-                            result.put(
-                                    StringData.fromString(SOURCE_PROPERTY_FIELDS[i].getName()),
-                                    value == null ? null : StringData.fromString(value.toString()));
-                        }
-                        return new GenericMapData(result);
+                    public Object convert(GenericRowData row, int pos) {
+                        return row.getMap(pos);
                     }
                 });
 
@@ -240,27 +246,23 @@ public class DebeziumAvroDecodingFormat
         }
     }
 
-    private static final DataTypes.Field[] SOURCE_PROPERTY_FIELDS = {
-        DataTypes.FIELD("version", DataTypes.STRING()),
-        DataTypes.FIELD("connector", DataTypes.STRING()),
-        DataTypes.FIELD("name", DataTypes.STRING()),
-        DataTypes.FIELD("ts_ms", DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(3).nullable()),
-        DataTypes.FIELD("snapshot", DataTypes.STRING().nullable()),
-        DataTypes.FIELD("db", DataTypes.STRING()),
-        DataTypes.FIELD("sequence", DataTypes.STRING().nullable()),
-        DataTypes.FIELD("schema", DataTypes.STRING().nullable()),
-        DataTypes.FIELD("table", DataTypes.STRING()),
-        DataTypes.FIELD("txId", DataTypes.STRING().nullable()),
-        DataTypes.FIELD("scn", DataTypes.STRING().nullable()),
-        DataTypes.FIELD("commit_scn", DataTypes.STRING().nullable()),
-        DataTypes.FIELD("lcr_position", DataTypes.STRING().nullable())
-    };
-
-    private static final Map<String, Integer> SOURCE_PROPERTY_POSITION =
-            IntStream.range(0, SOURCE_PROPERTY_FIELDS.length)
-                    .boxed()
-                    .collect(Collectors.toMap(i -> SOURCE_PROPERTY_FIELDS[i].getName(), i -> i));
-
-    private static final DataTypes.Field SOURCE_FIELD =
-            DataTypes.FIELD("source", DataTypes.ROW(SOURCE_PROPERTY_FIELDS));
+    /**
+     * Reads a property from the source MAP by key.
+     *
+     * <p>The source field contains GenericMapData injected at runtime by {@link
+     * DebeziumAvroDeserializationSchema#convertSourceToMap}. Safe to cast because the runtime type
+     * is guaranteed.
+     *
+     * @param row the rootRow containing source MapData at pos
+     * @param pos the source field position (4 in Debezium envelope)
+     * @param key the StringData key to lookup
+     * @return the field value, or null if not found
+     */
+    private static Object readProperty(GenericRowData row, int pos, StringData key) {
+        final GenericMapData map = (GenericMapData) row.getMap(pos);
+        if (map == null) {
+            return null;
+        }
+        return map.get(key);
+    }
 }

--- a/flink-formats/flink-avro-confluent-registry/src/main/java/org/apache/flink/formats/avro/registry/confluent/debezium/DebeziumAvroDeserializationSchema.java
+++ b/flink-formats/flink-avro-confluent-registry/src/main/java/org/apache/flink/formats/avro/registry/confluent/debezium/DebeziumAvroDeserializationSchema.java
@@ -25,8 +25,10 @@ import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.formats.avro.AvroRowDataDeserializationSchema;
 import org.apache.flink.formats.avro.AvroToRowDataConverters;
 import org.apache.flink.formats.avro.RegistryAvroDeserializationSchema;
+import org.apache.flink.formats.avro.SchemaCoder;
 import org.apache.flink.formats.avro.SchemaCoder.SchemaCoderProvider;
 import org.apache.flink.formats.avro.registry.confluent.ConfluentRegistryAvroDeserializationSchema;
+import org.apache.flink.formats.avro.registry.confluent.ConfluentSchemaRegistryCoder;
 import org.apache.flink.formats.avro.registry.confluent.debezium.DebeziumAvroDecodingFormat.ReadableMetadata;
 import org.apache.flink.formats.avro.typeutils.AvroSchemaConverter;
 import org.apache.flink.table.api.DataTypes;
@@ -41,12 +43,15 @@ import org.apache.flink.table.types.utils.DataTypeUtils;
 import org.apache.flink.types.RowKind;
 import org.apache.flink.util.Collector;
 
+import io.confluent.kafka.schemaregistry.client.CachedSchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import org.apache.avro.Schema;
 import org.apache.avro.Schema.Parser;
 import org.apache.avro.generic.GenericRecord;
 
 import javax.annotation.Nullable;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.HashMap;
@@ -109,11 +114,11 @@ public final class DebeziumAvroDeserializationSchema implements DeserializationS
     /** Position of source field in rootRow, -1 if not present. */
     private final int sourceFieldPosition;
 
-    /** Envelope schema for generic deserializer. */
-    private final Schema envelopeSchema;
-
     /** Generic Avro deserializer for extracting envelope with writer schema. */
     private transient RegistryAvroDeserializationSchema<GenericRecord> genericDeserializer;
+
+    /** Initialization context for the generic deserializer. */
+    private transient InitializationContext initContext;
 
     /** Cached source MapData for current message. */
     private transient MapData cachedSourceMap;
@@ -168,14 +173,12 @@ public final class DebeziumAvroDeserializationSchema implements DeserializationS
                 schemaString == null
                         ? AvroSchemaConverter.convertToSchema(debeziumAvroRowType, false)
                         : new Parser().parse(schemaString);
-        this.envelopeSchema = schema;
         this.avroDeserializer =
                 new AvroRowDataDeserializationSchema(
                         ConfluentRegistryAvroDeserializationSchema.forGeneric(
                                 schema, schemaRegistryUrl, registryConfigs),
                         AvroToRowDataConverters.createRowConverter(debeziumAvroRowType, false),
                         producedTypeInfo);
-
         this.hasMetadata = !requestedMetadata.isEmpty();
         this.sourceFieldPosition = debeziumAvroRowType.getFieldNames().indexOf("source");
         this.metadataConverters =
@@ -205,7 +208,6 @@ public final class DebeziumAvroDeserializationSchema implements DeserializationS
         this.hasMetadata = false;
         this.metadataConverters = new MetadataConverter[0];
         this.sourceFieldPosition = -1;
-        this.envelopeSchema = null;
         this.schemaRegistryUrl = null;
         this.registryConfigs = null;
     }
@@ -217,14 +219,12 @@ public final class DebeziumAvroDeserializationSchema implements DeserializationS
             boolean hasMetadata,
             MetadataConverter[] metadataConverters,
             int sourceFieldPosition,
-            Schema envelopeSchema,
             SchemaCoderProvider coderProvider) {
         this.producedTypeInfo = producedTypeInfo;
         this.avroDeserializer = avroDeserializer;
         this.hasMetadata = hasMetadata;
         this.metadataConverters = metadataConverters;
         this.sourceFieldPosition = sourceFieldPosition;
-        this.envelopeSchema = envelopeSchema;
         this.coderProvider = coderProvider;
         this.genericDeserializer = null;
         this.schemaRegistryUrl = null;
@@ -234,17 +234,16 @@ public final class DebeziumAvroDeserializationSchema implements DeserializationS
     @Override
     public void open(InitializationContext context) throws Exception {
         avroDeserializer.open(context);
+        this.initContext = context;
 
-        if (hasMetadata && this.genericDeserializer == null) {
-            if (this.coderProvider != null) {
-                this.genericDeserializer =
-                        new RegistryAvroDeserializationSchema<>(
-                                GenericRecord.class, this.envelopeSchema, this.coderProvider);
-            } else {
-                this.genericDeserializer =
-                        ConfluentRegistryAvroDeserializationSchema.forGeneric(
-                                this.envelopeSchema, schemaRegistryUrl, registryConfigs);
-            }
+        if (hasMetadata && this.coderProvider == null) {
+            // Set up the coder to dynamically fetch the exact writer schema later,
+            // ensuring the generic read resolves to it.
+            final SchemaRegistryClient client =
+                    new CachedSchemaRegistryClient(schemaRegistryUrl, 1000, registryConfigs);
+
+            final SchemaCoder coder = new ConfluentSchemaRegistryCoder(null, client);
+            this.coderProvider = () -> coder;
         }
     }
 
@@ -262,6 +261,16 @@ public final class DebeziumAvroDeserializationSchema implements DeserializationS
             return;
         }
         try {
+            // Initialize generic deserializer with the first record's runtime writer schema
+            if (hasMetadata && genericDeserializer == null) {
+                SchemaCoder coder = coderProvider.get();
+                Schema writerSchema = coder.readSchema(new ByteArrayInputStream(message));
+                this.genericDeserializer =
+                        new RegistryAvroDeserializationSchema<>(
+                                GenericRecord.class, writerSchema, coderProvider);
+                this.genericDeserializer.open(this.initContext);
+            }
+
             // Extract source as MapData when metadata is requested
             if (hasMetadata) {
                 GenericRecord envelope = genericDeserializer.deserialize(message);
@@ -314,33 +323,32 @@ public final class DebeziumAvroDeserializationSchema implements DeserializationS
             return;
         }
 
-        // Inject MapData at source position (4) in rootRow
-        GenericRowData augmentedRoot = rootRow;
-        if (sourceFieldPosition >= 0 && cachedSourceMap != null) {
-            augmentedRoot = new GenericRowData(rootRow.getArity());
-            for (int i = 0; i < rootRow.getArity(); i++) {
-                if (i == sourceFieldPosition) {
-                    augmentedRoot.setField(i, cachedSourceMap);
-                } else {
-                    augmentedRoot.setField(i, rootRow.getField(i));
-                }
-            }
-        }
-
         final int physicalArity = physicalRow.getArity();
         final int metadataArity = metadataConverters.length;
-
         final GenericRowData producedRow =
                 new GenericRowData(physicalRow.getRowKind(), physicalArity + metadataArity);
 
-        for (int physicalPos = 0; physicalPos < physicalArity; physicalPos++) {
-            producedRow.setField(physicalPos, physicalRow.getField(physicalPos));
+        for (int i = 0; i < physicalArity; i++) {
+            producedRow.setField(i, physicalRow.getField(i));
         }
 
-        for (int metadataPos = 0; metadataPos < metadataArity; metadataPos++) {
-            producedRow.setField(
-                    physicalArity + metadataPos,
-                    metadataConverters[metadataPos].convert(augmentedRoot, metadataPos));
+        // Temporarily inject source map to maintain object reuse safety.
+        final boolean shouldInjectSource = sourceFieldPosition >= 0 && cachedSourceMap != null;
+        Object originalSource = null;
+
+        if (shouldInjectSource) {
+            originalSource = rootRow.getField(sourceFieldPosition);
+            rootRow.setField(sourceFieldPosition, cachedSourceMap);
+        }
+
+        try {
+            for (int i = 0; i < metadataArity; i++) {
+                producedRow.setField(physicalArity + i, metadataConverters[i].convert(rootRow, i));
+            }
+        } finally {
+            if (shouldInjectSource) {
+                rootRow.setField(sourceFieldPosition, originalSource);
+            }
         }
 
         out.collect(producedRow);

--- a/flink-formats/flink-avro-confluent-registry/src/main/java/org/apache/flink/formats/avro/registry/confluent/debezium/DebeziumAvroDeserializationSchema.java
+++ b/flink-formats/flink-avro-confluent-registry/src/main/java/org/apache/flink/formats/avro/registry/confluent/debezium/DebeziumAvroDeserializationSchema.java
@@ -191,8 +191,9 @@ public final class DebeziumAvroDeserializationSchema implements DeserializationS
                                                     .indexOf(m.requiredAvroField.getName());
                                     return (MetadataConverter)
                                             (row, pos) -> {
-                                                // Simplified: always pass (rootRow, rootPosition)
-                                                // Converters handle scala (ts_ms), MapData (source)
+                                                // Converters take (rootRow, rootPosition);
+                                                // each handles its own type —
+                                                // scalar for ts_ms, MapData for source.
                                                 return m.converter.convert(row, rootPosition);
                                             };
                                 })

--- a/flink-formats/flink-avro-confluent-registry/src/main/java/org/apache/flink/formats/avro/registry/confluent/debezium/DebeziumAvroDeserializationSchema.java
+++ b/flink-formats/flink-avro-confluent-registry/src/main/java/org/apache/flink/formats/avro/registry/confluent/debezium/DebeziumAvroDeserializationSchema.java
@@ -25,12 +25,14 @@ import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.formats.avro.AvroRowDataDeserializationSchema;
 import org.apache.flink.formats.avro.AvroToRowDataConverters;
 import org.apache.flink.formats.avro.registry.confluent.ConfluentRegistryAvroDeserializationSchema;
+import org.apache.flink.formats.avro.registry.confluent.debezium.DebeziumAvroDecodingFormat.ReadableMetadata;
 import org.apache.flink.formats.avro.typeutils.AvroSchemaConverter;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.types.utils.DataTypeUtils;
 import org.apache.flink.types.RowKind;
 import org.apache.flink.util.Collector;
 
@@ -40,12 +42,14 @@ import org.apache.avro.Schema.Parser;
 import javax.annotation.Nullable;
 
 import java.io.IOException;
+import java.io.Serializable;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 import static java.lang.String.format;
 import static org.apache.flink.formats.avro.registry.confluent.debezium.DebeziumAvroFormatFactory.validateSchemaString;
-import static org.apache.flink.table.types.utils.TypeConversions.fromLogicalToDataType;
 
 /**
  * Deserialization schema from Debezium Avro to Flink Table/SQL internal data structure {@link
@@ -83,14 +87,22 @@ public final class DebeziumAvroDeserializationSchema implements DeserializationS
     /** TypeInformation of the produced {@link RowData}. */
     private final TypeInformation<RowData> producedTypeInfo;
 
+    /** Flag that indicates that an additional projection is required for metadata. */
+    private final boolean hasMetadata;
+
+    /** Metadata to be extracted for every record. */
+    private final MetadataConverter[] metadataConverters;
+
     public DebeziumAvroDeserializationSchema(
-            RowType rowType,
+            DataType physicalDataType,
+            List<ReadableMetadata> requestedMetadata,
             TypeInformation<RowData> producedTypeInfo,
             String schemaRegistryUrl,
             @Nullable String schemaString,
             @Nullable Map<String, ?> registryConfigs) {
         this.producedTypeInfo = producedTypeInfo;
-        RowType debeziumAvroRowType = createDebeziumAvroRowType(fromLogicalToDataType(rowType));
+        RowType debeziumAvroRowType =
+                createDebeziumAvroRowType(physicalDataType, requestedMetadata);
 
         validateSchemaString(schemaString, debeziumAvroRowType);
         Schema schema =
@@ -104,6 +116,28 @@ public final class DebeziumAvroDeserializationSchema implements DeserializationS
                                 schema, schemaRegistryUrl, registryConfigs),
                         AvroToRowDataConverters.createRowConverter(debeziumAvroRowType),
                         producedTypeInfo);
+
+        this.hasMetadata = requestedMetadata.size() > 0;
+        this.metadataConverters =
+                requestedMetadata.stream()
+                        .map(
+                                m -> {
+                                    final int rootPosition =
+                                            debeziumAvroRowType
+                                                    .getFieldNames()
+                                                    .indexOf(m.requiredAvroField.getName());
+                                    return (MetadataConverter)
+                                            (row, pos) -> {
+                                                Object result = row.getField(rootPosition);
+                                                if (result instanceof GenericRowData) {
+                                                    result =
+                                                            m.converter.convert(
+                                                                    (GenericRowData) result, pos);
+                                                }
+                                                return result;
+                                            };
+                                })
+                        .toArray(MetadataConverter[]::new);
     }
 
     @VisibleForTesting
@@ -112,6 +146,8 @@ public final class DebeziumAvroDeserializationSchema implements DeserializationS
             AvroRowDataDeserializationSchema avroDeserializer) {
         this.producedTypeInfo = producedTypeInfo;
         this.avroDeserializer = avroDeserializer;
+        this.hasMetadata = false;
+        this.metadataConverters = new MetadataConverter[0];
     }
 
     @Override
@@ -140,7 +176,7 @@ public final class DebeziumAvroDeserializationSchema implements DeserializationS
             String op = row.getField(2).toString();
             if (OP_CREATE.equals(op) || OP_READ.equals(op)) {
                 after.setRowKind(RowKind.INSERT);
-                out.collect(after);
+                emitRow(row, after, out);
             } else if (OP_UPDATE.equals(op)) {
                 if (before == null) {
                     throw new IllegalStateException(
@@ -148,15 +184,15 @@ public final class DebeziumAvroDeserializationSchema implements DeserializationS
                 }
                 before.setRowKind(RowKind.UPDATE_BEFORE);
                 after.setRowKind(RowKind.UPDATE_AFTER);
-                out.collect(before);
-                out.collect(after);
+                emitRow(row, before, out);
+                emitRow(row, after, out);
             } else if (OP_DELETE.equals(op)) {
                 if (before == null) {
                     throw new IllegalStateException(
                             String.format(REPLICA_IDENTITY_EXCEPTION, "DELETE"));
                 }
                 before.setRowKind(RowKind.DELETE);
-                out.collect(before);
+                emitRow(row, before, out);
             } else {
                 throw new IOException(
                         format(
@@ -167,6 +203,33 @@ public final class DebeziumAvroDeserializationSchema implements DeserializationS
             // a big try catch to protect the processing.
             throw new IOException("Can't deserialize Debezium Avro message.", t);
         }
+    }
+
+    private void emitRow(
+            GenericRowData rootRow, GenericRowData physicalRow, Collector<RowData> out) {
+        // shortcut in case no output projection is required
+        if (!hasMetadata) {
+            out.collect(physicalRow);
+            return;
+        }
+
+        final int physicalArity = physicalRow.getArity();
+        final int metadataArity = metadataConverters.length;
+
+        final GenericRowData producedRow =
+                new GenericRowData(physicalRow.getRowKind(), physicalArity + metadataArity);
+
+        for (int physicalPos = 0; physicalPos < physicalArity; physicalPos++) {
+            producedRow.setField(physicalPos, physicalRow.getField(physicalPos));
+        }
+
+        for (int metadataPos = 0; metadataPos < metadataArity; metadataPos++) {
+            producedRow.setField(
+                    physicalArity + metadataPos,
+                    metadataConverters[metadataPos].convert(rootRow, metadataPos));
+        }
+
+        out.collect(producedRow);
     }
 
     @Override
@@ -189,22 +252,41 @@ public final class DebeziumAvroDeserializationSchema implements DeserializationS
         }
         DebeziumAvroDeserializationSchema that = (DebeziumAvroDeserializationSchema) o;
         return Objects.equals(avroDeserializer, that.avroDeserializer)
-                && Objects.equals(producedTypeInfo, that.producedTypeInfo);
+                && Objects.equals(producedTypeInfo, that.producedTypeInfo)
+                && hasMetadata == that.hasMetadata;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(avroDeserializer, producedTypeInfo);
+        return Objects.hash(avroDeserializer, producedTypeInfo, hasMetadata);
     }
 
-    public static RowType createDebeziumAvroRowType(DataType databaseSchema) {
-        // Debezium Avro contains other information, e.g. "source", "ts_ms"
-        // but we don't need them
-        return (RowType)
+    public static RowType createDebeziumAvroRowType(
+            // Debezium Avro contains other information, e.g. "source", "ts_ms"
+            // but we don't need them
+            DataType databaseSchema, List<ReadableMetadata> readableMetadata) {
+        DataType payload =
                 DataTypes.ROW(
-                                DataTypes.FIELD("before", databaseSchema.nullable()),
-                                DataTypes.FIELD("after", databaseSchema.nullable()),
-                                DataTypes.FIELD("op", DataTypes.STRING()))
-                        .getLogicalType();
+                        DataTypes.FIELD("before", databaseSchema.nullable()),
+                        DataTypes.FIELD("after", databaseSchema.nullable()),
+                        DataTypes.FIELD("op", DataTypes.STRING()));
+
+        // append fields that are required for reading metadata in the payload
+        final List<DataTypes.Field> payloadMetadataFields =
+                readableMetadata.stream()
+                        .map(m -> m.requiredAvroField)
+                        .distinct()
+                        .collect(Collectors.toList());
+        payload = DataTypeUtils.appendRowFields(payload, payloadMetadataFields);
+
+        return (RowType) payload.getLogicalType();
+    }
+
+    /**
+     * Converter that extracts a metadata field from the row payload that comes out of the Avro
+     * schema and converts it to the desired data type.
+     */
+    interface MetadataConverter extends Serializable {
+        Object convert(GenericRowData row, int pos);
     }
 }

--- a/flink-formats/flink-avro-confluent-registry/src/main/java/org/apache/flink/formats/avro/registry/confluent/debezium/DebeziumAvroDeserializationSchema.java
+++ b/flink-formats/flink-avro-confluent-registry/src/main/java/org/apache/flink/formats/avro/registry/confluent/debezium/DebeziumAvroDeserializationSchema.java
@@ -25,6 +25,7 @@ import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.formats.avro.AvroRowDataDeserializationSchema;
 import org.apache.flink.formats.avro.AvroToRowDataConverters;
 import org.apache.flink.formats.avro.RegistryAvroDeserializationSchema;
+import org.apache.flink.formats.avro.SchemaCoder.SchemaCoderProvider;
 import org.apache.flink.formats.avro.registry.confluent.ConfluentRegistryAvroDeserializationSchema;
 import org.apache.flink.formats.avro.registry.confluent.debezium.DebeziumAvroDecodingFormat.ReadableMetadata;
 import org.apache.flink.formats.avro.typeutils.AvroSchemaConverter;
@@ -105,11 +106,20 @@ public final class DebeziumAvroDeserializationSchema implements DeserializationS
     /** Schema registry configs for generic deserializer. */
     private final Map<String, ?> registryConfigs;
 
+    /** Position of source field in rootRow, -1 if not present. */
+    private final int sourceFieldPosition;
+
+    /** Envelope schema for generic deserializer. */
+    private final Schema envelopeSchema;
+
     /** Generic Avro deserializer for extracting envelope with writer schema. */
     private transient RegistryAvroDeserializationSchema<GenericRecord> genericDeserializer;
 
     /** Cached source MapData for current message. */
     private transient MapData cachedSourceMap;
+
+    /** Provider for mock schema registry in tests. */
+    private transient SchemaCoderProvider coderProvider;
 
     /**
      * Converts Debezium source GenericRecord to {@code MAP<STRING, STRING>}.
@@ -158,7 +168,7 @@ public final class DebeziumAvroDeserializationSchema implements DeserializationS
                 schemaString == null
                         ? AvroSchemaConverter.convertToSchema(debeziumAvroRowType, false)
                         : new Parser().parse(schemaString);
-
+        this.envelopeSchema = schema;
         this.avroDeserializer =
                 new AvroRowDataDeserializationSchema(
                         ConfluentRegistryAvroDeserializationSchema.forGeneric(
@@ -166,7 +176,8 @@ public final class DebeziumAvroDeserializationSchema implements DeserializationS
                         AvroToRowDataConverters.createRowConverter(debeziumAvroRowType, false),
                         producedTypeInfo);
 
-        this.hasMetadata = requestedMetadata.size() > 0;
+        this.hasMetadata = !requestedMetadata.isEmpty();
+        this.sourceFieldPosition = debeziumAvroRowType.getFieldNames().indexOf("source");
         this.metadataConverters =
                 requestedMetadata.stream()
                         .map(
@@ -193,6 +204,8 @@ public final class DebeziumAvroDeserializationSchema implements DeserializationS
         this.avroDeserializer = avroDeserializer;
         this.hasMetadata = false;
         this.metadataConverters = new MetadataConverter[0];
+        this.sourceFieldPosition = -1;
+        this.envelopeSchema = null;
         this.schemaRegistryUrl = null;
         this.registryConfigs = null;
     }
@@ -203,12 +216,17 @@ public final class DebeziumAvroDeserializationSchema implements DeserializationS
             AvroRowDataDeserializationSchema avroDeserializer,
             boolean hasMetadata,
             MetadataConverter[] metadataConverters,
-            @Nullable RegistryAvroDeserializationSchema<GenericRecord> genericDeserializer) {
+            int sourceFieldPosition,
+            Schema envelopeSchema,
+            SchemaCoderProvider coderProvider) {
         this.producedTypeInfo = producedTypeInfo;
         this.avroDeserializer = avroDeserializer;
         this.hasMetadata = hasMetadata;
         this.metadataConverters = metadataConverters;
-        this.genericDeserializer = genericDeserializer;
+        this.sourceFieldPosition = sourceFieldPosition;
+        this.envelopeSchema = envelopeSchema;
+        this.coderProvider = coderProvider;
+        this.genericDeserializer = null;
         this.schemaRegistryUrl = null;
         this.registryConfigs = null;
     }
@@ -218,9 +236,15 @@ public final class DebeziumAvroDeserializationSchema implements DeserializationS
         avroDeserializer.open(context);
 
         if (hasMetadata && this.genericDeserializer == null) {
-            this.genericDeserializer =
-                    ConfluentRegistryAvroDeserializationSchema.forGeneric(
-                            null, schemaRegistryUrl, registryConfigs);
+            if (this.coderProvider != null) {
+                this.genericDeserializer =
+                        new RegistryAvroDeserializationSchema<>(
+                                GenericRecord.class, this.envelopeSchema, this.coderProvider);
+            } else {
+                this.genericDeserializer =
+                        ConfluentRegistryAvroDeserializationSchema.forGeneric(
+                                this.envelopeSchema, schemaRegistryUrl, registryConfigs);
+            }
         }
     }
 
@@ -291,14 +315,15 @@ public final class DebeziumAvroDeserializationSchema implements DeserializationS
         }
 
         // Inject MapData at source position (4) in rootRow
-        final int sourcePosition = 4; // Stable Debezium envelope position
-        GenericRowData agumentedRoot = new GenericRowData(rootRow.getArity());
-
-        for (int i = 0; i < rootRow.getArity(); i++) {
-            if (i == sourcePosition && cachedSourceMap != null) {
-                agumentedRoot.setField(i, cachedSourceMap);
-            } else {
-                agumentedRoot.setField(i, rootRow.getField(i));
+        GenericRowData augmentedRoot = rootRow;
+        if (sourceFieldPosition >= 0 && cachedSourceMap != null) {
+            augmentedRoot = new GenericRowData(rootRow.getArity());
+            for (int i = 0; i < rootRow.getArity(); i++) {
+                if (i == sourceFieldPosition) {
+                    augmentedRoot.setField(i, cachedSourceMap);
+                } else {
+                    augmentedRoot.setField(i, rootRow.getField(i));
+                }
             }
         }
 
@@ -315,7 +340,7 @@ public final class DebeziumAvroDeserializationSchema implements DeserializationS
         for (int metadataPos = 0; metadataPos < metadataArity; metadataPos++) {
             producedRow.setField(
                     physicalArity + metadataPos,
-                    metadataConverters[metadataPos].convert(agumentedRoot, metadataPos));
+                    metadataConverters[metadataPos].convert(augmentedRoot, metadataPos));
         }
 
         out.collect(producedRow);

--- a/flink-formats/flink-avro-confluent-registry/src/main/java/org/apache/flink/formats/avro/registry/confluent/debezium/DebeziumAvroDeserializationSchema.java
+++ b/flink-formats/flink-avro-confluent-registry/src/main/java/org/apache/flink/formats/avro/registry/confluent/debezium/DebeziumAvroDeserializationSchema.java
@@ -24,12 +24,16 @@ import org.apache.flink.api.common.serialization.DeserializationSchema;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.formats.avro.AvroRowDataDeserializationSchema;
 import org.apache.flink.formats.avro.AvroToRowDataConverters;
+import org.apache.flink.formats.avro.RegistryAvroDeserializationSchema;
 import org.apache.flink.formats.avro.registry.confluent.ConfluentRegistryAvroDeserializationSchema;
 import org.apache.flink.formats.avro.registry.confluent.debezium.DebeziumAvroDecodingFormat.ReadableMetadata;
 import org.apache.flink.formats.avro.typeutils.AvroSchemaConverter;
 import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.data.GenericMapData;
 import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.MapData;
 import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.utils.DataTypeUtils;
@@ -38,11 +42,13 @@ import org.apache.flink.util.Collector;
 
 import org.apache.avro.Schema;
 import org.apache.avro.Schema.Parser;
+import org.apache.avro.generic.GenericRecord;
 
 import javax.annotation.Nullable;
 
 import java.io.IOException;
 import java.io.Serializable;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -93,6 +99,46 @@ public final class DebeziumAvroDeserializationSchema implements DeserializationS
     /** Metadata to be extracted for every record. */
     private final MetadataConverter[] metadataConverters;
 
+    /** Schema registry URL for generic deserializer. */
+    private final String schemaRegistryUrl;
+
+    /** Schema registry configs for generic deserializer. */
+    private final Map<String, ?> registryConfigs;
+
+    /** Generic Avro deserializer for extracting envelope with writer schema. */
+    private transient RegistryAvroDeserializationSchema<GenericRecord> genericDeserializer;
+
+    /** Cached source MapData for current message. */
+    private transient MapData cachedSourceMap;
+
+    /**
+     * Converts Debezium source GenericRecord to {@code MAP<STRING, STRING>}.
+     *
+     * <p>Extracts all fields from writer's source schema dynamically, preserving connector-specific
+     * fields before projection.
+     *
+     * @param sourceRecord GenericRecord from writer schema
+     * @return MapData with all source fields as strings, null if input is null
+     */
+    private static MapData convertSourceToMap(@Nullable GenericRecord sourceRecord) {
+        if (sourceRecord == null) {
+            return null;
+        }
+
+        Map<StringData, StringData> map = new HashMap<>();
+        Schema sourceSchema = sourceRecord.getSchema();
+
+        for (Schema.Field field : sourceSchema.getFields()) {
+            String fieldName = field.name();
+            Object fieldValue = sourceRecord.get(fieldName);
+            map.put(
+                    StringData.fromString(fieldName),
+                    fieldValue != null ? StringData.fromString(fieldValue.toString()) : null);
+        }
+
+        return new GenericMapData(map);
+    }
+
     public DebeziumAvroDeserializationSchema(
             DataType physicalDataType,
             List<ReadableMetadata> requestedMetadata,
@@ -101,20 +147,23 @@ public final class DebeziumAvroDeserializationSchema implements DeserializationS
             @Nullable String schemaString,
             @Nullable Map<String, ?> registryConfigs) {
         this.producedTypeInfo = producedTypeInfo;
+        this.schemaRegistryUrl = schemaRegistryUrl;
+        this.registryConfigs = registryConfigs;
+
         RowType debeziumAvroRowType =
                 createDebeziumAvroRowType(physicalDataType, requestedMetadata);
 
         validateSchemaString(schemaString, debeziumAvroRowType);
         Schema schema =
                 schemaString == null
-                        ? AvroSchemaConverter.convertToSchema(debeziumAvroRowType)
+                        ? AvroSchemaConverter.convertToSchema(debeziumAvroRowType, false)
                         : new Parser().parse(schemaString);
 
         this.avroDeserializer =
                 new AvroRowDataDeserializationSchema(
                         ConfluentRegistryAvroDeserializationSchema.forGeneric(
                                 schema, schemaRegistryUrl, registryConfigs),
-                        AvroToRowDataConverters.createRowConverter(debeziumAvroRowType),
+                        AvroToRowDataConverters.createRowConverter(debeziumAvroRowType, false),
                         producedTypeInfo);
 
         this.hasMetadata = requestedMetadata.size() > 0;
@@ -128,13 +177,9 @@ public final class DebeziumAvroDeserializationSchema implements DeserializationS
                                                     .indexOf(m.requiredAvroField.getName());
                                     return (MetadataConverter)
                                             (row, pos) -> {
-                                                Object result = row.getField(rootPosition);
-                                                if (result instanceof GenericRowData) {
-                                                    result =
-                                                            m.converter.convert(
-                                                                    (GenericRowData) result, pos);
-                                                }
-                                                return result;
+                                                // Simplified: always pass (rootRow, rootPosition)
+                                                // Converters handle scala (ts_ms), MapData (source)
+                                                return m.converter.convert(row, rootPosition);
                                             };
                                 })
                         .toArray(MetadataConverter[]::new);
@@ -148,11 +193,35 @@ public final class DebeziumAvroDeserializationSchema implements DeserializationS
         this.avroDeserializer = avroDeserializer;
         this.hasMetadata = false;
         this.metadataConverters = new MetadataConverter[0];
+        this.schemaRegistryUrl = null;
+        this.registryConfigs = null;
+    }
+
+    @VisibleForTesting
+    DebeziumAvroDeserializationSchema(
+            TypeInformation<RowData> producedTypeInfo,
+            AvroRowDataDeserializationSchema avroDeserializer,
+            boolean hasMetadata,
+            MetadataConverter[] metadataConverters,
+            @Nullable RegistryAvroDeserializationSchema<GenericRecord> genericDeserializer) {
+        this.producedTypeInfo = producedTypeInfo;
+        this.avroDeserializer = avroDeserializer;
+        this.hasMetadata = hasMetadata;
+        this.metadataConverters = metadataConverters;
+        this.genericDeserializer = genericDeserializer;
+        this.schemaRegistryUrl = null;
+        this.registryConfigs = null;
     }
 
     @Override
     public void open(InitializationContext context) throws Exception {
         avroDeserializer.open(context);
+
+        if (hasMetadata && this.genericDeserializer == null) {
+            this.genericDeserializer =
+                    ConfluentRegistryAvroDeserializationSchema.forGeneric(
+                            null, schemaRegistryUrl, registryConfigs);
+        }
     }
 
     @Override
@@ -169,6 +238,14 @@ public final class DebeziumAvroDeserializationSchema implements DeserializationS
             return;
         }
         try {
+            // Extract source as MapData when metadata is requested
+            if (hasMetadata) {
+                GenericRecord envelope = genericDeserializer.deserialize(message);
+                GenericRecord sourceRecord = (GenericRecord) envelope.get("source");
+                this.cachedSourceMap = convertSourceToMap(sourceRecord);
+            }
+
+            // Deserialize with typed schema
             GenericRowData row = (GenericRowData) avroDeserializer.deserialize(message);
 
             GenericRowData before = (GenericRowData) row.getField(0);
@@ -213,6 +290,18 @@ public final class DebeziumAvroDeserializationSchema implements DeserializationS
             return;
         }
 
+        // Inject MapData at source position (4) in rootRow
+        final int sourcePosition = 4; // Stable Debezium envelope position
+        GenericRowData agumentedRoot = new GenericRowData(rootRow.getArity());
+
+        for (int i = 0; i < rootRow.getArity(); i++) {
+            if (i == sourcePosition && cachedSourceMap != null) {
+                agumentedRoot.setField(i, cachedSourceMap);
+            } else {
+                agumentedRoot.setField(i, rootRow.getField(i));
+            }
+        }
+
         final int physicalArity = physicalRow.getArity();
         final int metadataArity = metadataConverters.length;
 
@@ -226,7 +315,7 @@ public final class DebeziumAvroDeserializationSchema implements DeserializationS
         for (int metadataPos = 0; metadataPos < metadataArity; metadataPos++) {
             producedRow.setField(
                     physicalArity + metadataPos,
-                    metadataConverters[metadataPos].convert(rootRow, metadataPos));
+                    metadataConverters[metadataPos].convert(agumentedRoot, metadataPos));
         }
 
         out.collect(producedRow);
@@ -262,8 +351,6 @@ public final class DebeziumAvroDeserializationSchema implements DeserializationS
     }
 
     public static RowType createDebeziumAvroRowType(
-            // Debezium Avro contains other information, e.g. "source", "ts_ms"
-            // but we don't need them
             DataType databaseSchema, List<ReadableMetadata> readableMetadata) {
         DataType payload =
                 DataTypes.ROW(

--- a/flink-formats/flink-avro-confluent-registry/src/main/java/org/apache/flink/formats/avro/registry/confluent/debezium/DebeziumAvroFormatFactory.java
+++ b/flink-formats/flink-avro-confluent-registry/src/main/java/org/apache/flink/formats/avro/registry/confluent/debezium/DebeziumAvroFormatFactory.java
@@ -21,18 +21,14 @@ package org.apache.flink.formats.avro.registry.confluent.debezium;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.serialization.DeserializationSchema;
 import org.apache.flink.api.common.serialization.SerializationSchema;
-import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.formats.avro.typeutils.AvroSchemaConverter;
 import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.connector.ChangelogMode;
-import org.apache.flink.table.connector.Projection;
 import org.apache.flink.table.connector.format.DecodingFormat;
 import org.apache.flink.table.connector.format.EncodingFormat;
-import org.apache.flink.table.connector.format.ProjectableDecodingFormat;
 import org.apache.flink.table.connector.sink.DynamicTableSink;
-import org.apache.flink.table.connector.source.DynamicTableSource;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.factories.DeserializationFormatFactory;
 import org.apache.flink.table.factories.DynamicTableFactory;
@@ -84,34 +80,7 @@ public class DebeziumAvroFormatFactory
         String schema = formatOptions.getOptional(SCHEMA).orElse(null);
         Map<String, ?> optionalPropertiesMap = buildOptionalPropertiesMap(formatOptions);
 
-        return new ProjectableDecodingFormat<DeserializationSchema<RowData>>() {
-            @Override
-            public DeserializationSchema<RowData> createRuntimeDecoder(
-                    DynamicTableSource.Context context,
-                    DataType producedDataType,
-                    int[][] projections) {
-                producedDataType = Projection.of(projections).project(producedDataType);
-                final RowType rowType = (RowType) producedDataType.getLogicalType();
-                final TypeInformation<RowData> producedTypeInfo =
-                        context.createTypeInformation(producedDataType);
-                return new DebeziumAvroDeserializationSchema(
-                        rowType,
-                        producedTypeInfo,
-                        schemaRegistryURL,
-                        schema,
-                        optionalPropertiesMap);
-            }
-
-            @Override
-            public ChangelogMode getChangelogMode() {
-                return ChangelogMode.newBuilder()
-                        .addContainedKind(RowKind.INSERT)
-                        .addContainedKind(RowKind.UPDATE_BEFORE)
-                        .addContainedKind(RowKind.UPDATE_AFTER)
-                        .addContainedKind(RowKind.DELETE)
-                        .build();
-            }
-        };
+        return new DebeziumAvroDecodingFormat(schemaRegistryURL, schema, optionalPropertiesMap);
     }
 
     @Override

--- a/flink-formats/flink-avro-confluent-registry/src/main/java/org/apache/flink/formats/avro/registry/confluent/debezium/DebeziumAvroSerializationSchema.java
+++ b/flink-formats/flink-avro-confluent-registry/src/main/java/org/apache/flink/formats/avro/registry/confluent/debezium/DebeziumAvroSerializationSchema.java
@@ -81,7 +81,7 @@ public class DebeziumAvroSerializationSchema implements SerializationSchema<RowD
         validateSchemaString(schemaString, debeziumAvroRowType);
         Schema schema =
                 schemaString == null
-                        ? AvroSchemaConverter.convertToSchema(debeziumAvroRowType)
+                        ? AvroSchemaConverter.convertToSchema(debeziumAvroRowType, false)
                         : new Parser().parse(schemaString);
 
         this.avroSerializer =
@@ -89,7 +89,7 @@ public class DebeziumAvroSerializationSchema implements SerializationSchema<RowD
                         debeziumAvroRowType,
                         ConfluentRegistryAvroSerializationSchema.forGeneric(
                                 schemaRegistrySubject, schema, schemaRegistryUrl, registryConfigs),
-                        RowDataToAvroConverters.createConverter(debeziumAvroRowType));
+                        RowDataToAvroConverters.createConverter(debeziumAvroRowType, false));
     }
 
     @VisibleForTesting

--- a/flink-formats/flink-avro-confluent-registry/src/main/java/org/apache/flink/formats/avro/registry/confluent/debezium/DebeziumAvroSerializationSchema.java
+++ b/flink-formats/flink-avro-confluent-registry/src/main/java/org/apache/flink/formats/avro/registry/confluent/debezium/DebeziumAvroSerializationSchema.java
@@ -81,7 +81,7 @@ public class DebeziumAvroSerializationSchema implements SerializationSchema<RowD
         validateSchemaString(schemaString, debeziumAvroRowType);
         Schema schema =
                 schemaString == null
-                        ? AvroSchemaConverter.convertToSchema(debeziumAvroRowType, false)
+                        ? AvroSchemaConverter.convertToSchema(debeziumAvroRowType)
                         : new Parser().parse(schemaString);
 
         this.avroSerializer =
@@ -89,7 +89,7 @@ public class DebeziumAvroSerializationSchema implements SerializationSchema<RowD
                         debeziumAvroRowType,
                         ConfluentRegistryAvroSerializationSchema.forGeneric(
                                 schemaRegistrySubject, schema, schemaRegistryUrl, registryConfigs),
-                        RowDataToAvroConverters.createConverter(debeziumAvroRowType, false));
+                        RowDataToAvroConverters.createConverter(debeziumAvroRowType));
     }
 
     @VisibleForTesting

--- a/flink-formats/flink-avro-confluent-registry/src/test/java/org/apache/flink/formats/avro/registry/confluent/debezium/DebeziumAvroFormatFactoryTest.java
+++ b/flink-formats/flink-avro-confluent-registry/src/test/java/org/apache/flink/formats/avro/registry/confluent/debezium/DebeziumAvroFormatFactoryTest.java
@@ -43,7 +43,6 @@ import java.util.Map;
 import static org.apache.flink.table.factories.utils.FactoryMocks.createTableSink;
 import static org.apache.flink.table.factories.utils.FactoryMocks.createTableSource;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /** Tests for {@link DebeziumAvroFormatFactory}. */
@@ -162,13 +161,13 @@ class DebeziumAvroFormatFactoryTest {
                         AVRO_SCHEMA,
                         registryConfigs);
         DeserializationSchema<RowData> actualDeser = createDeserializationSchema(options);
-        assertEquals(expectedDeser, actualDeser);
+        assertThat(actualDeser).isEqualTo(expectedDeser);
 
         DebeziumAvroSerializationSchema expectedSer =
                 new DebeziumAvroSerializationSchema(
                         ROW_TYPE, REGISTRY_URL, SUBJECT, AVRO_SCHEMA, registryConfigs);
         SerializationSchema<RowData> actualSer = createSerializationSchema(options);
-        assertEquals(expectedSer, actualSer);
+        assertThat(actualSer).isEqualTo(expectedSer);
     }
 
     @Test

--- a/flink-formats/flink-avro-confluent-registry/src/test/java/org/apache/flink/formats/avro/registry/confluent/debezium/DebeziumAvroFormatFactoryTest.java
+++ b/flink-formats/flink-avro-confluent-registry/src/test/java/org/apache/flink/formats/avro/registry/confluent/debezium/DebeziumAvroFormatFactoryTest.java
@@ -36,6 +36,7 @@ import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nonnull;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -129,19 +130,20 @@ class DebeziumAvroFormatFactoryTest {
 
         DebeziumAvroDeserializationSchema expectedDeser =
                 new DebeziumAvroDeserializationSchema(
-                        ROW_TYPE,
+                        SCHEMA.toPhysicalRowDataType(),
+                        Collections.emptyList(),
                         InternalTypeInfo.of(ROW_TYPE),
                         REGISTRY_URL,
                         null,
                         registryConfigs);
         DeserializationSchema<RowData> actualDeser = createDeserializationSchema(options);
-        assertEquals(expectedDeser, actualDeser);
+        assertThat(actualDeser).isEqualTo(expectedDeser);
 
         DebeziumAvroSerializationSchema expectedSer =
                 new DebeziumAvroSerializationSchema(
                         ROW_TYPE, REGISTRY_URL, SUBJECT, null, registryConfigs);
         SerializationSchema<RowData> actualSer = createSerializationSchema(options);
-        assertEquals(expectedSer, actualSer);
+        assertThat(actualSer).isEqualTo(expectedSer);
     }
 
     @Test
@@ -153,19 +155,20 @@ class DebeziumAvroFormatFactoryTest {
 
         DebeziumAvroDeserializationSchema expectedDeser =
                 new DebeziumAvroDeserializationSchema(
-                        ROW_TYPE,
+                        SCHEMA.toPhysicalRowDataType(),
+                        Collections.emptyList(),
                         InternalTypeInfo.of(ROW_TYPE),
                         REGISTRY_URL,
                         AVRO_SCHEMA,
                         registryConfigs);
         DeserializationSchema<RowData> actualDeser = createDeserializationSchema(options);
-        assertThat(actualDeser).isEqualTo(expectedDeser);
+        assertEquals(expectedDeser, actualDeser);
 
         DebeziumAvroSerializationSchema expectedSer =
                 new DebeziumAvroSerializationSchema(
                         ROW_TYPE, REGISTRY_URL, SUBJECT, AVRO_SCHEMA, registryConfigs);
         SerializationSchema<RowData> actualSer = createSerializationSchema(options);
-        assertThat(actualSer).isEqualTo(expectedSer);
+        assertEquals(expectedSer, actualSer);
     }
 
     @Test

--- a/flink-formats/flink-avro-confluent-registry/src/test/java/org/apache/flink/formats/avro/registry/confluent/debezium/DebeziumAvroSerDeSchemaTest.java
+++ b/flink-formats/flink-avro-confluent-registry/src/test/java/org/apache/flink/formats/avro/registry/confluent/debezium/DebeziumAvroSerDeSchemaTest.java
@@ -27,14 +27,18 @@ import org.apache.flink.formats.avro.RegistryAvroDeserializationSchema;
 import org.apache.flink.formats.avro.RegistryAvroSerializationSchema;
 import org.apache.flink.formats.avro.RowDataToAvroConverters;
 import org.apache.flink.formats.avro.registry.confluent.ConfluentSchemaRegistryCoder;
+import org.apache.flink.formats.avro.registry.confluent.debezium.DebeziumAvroDecodingFormat.ReadableMetadata;
 import org.apache.flink.formats.avro.typeutils.AvroSchemaConverter;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
+import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
+import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.types.utils.DataTypeUtils;
 import org.apache.flink.util.Collector;
 import org.apache.flink.util.FileUtils;
 import org.apache.flink.util.SimpleUserCodeClassLoader;
@@ -54,6 +58,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 import static org.apache.flink.table.api.DataTypes.BIGINT;
@@ -88,7 +93,7 @@ class DebeziumAvroSerDeSchemaTest {
 
         RowType rowTypeDe =
                 DebeziumAvroDeserializationSchema.createDebeziumAvroRowType(
-                        fromLogicalToDataType(rowType));
+                        fromLogicalToDataType(rowType), Collections.emptyList());
         RowType rowTypeSe =
                 DebeziumAvroSerializationSchema.createDebeziumAvroRowType(
                         fromLogicalToDataType(rowType));
@@ -146,10 +151,42 @@ class DebeziumAvroSerDeSchemaTest {
         assertThat(actual).isEqualTo(expected);
     }
 
+    @Test
+    void testDeserializationWithMetadata() throws Exception {
+        testDeserializationWithMetadata(
+                "debezium-avro-insert.avro",
+                row -> {
+                    // Physical columns
+                    assertThat(row.getLong(0)).isEqualTo(1L);
+                    assertThat(row.getString(1).toString()).isEqualTo("lisi");
+                    assertThat(row.getString(2).toString()).isEqualTo("test debezium avro data");
+                    assertThat(row.getDouble(3)).isEqualTo(21.799999237060547);
+
+                    // Metadata: ingestion-timestamp (field index 4)
+                    assertThat(row.getTimestamp(4, 3)).isNotNull();
+
+                    // Metadata: source.timestamp (field index 5)
+                    assertThat(row.getTimestamp(5, 3)).isNotNull();
+
+                    // Metadata: source.database (field index 6)
+                    assertThat(row.getString(6).toString()).isEqualTo("test1");
+
+                    // Metadata: source.schema (field index 7) - may be null for MySQL
+                    // MySQL doesn't have schema field in source
+
+                    // Metadata: source.table (field index 8)
+                    assertThat(row.getString(8).toString()).isEqualTo("person");
+
+                    // Metadata: source.properties (field index 9)
+                    assertThat(row.getMap(9)).isNotNull();
+                    assertThat(row.getMap(9).size()).isGreaterThan(0);
+                });
+    }
+
     public List<String> testDeserialization(String dataPath) throws Exception {
         RowType rowTypeDe =
                 DebeziumAvroDeserializationSchema.createDebeziumAvroRowType(
-                        fromLogicalToDataType(rowType));
+                        fromLogicalToDataType(rowType), Collections.emptyList());
 
         client.register(SUBJECT, DEBEZIUM_SCHEMA_COMPATIBLE_TEST, 1, 81);
 
@@ -162,6 +199,36 @@ class DebeziumAvroSerDeSchemaTest {
         dbzDeserializer.deserialize(readBytesFromFile(dataPath), collector);
 
         return collector.list.stream().map(Object::toString).collect(Collectors.toList());
+    }
+
+    private void testDeserializationWithMetadata(String dataPath, Consumer<RowData> testConsumer)
+            throws Exception {
+        final List<ReadableMetadata> requestedMetadata = Arrays.asList(ReadableMetadata.values());
+
+        final DataType producedDataType =
+                DataTypeUtils.appendRowFields(
+                        fromLogicalToDataType(rowType),
+                        requestedMetadata.stream()
+                                .map(m -> DataTypes.FIELD(m.key, m.dataType))
+                                .collect(Collectors.toList()));
+
+        RowType rowTypeDe =
+                DebeziumAvroDeserializationSchema.createDebeziumAvroRowType(
+                        fromLogicalToDataType(rowType), requestedMetadata);
+
+        client.register(SUBJECT, DEBEZIUM_SCHEMA_COMPATIBLE_TEST, 1, 81);
+
+        DebeziumAvroDeserializationSchema dbzDeserializer =
+                new DebeziumAvroDeserializationSchema(
+                        InternalTypeInfo.of(producedDataType.getLogicalType()),
+                        getDeserializationSchema(rowTypeDe));
+        dbzDeserializer.open(new MockInitializationContext());
+
+        SimpleCollector collector = new SimpleCollector();
+        dbzDeserializer.deserialize(readBytesFromFile(dataPath), collector);
+
+        assertThat(collector.list).hasSize(1);
+        assertThat(collector.list.get(0)).satisfies(testConsumer);
     }
 
     private AvroRowDataDeserializationSchema getDeserializationSchema(RowType rowType) {

--- a/flink-formats/flink-avro-confluent-registry/src/test/java/org/apache/flink/formats/avro/registry/confluent/debezium/DebeziumAvroSerDeSchemaTest.java
+++ b/flink-formats/flink-avro-confluent-registry/src/test/java/org/apache/flink/formats/avro/registry/confluent/debezium/DebeziumAvroSerDeSchemaTest.java
@@ -59,9 +59,7 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
@@ -171,22 +169,6 @@ class DebeziumAvroSerDeSchemaTest {
         dbzDeserializer.deserialize(null, collector);
         dbzDeserializer.deserialize(new byte[] {}, collector);
         assertThat(collector.list).isEmpty();
-    }
-
-    @Test
-    void testMapHelperMethods() {
-        Map<StringData, StringData> testMap = new HashMap<>();
-        testMap.put(StringData.fromString("db"), StringData.fromString("inventory"));
-        testMap.put(StringData.fromString("table"), StringData.fromString("customers"));
-        MapData mapData = new GenericMapData(testMap);
-
-        // Test getMapValue
-        assertThat(getMapValue(mapData, "db")).isEqualTo("inventory");
-        assertThat(getMapValue(mapData, "table")).isEqualTo("customers");
-        assertThat(getMapValue(mapData, "nonexistent")).isNull();
-
-        // Test null map
-        assertThat(getMapValue(null, "db")).isNull();
     }
 
     @Test

--- a/flink-formats/flink-avro-confluent-registry/src/test/java/org/apache/flink/formats/avro/registry/confluent/debezium/DebeziumAvroSerDeSchemaTest.java
+++ b/flink-formats/flink-avro-confluent-registry/src/test/java/org/apache/flink/formats/avro/registry/confluent/debezium/DebeziumAvroSerDeSchemaTest.java
@@ -341,8 +341,8 @@ class DebeziumAvroSerDeSchemaTest {
                         true,
                         metadataConverters,
                         sourceFieldPosition,
-                        DEBEZIUM_SCHEMA_COMPATIBLE_TEST,
                         () -> registryCoder);
+
         dbzDeserializer.open(new MockInitializationContext());
 
         SimpleCollector collector = new SimpleCollector();

--- a/flink-formats/flink-avro-confluent-registry/src/test/java/org/apache/flink/formats/avro/registry/confluent/debezium/DebeziumAvroSerDeSchemaTest.java
+++ b/flink-formats/flink-avro-confluent-registry/src/test/java/org/apache/flink/formats/avro/registry/confluent/debezium/DebeziumAvroSerDeSchemaTest.java
@@ -32,7 +32,9 @@ import org.apache.flink.formats.avro.typeutils.AvroSchemaConverter;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
 import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.data.GenericMapData;
 import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.MapData;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
@@ -57,7 +59,9 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
@@ -152,34 +156,92 @@ class DebeziumAvroSerDeSchemaTest {
     }
 
     @Test
+    void testTombstoneMessages() throws Exception {
+        RowType rowTypeDe =
+                DebeziumAvroDeserializationSchema.createDebeziumAvroRowType(
+                        fromLogicalToDataType(rowType), Collections.emptyList());
+        client.register(SUBJECT, DEBEZIUM_SCHEMA_COMPATIBLE_TEST, 1, 81);
+
+        DebeziumAvroDeserializationSchema dbzDeserializer =
+                new DebeziumAvroDeserializationSchema(
+                        InternalTypeInfo.of(rowType), getDeserializationSchema(rowTypeDe));
+        dbzDeserializer.open(new MockInitializationContext());
+
+        SimpleCollector collector = new SimpleCollector();
+        dbzDeserializer.deserialize(null, collector);
+        dbzDeserializer.deserialize(new byte[] {}, collector);
+        assertThat(collector.list).isEmpty();
+    }
+
+    @Test
+    void testMapHelperMethods() {
+        Map<StringData, StringData> testMap = new HashMap<>();
+        testMap.put(StringData.fromString("db"), StringData.fromString("inventory"));
+        testMap.put(StringData.fromString("table"), StringData.fromString("customers"));
+        MapData mapData = new GenericMapData(testMap);
+
+        // Test getMapValue
+        assertThat(getMapValue(mapData, "db")).isEqualTo("inventory");
+        assertThat(getMapValue(mapData, "table")).isEqualTo("customers");
+        assertThat(getMapValue(mapData, "nonexistent")).isNull();
+
+        // Test null map
+        assertThat(getMapValue(null, "db")).isNull();
+    }
+
+    @Test
     void testDeserializationWithMetadata() throws Exception {
         testDeserializationWithMetadata(
                 "debezium-avro-insert.avro",
                 row -> {
-                    // Physical columns
+                    // Physical columns (0-3): id, name, description, weight
                     assertThat(row.getLong(0)).isEqualTo(1L);
                     assertThat(row.getString(1).toString()).isEqualTo("lisi");
                     assertThat(row.getString(2).toString()).isEqualTo("test debezium avro data");
                     assertThat(row.getDouble(3)).isEqualTo(21.799999237060547);
 
-                    // Metadata: ingestion-timestamp (field index 4)
-                    assertThat(row.getTimestamp(4, 3)).isNotNull();
+                    // Metadata columns (4-9)
+                    // 4: ingestion-timestamp (envelope ts_ms = 1599207472705);
+                    assertThat(row.getTimestamp(4, 3).getMillisecond()).isEqualTo(1599207472705L);
 
-                    // Metadata: source.timestamp (field index 5)
-                    assertThat(row.getTimestamp(5, 3)).isNotNull();
+                    // 5: source.timestamp (source ts_ms = 1599207472000)
+                    assertThat(row.getTimestamp(5, 3).getMillisecond()).isEqualTo(1599207472000L);
 
-                    // Metadata: source.database (field index 6)
+                    // 6: source.database
                     assertThat(row.getString(6).toString()).isEqualTo("test1");
 
-                    // Metadata: source.schema (field index 7) - may be null for MySQL
-                    // MySQL doesn't have schema field in source
+                    // 7: source.schema (Mysql doesn't use schema field)
+                    assertThat(row.isNullAt(7)).isTrue();
 
-                    // Metadata: source.table (field index 8)
+                    // 8. source.table
                     assertThat(row.getString(8).toString()).isEqualTo("person");
 
-                    // Metadata: source.properties (field index 9)
-                    assertThat(row.getMap(9)).isNotNull();
-                    assertThat(row.getMap(9).size()).isGreaterThan(0);
+                    // 9. source.properties (MAP with all source fields)
+                    MapData sourceMap = row.getMap(9);
+                    assertThat(sourceMap).isNotNull();
+
+                    // Mysql source has 14 fields
+                    assertThat(sourceMap.size()).isEqualTo(14);
+
+                    // Verify common fields (all Debezium connectors) with exact values
+                    assertThat(getMapValue(sourceMap, "version")).isEqualTo("1.2.2.Final");
+                    assertThat(getMapValue(sourceMap, "connector")).isEqualTo("mysql");
+                    assertThat(getMapValue(sourceMap, "name")).isEqualTo("fullfillment");
+                    assertThat(getMapValue(sourceMap, "ts_ms")).isEqualTo("1599207472000");
+                    assertThat(getMapValue(sourceMap, "snapshot")).isEqualTo("false");
+                    assertThat(getMapValue(sourceMap, "db")).isEqualTo("test1");
+                    assertThat(getMapValue(sourceMap, "table")).isEqualTo("person");
+
+                    // Verify MySQL-specific fields with exact values (writer schema intact)
+                    assertThat(getMapValue(sourceMap, "server_id")).isEqualTo("1");
+                    assertThat(getMapValue(sourceMap, "file")).isEqualTo("mysql-bin.000005");
+                    assertThat(getMapValue(sourceMap, "pos")).isEqualTo("213795");
+                    assertThat(getMapValue(sourceMap, "row")).isEqualTo("0");
+                    assertThat(getMapValue(sourceMap, "thread")).isEqualTo("2");
+
+                    // Verify nullable MySQL fields (null values in this test data)
+                    assertThat(getMapValue(sourceMap, "gtid")).isNull();
+                    assertThat(getMapValue(sourceMap, "query")).isNull();
                 });
     }
 
@@ -218,10 +280,24 @@ class DebeziumAvroSerDeSchemaTest {
 
         client.register(SUBJECT, DEBEZIUM_SCHEMA_COMPATIBLE_TEST, 1, 81);
 
+        ConfluentSchemaRegistryCoder registryCoder =
+                new ConfluentSchemaRegistryCoder(SUBJECT, client);
+
+        RegistryAvroDeserializationSchema<GenericRecord> genericDeserializer =
+                new RegistryAvroDeserializationSchema<>(
+                        GenericRecord.class, DEBEZIUM_SCHEMA_COMPATIBLE_TEST, () -> registryCoder);
+        genericDeserializer.open(new MockInitializationContext());
+
+        DebeziumAvroDeserializationSchema.MetadataConverter[] metadataConverters =
+                createMetadataConverters(rowTypeDe, requestedMetadata);
+
         DebeziumAvroDeserializationSchema dbzDeserializer =
                 new DebeziumAvroDeserializationSchema(
                         InternalTypeInfo.of(producedDataType.getLogicalType()),
-                        getDeserializationSchema(rowTypeDe));
+                        getDeserializationSchema(rowTypeDe),
+                        true,
+                        metadataConverters,
+                        genericDeserializer);
         dbzDeserializer.open(new MockInitializationContext());
 
         SimpleCollector collector = new SimpleCollector();
@@ -253,9 +329,24 @@ class DebeziumAvroSerDeSchemaTest {
                 rowType,
                 new RegistryAvroSerializationSchema<>(
                         GenericRecord.class,
-                        AvroSchemaConverter.convertToSchema(rowType),
+                        AvroSchemaConverter.convertToSchema(rowType, false),
                         () -> registryCoder),
-                RowDataToAvroConverters.createConverter(rowType));
+                RowDataToAvroConverters.createConverter(rowType, false));
+    }
+
+    private static DebeziumAvroDeserializationSchema.MetadataConverter[] createMetadataConverters(
+            RowType debeziumAvroRowType, List<ReadableMetadata> requestedMetadata) {
+        return requestedMetadata.stream()
+                .map(
+                        m -> {
+                            final int rootPosition =
+                                    debeziumAvroRowType
+                                            .getFieldNames()
+                                            .indexOf(m.requiredAvroField.getName());
+                            return (DebeziumAvroDeserializationSchema.MetadataConverter)
+                                    (row, pos) -> m.converter.convert(row, rootPosition);
+                        })
+                .toArray(DebeziumAvroDeserializationSchema.MetadataConverter[]::new);
     }
 
     private static RowData debeziumRow2RowData() {
@@ -276,6 +367,15 @@ class DebeziumAvroSerDeSchemaTest {
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    private static String getMapValue(MapData map, String key) {
+        if (map == null) {
+            return null;
+        }
+        GenericMapData genericMap = (GenericMapData) map;
+        StringData value = (StringData) genericMap.get(StringData.fromString(key));
+        return value != null ? value.toString() : null;
     }
 
     private static class SimpleCollector implements Collector<RowData> {

--- a/flink-formats/flink-avro-confluent-registry/src/test/java/org/apache/flink/formats/avro/registry/confluent/debezium/DebeziumAvroSerDeSchemaTest.java
+++ b/flink-formats/flink-avro-confluent-registry/src/test/java/org/apache/flink/formats/avro/registry/confluent/debezium/DebeziumAvroSerDeSchemaTest.java
@@ -245,6 +245,45 @@ class DebeziumAvroSerDeSchemaTest {
                 });
     }
 
+    @Test
+    void testDeserializationWithMetadata_SourceDatabaseOnly() throws Exception {
+        testDeserializationWithMetadata(
+                "debezium-avro-insert.avro",
+                Collections.singletonList(ReadableMetadata.SOURCE_DATABASE),
+                row -> {
+                    assertThat(row.getLong(0)).isEqualTo(1L);
+                    assertThat(row.getString(4).toString()).isEqualTo("test1");
+                });
+    }
+
+    @Test
+    void testDeserializationWithMetadata_SourcePropertiesOnly() throws Exception {
+        testDeserializationWithMetadata(
+                "debezium-avro-insert.avro",
+                Collections.singletonList(ReadableMetadata.SOURCE_PROPERTIES),
+                row -> {
+                    MapData sourceMap = row.getMap(4);
+                    assertThat(sourceMap).isNotNull();
+                    assertThat(getMapValue(sourceMap, "db")).isEqualTo("test1");
+                    assertThat(getMapValue(sourceMap, "table")).isEqualTo("person");
+                });
+    }
+
+    @Test
+    void testDeserializationWithMetadata_MixedOrder() throws Exception {
+        testDeserializationWithMetadata(
+                "debezium-avro-insert.avro",
+                Arrays.asList(
+                        ReadableMetadata.SOURCE_TABLE,
+                        ReadableMetadata.INGESTION_TIMESTAMP,
+                        ReadableMetadata.SOURCE_DATABASE),
+                row -> {
+                    assertThat(row.getString(4).toString()).isEqualTo("person");
+                    assertThat(row.getTimestamp(5, 3).getMillisecond()).isEqualTo(1599207472705L);
+                    assertThat(row.getString(6).toString()).isEqualTo("test1");
+                });
+    }
+
     public List<String> testDeserialization(String dataPath) throws Exception {
         RowType rowTypeDe =
                 DebeziumAvroDeserializationSchema.createDebeziumAvroRowType(
@@ -265,8 +304,15 @@ class DebeziumAvroSerDeSchemaTest {
 
     private void testDeserializationWithMetadata(String dataPath, Consumer<RowData> testConsumer)
             throws Exception {
-        final List<ReadableMetadata> requestedMetadata = Arrays.asList(ReadableMetadata.values());
+        testDeserializationWithMetadata(
+                dataPath, Arrays.asList(ReadableMetadata.values()), testConsumer);
+    }
 
+    private void testDeserializationWithMetadata(
+            String dataPath,
+            List<ReadableMetadata> requestedMetadata,
+            Consumer<RowData> testConsumer)
+            throws Exception {
         final DataType producedDataType =
                 DataTypeUtils.appendRowFields(
                         fromLogicalToDataType(rowType),
@@ -283,13 +329,10 @@ class DebeziumAvroSerDeSchemaTest {
         ConfluentSchemaRegistryCoder registryCoder =
                 new ConfluentSchemaRegistryCoder(SUBJECT, client);
 
-        RegistryAvroDeserializationSchema<GenericRecord> genericDeserializer =
-                new RegistryAvroDeserializationSchema<>(
-                        GenericRecord.class, DEBEZIUM_SCHEMA_COMPATIBLE_TEST, () -> registryCoder);
-        genericDeserializer.open(new MockInitializationContext());
-
         DebeziumAvroDeserializationSchema.MetadataConverter[] metadataConverters =
                 createMetadataConverters(rowTypeDe, requestedMetadata);
+
+        int sourceFieldPosition = rowTypeDe.getFieldNames().indexOf("source");
 
         DebeziumAvroDeserializationSchema dbzDeserializer =
                 new DebeziumAvroDeserializationSchema(
@@ -297,7 +340,9 @@ class DebeziumAvroSerDeSchemaTest {
                         getDeserializationSchema(rowTypeDe),
                         true,
                         metadataConverters,
-                        genericDeserializer);
+                        sourceFieldPosition,
+                        DEBEZIUM_SCHEMA_COMPATIBLE_TEST,
+                        () -> registryCoder);
         dbzDeserializer.open(new MockInitializationContext());
 
         SimpleCollector collector = new SimpleCollector();


### PR DESCRIPTION
## What is the purpose of the change

This pull request implements metadata reading support for the `debezium-avro-confluent` format, bringing feature parity with the `debezium-json` format. Users can now access Debezium metadata fields when using Avro-encoded Debezium messages from Kafka.

JIRA: [FLINK-20454](https://issues.apache.org/jira/browse/FLINK-20454)

## Brief change log

- Add `DebeziumAvroDecodingFormat` implementing `ProjectableDecodingFormat` with metadata support
- Implement metadata fields:
  - `ingestion-timestamp`, `source.timestamp`, `source.database`, `source.schema`, `source.table`
  -  `source.properties` (MAP<STRING, STRING>) - dynamically preserves all connector-specific fields
- Runtime conversion from Avro `GenericRecord` to `MapData` for connector-agnostic support
- Add metadata deserialization tests
- Update documentation with Avro format examples


## Verifying this change

This change added tests and can be verified as follows:

- Added `DebeziumAvroSerDeSchemaTest.testDeserializationWithMetadata()` validating all metadata fields
- Updated `DebeziumAvroFormatFactoryTest` to verify the factory creates schemas with metadata support


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): yes (adds metadata extraction in deser path, but only when metadata columns are explicitly requested)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? docs

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change the checkbox below to `[X]` followed by the name of the tool, and uncomment the
"Generated-by" line. See the ASF Generative Tooling Guidance for details:
https://www.apache.org/legal/generative-tooling.html

You are responsible for the quality and correctness of every change in this PR
regardless of the tooling used. Low-effort AI-generated PRs will be closed. See
AGENTS.md for the full guidance.
-->

- [x] Yes (please specify the tool below)

Generated-by: Claude Sonnect 4.5