### PR TITLE
[FLINK-39978][runtime-web] Restyle Cancel Job/Application action as a danger button

### DIFF
--- a/flink-runtime-web/web-dashboard/src/app/pages/application/application-detail/status/application-status.component.html
+++ b/flink-runtime-web/web-dashboard/src/app/pages/application/application-detail/status/application-status.component.html
@@ -20,7 +20,10 @@
   <div class="operate-action">
     <span *ngIf="statusTips">{{ statusTips }}</span>
     <ng-container *ngIf="!statusTips">
-      <a
+      <button
+        nz-button
+        nzDanger
+        nzSize="small"
         nz-popconfirm
         nzPopconfirmTitle="Cancel Application?"
         nzOkText="Yes"
@@ -32,7 +35,7 @@
         "
       >
         Cancel Application
-      </a>
+      </button>
     </ng-container>
   </div>
 </ng-template>

--- a/flink-runtime-web/web-dashboard/src/app/pages/application/application-detail/status/application-status.component.less
+++ b/flink-runtime-web/web-dashboard/src/app/pages/application/application-detail/status/application-status.component.less
@@ -31,7 +31,18 @@
   }
 
   .operate-action {
-    font-size: 24px;
+    font-size: @font-size-base;
+
+    button {
+      transition: all 0.3s ease;
+
+      &:hover {
+        border-color: @error-color;
+        background-color: @error-color;
+        color: #fff;
+        box-shadow: 0 2px 6px fade(@error-color, 30%);
+      }
+    }
   }
 
   .status-wrapper {

--- a/flink-runtime-web/web-dashboard/src/app/pages/application/application-detail/status/application-status.component.ts
+++ b/flink-runtime-web/web-dashboard/src/app/pages/application/application-detail/status/application-status.component.ts
@@ -35,6 +35,7 @@ import {
   ApplicationModuleConfig
 } from '@flink-runtime-web/pages/application/application.config';
 import { ApplicationService, StatusService } from '@flink-runtime-web/services';
+import { NzButtonModule } from 'ng-zorro-antd/button';
 import { NzDescriptionsModule } from 'ng-zorro-antd/descriptions';
 import { NzDividerModule } from 'ng-zorro-antd/divider';
 import { NzPopconfirmModule } from 'ng-zorro-antd/popconfirm';
@@ -47,6 +48,7 @@ import { NzSkeletonModule } from 'ng-zorro-antd/skeleton';
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
     NgIf,
+    NzButtonModule,
     NzPopconfirmModule,
     NzDescriptionsModule,
     NzDividerModule,

--- a/flink-runtime-web/web-dashboard/src/app/pages/job/job-detail/status/job-status.component.html
+++ b/flink-runtime-web/web-dashboard/src/app/pages/job/job-detail/status/job-status.component.html
@@ -29,7 +29,10 @@
   <div class="operate-action">
     <span *ngIf="statusTips">{{ statusTips }}</span>
     <ng-container *ngIf="!statusTips">
-      <a
+      <button
+        nz-button
+        nzDanger
+        nzSize="small"
         nz-popconfirm
         nzPopconfirmTitle="Cancel Job?"
         nzOkText="Yes"
@@ -43,7 +46,7 @@
         "
       >
         Cancel Job
-      </a>
+      </button>
     </ng-container>
   </div>
 </ng-template>

--- a/flink-runtime-web/web-dashboard/src/app/pages/job/job-detail/status/job-status.component.less
+++ b/flink-runtime-web/web-dashboard/src/app/pages/job/job-detail/status/job-status.component.less
@@ -31,7 +31,18 @@
   }
 
   .operate-action {
-    font-size: 24px;
+    font-size: @font-size-base;
+
+    button {
+      transition: all 0.3s ease;
+
+      &:hover {
+        border-color: @error-color;
+        background-color: @error-color;
+        color: #fff;
+        box-shadow: 0 2px 6px fade(@error-color, 30%);
+      }
+    }
   }
 
   .status-wrapper {

--- a/flink-runtime-web/web-dashboard/src/app/pages/job/job-detail/status/job-status.component.ts
+++ b/flink-runtime-web/web-dashboard/src/app/pages/job/job-detail/status/job-status.component.ts
@@ -31,6 +31,7 @@ import { JobDetailCorrect } from '@flink-runtime-web/interfaces';
 import { JobLocalService } from '@flink-runtime-web/pages/job/job-local.service';
 import { JOB_MODULE_CONFIG, JOB_MODULE_DEFAULT_CONFIG, JobModuleConfig } from '@flink-runtime-web/pages/job/job.config';
 import { JobManagerService, JobService, StatusService } from '@flink-runtime-web/services';
+import { NzButtonModule } from 'ng-zorro-antd/button';
 import { NzDescriptionsModule } from 'ng-zorro-antd/descriptions';
 import { NzDividerModule } from 'ng-zorro-antd/divider';
 import { NzPopconfirmModule } from 'ng-zorro-antd/popconfirm';
@@ -43,6 +44,7 @@ import { NzSkeletonModule } from 'ng-zorro-antd/skeleton';
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
     NgIf,
+    NzButtonModule,
     NzPopconfirmModule,
     NzDescriptionsModule,
     NzDividerModule,


### PR DESCRIPTION
## What is the purpose of the change

The **Cancel** action on the Job and Application detail pages renders as an oversized 24px blue text link. That's inconsistent with the sibling action links (e.g. "Job Manager Log") and doesn't visually signal that it is a destructive action. This restyles it as a small danger button.

## Brief change log

- Render the *Cancel Job* / *Cancel Application* action as an ng-zorro `nz-button nzDanger nzSize="small"` instead of a 24px `<a>` text link
- Smooth fill-on-hover (danger red, white text) transition
- No behaviour change — the confirmation dialog and cancel logic are untouched

**Before:**
<img width="1449" height="209" alt="image" src="https://github.com/user-attachments/assets/106587ff-163a-4006-b58b-f24c09f87437" />
<img width="1459" height="212" alt="image (1)" src="https://github.com/user-attachments/assets/10785a9e-c145-4456-94ce-bde4f5933e4d" />

**After:**
<img width="1455" height="200" alt="image" src="https://github.com/user-attachments/assets/1adbb58d-b461-4cc3-ba74-9b972f50cdfa" />
<img width="1455" height="200" alt="image" src="https://github.com/user-attachments/assets/7b00caf9-597b-41b5-980b-ece1c9695f09" />

## Verifying this change

Frontend-only styling change, verified manually: open a running job's (and a running application's) detail page and confirm the Cancel action renders as a small red danger button that fills on hover, and that the confirmation dialog and cancellation still work.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (Claude Code)
