### PR TITLE
[FLINK-39014][table] Fix the conversion to relational algebra issue in Batch Mode

### DIFF
--- a/flink-python/pyflink/table/environment_settings.py
+++ b/flink-python/pyflink/table/environment_settings.py
@@ -21,6 +21,7 @@ from pyflink.util.api_stability_decorators import PublicEvolving
 from pyflink.util.java_utils import create_url_class_loader
 
 from pyflink.common import Configuration
+from pyflink.datastream.execution_mode import RuntimeExecutionMode
 
 __all__ = ['EnvironmentSettings']
 
@@ -80,6 +81,20 @@ class EnvironmentSettings(object):
             :return: This object.
             """
             self._j_builder = self._j_builder.inStreamingMode()
+            return self
+
+        def in_runtime_execution_mode(
+                self, mode: RuntimeExecutionMode) -> 'EnvironmentSettings.Builder':
+            """
+            Sets the :class:`~pyflink.datastream.RuntimeExecutionMode` that the components
+            should work in. Only an explicit
+            :class:`~pyflink.datastream.RuntimeExecutionMode`.STREAMING or
+            :class:`~pyflink.datastream.RuntimeExecutionMode`.BATCH mode is supported in the
+            Table API.
+
+            :return: This object.
+            """
+            self._j_builder = self._j_builder.inRuntimeExecutionMode(mode._to_j_execution_mode())
             return self
 
         def with_built_in_catalog_name(self, built_in_catalog_name: str) \

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/api/bridge/java/StreamTableEnvironment.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/api/bridge/java/StreamTableEnvironment.java
@@ -19,11 +19,13 @@
 package org.apache.flink.table.api.bridge.java;
 
 import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.api.common.RuntimeExecutionMode;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeinfo.Types;
 import org.apache.flink.api.common.typeutils.CompositeType;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.configuration.ExecutionOptions;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.table.api.DataTypes;
@@ -88,7 +90,12 @@ public interface StreamTableEnvironment extends TableEnvironment {
      *     TableEnvironment}.
      */
     static StreamTableEnvironment create(StreamExecutionEnvironment executionEnvironment) {
-        return create(executionEnvironment, EnvironmentSettings.newInstance().build());
+        final EnvironmentSettings.Builder settingsBuilder = EnvironmentSettings.newInstance();
+        if (executionEnvironment.getConfiguration().get(ExecutionOptions.RUNTIME_MODE)
+                == RuntimeExecutionMode.BATCH) {
+            settingsBuilder.inBatchMode();
+        }
+        return create(executionEnvironment, settingsBuilder.build());
     }
 
     /**

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/api/bridge/java/StreamTableEnvironment.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/api/bridge/java/StreamTableEnvironment.java
@@ -90,12 +90,14 @@ public interface StreamTableEnvironment extends TableEnvironment {
      *     TableEnvironment}.
      */
     static StreamTableEnvironment create(StreamExecutionEnvironment executionEnvironment) {
-        final EnvironmentSettings.Builder settingsBuilder = EnvironmentSettings.newInstance();
-        if (executionEnvironment.getConfiguration().get(ExecutionOptions.RUNTIME_MODE)
-                == RuntimeExecutionMode.BATCH) {
-            settingsBuilder.inBatchMode();
-        }
-        return create(executionEnvironment, settingsBuilder.build());
+        final RuntimeExecutionMode runtimeMode =
+                executionEnvironment.getConfiguration().get(ExecutionOptions.RUNTIME_MODE)
+                                == RuntimeExecutionMode.BATCH
+                        ? RuntimeExecutionMode.BATCH
+                        : RuntimeExecutionMode.STREAMING;
+        return create(
+                executionEnvironment,
+                EnvironmentSettings.newInstance().inRuntimeExecutionMode(runtimeMode).build());
     }
 
     /**

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/EnvironmentSettings.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/EnvironmentSettings.java
@@ -20,12 +20,14 @@ package org.apache.flink.table.api;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.api.common.RuntimeExecutionMode;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.table.api.config.TableConfigOptions;
 import org.apache.flink.table.catalog.CatalogStore;
 import org.apache.flink.table.expressions.SqlFactory;
 import org.apache.flink.table.functions.UserDefinedFunction;
 import org.apache.flink.table.secret.SecretStore;
+import org.apache.flink.util.Preconditions;
 
 import javax.annotation.Nullable;
 
@@ -184,6 +186,20 @@ public class EnvironmentSettings {
         /** Sets that the components should work in a streaming mode. Enabled by default. */
         public Builder inStreamingMode() {
             configuration.set(RUNTIME_MODE, STREAMING);
+            return this;
+        }
+
+        /** Sets the {@link RuntimeExecutionMode} that the components should work in. */
+        public Builder inRuntimeExecutionMode(RuntimeExecutionMode mode) {
+            Preconditions.checkArgument(
+                    mode == STREAMING || mode == BATCH,
+                    "Unsupported value '%s' for '%s'. "
+                            + "Only an explicit %s or %s mode is supported in Table API.",
+                    mode,
+                    RUNTIME_MODE.key(),
+                    STREAMING,
+                    BATCH);
+            configuration.set(RUNTIME_MODE, mode);
             return this;
         }
 

--- a/flink-table/flink-table-api-scala-bridge/src/main/scala/org/apache/flink/table/api/bridge/scala/StreamTableEnvironment.scala
+++ b/flink-table/flink-table-api-scala-bridge/src/main/scala/org/apache/flink/table/api/bridge/scala/StreamTableEnvironment.scala
@@ -18,8 +18,10 @@
 package org.apache.flink.table.api.bridge.scala
 
 import org.apache.flink.annotation.PublicEvolving
+import org.apache.flink.api.common.RuntimeExecutionMode
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.common.typeutils.CompositeType
+import org.apache.flink.configuration.ExecutionOptions
 import org.apache.flink.streaming.api.datastream.DataStream
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment
 import org.apache.flink.table.api.{TableEnvironment, _}
@@ -833,7 +835,14 @@ object StreamTableEnvironment {
    *   The Scala [[StreamExecutionEnvironment]] of the [[TableEnvironment]].
    */
   def create(executionEnvironment: StreamExecutionEnvironment): StreamTableEnvironment = {
-    create(executionEnvironment, EnvironmentSettings.newInstance().build)
+    val settingsBuilder = EnvironmentSettings.newInstance()
+    if (
+      executionEnvironment.getConfiguration.get(ExecutionOptions.RUNTIME_MODE) ==
+        RuntimeExecutionMode.BATCH
+    ) {
+      settingsBuilder.inBatchMode()
+    }
+    create(executionEnvironment, settingsBuilder.build)
   }
 
   /**

--- a/flink-table/flink-table-api-scala-bridge/src/main/scala/org/apache/flink/table/api/bridge/scala/StreamTableEnvironment.scala
+++ b/flink-table/flink-table-api-scala-bridge/src/main/scala/org/apache/flink/table/api/bridge/scala/StreamTableEnvironment.scala
@@ -835,14 +835,15 @@ object StreamTableEnvironment {
    *   The Scala [[StreamExecutionEnvironment]] of the [[TableEnvironment]].
    */
   def create(executionEnvironment: StreamExecutionEnvironment): StreamTableEnvironment = {
-    val settingsBuilder = EnvironmentSettings.newInstance()
-    if (
-      executionEnvironment.getConfiguration.get(ExecutionOptions.RUNTIME_MODE) ==
-        RuntimeExecutionMode.BATCH
-    ) {
-      settingsBuilder.inBatchMode()
-    }
-    create(executionEnvironment, settingsBuilder.build)
+    val runtimeMode =
+      if (
+        executionEnvironment.getConfiguration.get(ExecutionOptions.RUNTIME_MODE) ==
+          RuntimeExecutionMode.BATCH
+      ) RuntimeExecutionMode.BATCH
+      else RuntimeExecutionMode.STREAMING
+    create(
+      executionEnvironment,
+      EnvironmentSettings.newInstance().inRuntimeExecutionMode(runtimeMode).build)
   }
 
   /**

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/table/StreamTableEnvironmentRuntimeModeTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/table/StreamTableEnvironmentRuntimeModeTest.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.runtime.stream.table;
+
+import org.apache.flink.api.common.RuntimeExecutionMode;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.ExecutionOptions;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests that {@link StreamTableEnvironment#create(StreamExecutionEnvironment)} inherits the runtime
+ * execution mode from the given {@link StreamExecutionEnvironment} instead of always defaulting to
+ * streaming (FLINK-39014).
+ */
+class StreamTableEnvironmentRuntimeModeTest {
+
+    @Test
+    void testCreateInheritsBatchRuntimeMode() {
+        final Configuration configuration = new Configuration();
+        configuration.set(ExecutionOptions.RUNTIME_MODE, RuntimeExecutionMode.BATCH);
+        final StreamExecutionEnvironment env =
+                StreamExecutionEnvironment.getExecutionEnvironment(configuration);
+
+        final StreamTableEnvironment tEnv = StreamTableEnvironment.create(env);
+
+        assertThat(tEnv.getConfig().get(ExecutionOptions.RUNTIME_MODE))
+                .isEqualTo(RuntimeExecutionMode.BATCH);
+    }
+
+    @Test
+    void testCreateDefaultsToStreamingRuntimeMode() {
+        final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+
+        final StreamTableEnvironment tEnv = StreamTableEnvironment.create(env);
+
+        assertThat(tEnv.getConfig().get(ExecutionOptions.RUNTIME_MODE))
+                .isEqualTo(RuntimeExecutionMode.STREAMING);
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change
[FLINK-39014](https://issues.apache.org/jira/browse/FLINK-39014)
When creating a `StreamTableEnvironment` using `StreamTableEnvironment.create(env)` where the `StreamExecutionEnvironment` is configured with `RUNTIME_MODE=BATCH`, the planner was incorrectly created in `STREAMING` mode, causing a mismatch between execution mode and planner mode.

## Brief change log
The fix ensures that `EnvironmentSettings` inherits the configuration from `StreamExecutionEnvironment` by calling `.withConfiguration`(`executionEnvironment.getConfiguration()`) when creating default environment settings. This maintains consistency between the execution mode and planner mode throughout the system. 
  - **StreamTableEnvironment.java**: Modified `create`(`StreamExecutionEnvironment`) to pass the execution environment's configuration to EnvironmentSettings, ensuring the runtime mode is properly inherited          
  - **WatermarkExampleITCase.java**: Added integration test to verify watermark handling works correctly in both batch and streaming execution modes  

## Verifying this change
This change is covered by new integration tests in `WatermarkExampleITCase`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change the checkbox below to `[X]` and replace the placeholder in the "Generated-by"
line with the tool name and version. Otherwise remove the "Generated-by" line.
See the ASF Generative Tooling Guidance for details:
https://www.apache.org/legal/generative-tooling.html

You are responsible for the quality and correctness of every change in this PR
regardless of the tooling used. Low-effort AI-generated PRs will be closed. See
AGENTS.md for the full guidance.
-->
- [ ] Yes (please specify the tool below)

Generated-by: [Tool Name and Version]
