### PR TITLE
[FLINK-39215] [python] Clean up PythonDriver tmp dir on launch failure

### DIFF
--- a/flink-python/src/main/java/org/apache/flink/client/python/PythonDriver.java
+++ b/flink-python/src/main/java/org/apache/flink/client/python/PythonDriver.java
@@ -22,6 +22,7 @@ import org.apache.flink.client.program.ProgramAbortException;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.entrypoint.parser.CommandLineParser;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.util.FileUtils;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -82,19 +83,21 @@ public final class PythonDriver {
         PythonEnvUtils.setGatewayServer(gatewayServer);
 
         PythonEnvUtils.PythonProcessShutdownHook shutdownHook = null;
+        Process pythonProcess = null;
+        String tmpDir = null;
 
         // commands which will be exec in python progress.
         final List<String> commands = constructPythonCommands(pythonDriverOptions);
         try {
             // prepare the exec environment of python progress.
-            String tmpDir =
+            tmpDir =
                     System.getProperty("java.io.tmpdir")
                             + File.separator
                             + "pyflink"
                             + File.separator
                             + UUID.randomUUID();
             // start the python process.
-            Process pythonProcess =
+            pythonProcess =
                     PythonEnvUtils.launchPy4jPythonClient(
                             gatewayServer,
                             config,
@@ -131,6 +134,19 @@ public final class PythonDriver {
             }
         } catch (Throwable e) {
             LOG.error("Run python process failed", e);
+
+            if (shutdownHook == null) {
+                if (pythonProcess != null) {
+                    new PythonEnvUtils.PythonProcessShutdownHook(
+                                    pythonProcess, gatewayServer, tmpDir)
+                            .run();
+                } else {
+                    if (tmpDir != null) {
+                        FileUtils.deleteDirectoryQuietly(new File(tmpDir));
+                    }
+                    gatewayServer.shutdown();
+                }
+            }
 
             if (PythonEnvUtils.capturedJavaException != null) {
                 throw PythonEnvUtils.capturedJavaException;

--- a/flink-python/src/test/java/org/apache/flink/client/python/PythonDriverTest.java
+++ b/flink-python/src/test/java/org/apache/flink/client/python/PythonDriverTest.java
@@ -18,18 +18,24 @@
 
 package org.apache.flink.client.python;
 
+import org.apache.flink.client.program.ProgramAbortException;
 import org.apache.flink.configuration.Configuration;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import py4j.GatewayServer;
 
 import java.io.IOException;
 import java.net.Socket;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
+import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Tests for the {@link PythonDriver}. */
 class PythonDriverTest {
@@ -43,6 +49,42 @@ class PythonDriverTest {
             throw new RuntimeException("Connect Gateway Server failed");
         } finally {
             gatewayServer.shutdown();
+        }
+    }
+
+    @Test
+    void testCleanupTmpDirWhenPythonClientLaunchFails(@TempDir Path tmpDir) throws IOException {
+        Path entryPointScript = tmpDir.resolve("entrypoint.py");
+        Files.write(entryPointScript, new byte[0]);
+        Path pyflinkTmpDir = tmpDir.resolve("pyflink");
+        String originalTmpDir = System.getProperty("java.io.tmpdir");
+
+        try {
+            System.setProperty("java.io.tmpdir", tmpDir.toString());
+
+            assertThatThrownBy(
+                            () ->
+                                    PythonDriver.main(
+                                            new String[] {
+                                                "-py",
+                                                entryPointScript.toString(),
+                                                "-pyclientexec",
+                                                tmpDir.resolve("missing-python-executable")
+                                                        .toString()
+                                            }))
+                    .isInstanceOf(ProgramAbortException.class);
+
+            if (Files.exists(pyflinkTmpDir)) {
+                try (Stream<Path> remainingTmpDirs = Files.list(pyflinkTmpDir)) {
+                    assertThat(remainingTmpDirs).isEmpty();
+                }
+            }
+        } finally {
+            if (originalTmpDir == null) {
+                System.clearProperty("java.io.tmpdir");
+            } else {
+                System.setProperty("java.io.tmpdir", originalTmpDir);
+            }
         }
     }
 


### PR DESCRIPTION
## What is the purpose of the change

This PR fixes FLINK-39215, where `PythonDriver` could leave behind a generated `pyflink/<uuid>` temporary directory if `PythonEnvUtils.launchPy4jPythonClient(...)` failed after preparing the Python environment but before returning the Python process.

Root cause: `PythonDriver` created the shutdown hook only after `launchPy4jPythonClient(...)` returned successfully. When `preparePythonEnvironment(...)` had already populated the temporary directory and `startPythonProcess(...)` then failed, no shutdown hook existed to clean up that directory.

## Brief change log

- Keep the generated `tmpDir` and Python process reference visible to the failure path in `PythonDriver`.
- Clean up the generated temporary directory and gateway when Python client launch fails before the normal shutdown hook is registered.
- Add a focused `PythonDriverTest` regression test that triggers a Python client launch failure with an invalid `-pyclientexec` and verifies that no per-run `pyflink` tmp directory remains.

## Verifying this change

This change added tests and can be verified as follows:

- Added `PythonDriverTest#testCleanupTmpDirWhenPythonClientLaunchFails`.
- Verified the new regression test failed before the production fix because a `pyflink/<uuid>` temporary directory was left behind.
- Verified the focused regression test after the fix:
  - `./mvnw -pl flink-python -Dtest=PythonDriverTest#testCleanupTmpDirWhenPythonClientLaunchFails test -DskipITs -Drat.skip=true -Dcheckstyle.skip=true`
- Verified the full `PythonDriverTest` class:
  - `./mvnw -pl flink-python -Dtest=PythonDriverTest test -DskipITs -Drat.skip=true -Dcheckstyle.skip=true`
- Verified related Python client process tests with a temporary `python -> python3` symlink because this environment does not provide a `python` command by default:
  - `./mvnw -pl flink-python -Dtest=PythonDriverTest,PythonEnvUtilsTest test -DskipITs -Drat.skip=true -Dcheckstyle.skip=true`
- Verified `git diff --check`.

## Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): no
- The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
- The serializers: no
- The runtime per-record code paths (performance sensitive): no
- Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
- The S3 file system connector: no

## Documentation

- Does this pull request introduce a new feature? no
- If yes, how is the feature documented? not applicable

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes: Hermes Agent (OpenAI GPT-5.5)

Generated-by: Hermes Agent (OpenAI GPT-5.5)
