### PR TITLE
[FLINK-39674][formats] Upgrade Confluent Schema Registry client

### DIFF
--- a/flink-formats/flink-avro-confluent-registry/pom.xml
+++ b/flink-formats/flink-avro-confluent-registry/pom.xml
@@ -32,7 +32,8 @@ under the License.
 	<name>Flink : Formats : Avro confluent registry</name>
 
 	<properties>
-		<confluent.version>7.5.3</confluent.version>
+		<confluent.version>7.9.8</confluent.version>
+		<kafka.compatibility.version>3.9.2</kafka.compatibility.version>
 	</properties>
 
 	<repositories>
@@ -161,6 +162,12 @@ under the License.
 			<version>${project.version}</version>
 			<scope>test</scope>
 			<type>test-jar</type>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.kafka</groupId>
+			<artifactId>kafka-clients</artifactId>
+			<version>${kafka.compatibility.version}</version>
+			<scope>test</scope>
 		</dependency>
 
 		<!-- ArchUnit test dependencies -->

--- a/flink-formats/flink-avro-confluent-registry/src/test/java/org/apache/flink/formats/avro/registry/confluent/CachedSchemaCoderProviderTest.java
+++ b/flink-formats/flink-avro-confluent-registry/src/test/java/org/apache/flink/formats/avro/registry/confluent/CachedSchemaCoderProviderTest.java
@@ -112,6 +112,21 @@ class CachedSchemaCoderProviderTest {
         assertThat(bearerAuthCredentialProvider.getBearerToken(null)).isEqualTo(token);
     }
 
+    @Test
+    void testThatOauthBearerAuthIsCompatibleWithKafkaClient39() {
+        Map<String, String> configs = new HashMap<>();
+        configs.put("bearer.auth.credentials.source", "OAUTHBEARER");
+        configs.put("bearer.auth.issuer.endpoint.url", "https://issuer.example/token");
+        configs.put("bearer.auth.client.id", "registry-api");
+        configs.put("bearer.auth.client.secret", "secret");
+
+        CachedSchemaCoderProvider provider = initCachedSchemaCoderProvider(configs);
+        BearerAuthCredentialProvider bearerAuthCredentialProvider =
+                getBearerAuthFromProvider(provider);
+
+        assertThat(bearerAuthCredentialProvider).isNotNull();
+    }
+
     private String getAbsolutePath(String path) throws URISyntaxException {
         return CachedSchemaCoderProviderTest.class.getResource(path).toURI().getPath();
     }

--- a/flink-formats/flink-sql-avro-confluent-registry/src/main/resources/META-INF/NOTICE
+++ b/flink-formats/flink-sql-avro-confluent-registry/src/main/resources/META-INF/NOTICE
@@ -9,6 +9,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - com.fasterxml.jackson.core:jackson-annotations:2.21
 - com.fasterxml.jackson.core:jackson-core:2.21.3
 - com.fasterxml.jackson.core:jackson-databind:2.21.3
+- com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.21.3
 - com.google.guava:guava:32.0.1-jre
 - commons-io:commons-io:2.15.1
 - io.confluent:common-utils:7.9.8
@@ -23,4 +24,4 @@ This project bundles the following dependencies under the Apache Software Licens
 This project bundles the following dependencies under the BSD license.
 See bundled license files for details.
 
-- com.github.luben:zstd-jni:1.5.5-1
+- com.github.luben:zstd-jni:1.5.6-4

--- a/flink-formats/flink-sql-avro-confluent-registry/src/main/resources/META-INF/NOTICE
+++ b/flink-formats/flink-sql-avro-confluent-registry/src/main/resources/META-INF/NOTICE
@@ -11,12 +11,12 @@ This project bundles the following dependencies under the Apache Software Licens
 - com.fasterxml.jackson.core:jackson-databind:2.21.3
 - com.google.guava:guava:32.0.1-jre
 - commons-io:commons-io:2.15.1
-- io.confluent:common-utils:7.5.3
-- io.confluent:kafka-schema-registry-client:7.5.3
+- io.confluent:common-utils:7.9.8
+- io.confluent:kafka-schema-registry-client:7.9.8
 - org.apache.avro:avro:1.11.5
 - org.apache.commons:commons-compress:1.26.0
 - org.apache.commons:commons-lang3:3.18.0
-- org.apache.kafka:kafka-clients:7.5.3-ccs
+- org.apache.kafka:kafka-clients:7.9.8-ccs
 - org.xerial.snappy:snappy-java:1.1.10.7
 - org.yaml:snakeyaml:2.3
 


### PR DESCRIPTION
## Summary

This PR updates `flink-avro-confluent-registry` to a newer Confluent Schema Registry client and adds a focused regression test for Kafka 3.9.x OAuth compatibility.

## Root Cause

`flink-avro-confluent-registry` still used `io.confluent:kafka-schema-registry-client:7.5.3`. With Kafka client 3.9.x on the classpath, the Schema Registry OAuth bearer path can fail during client initialization because Confluent 7.5.3 calls the old `HttpAccessTokenRetriever` constructor signature that is no longer present in Kafka 3.9.x.

## Changes

- Upgrade `io.confluent:kafka-schema-registry-client` from `7.5.3` to `7.9.8`.
- Add a test-scoped Kafka 3.9.2 dependency for compatibility validation.
- Add a focused regression test that initializes the Schema Registry OAuth bearer credential path with Kafka 3.9.2 on the test classpath.

## Validation

- Added RED regression coverage:
  - `./mvnw -pl flink-formats/flink-avro-confluent-registry -Dtest=CachedSchemaCoderProviderTest#testThatOauthBearerAuthIsCompatibleWithKafkaClient39 test -DskipITs -Drat.skip=true -Dcheckstyle.skip=true`
  - Fails before the dependency upgrade with `NoSuchMethodError` from `OauthCredentialProvider.getTokenRetriever(...)`.
- Verified GREEN after the upgrade:
  - `./mvnw -pl flink-formats/flink-avro-confluent-registry -Dtest=CachedSchemaCoderProviderTest#testThatOauthBearerAuthIsCompatibleWithKafkaClient39 test -DskipITs -Drat.skip=true -Dcheckstyle.skip=true`
- Ran the module test suite:
  - `./mvnw -pl flink-formats/flink-avro-confluent-registry test -DskipITs`
  - Result: 28 tests, 0 failures, 0 errors; checkstyle and spotless clean.
- Verified the final dependency tree includes:
  - `io.confluent:kafka-schema-registry-client:7.9.8`
  - `org.apache.kafka:kafka-clients:3.9.2` in test scope.

## Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): yes
- The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
- The serializers: no
- The runtime per-record code paths (performance sensitive): no
- Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
- The S3 file system connector: no

## Documentation

- Does this pull request introduce a new feature? no
- If yes, how is the feature documented? not applicable

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes, Hermes Agent with OpenAI GPT-5.5

Generated-by: Hermes Agent (OpenAI GPT-5.5)
