### PR TITLE
[FLINK-39968] [core] Reduce redundant AtomicBoolean allocation in MemorySegment to improve construction performance

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/core/memory/MemorySegment.java
+++ b/flink-core/src/main/java/org/apache/flink/core/memory/MemorySegment.java
@@ -33,7 +33,6 @@ import java.nio.BufferUnderflowException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.ReadOnlyBufferException;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
@@ -136,7 +135,7 @@ public final class MemorySegment {
      */
     private final boolean allowWrap;
 
-    private final AtomicBoolean isFreedAtomic;
+    private boolean isFreed = false;
 
     /**
      * Creates a new memory segment that represents the memory of the byte array.
@@ -158,7 +157,6 @@ public final class MemorySegment {
         this.owner = owner;
         this.allowWrap = true;
         this.cleaner = null;
-        this.isFreedAtomic = new AtomicBoolean(false);
     }
 
     /**
@@ -204,7 +202,6 @@ public final class MemorySegment {
         this.owner = owner;
         this.allowWrap = allowWrap;
         this.cleaner = cleaner;
-        this.isFreedAtomic = new AtomicBoolean(false);
     }
 
     // ------------------------------------------------------------------------
@@ -237,13 +234,14 @@ public final class MemorySegment {
      * segment and will fail. The actual memory (heap or off-heap) will only be released after this
      * memory segment object has become garbage collected.
      */
-    public void free() {
-        if (isFreedAtomic.getAndSet(true)) {
+    public synchronized void free() {
+        if (isFreed) {
             // the segment has already been freed
             if (checkMultipleFree) {
                 throw new IllegalStateException("MemorySegment can be freed only once!");
             }
         } else {
+            isFreed = true;
             // this ensures we can place no more data and trigger
             // the checks for the freed segment
             address = addressLimit + 1;


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

- In the in-operator-chain data copy transmission (the default scenario with massive temporary segment creation), isFreedAtomic is never used, resulting in meaningless object allocation; reduce redundant AtomicBoolean allocation in MemorySegment to improve construction performance
- End-to-end benchmark (Nexmark): The overall job throughput is improved, verifying the effectiveness of the optimization in real streaming scenarios. delivering an average performance improvement of 1.8%

## Brief change log

- Replace the member variable final AtomicBoolean isFreedAtomic with a primitive boolean isFreed; 
- Add the synchronized modifier to the free() method to ensure the atomicity and thread safety of the free state judgment and modification;


## Verifying this change
This change is already covered by existing tests, such as *MemorySegmentTestBase*.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (yes )
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)

