### PR TITLE
[FLINK-36317][runtime] Populate ArchivedExecutionGraph with CheckpointStatsSnapshot in WaitingForResources state

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ArchivedExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ArchivedExecutionGraph.java
@@ -517,6 +517,37 @@ public class ArchivedExecutionGraph implements AccessExecutionGraph, Serializabl
                 null);
     }
 
+    /**
+     * Returns a new {@link ArchivedExecutionGraph} that is identical to this one but with the given
+     * {@link CheckpointStatsSnapshot}.
+     */
+    public ArchivedExecutionGraph withCheckpointStatsSnapshot(
+            @Nullable CheckpointStatsSnapshot newCheckpointStatsSnapshot) {
+        return new ArchivedExecutionGraph(
+                jobID,
+                jobName,
+                tasks,
+                verticesInCreationOrder,
+                stateTimestamps,
+                state,
+                jobType,
+                failureCause,
+                plan,
+                archivedUserAccumulators,
+                serializedUserAccumulators,
+                archivedExecutionConfig,
+                isStoppable,
+                jobCheckpointingConfiguration,
+                newCheckpointStatsSnapshot,
+                stateBackendName,
+                checkpointStorageName,
+                stateChangelogEnabled,
+                changelogStorageName,
+                streamGraphJson,
+                pendingOperatorCount,
+                applicationId);
+    }
+
     private static ArchivedExecutionGraph createSparseArchivedExecutionGraph(
             JobID jobId,
             String jobName,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/WaitingForResources.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/WaitingForResources.java
@@ -20,6 +20,8 @@ package org.apache.flink.runtime.scheduler.adaptive;
 
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.JobStatus;
+import org.apache.flink.runtime.checkpoint.CheckpointStatsSnapshot;
+import org.apache.flink.runtime.executiongraph.ArchivedExecutionGraph;
 import org.apache.flink.runtime.executiongraph.ExecutionGraph;
 import org.apache.flink.runtime.scheduler.adaptive.timeline.RescaleTimeline;
 import org.apache.flink.util.Preconditions;
@@ -99,6 +101,19 @@ class WaitingForResources extends StateWithoutExecutionGraph
     @Override
     public JobStatus getJobStatus() {
         return JobStatus.CREATED;
+    }
+
+    @Override
+    public ArchivedExecutionGraph getJob() {
+        ArchivedExecutionGraph archivedGraph = super.getJob();
+        if (previousExecutionGraph != null) {
+            CheckpointStatsSnapshot previousSnapshot =
+                    previousExecutionGraph.getCheckpointStatsSnapshot();
+            if (previousSnapshot != null) {
+                return archivedGraph.withCheckpointStatsSnapshot(previousSnapshot);
+            }
+        }
+        return archivedGraph;
     }
 
     @Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/WaitingForResourcesTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/WaitingForResourcesTest.java
@@ -19,6 +19,8 @@
 package org.apache.flink.runtime.scheduler.adaptive;
 
 import org.apache.flink.core.testutils.ScheduledTask;
+import org.apache.flink.runtime.checkpoint.CheckpointStatsSnapshot;
+import org.apache.flink.runtime.executiongraph.ArchivedExecutionGraph;
 import org.apache.flink.runtime.executiongraph.ExecutionGraph;
 import org.apache.flink.runtime.scheduler.adaptive.timeline.RescaleTimeline;
 import org.apache.flink.util.clock.ManualClock;
@@ -281,6 +283,39 @@ class WaitingForResourcesTest {
         // choose time that includes inner execution as well
         ctx.runScheduledTasks(10);
         assertThat(executed).isTrue();
+    }
+
+    @Test
+    void testGetJobIncludesCheckpointStatsFromPreviousExecutionGraph() {
+        ExecutionGraph previousExecutionGraph = org.mockito.Mockito.mock(ExecutionGraph.class);
+        CheckpointStatsSnapshot expectedSnapshot = CheckpointStatsSnapshot.empty();
+        org.mockito.Mockito.when(previousExecutionGraph.getCheckpointStatsSnapshot())
+                .thenReturn(expectedSnapshot);
+
+        WaitingForResources wfr =
+                new WaitingForResources(
+                        ctx,
+                        LOG,
+                        DISABLED_RESOURCE_WAIT_TIMEOUT,
+                        previousExecutionGraph,
+                        context -> TestingStateTransitionManager.withNoOp());
+
+        ArchivedExecutionGraph archivedGraph = wfr.getJob();
+        assertThat(archivedGraph.getCheckpointStatsSnapshot()).isSameAs(expectedSnapshot);
+    }
+
+    @Test
+    void testGetJobWithoutPreviousExecutionGraphReturnsNullCheckpointStats() {
+        WaitingForResources wfr =
+                new WaitingForResources(
+                        ctx,
+                        LOG,
+                        DISABLED_RESOURCE_WAIT_TIMEOUT,
+                        context -> TestingStateTransitionManager.withNoOp());
+
+        ArchivedExecutionGraph archivedGraph = wfr.getJob();
+        assertThat(archivedGraph).isNotNull();
+        assertThat(archivedGraph.getCheckpointStatsSnapshot()).isNull();
     }
 
     private static class MockContext extends MockStateWithoutExecutionGraphContext


### PR DESCRIPTION
## What is the purpose of the change

When a Flink job fails and restarts, it transitions through `Restarting → WaitingForResources`. During this state, the `previousExecutionGraph` (which contains checkpoint statistics from the prior execution) is available, but the REST API/Web UI cannot access these stats because `StateWithoutExecutionGraph.getJob()` creates a sparse `ArchivedExecutionGraph` with empty checkpoint data.

This PR fixes that by:
1. Adding `withCheckpointStatsSnapshot()` to `ArchivedExecutionGraph` — creates a copy with different checkpoint stats
2. Overriding `getJob()` in `WaitingForResources` — attaches checkpoint stats from the `previousExecutionGraph` when available

## Brief change log

- Added `ArchivedExecutionGraph.withCheckpointStatsSnapshot()` method
- Overrode `WaitingForResources.getJob()` to preserve checkpoint stats from the previous execution graph
- Added 2 unit tests in `WaitingForResourcesTest`

## Verifying this change

This change is verified by new unit tests:
- `testGetJobIncludesCheckpointStatsFromPreviousExecutionGraph` — verifies checkpoint stats from a mock previous execution graph are preserved
- `testGetJobWithoutPreviousExecutionGraphReturnsNullCheckpointStats` — verifies the default behavior when no previous execution graph exists

## Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): no
- The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
- The serializers: no
- The runtime per-record code paths (performance sensitive): no
- Anything that affects deployment or recovery: no
- The (broadcasting) coordination functionality: no

## Documentation

- Does this pull request introduce a new feature? no
- If yes, how is the feature documented? not applicable