### PR TITLE
[FLINK-39680][FLINK-21378] Supports unaligned checkpoint on pointwise edges

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
@@ -1811,13 +1811,25 @@ public class CheckpointCoordinator {
                 vertexFinishedStateChecker.validateOperatorsFinishedState();
             }
 
+            // Extract old edge patterns from MasterState (persisted by
+            // EdgeDistributionPatternHook).
+            // null means old checkpoint lacks this info; fallback to ALL_TO_ALL.
+            EdgeDistributionPatternSnapshot oldEdgePatterns = null;
+            for (MasterState ms : latest.getMasterHookStates()) {
+                if (EdgeDistributionPatternSnapshot.HOOK_IDENTIFIER.equals(ms.name())) {
+                    oldEdgePatterns = EdgeDistributionPatternSnapshot.fromBytes(ms.bytes());
+                    break;
+                }
+            }
+
             StateAssignmentOperation stateAssignmentOperation =
                     new StateAssignmentOperation(
                             latest.getCheckpointID(),
                             tasks,
                             operatorStates,
                             allowNonRestoredState,
-                            recoverOutputOnDownstreamTask);
+                            recoverOutputOnDownstreamTask,
+                            oldEdgePatterns);
 
             stateAssignmentOperation.assignStates();
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/EdgeDistributionPatternSnapshot.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/EdgeDistributionPatternSnapshot.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.checkpoint;
+
+import org.apache.flink.runtime.jobgraph.DistributionPattern;
+import org.apache.flink.runtime.jobgraph.OperatorID;
+
+import javax.annotation.Nullable;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Snapshot of per-operator output edge {@link DistributionPattern}s, persisted via {@link
+ * MasterTriggerRestoreHook} / {@link MasterState} so that the correct old distribution pattern is
+ * available when restoring from a checkpoint after a shuffle-mode change.
+ *
+ * <p>Key = outputOperatorID (generated, chain-tail), Value = one {@link DistributionPattern} per
+ * output partition (indexed by partitionIndex).
+ */
+public class EdgeDistributionPatternSnapshot {
+
+    public static final String HOOK_IDENTIFIER = "__flink_edge_distribution_patterns__";
+
+    private static final int FORMAT_VERSION = 1;
+    private static final byte PATTERN_POINTWISE = 0;
+    private static final byte PATTERN_ALL_TO_ALL = 1;
+
+    private final Map<OperatorID, DistributionPattern[]> outputEdgePatterns;
+
+    public EdgeDistributionPatternSnapshot(
+            Map<OperatorID, DistributionPattern[]> outputEdgePatterns) {
+        this.outputEdgePatterns = Collections.unmodifiableMap(new HashMap<>(outputEdgePatterns));
+    }
+
+    @Nullable
+    public DistributionPattern[] getOutputPatterns(OperatorID outputOperatorID) {
+        DistributionPattern[] patterns = outputEdgePatterns.get(outputOperatorID);
+        return patterns != null ? patterns.clone() : null;
+    }
+
+    @Nullable
+    public DistributionPattern getOutputPattern(OperatorID outputOperatorID, int partitionIndex) {
+        DistributionPattern[] patterns = outputEdgePatterns.get(outputOperatorID);
+        if (patterns == null || partitionIndex < 0 || partitionIndex >= patterns.length) {
+            return null;
+        }
+        return patterns[partitionIndex];
+    }
+
+    public byte[] toBytes() throws IOException {
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream();
+                DataOutputStream dos = new DataOutputStream(baos)) {
+            dos.writeInt(FORMAT_VERSION);
+            dos.writeInt(outputEdgePatterns.size());
+            for (Map.Entry<OperatorID, DistributionPattern[]> entry :
+                    outputEdgePatterns.entrySet()) {
+                OperatorID opId = entry.getKey();
+                dos.writeLong(opId.getLowerPart());
+                dos.writeLong(opId.getUpperPart());
+                DistributionPattern[] patterns = entry.getValue();
+                dos.writeInt(patterns.length);
+                for (DistributionPattern p : patterns) {
+                    dos.writeByte(
+                            p == DistributionPattern.ALL_TO_ALL
+                                    ? PATTERN_ALL_TO_ALL
+                                    : PATTERN_POINTWISE);
+                }
+            }
+            dos.flush();
+            return baos.toByteArray();
+        }
+    }
+
+    public static EdgeDistributionPatternSnapshot fromBytes(byte[] bytes) throws IOException {
+        try (ByteArrayInputStream bais = new ByteArrayInputStream(bytes);
+                DataInputStream dis = new DataInputStream(bais)) {
+            int version = dis.readInt();
+            if (version != FORMAT_VERSION) {
+                throw new IOException(
+                        "Unsupported EdgeDistributionPatternSnapshot version: " + version);
+            }
+            int numOperators = dis.readInt();
+            Map<OperatorID, DistributionPattern[]> map = new HashMap<>(numOperators);
+            for (int i = 0; i < numOperators; i++) {
+                OperatorID opId = new OperatorID(dis.readLong(), dis.readLong());
+                int numPartitions = dis.readInt();
+                DistributionPattern[] patterns = new DistributionPattern[numPartitions];
+                for (int j = 0; j < numPartitions; j++) {
+                    byte b = dis.readByte();
+                    if (b == PATTERN_ALL_TO_ALL) {
+                        patterns[j] = DistributionPattern.ALL_TO_ALL;
+                    } else if (b == PATTERN_POINTWISE) {
+                        patterns[j] = DistributionPattern.POINTWISE;
+                    } else {
+                        throw new IOException("Unknown DistributionPattern byte in snapshot: " + b);
+                    }
+                }
+                map.put(opId, patterns);
+            }
+            return new EdgeDistributionPatternSnapshot(map);
+        }
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/InflightDataRescalingDescriptor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/InflightDataRescalingDescriptor.java
@@ -17,6 +17,8 @@
 
 package org.apache.flink.runtime.checkpoint;
 
+import java.io.IOException;
+import java.io.ObjectInputStream;
 import java.io.ObjectStreamException;
 import java.io.Serializable;
 import java.util.Arrays;
@@ -142,7 +144,7 @@ public class InflightDataRescalingDescriptor implements Serializable {
 
         /**
          * Set when channels are merged because the connected operator has been rescaled for each
-         * gate/partition.
+         * gate/partition. Used for ALL_TO_ALL → ALL_TO_ALL path.
          */
         private final RescaleMappings rescaledChannelsMappings;
 
@@ -150,6 +152,9 @@ public class InflightDataRescalingDescriptor implements Serializable {
         private final Set<Integer> ambiguousSubtaskIndexes;
 
         private final MappingType mappingType;
+
+        /** Bundled scalar topology parameters for POINTWISE-aware rescaling. */
+        private PointwiseRescaleParams rescaleParams;
 
         /** Type of mapping which should be used for this in-flight data. */
         public enum MappingType {
@@ -162,10 +167,25 @@ public class InflightDataRescalingDescriptor implements Serializable {
                 RescaleMappings rescaledChannelsMappings,
                 Set<Integer> ambiguousSubtaskIndexes,
                 MappingType mappingType) {
+            this(
+                    oldSubtaskIndexes,
+                    rescaledChannelsMappings,
+                    ambiguousSubtaskIndexes,
+                    mappingType,
+                    PointwiseRescaleParams.EMPTY);
+        }
+
+        public InflightDataGateOrPartitionRescalingDescriptor(
+                int[] oldSubtaskIndexes,
+                RescaleMappings rescaledChannelsMappings,
+                Set<Integer> ambiguousSubtaskIndexes,
+                MappingType mappingType,
+                PointwiseRescaleParams rescaleParams) {
             this.oldSubtaskIndexes = oldSubtaskIndexes;
             this.rescaledChannelsMappings = rescaledChannelsMappings;
             this.ambiguousSubtaskIndexes = ambiguousSubtaskIndexes;
             this.mappingType = mappingType;
+            this.rescaleParams = rescaleParams;
         }
 
         public int[] getOldSubtaskInstances() {
@@ -178,6 +198,21 @@ public class InflightDataRescalingDescriptor implements Serializable {
 
         public boolean isIdentity() {
             return mappingType == MappingType.IDENTITY;
+        }
+
+        public PointwiseRescaleParams getPointwiseRescaleParams() {
+            return rescaleParams;
+        }
+
+        public boolean isPointwiseRescaling() {
+            return !rescaleParams.equals(PointwiseRescaleParams.EMPTY);
+        }
+
+        private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
+            in.defaultReadObject();
+            if (rescaleParams == null) {
+                rescaleParams = PointwiseRescaleParams.EMPTY;
+            }
         }
 
         @Override
@@ -193,13 +228,18 @@ public class InflightDataRescalingDescriptor implements Serializable {
             return Arrays.equals(oldSubtaskIndexes, that.oldSubtaskIndexes)
                     && Objects.equals(rescaledChannelsMappings, that.rescaledChannelsMappings)
                     && Objects.equals(ambiguousSubtaskIndexes, that.ambiguousSubtaskIndexes)
-                    && mappingType == that.mappingType;
+                    && mappingType == that.mappingType
+                    && Objects.equals(rescaleParams, that.rescaleParams);
         }
 
         @Override
         public int hashCode() {
             int result =
-                    Objects.hash(rescaledChannelsMappings, ambiguousSubtaskIndexes, mappingType);
+                    Objects.hash(
+                            rescaledChannelsMappings,
+                            ambiguousSubtaskIndexes,
+                            mappingType,
+                            rescaleParams);
             result = 31 * result + Arrays.hashCode(oldSubtaskIndexes);
             return result;
         }
@@ -215,6 +255,8 @@ public class InflightDataRescalingDescriptor implements Serializable {
                     + ambiguousSubtaskIndexes
                     + ", mappingType="
                     + mappingType
+                    + ", rescaleParams="
+                    + rescaleParams
                     + '}';
         }
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/InflightDataRescalingDescriptor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/InflightDataRescalingDescriptor.java
@@ -57,6 +57,11 @@ public class InflightDataRescalingDescriptor implements Serializable {
         return gateOrPartitionDescriptors[gateOrPartitionIndex].getRescaleMappings();
     }
 
+    public InflightDataGateOrPartitionRescalingDescriptor getGateOrPartitionDescriptor(
+            int gateOrPartitionIndex) {
+        return gateOrPartitionDescriptors[gateOrPartitionIndex];
+    }
+
     public boolean isAmbiguous(int gateOrPartitionIndex, int oldSubtaskIndex) {
         return gateOrPartitionDescriptors[gateOrPartitionIndex].ambiguousSubtaskIndexes.contains(
                 oldSubtaskIndex);
@@ -144,7 +149,7 @@ public class InflightDataRescalingDescriptor implements Serializable {
 
         /**
          * Set when channels are merged because the connected operator has been rescaled for each
-         * gate/partition. Used for ALL_TO_ALL → ALL_TO_ALL path.
+         * gate/partition.
          */
         private final RescaleMappings rescaledChannelsMappings;
 
@@ -271,6 +276,12 @@ public class InflightDataRescalingDescriptor implements Serializable {
         @Override
         public int[] getOldSubtaskIndexes(int gateOrPartitionIndex) {
             return EMPTY_INT_ARRAY;
+        }
+
+        @Override
+        public InflightDataGateOrPartitionRescalingDescriptor getGateOrPartitionDescriptor(
+                int gateOrPartitionIndex) {
+            return InflightDataGateOrPartitionRescalingDescriptor.NO_STATE;
         }
 
         @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/PointwiseChannelMappingUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/PointwiseChannelMappingUtils.java
@@ -1,0 +1,487 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.checkpoint;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.runtime.io.network.api.writer.SubtaskStateMapper;
+import org.apache.flink.runtime.jobgraph.DistributionPattern;
+import org.apache.flink.util.Preconditions;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.IntStream;
+
+/**
+ * Topology computation utilities for POINTWISE edge unaligned-checkpoint rescaling. Shared by JM
+ * (subtask assignment / descriptor generation) and TM (channel routing at recovery time).
+ *
+ * <h3>Atomic primitives</h3>
+ *
+ * <p>All business methods are compositions of six atomic primitives:
+ *
+ * <ul>
+ *   <li>{@link #consumersOf} — topology edge: upstream → downstream subtask set
+ *   <li>{@link #producersOf} — topology edge: downstream → upstream subtask set
+ *   <li>{@link #localIndexToGlobalSubtaskIndex} — local channel/subpartition index → peer global
+ *       subtask index (local-to-global)
+ *   <li>{@link #globalSubtaskIndexToLocalIndex} — inverse: peer global subtask index → local
+ *       channel/subpartition index (global-to-local)
+ *   <li>{@link #oldSubtasksAssignedTo} — cross-generation: new subtask → inherited old subtask set
+ *       (ROUND_ROBIN)
+ *   <li>{@link #newSubtaskAssignedFrom} — cross-generation inverse: old subtask → inheriting new
+ *       subtask (modulo)
+ * </ul>
+ *
+ * <h3>Core chain</h3>
+ *
+ * <p>One chain, two directions. JM walks it forward (set-level) when assigning state to decide
+ * <em>which</em> old subtasks to recover from; JM distributes buffers (downstream-recovery mode) or
+ * TM reads them (upstream-recovery mode) by walking backward to decide <em>where</em> each buffer
+ * goes.
+ *
+ * <p><b>Forward (JM, set-level)</b> — "which old upstreams does new upstream U need state from?"
+ *
+ * <pre>
+ *   newUp ──consumersOf──→ newDown ──oldSubtasksAssignedTo──→ oldDown ──producersOf──→ oldUp
+ * </pre>
+ *
+ * <p>Implemented by {@link #computeInheritedOldUpstreams}. Its inverse {@link
+ * #computePrimaryUpstreamMapping} resolves the input side: for a given new downstream, which new
+ * upstream is responsible for recovering each old upstream's data.
+ *
+ * <p><b>Backward (TM)</b> — "where does old buffer (oldUp, localSP) go?"
+ *
+ * <pre>
+ *   (oldUp, localSP) ──{@link #localIndexToGlobalSubtaskIndex}──→ oldDown
+ *                      ──{@link #newSubtaskAssignedFrom}──→ newDown
+ *                      ──{@link #globalSubtaskIndexToLocalIndex}──→ newLocalSP
+ * </pre>
+ *
+ * <p>Output-side local-to-global and global-to-local both use <b>modulo mapping</b> ({@code D %
+ * numConsumers}), matching the subpartition numbering in {@link
+ * org.apache.flink.runtime.executiongraph.VertexInputInfoComputationUtils#computeConsumedSubpartitionRange}.
+ *
+ * <h3>Primary upstream</h3>
+ *
+ * <p>When a POINTWISE edge has {@code newUpPar > newDownPar}, multiple new upstreams connect to the
+ * same downstream. {@link #computeInheritedOldUpstreams} may cause multiple new upstreams to trace
+ * back to the same old state. To avoid duplicates, only the first upstream ({@code
+ * producersOf(D)[0]}) is responsible for recovering that downstream's state; other upstreams do not
+ * recover. This behavior is consistent on the JM side (buffer distribution to downstream) and the
+ * TM side (output recovery) via {@link #computeNewLocalSubpartitionIndex}.
+ *
+ * <h3>Identity fast path</h3>
+ *
+ * <p>When neither parallelism nor pattern changes (in-place recovery), each subtask recovers its
+ * own state. {@link #computeInheritedOldUpstreams} satisfies {@code computeInheritedOldUpstreams(N)
+ * = {N}}, producing no overlap — the primary upstream is itself, requiring no extra handling.
+ *
+ * <p>All arithmetic mirrors {@link
+ * org.apache.flink.runtime.executiongraph.VertexInputInfoComputationUtils#computeVertexInputInfoForPointwise}
+ * but operates on scalar parallelisms only (no scheduler-layer objects), so it can run on TM.
+ */
+@Internal
+public final class PointwiseChannelMappingUtils {
+
+    private PointwiseChannelMappingUtils() {}
+
+    // ============================== Business methods ==============================
+
+    /**
+     * Computes the set of old upstreams whose state a new upstream inherits. Chains consumersOf →
+     * oldSubtasksAssignedTo → producersOf (see class javadoc). Results may overlap — multiple new
+     * upstreams may trace back to the same old upstream; only the primary upstream ({@code
+     * producersOf(D)[0]}) is responsible for recovery.
+     */
+    public static int[] computeInheritedOldUpstreams(
+            int newUpstreamSubtaskIndex, PointwiseRescaleParams params) {
+        final int newUpstreamParallelism = params.getNewUpParallelism();
+        final int newDownstreamParallelism = params.getNewDownParallelism();
+        final int oldUpstreamParallelism = params.getOldUpParallelism();
+        final int oldDownstreamParallelism = params.getOldDownParallelism();
+
+        int[] newDownstreams;
+        if (params.getNewDistributionPattern() == DistributionPattern.POINTWISE) {
+            newDownstreams =
+                    consumersOf(
+                            newUpstreamSubtaskIndex,
+                            newUpstreamParallelism,
+                            newDownstreamParallelism);
+        } else {
+            newDownstreams = IntStream.range(0, newDownstreamParallelism).toArray();
+        }
+
+        Set<Integer> oldDownstreams = new HashSet<>();
+        for (int newDownstream : newDownstreams) {
+            for (int oldDownstream :
+                    oldSubtasksAssignedTo(
+                            newDownstream, oldDownstreamParallelism, newDownstreamParallelism)) {
+                oldDownstreams.add(oldDownstream);
+            }
+        }
+
+        Set<Integer> oldUpstreams = new HashSet<>();
+        for (int oldDownstream : oldDownstreams) {
+            if (params.getOldDistributionPattern() == DistributionPattern.ALL_TO_ALL) {
+                for (int i = 0; i < oldUpstreamParallelism; i++) {
+                    oldUpstreams.add(i);
+                }
+            } else {
+                for (int oldUpstream :
+                        producersOf(
+                                oldDownstream, oldUpstreamParallelism, oldDownstreamParallelism)) {
+                    oldUpstreams.add(oldUpstream);
+                }
+            }
+        }
+
+        return oldUpstreams.stream().sorted().mapToInt(Integer::intValue).toArray();
+    }
+
+    /**
+     * For a given new downstream, determines which new upstream is responsible for recovering each
+     * old upstream. Inverse of {@link #computeInheritedOldUpstreams} scoped to connected new
+     * upstreams, using first-claim: when multiple new upstreams trace the same old upstream, only
+     * the first claimant is responsible. Returns {@code result[oldUp] = newUp}, or -1 if unclaimed.
+     */
+    public static int[] computePrimaryUpstreamMapping(
+            int newDownstreamSubtaskIndex, PointwiseRescaleParams params) {
+        int[] connectedNewUpstreams;
+        if (params.getNewDistributionPattern() == DistributionPattern.POINTWISE) {
+            connectedNewUpstreams =
+                    producersOf(
+                            newDownstreamSubtaskIndex,
+                            params.getNewUpParallelism(),
+                            params.getNewDownParallelism());
+        } else {
+            connectedNewUpstreams = IntStream.range(0, params.getNewUpParallelism()).toArray();
+        }
+
+        int[] mapping = new int[params.getOldUpParallelism()];
+        Arrays.fill(mapping, -1);
+
+        for (int newUpstream : connectedNewUpstreams) {
+            for (int oldUpstream : computeInheritedOldUpstreams(newUpstream, params)) {
+                if (mapping[oldUpstream] < 0) {
+                    mapping[oldUpstream] = newUpstream;
+                }
+            }
+        }
+
+        return mapping;
+    }
+
+    /**
+     * Old-topology local input channel count. A2A = oldUpstreamParallelism, PW =
+     * producersOf(subtask).length.
+     */
+    public static int getOldLocalChannelCount(
+            int downstreamSubtaskIndex, PointwiseRescaleParams params) {
+        if (params.getOldDistributionPattern() == DistributionPattern.ALL_TO_ALL) {
+            return params.getOldUpParallelism();
+        }
+        return producersOf(
+                        downstreamSubtaskIndex,
+                        params.getOldUpParallelism(),
+                        params.getOldDownParallelism())
+                .length;
+    }
+
+    /**
+     * New upstream subtask index → local input channel index in the new topology. Never returns -1;
+     * input-side recovery only routes to upstreams confirmed by {@link
+     * #computePrimaryUpstreamMapping}, so a miss throws.
+     */
+    public static int computeNewLocalInputChannelIndex(
+            int newUpstreamSubtaskIndex,
+            int newDownstreamSubtaskIndex,
+            PointwiseRescaleParams params) {
+        if (params.getNewDistributionPattern() == DistributionPattern.ALL_TO_ALL) {
+            return newUpstreamSubtaskIndex;
+        }
+        int localIndex =
+                globalSubtaskIndexToLocalIndex(
+                        newDownstreamSubtaskIndex,
+                        newUpstreamSubtaskIndex,
+                        params.getNewUpParallelism(),
+                        params.getNewDownParallelism(),
+                        true,
+                        params.getNewDistributionPattern());
+        if (localIndex < 0) {
+            throw new IllegalStateException(
+                    "newUpstreamSubtaskIndex="
+                            + newUpstreamSubtaskIndex
+                            + " not found in producers of subtask "
+                            + newDownstreamSubtaskIndex
+                            + " with params "
+                            + params);
+        }
+        return localIndex;
+    }
+
+    /**
+     * New downstream subtask index → local subpartition index in the new topology (modulo mapping).
+     * Returns -1 when this upstream is not responsible for recovering the downstream:
+     *
+     * <ol>
+     *   <li><b>Not connected</b>: downstream not in {@code consumersOf(upstream)} — old upstreams
+     *       traced by {@link #computeInheritedOldUpstreams} on JM may not all connect to this one
+     *   <li><b>Not primary upstream</b>: when {@code upPar > downPar}, multiple upstreams connect
+     *       to the same downstream; only {@code producersOf(D)[0]} recovers — JM and TM consistent
+     * </ol>
+     */
+    public static int computeNewLocalSubpartitionIndex(
+            int newDownstreamSubtaskIndex,
+            int newUpstreamSubtaskIndex,
+            PointwiseRescaleParams params) {
+        if (params.getNewDistributionPattern() == DistributionPattern.ALL_TO_ALL) {
+            return newDownstreamSubtaskIndex;
+        }
+        int localIndex =
+                globalSubtaskIndexToLocalIndex(
+                        newUpstreamSubtaskIndex,
+                        newDownstreamSubtaskIndex,
+                        params.getNewUpParallelism(),
+                        params.getNewDownParallelism(),
+                        false,
+                        params.getNewDistributionPattern());
+        if (localIndex < 0) {
+            return -1;
+        }
+        // Primary producer dedup: only producersOf(D)[0] writes.
+        int[] producers =
+                producersOf(
+                        newDownstreamSubtaskIndex,
+                        params.getNewUpParallelism(),
+                        params.getNewDownParallelism());
+        if (producers[0] != newUpstreamSubtaskIndex) {
+            return -1;
+        }
+        return localIndex;
+    }
+
+    // ============================== Atomic primitives ==============================
+
+    /**
+     * Topology edge: downstream subtask → upstream subtask indices that produce for it. Mirrors the
+     * assignment algorithm in {@link
+     * org.apache.flink.runtime.executiongraph.VertexInputInfoComputationUtils#computeVertexInputInfoForPointwise}.
+     * Uses floor division when upPar >= downPar (each downstream connects to a contiguous range of
+     * upstreams), ceiling division when upPar < downPar (each downstream connects to one upstream).
+     */
+    static int[] producersOf(
+            int downstreamIndex, int upstreamParallelism, int downstreamParallelism) {
+        Preconditions.checkArgument(
+                upstreamParallelism > 0 && downstreamParallelism > 0,
+                "parallelisms must be positive, got upstreamParallelism=%s, downstreamParallelism=%s",
+                upstreamParallelism,
+                downstreamParallelism);
+        Preconditions.checkArgument(
+                downstreamIndex >= 0 && downstreamIndex < downstreamParallelism,
+                "index out of range: downstreamIndex=%s, downstreamParallelism=%s",
+                downstreamIndex,
+                downstreamParallelism);
+        if (upstreamParallelism >= downstreamParallelism) {
+            int start = downstreamIndex * upstreamParallelism / downstreamParallelism;
+            int end = (downstreamIndex + 1) * upstreamParallelism / downstreamParallelism;
+            int[] result = new int[end - start];
+            for (int i = 0; i < result.length; i++) {
+                result[i] = start + i;
+            }
+            return result;
+        } else {
+            for (int u = 0; u < upstreamParallelism; u++) {
+                int start =
+                        (u * downstreamParallelism + upstreamParallelism - 1) / upstreamParallelism;
+                int end =
+                        ((u + 1) * downstreamParallelism + upstreamParallelism - 1)
+                                / upstreamParallelism;
+                if (downstreamIndex >= start && downstreamIndex < end) {
+                    return new int[] {u};
+                }
+            }
+            throw new IllegalStateException(
+                    "No producer found for downstreamIndex="
+                            + downstreamIndex
+                            + " (upstreamParallelism="
+                            + upstreamParallelism
+                            + ", downstreamParallelism="
+                            + downstreamParallelism
+                            + ")");
+        }
+    }
+
+    /**
+     * Topology edge: upstream subtask → downstream subtask indices it produces for. Dual of
+     * producersOf with symmetric division: ceiling division when upPar < downPar (each upstream
+     * connects to a contiguous range of downstreams), floor division when upPar >= downPar.
+     */
+    static int[] consumersOf(
+            int upstreamIndex, int upstreamParallelism, int downstreamParallelism) {
+        Preconditions.checkArgument(
+                upstreamParallelism > 0 && downstreamParallelism > 0,
+                "parallelisms must be positive, got upstreamParallelism=%s, downstreamParallelism=%s",
+                upstreamParallelism,
+                downstreamParallelism);
+        Preconditions.checkArgument(
+                upstreamIndex >= 0 && upstreamIndex < upstreamParallelism,
+                "index out of range: upstreamIndex=%s, upstreamParallelism=%s",
+                upstreamIndex,
+                upstreamParallelism);
+        if (upstreamParallelism < downstreamParallelism) {
+            int start =
+                    (upstreamIndex * downstreamParallelism + upstreamParallelism - 1)
+                            / upstreamParallelism;
+            int end =
+                    ((upstreamIndex + 1) * downstreamParallelism + upstreamParallelism - 1)
+                            / upstreamParallelism;
+            int[] result = new int[end - start];
+            for (int i = 0; i < result.length; i++) {
+                result[i] = start + i;
+            }
+            return result;
+        } else {
+            for (int d = 0; d < downstreamParallelism; d++) {
+                int start = d * upstreamParallelism / downstreamParallelism;
+                int end = (d + 1) * upstreamParallelism / downstreamParallelism;
+                if (upstreamIndex >= start && upstreamIndex < end) {
+                    return new int[] {d};
+                }
+            }
+            throw new IllegalStateException(
+                    "No consumer found for upstreamIndex="
+                            + upstreamIndex
+                            + " (upstreamParallelism="
+                            + upstreamParallelism
+                            + ", downstreamParallelism="
+                            + downstreamParallelism
+                            + ")");
+        }
+    }
+
+    /**
+     * Cross-generation: new subtask → inherited old subtask set. Delegates to {@link
+     * SubtaskStateMapper#ROUND_ROBIN}, i.e. {@code {old | old % newPar == newIdx}}.
+     */
+    public static int[] oldSubtasksAssignedTo(
+            int newSubtaskIndex, int oldParallelism, int newParallelism) {
+        return SubtaskStateMapper.ROUND_ROBIN.getOldSubtasks(
+                newSubtaskIndex, oldParallelism, newParallelism);
+    }
+
+    /**
+     * Cross-generation inverse: old subtask → inheriting new subtask. ROUND_ROBIN inverse: {@code
+     * old % newPar}.
+     */
+    public static int newSubtaskAssignedFrom(int oldSubtaskIndex, int newParallelism) {
+        return oldSubtaskIndex % newParallelism;
+    }
+
+    /**
+     * Local-to-global: translates a local channel/subpartition index to the peer's global subtask
+     * index.
+     *
+     * <p>Input side (downstream→upstream): {@code producersOf(subtask)[localIndex]}, sequential
+     * lookup. Output side (upstream→downstream): <b>modulo mapping</b> — finds consumer D where
+     * {@code D % numConsumers == localIndex}, matching the subpartition numbering in {@code
+     * VertexInputInfoComputationUtils.computeConsumedSubpartitionRange} (the i-th subpartition
+     * corresponds to global consumer D where D % len == i).
+     *
+     * <p>Under ALL_TO_ALL every subtask connects to all peers, so local index equals the global
+     * subtask index.
+     */
+    public static int localIndexToGlobalSubtaskIndex(
+            int subtaskIndex,
+            int localIndex,
+            int upstreamParallelism,
+            int downstreamParallelism,
+            boolean isInputSide,
+            DistributionPattern distributionPattern) {
+        if (distributionPattern == DistributionPattern.ALL_TO_ALL) {
+            return localIndex;
+        }
+        if (isInputSide) {
+            int[] producers = producersOf(subtaskIndex, upstreamParallelism, downstreamParallelism);
+            return producers[localIndex];
+        } else {
+            int[] consumers = consumersOf(subtaskIndex, upstreamParallelism, downstreamParallelism);
+            for (int c : consumers) {
+                if (c % consumers.length == localIndex) {
+                    return c;
+                }
+            }
+            throw new IllegalStateException(
+                    "No consumer with modulo position "
+                            + localIndex
+                            + " for upstream "
+                            + subtaskIndex
+                            + " (consumers="
+                            + Arrays.toString(consumers)
+                            + ")");
+        }
+    }
+
+    /**
+     * Global-to-local: inverse of {@link #localIndexToGlobalSubtaskIndex}.
+     *
+     * <p>Input side: linear search for peerSubtaskIndex in the producers array. Output side:
+     * computes {@code peerSubtaskIndex % consumers.length} directly using the same modulo relation
+     * as the forward mapping (no traversal needed, since forward satisfies {@code D % len ==
+     * localIdx}, so inverse is {@code localIdx = peer % len}).
+     *
+     * @return local index, or -1 if not connected
+     */
+    static int globalSubtaskIndexToLocalIndex(
+            int subtaskIndex,
+            int peerSubtaskIndex,
+            int upstreamParallelism,
+            int downstreamParallelism,
+            boolean isInputSide,
+            DistributionPattern distributionPattern) {
+        if (distributionPattern == DistributionPattern.ALL_TO_ALL) {
+            return peerSubtaskIndex;
+        }
+        if (isInputSide) {
+            int[] producers = producersOf(subtaskIndex, upstreamParallelism, downstreamParallelism);
+            for (int i = 0; i < producers.length; i++) {
+                if (producers[i] == peerSubtaskIndex) {
+                    return i;
+                }
+            }
+            return -1;
+        } else {
+            int[] consumers = consumersOf(subtaskIndex, upstreamParallelism, downstreamParallelism);
+            if (!containsValue(consumers, peerSubtaskIndex)) {
+                return -1;
+            }
+            return peerSubtaskIndex % consumers.length;
+        }
+    }
+
+    // ============================== Utilities ==============================
+
+    private static boolean containsValue(int[] arr, int v) {
+        for (int x : arr) {
+            if (x == v) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/PointwiseRescaleParams.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/PointwiseRescaleParams.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.checkpoint;
+
+import org.apache.flink.runtime.jobgraph.DistributionPattern;
+
+import java.io.ObjectStreamException;
+import java.io.Serializable;
+import java.util.Objects;
+
+/** Bundled scalar parameters for POINTWISE-aware rescaling on a single gate or partition. */
+public final class PointwiseRescaleParams implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    public static final PointwiseRescaleParams EMPTY =
+            new PointwiseRescaleParams(
+                    DistributionPattern.ALL_TO_ALL, DistributionPattern.ALL_TO_ALL, 0, 0, 0, 0);
+
+    private final DistributionPattern oldDistributionPattern;
+    private final DistributionPattern newDistributionPattern;
+    private final int oldUpParallelism;
+    private final int oldDownParallelism;
+    private final int newUpParallelism;
+    private final int newDownParallelism;
+
+    public PointwiseRescaleParams(
+            DistributionPattern oldDistributionPattern,
+            DistributionPattern newDistributionPattern,
+            int oldUpParallelism,
+            int oldDownParallelism,
+            int newUpParallelism,
+            int newDownParallelism) {
+        this.oldDistributionPattern = oldDistributionPattern;
+        this.newDistributionPattern = newDistributionPattern;
+        this.oldUpParallelism = oldUpParallelism;
+        this.oldDownParallelism = oldDownParallelism;
+        this.newUpParallelism = newUpParallelism;
+        this.newDownParallelism = newDownParallelism;
+    }
+
+    public DistributionPattern getOldDistributionPattern() {
+        return oldDistributionPattern;
+    }
+
+    public DistributionPattern getNewDistributionPattern() {
+        return newDistributionPattern;
+    }
+
+    public int getOldUpParallelism() {
+        return oldUpParallelism;
+    }
+
+    public int getOldDownParallelism() {
+        return oldDownParallelism;
+    }
+
+    public int getNewUpParallelism() {
+        return newUpParallelism;
+    }
+
+    public int getNewDownParallelism() {
+        return newDownParallelism;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        PointwiseRescaleParams that = (PointwiseRescaleParams) o;
+        return oldUpParallelism == that.oldUpParallelism
+                && oldDownParallelism == that.oldDownParallelism
+                && newUpParallelism == that.newUpParallelism
+                && newDownParallelism == that.newDownParallelism
+                && oldDistributionPattern == that.oldDistributionPattern
+                && newDistributionPattern == that.newDistributionPattern;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(
+                oldDistributionPattern,
+                newDistributionPattern,
+                oldUpParallelism,
+                oldDownParallelism,
+                newUpParallelism,
+                newDownParallelism);
+    }
+
+    private Object readResolve() throws ObjectStreamException {
+        if (oldUpParallelism == 0
+                && oldDownParallelism == 0
+                && newUpParallelism == 0
+                && newDownParallelism == 0) {
+            return EMPTY;
+        }
+        return this;
+    }
+
+    @Override
+    public String toString() {
+        return "PointwiseRescaleParams{"
+                + "oldPattern="
+                + oldDistributionPattern
+                + ", newPattern="
+                + newDistributionPattern
+                + ", oldUp="
+                + oldUpParallelism
+                + ", oldDown="
+                + oldDownParallelism
+                + ", newUp="
+                + newUpParallelism
+                + ", newDown="
+                + newDownParallelism
+                + '}';
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/StateAssignmentOperation.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/StateAssignmentOperation.java
@@ -48,6 +48,8 @@ import org.apache.flink.util.Preconditions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nullable;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -76,6 +78,7 @@ public class StateAssignmentOperation {
     private final long restoreCheckpointId;
     private final boolean allowNonRestoredState;
     private final boolean recoverOutputOnDownstreamTask;
+    @Nullable private final EdgeDistributionPatternSnapshot oldEdgePatterns;
 
     /** The state assignments for each ExecutionJobVertex that will be filled in multiple passes. */
     private final Map<ExecutionJobVertex, TaskStateAssignment> vertexAssignments;
@@ -93,12 +96,29 @@ public class StateAssignmentOperation {
             Map<OperatorID, OperatorState> operatorStates,
             boolean allowNonRestoredState,
             boolean recoverOutputOnDownstreamTask) {
+        this(
+                restoreCheckpointId,
+                tasks,
+                operatorStates,
+                allowNonRestoredState,
+                recoverOutputOnDownstreamTask,
+                null);
+    }
+
+    public StateAssignmentOperation(
+            long restoreCheckpointId,
+            Set<ExecutionJobVertex> tasks,
+            Map<OperatorID, OperatorState> operatorStates,
+            boolean allowNonRestoredState,
+            boolean recoverOutputOnDownstreamTask,
+            @Nullable EdgeDistributionPatternSnapshot oldEdgePatterns) {
 
         this.restoreCheckpointId = restoreCheckpointId;
         this.tasks = Preconditions.checkNotNull(tasks);
         this.operatorStates = Preconditions.checkNotNull(operatorStates);
         this.allowNonRestoredState = allowNonRestoredState;
         this.recoverOutputOnDownstreamTask = recoverOutputOnDownstreamTask;
+        this.oldEdgePatterns = oldEdgePatterns;
         this.vertexAssignments = CollectionUtil.newHashMapWithExpectedSize(tasks.size());
     }
 
@@ -148,7 +168,8 @@ public class StateAssignmentOperation {
                             operatorStates,
                             consumerAssignment,
                             vertexAssignments,
-                            recoverOutputOnDownstreamTask);
+                            recoverOutputOnDownstreamTask,
+                            oldEdgePatterns);
             vertexAssignments.put(executionJobVertex, stateAssignment);
             for (final IntermediateResult producedDataSet : executionJobVertex.getInputs()) {
                 consumerAssignment.put(producedDataSet.getId(), stateAssignment);
@@ -408,7 +429,10 @@ public class StateAssignmentOperation {
         final List<IntermediateDataSet> outputs =
                 executionJobVertex.getJobVertex().getProducedDataSets();
 
-        if (outputState.getParallelism() == executionJobVertex.getParallelism()) {
+        // 1:1 assignment when parallelism unchanged and no PW edges; PW edges need topology-aware
+        // redistribution even at same parallelism (pattern change alters subpartition coverage)
+        if (outputState.getParallelism() == executionJobVertex.getParallelism()
+                && !assignment.hasPointwiseEdge(assignment.getDownstreamAssignments(), false)) {
             assignment.resultSubpartitionStates.putAll(
                     toInstanceMap(assignment.outputOperatorID, outputOperatorState));
             return;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/TaskStateAssignment.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/TaskStateAssignment.java
@@ -26,6 +26,7 @@ import org.apache.flink.runtime.checkpoint.channel.ResultSubpartitionInfo;
 import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
 import org.apache.flink.runtime.executiongraph.IntermediateResult;
 import org.apache.flink.runtime.io.network.api.writer.SubtaskStateMapper;
+import org.apache.flink.runtime.jobgraph.DistributionPattern;
 import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.jobgraph.OperatorInstanceID;
@@ -112,6 +113,7 @@ class TaskStateAssignment {
             outputRescalingDescriptors = new HashMap<>();
 
     private final boolean recoverOutputOnDownstreamTask;
+    @Nullable private final EdgeDistributionPatternSnapshot oldEdgePatterns;
 
     @Nullable private TaskStateAssignment[] downstreamAssignments;
     @Nullable private TaskStateAssignment[] upstreamAssignments;
@@ -127,6 +129,22 @@ class TaskStateAssignment {
             Map<IntermediateDataSetID, TaskStateAssignment> consumerAssignment,
             Map<ExecutionJobVertex, TaskStateAssignment> vertexAssignments,
             boolean recoverOutputOnDownstreamTask) {
+        this(
+                executionJobVertex,
+                oldState,
+                consumerAssignment,
+                vertexAssignments,
+                recoverOutputOnDownstreamTask,
+                null);
+    }
+
+    public TaskStateAssignment(
+            ExecutionJobVertex executionJobVertex,
+            Map<OperatorID, OperatorState> oldState,
+            Map<IntermediateDataSetID, TaskStateAssignment> consumerAssignment,
+            Map<ExecutionJobVertex, TaskStateAssignment> vertexAssignments,
+            boolean recoverOutputOnDownstreamTask,
+            @Nullable EdgeDistributionPatternSnapshot oldEdgePatterns) {
 
         this.executionJobVertex = executionJobVertex;
         this.oldState = oldState;
@@ -144,6 +162,7 @@ class TaskStateAssignment {
         this.consumerAssignment = checkNotNull(consumerAssignment);
         this.vertexAssignments = checkNotNull(vertexAssignments);
         this.recoverOutputOnDownstreamTask = recoverOutputOnDownstreamTask;
+        this.oldEdgePatterns = oldEdgePatterns;
         final int expectedNumberOfSubtasks = newParallelism * oldState.size();
 
         subManagedOperatorState =
@@ -368,9 +387,10 @@ class TaskStateAssignment {
                         .map(assignment -> mappingRetriever.apply(assignment, false))
                         .toArray(SubtasksRescaleMapping[]::new);
 
-        // no state on input and output, especially for any aligned checkpoint
+        // PW edges: pattern change alters subpartition coverage even at same parallelism
         if (subtaskGateOrPartitionMappings.isEmpty()
-                && Arrays.stream(rescaledChannelsMappings).allMatch(Objects::isNull)) {
+                && Arrays.stream(rescaledChannelsMappings).allMatch(Objects::isNull)
+                && !hasPointwiseEdge(connectedAssignments, isInput)) {
             return InflightDataRescalingDescriptor.NO_RESCALE;
         }
 
@@ -411,6 +431,25 @@ class TaskStateAssignment {
                             }
                             TaskStateAssignment connectedAssignment =
                                     connectedAssignments[partition];
+
+                            DistributionPattern oldPattern =
+                                    resolveOldDistributionPattern(
+                                            isInput, partition, connectedAssignment);
+                            DistributionPattern newPattern =
+                                    resolveNewDistributionPattern(isInput, partition);
+
+                            if (oldEdgePatterns != null
+                                    && (oldPattern == DistributionPattern.POINTWISE
+                                            || newPattern == DistributionPattern.POINTWISE)) {
+                                return createPointwiseRescalingDescriptor(
+                                        instanceID,
+                                        partition,
+                                        isInput,
+                                        connectedAssignment,
+                                        oldPattern,
+                                        newPattern);
+                            }
+
                             SubtasksRescaleMapping rescaleMapping =
                                     Optional.ofNullable(rescaledChannelsMappings[partition])
                                             .orElseGet(
@@ -508,9 +547,39 @@ class TaskStateAssignment {
                                 .get(gateIndex)
                                 .getUpstreamSubtaskStateMapper(),
                         "No channel rescaler found during rescaling of channel state");
-        final RescaleMappings mapping =
-                mapper.getNewToOldSubtasksMapping(
-                        oldState.get(outputOperatorID).getParallelism(), newParallelism);
+
+        final RescaleMappings mapping;
+        if (mapper == SubtaskStateMapper.POINTWISE_UPSTREAM) {
+            PointwiseRescaleParams params =
+                    buildOutputPointwiseRescaleParams(partitionIndex, downstreamAssignment);
+            int oldParallelism = oldState.get(outputOperatorID).getParallelism();
+            boolean isIdentity =
+                    oldParallelism == newParallelism
+                            && params.getOldUpParallelism() == params.getNewUpParallelism()
+                            && params.getOldDownParallelism() == params.getNewDownParallelism()
+                            && params.getOldDistributionPattern()
+                                    == params.getNewDistributionPattern();
+            if (isIdentity) {
+                mapping =
+                        RescaleMappings.of(
+                                IntStream.range(0, newParallelism).mapToObj(idx -> new int[] {idx}),
+                                oldParallelism);
+            } else {
+                mapping =
+                        RescaleMappings.of(
+                                IntStream.range(0, newParallelism)
+                                        .mapToObj(
+                                                idx ->
+                                                        PointwiseChannelMappingUtils
+                                                                .computeInheritedOldUpstreams(
+                                                                        idx, params)),
+                                oldParallelism);
+            }
+        } else {
+            mapping =
+                    mapper.getNewToOldSubtasksMapping(
+                            oldState.get(outputOperatorID).getParallelism(), newParallelism);
+        }
         return outputSubtaskMappings.compute(
                 partitionIndex,
                 (idx, oldMapping) ->
@@ -581,10 +650,160 @@ class TaskStateAssignment {
         return false;
     }
 
+    boolean hasPointwiseEdge(TaskStateAssignment[] connectedAssignments, boolean isInput) {
+        if (oldEdgePatterns == null) {
+            return false;
+        }
+        for (int i = 0; i < connectedAssignments.length; i++) {
+            if (!hasInFlightData(isInput, i)) {
+                continue;
+            }
+            DistributionPattern oldPattern =
+                    resolveOldDistributionPattern(isInput, i, connectedAssignments[i]);
+            DistributionPattern newPattern = resolveNewDistributionPattern(isInput, i);
+            if (oldPattern == DistributionPattern.POINTWISE
+                    || newPattern == DistributionPattern.POINTWISE) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private DistributionPattern resolveOldDistributionPattern(
+            boolean isInput, int gateOrPartitionIdx, TaskStateAssignment connectedAssignment) {
+        if (oldEdgePatterns == null) {
+            return DistributionPattern.ALL_TO_ALL;
+        }
+        if (isInput) {
+            int partitionIdxInUpstream =
+                    Arrays.asList(connectedAssignment.getDownstreamAssignments()).indexOf(this);
+            if (partitionIdxInUpstream < 0) {
+                return DistributionPattern.ALL_TO_ALL;
+            }
+            DistributionPattern pattern =
+                    oldEdgePatterns.getOutputPattern(
+                            connectedAssignment.outputOperatorID, partitionIdxInUpstream);
+            return pattern != null ? pattern : DistributionPattern.ALL_TO_ALL;
+        } else {
+            DistributionPattern pattern =
+                    oldEdgePatterns.getOutputPattern(outputOperatorID, gateOrPartitionIdx);
+            return pattern != null ? pattern : DistributionPattern.ALL_TO_ALL;
+        }
+    }
+
+    private DistributionPattern resolveNewDistributionPattern(
+            boolean isInput, int gateOrPartitionIdx) {
+        if (isInput) {
+            return executionJobVertex
+                    .getInputs()
+                    .get(gateOrPartitionIdx)
+                    .getConsumingDistributionPattern();
+        } else {
+            return executionJobVertex.getProducedDataSets()[gateOrPartitionIdx]
+                    .getConsumingDistributionPattern();
+        }
+    }
+
+    private InflightDataGateOrPartitionRescalingDescriptor createPointwiseRescalingDescriptor(
+            OperatorInstanceID instanceID,
+            int partition,
+            boolean isInput,
+            TaskStateAssignment connectedAssignment,
+            DistributionPattern oldPattern,
+            DistributionPattern newPattern) {
+        final int oldUpParallelism;
+        final int oldDownParallelism;
+        final int newUpParallelism;
+        final int newDownParallelism;
+
+        if (isInput) {
+            oldUpParallelism =
+                    connectedAssignment
+                            .oldState
+                            .get(connectedAssignment.outputOperatorID)
+                            .getParallelism();
+            oldDownParallelism = oldState.get(inputOperatorID).getParallelism();
+            newUpParallelism = connectedAssignment.newParallelism;
+            newDownParallelism = newParallelism;
+        } else {
+            oldUpParallelism = oldState.get(outputOperatorID).getParallelism();
+            oldDownParallelism =
+                    connectedAssignment
+                            .oldState
+                            .get(connectedAssignment.inputOperatorID)
+                            .getParallelism();
+            newUpParallelism = newParallelism;
+            newDownParallelism = connectedAssignment.newParallelism;
+        }
+
+        PointwiseRescaleParams params =
+                new PointwiseRescaleParams(
+                        oldPattern,
+                        newPattern,
+                        oldUpParallelism,
+                        oldDownParallelism,
+                        newUpParallelism,
+                        newDownParallelism);
+
+        int[] oldSubtaskInstances =
+                computePointwiseOldSubtaskInstances(instanceID.getSubtaskId(), isInput, params);
+
+        // identity: no old state to recover, or both parallelism + pattern unchanged (in-place)
+        boolean isIdentity =
+                oldSubtaskInstances.length == 0
+                        || (oldUpParallelism == newUpParallelism
+                                && oldDownParallelism == newDownParallelism
+                                && oldPattern == newPattern);
+
+        // PW edges: channel mapping and ambiguous are unused on TM (TM re-routes via params)
+        return log(
+                new InflightDataGateOrPartitionRescalingDescriptor(
+                        oldSubtaskInstances,
+                        RescaleMappings.SYMMETRIC_IDENTITY,
+                        emptySet(),
+                        isIdentity ? MappingType.IDENTITY : MappingType.RESCALING,
+                        params),
+                instanceID.getSubtaskId(),
+                partition);
+    }
+
+    private static int[] computePointwiseOldSubtaskInstances(
+            int newSubtaskIdx, boolean isInput, PointwiseRescaleParams params) {
+        if (isInput) {
+            // input: ROUND_ROBIN exact mapping, new downstream inherits a set of old downstreams
+            return SubtaskStateMapper.ROUND_ROBIN.getOldSubtasks(
+                    newSubtaskIdx, params.getOldDownParallelism(), params.getNewDownParallelism());
+        } else {
+            // output: computeInheritedOldUpstreams traces historical upstreams, may overlap
+            return PointwiseChannelMappingUtils.computeInheritedOldUpstreams(newSubtaskIdx, params);
+        }
+    }
+
+    private PointwiseRescaleParams buildOutputPointwiseRescaleParams(
+            int partitionIndex, TaskStateAssignment downstreamAssignment) {
+        DistributionPattern oldPattern =
+                resolveOldDistributionPattern(false, partitionIndex, downstreamAssignment);
+        DistributionPattern newPattern = resolveNewDistributionPattern(false, partitionIndex);
+        int oldUpParallelism = oldState.get(outputOperatorID).getParallelism();
+        int oldDownParallelism =
+                downstreamAssignment
+                        .oldState
+                        .get(downstreamAssignment.inputOperatorID)
+                        .getParallelism();
+        return new PointwiseRescaleParams(
+                oldPattern,
+                newPattern,
+                oldUpParallelism,
+                oldDownParallelism,
+                newParallelism,
+                downstreamAssignment.newParallelism);
+    }
+
     void distributeOutputBuffersToDownstream() {
         for (Map.Entry<OperatorInstanceID, List<ResultSubpartitionStateHandle>> entry :
                 resultSubpartitionStates.entrySet()) {
             OperatorInstanceID operatorInstanceID = entry.getKey();
+            int newUpstreamSubtaskIndex = operatorInstanceID.getSubtaskId();
             List<ResultSubpartitionStateHandle> stateHandles = entry.getValue();
 
             ResultSubpartitionDistributor distributor =
@@ -592,23 +811,44 @@ class TaskStateAssignment {
                             getOutputRescalingDescriptor(operatorInstanceID));
 
             for (final ResultSubpartitionStateHandle stateHandle : stateHandles) {
-                distributeOutputBufferToDownstream(stateHandle, distributor);
+                ResultSubpartitionInfo info = stateHandle.getInfo();
+                int partitionIdx = info.getPartitionIdx();
+                TaskStateAssignment downstreamAssignment = getDownstreamAssignments()[partitionIdx];
+
+                DistributionPattern oldPattern =
+                        resolveOldDistributionPattern(false, partitionIdx, downstreamAssignment);
+                DistributionPattern newPattern = resolveNewDistributionPattern(false, partitionIdx);
+                if (oldEdgePatterns != null
+                        && (oldPattern == DistributionPattern.POINTWISE
+                                || newPattern == DistributionPattern.POINTWISE)) {
+                    // PW edge: subpartition index ≠ global subtask ID, topology-aware routing
+                    // needed
+                    distributePointwiseOutputBufferToDownstream(
+                            stateHandle,
+                            partitionIdx,
+                            downstreamAssignment,
+                            newUpstreamSubtaskIndex);
+                } else {
+                    // A2A edge: local index == global subtask ID, original distributor suffices
+                    distributeA2AOutputBufferToDownstream(
+                            stateHandle, distributor, partitionIdx, downstreamAssignment);
+                }
             }
         }
     }
 
-    private void distributeOutputBufferToDownstream(
-            ResultSubpartitionStateHandle stateHandle, ResultSubpartitionDistributor distributor) {
-        // From the perspective of the downstream task, the oldUpstreamSubtaskIndex will be
-        // treated as the inputChannelIdx, and the info.getSubPartitionIdx() will be treated
-        // as the oldDownstreamSubtaskIndex.
-        int oldUpstreamSubtaskIndex = stateHandle.getSubtaskIndex();
+    private void distributeA2AOutputBufferToDownstream(
+            ResultSubpartitionStateHandle stateHandle,
+            ResultSubpartitionDistributor distributor,
+            int partitionIdx,
+            TaskStateAssignment downstreamAssignment) {
         ResultSubpartitionInfo info = stateHandle.getInfo();
-        int partitionIdx = info.getPartitionIdx();
+        // A2A path: oldUpstreamSubtaskIndex is the inputChannelIdx, and
+        // info.getSubPartitionIdx() is the oldDownstreamSubtaskIndex.
+        int oldUpstreamSubtaskIndex = stateHandle.getSubtaskIndex();
         int oldDownstreamSubtaskIndex = info.getSubPartitionIdx();
 
         int gateIdxResultPartition = findInputGateIdxForResultPartition(partitionIdx);
-        TaskStateAssignment downstreamAssignment = getDownstreamAssignments()[partitionIdx];
 
         List<ResultSubpartitionInfo> mappedSubpartitions = distributor.getMappedSubpartitions(info);
         for (final ResultSubpartitionInfo mappedSubpartition : mappedSubpartitions) {
@@ -634,6 +874,87 @@ class TaskStateAssignment {
                             downstreamOperatorInstance, k -> new ArrayList<>());
             upstreamOutputBufferHandles.add(upstreamOutputBufferHandle);
         }
+    }
+
+    private void distributePointwiseOutputBufferToDownstream(
+            ResultSubpartitionStateHandle stateHandle,
+            int partitionIdx,
+            TaskStateAssignment downstreamAssignment,
+            int newUpstreamSubtaskIndex) {
+        int oldUpstreamSubtaskIndex = stateHandle.getSubtaskIndex();
+        ResultSubpartitionInfo info = stateHandle.getInfo();
+        int subPartitionIdx = info.getSubPartitionIdx();
+
+        PointwiseRescaleParams params =
+                buildOutputPointwiseRescaleParams(partitionIdx, downstreamAssignment);
+
+        int oldUpPar = params.getOldUpParallelism();
+        int oldDownPar = params.getOldDownParallelism();
+        int newDownPar = params.getNewDownParallelism();
+
+        DistributionPattern oldPattern = params.getOldDistributionPattern();
+
+        int globalOldDownstream =
+                PointwiseChannelMappingUtils.localIndexToGlobalSubtaskIndex(
+                        oldUpstreamSubtaskIndex,
+                        subPartitionIdx,
+                        oldUpPar,
+                        oldDownPar,
+                        false,
+                        oldPattern);
+
+        int targetDownstreamSubtaskId =
+                PointwiseChannelMappingUtils.newSubtaskAssignedFrom(
+                        globalOldDownstream, newDownPar);
+
+        if (!getOutputMapping(partitionIdx).rescaleMappings.isIdentity()) {
+            // identity: computeInheritedOldUpstreams(N)={N}, each upstream recovers itself only;
+            // non-identity: multiple upstreams may trace the same old upstream, only primary
+            // recovers
+            int upstreamSubpartitionIfResponsive =
+                    PointwiseChannelMappingUtils.computeNewLocalSubpartitionIndex(
+                            targetDownstreamSubtaskId, newUpstreamSubtaskIndex, params);
+            if (upstreamSubpartitionIfResponsive < 0) {
+                return;
+            }
+        }
+
+        int oldDownstreamChannelIndex =
+                PointwiseChannelMappingUtils.globalSubtaskIndexToLocalIndex(
+                        globalOldDownstream,
+                        oldUpstreamSubtaskIndex,
+                        oldUpPar,
+                        oldDownPar,
+                        true,
+                        oldPattern);
+        checkState(
+                oldDownstreamChannelIndex >= 0,
+                "Failed to find a subtask channel for "
+                        + stateHandle
+                        + " when distributing output buffers for "
+                        + params);
+
+        int gateIdxResultPartition = findInputGateIdxForResultPartition(partitionIdx);
+
+        OperatorInstanceID downstreamOperatorInstance =
+                new OperatorInstanceID(
+                        targetDownstreamSubtaskId, downstreamAssignment.inputOperatorID);
+
+        InputChannelInfo inputChannelInfo =
+                new InputChannelInfo(gateIdxResultPartition, oldDownstreamChannelIndex);
+
+        InputChannelStateHandle upstreamOutputBufferHandle =
+                new InputChannelStateHandle(
+                        globalOldDownstream,
+                        inputChannelInfo,
+                        stateHandle.getDelegate(),
+                        stateHandle.getOffsets(),
+                        stateHandle.getStateSize());
+
+        List<InputChannelStateHandle> upstreamOutputBufferHandles =
+                downstreamAssignment.upstreamOutputBufferStates.computeIfAbsent(
+                        downstreamOperatorInstance, k -> new ArrayList<>());
+        upstreamOutputBufferHandles.add(upstreamOutputBufferHandle);
     }
 
     private int findInputGateIdxForResultPartition(int partitionIndex) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/ChannelStateFilteringHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/ChannelStateFilteringHandler.java
@@ -21,6 +21,9 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.core.memory.DataOutputSerializer;
 import org.apache.flink.runtime.checkpoint.InflightDataRescalingDescriptor;
+import org.apache.flink.runtime.checkpoint.InflightDataRescalingDescriptor.InflightDataGateOrPartitionRescalingDescriptor;
+import org.apache.flink.runtime.checkpoint.PointwiseChannelMappingUtils;
+import org.apache.flink.runtime.checkpoint.PointwiseRescaleParams;
 import org.apache.flink.runtime.checkpoint.RescaleMappings;
 import org.apache.flink.runtime.io.network.api.SubtaskConnectionDescriptor;
 import org.apache.flink.runtime.io.network.api.serialization.RecordDeserializer;
@@ -194,31 +197,68 @@ public class ChannelStateFilteringHandler implements Closeable {
 
         Map<SubtaskConnectionDescriptor, VirtualChannel<T>> gateVirtualChannels = new HashMap<>();
 
-        for (int oldSubtaskIndex : oldSubtaskIndexes) {
-            int numChannels = gate.getNumberOfInputChannels();
-            int[] oldChannelIndexes = getOldChannelIndexes(channelMapping, numChannels);
+        InflightDataGateOrPartitionRescalingDescriptor gateDesc =
+                rescalingDescriptor.getGateOrPartitionDescriptor(gateIndex);
 
-            for (int oldChannelIndex : oldChannelIndexes) {
-                SubtaskConnectionDescriptor key =
-                        new SubtaskConnectionDescriptor(oldSubtaskIndex, oldChannelIndex);
+        if (gateDesc.isPointwiseRescaling()) {
+            PointwiseRescaleParams params = gateDesc.getPointwiseRescaleParams();
+            for (int oldSubtaskIndex : oldSubtaskIndexes) {
+                int numLocal =
+                        PointwiseChannelMappingUtils.getOldLocalChannelCount(
+                                oldSubtaskIndex, params);
+                for (int localIdx = 0; localIdx < numLocal; localIdx++) {
+                    int oldChannelIndex =
+                            PointwiseChannelMappingUtils.localIndexToGlobalSubtaskIndex(
+                                    oldSubtaskIndex,
+                                    localIdx,
+                                    params.getOldUpParallelism(),
+                                    params.getOldDownParallelism(),
+                                    true,
+                                    params.getOldDistributionPattern());
+                    SubtaskConnectionDescriptor key =
+                            new SubtaskConnectionDescriptor(oldSubtaskIndex, oldChannelIndex);
+                    if (gateVirtualChannels.containsKey(key)) {
+                        continue;
+                    }
 
-                if (gateVirtualChannels.containsKey(key)) {
-                    continue;
+                    // PW edges use deterministic distribution, no record-level filtering needed
+                    RecordFilter<T> recordFilter =
+                            VirtualChannelRecordFilterFactory.createPassThroughFilter();
+                    RecordDeserializer<DeserializationDelegate<StreamElement>> deserializer =
+                            createDeserializer(filterContext.getTmpDirectories());
+                    VirtualChannel<T> vc = new VirtualChannel<>(deserializer, recordFilter);
+                    gateVirtualChannels.put(key, vc);
                 }
+            }
+        } else {
+            for (int oldSubtaskIndex : oldSubtaskIndexes) {
+                int numChannels = gate.getNumberOfInputChannels();
+                int[] oldChannelIndexes = getOldChannelIndexes(channelMapping, numChannels);
 
-                // Only ambiguous channels need actual filtering; non-ambiguous ones pass through
-                boolean isAmbiguous = rescalingDescriptor.isAmbiguous(gateIndex, oldSubtaskIndex);
+                for (int oldChannelIndex : oldChannelIndexes) {
+                    SubtaskConnectionDescriptor key =
+                            new SubtaskConnectionDescriptor(oldSubtaskIndex, oldChannelIndex);
 
-                RecordFilter<T> recordFilter =
-                        isAmbiguous
-                                ? filterFactory.createFilter()
-                                : VirtualChannelRecordFilterFactory.createPassThroughFilter();
+                    if (gateVirtualChannels.containsKey(key)) {
+                        continue;
+                    }
 
-                RecordDeserializer<DeserializationDelegate<StreamElement>> deserializer =
-                        createDeserializer(filterContext.getTmpDirectories());
+                    // Only ambiguous channels need actual filtering; non-ambiguous ones pass
+                    // through
+                    boolean isAmbiguous =
+                            rescalingDescriptor.isAmbiguous(gateIndex, oldSubtaskIndex);
 
-                VirtualChannel<T> vc = new VirtualChannel<>(deserializer, recordFilter);
-                gateVirtualChannels.put(key, vc);
+                    RecordFilter<T> recordFilter =
+                            isAmbiguous
+                                    ? filterFactory.createFilter()
+                                    : VirtualChannelRecordFilterFactory.createPassThroughFilter();
+
+                    RecordDeserializer<DeserializationDelegate<StreamElement>> deserializer =
+                            createDeserializer(filterContext.getTmpDirectories());
+
+                    VirtualChannel<T> vc = new VirtualChannel<>(deserializer, recordFilter);
+                    gateVirtualChannels.put(key, vc);
+                }
             }
         }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/RecoveredChannelStateHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/RecoveredChannelStateHandler.java
@@ -21,6 +21,8 @@ import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.core.memory.MemorySegment;
 import org.apache.flink.core.memory.MemorySegmentFactory;
 import org.apache.flink.runtime.checkpoint.InflightDataRescalingDescriptor;
+import org.apache.flink.runtime.checkpoint.PointwiseChannelMappingUtils;
+import org.apache.flink.runtime.checkpoint.PointwiseRescaleParams;
 import org.apache.flink.runtime.checkpoint.RescaleMappings;
 import org.apache.flink.runtime.io.network.api.SubtaskConnectionDescriptor;
 import org.apache.flink.runtime.io.network.api.serialization.EventSerializer;
@@ -34,6 +36,7 @@ import org.apache.flink.runtime.io.network.partition.CheckpointedResultPartition
 import org.apache.flink.runtime.io.network.partition.consumer.InputChannel;
 import org.apache.flink.runtime.io.network.partition.consumer.InputGate;
 import org.apache.flink.runtime.io.network.partition.consumer.RecoveredInputChannel;
+import org.apache.flink.runtime.jobgraph.DistributionPattern;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -78,9 +81,11 @@ class InputChannelRecoveredStateHandler
     private final InputGate[] inputGates;
 
     private final InflightDataRescalingDescriptor channelMapping;
+    private final int subtaskIndex;
 
     private final Map<InputChannelInfo, RecoveredInputChannel> rescaledChannels = new HashMap<>();
     private final Map<Integer, RescaleMappings> oldToNewMappings = new HashMap<>();
+    private final Map<Integer, int[]> pointwiseUpstreamAssignmentCache = new HashMap<>();
 
     /**
      * Optional filtering handler for filtering recovered buffers. When non-null, filtering is
@@ -112,10 +117,12 @@ class InputChannelRecoveredStateHandler
             InputGate[] inputGates,
             InflightDataRescalingDescriptor channelMapping,
             @Nullable ChannelStateFilteringHandler filteringHandler,
-            int memorySegmentSize) {
+            int memorySegmentSize,
+            int subtaskIndex) {
         this.inputGates = inputGates;
         this.channelMapping = channelMapping;
         this.filteringHandler = filteringHandler;
+        this.subtaskIndex = subtaskIndex;
         checkArgument(
                 memorySegmentSize > 0, "memorySegmentSize must be positive: %s", memorySegmentSize);
         this.memorySegmentSize = memorySegmentSize;
@@ -185,18 +192,25 @@ class InputChannelRecoveredStateHandler
         Buffer buffer = bufferWithContext.context;
         try {
             if (buffer.readableBytes() > 0) {
-                RecoveredInputChannel channel = getMappedChannels(channelInfo);
-
-                if (filteringHandler != null) {
-                    recoverWithFiltering(
-                            channel, channelInfo, oldSubtaskIndex, buffer.retainBuffer());
+                if (isPointwiseRescaling(channelInfo.getGateIdx())) {
+                    recoverPointwise(channelInfo, oldSubtaskIndex, buffer);
                 } else {
-                    channel.onRecoveredStateBuffer(
-                            EventSerializer.toBuffer(
-                                    new SubtaskConnectionDescriptor(
-                                            oldSubtaskIndex, channelInfo.getInputChannelIdx()),
-                                    false));
-                    channel.onRecoveredStateBuffer(buffer.retainBuffer());
+                    RecoveredInputChannel channel = getMappedChannels(channelInfo);
+                    if (filteringHandler != null) {
+                        recoverWithFiltering(
+                                channel,
+                                channelInfo.getGateIdx(),
+                                channelInfo.getInputChannelIdx(),
+                                oldSubtaskIndex,
+                                buffer.retainBuffer());
+                    } else {
+                        channel.onRecoveredStateBuffer(
+                                EventSerializer.toBuffer(
+                                        new SubtaskConnectionDescriptor(
+                                                oldSubtaskIndex, channelInfo.getInputChannelIdx()),
+                                        false));
+                        channel.onRecoveredStateBuffer(buffer.retainBuffer());
+                    }
                 }
             }
         } finally {
@@ -204,18 +218,74 @@ class InputChannelRecoveredStateHandler
         }
     }
 
+    private void recoverPointwise(InputChannelInfo channelInfo, int oldSubtaskIndex, Buffer buffer)
+            throws IOException, InterruptedException {
+        PointwiseRescaleParams params =
+                channelMapping
+                        .getGateOrPartitionDescriptor(channelInfo.getGateIdx())
+                        .getPointwiseRescaleParams();
+
+        // Step 1: old local channel index → old global upstream subtask ID
+        int oldUpstreamSubtaskIndex =
+                PointwiseChannelMappingUtils.localIndexToGlobalSubtaskIndex(
+                        oldSubtaskIndex,
+                        channelInfo.getInputChannelIdx(),
+                        params.getOldUpParallelism(),
+                        params.getOldDownParallelism(),
+                        true,
+                        params.getOldDistributionPattern());
+
+        // Step 2: old global upstream → new global upstream (A2A: modulo, PW: first-claim)
+        int newUpstreamSubtaskIndex;
+        if (params.getNewDistributionPattern() == DistributionPattern.ALL_TO_ALL) {
+            newUpstreamSubtaskIndex =
+                    PointwiseChannelMappingUtils.newSubtaskAssignedFrom(
+                            oldUpstreamSubtaskIndex, params.getNewUpParallelism());
+        } else {
+            int[] oldToNewUpstream =
+                    pointwiseUpstreamAssignmentCache.computeIfAbsent(
+                            channelInfo.getGateIdx(),
+                            idx ->
+                                    PointwiseChannelMappingUtils.computePrimaryUpstreamMapping(
+                                            subtaskIndex, params));
+            newUpstreamSubtaskIndex = oldToNewUpstream[oldUpstreamSubtaskIndex];
+        }
+
+        // Step 3: new global upstream → new local channel index
+        int newLocalChannelIndex =
+                PointwiseChannelMappingUtils.computeNewLocalInputChannelIndex(
+                        newUpstreamSubtaskIndex, subtaskIndex, params);
+
+        if (filteringHandler == null) {
+            SubtaskConnectionDescriptor descriptor =
+                    new SubtaskConnectionDescriptor(oldSubtaskIndex, oldUpstreamSubtaskIndex);
+            RecoveredInputChannel channel =
+                    getChannel(channelInfo.getGateIdx(), newLocalChannelIndex);
+            channel.onRecoveredStateBuffer(EventSerializer.toBuffer(descriptor, false));
+            channel.onRecoveredStateBuffer(buffer.retainBuffer());
+        } else {
+            recoverWithFiltering(
+                    getChannel(channelInfo.getGateIdx(), newLocalChannelIndex),
+                    channelInfo.getGateIdx(),
+                    oldUpstreamSubtaskIndex,
+                    oldSubtaskIndex,
+                    buffer.retainBuffer());
+        }
+    }
+
     private void recoverWithFiltering(
             RecoveredInputChannel channel,
-            InputChannelInfo channelInfo,
+            int gateIdx,
+            int inputChannelIdx,
             int oldSubtaskIndex,
             Buffer retainedBuffer)
             throws IOException, InterruptedException {
         checkState(filteringHandler != null, "filtering handler not set.");
         List<Buffer> filteredBuffers =
                 filteringHandler.filterAndRewrite(
-                        channelInfo.getGateIdx(),
+                        gateIdx,
                         oldSubtaskIndex,
-                        channelInfo.getInputChannelIdx(),
+                        inputChannelIdx,
                         retainedBuffer,
                         channel::requestBufferBlocking);
 
@@ -260,6 +330,10 @@ class InputChannelRecoveredStateHandler
 
     @Nonnull
     private RecoveredInputChannel calculateMapping(InputChannelInfo info) {
+        // PW path is already intercepted by recoverPointwise in recover(); defensive guard
+        if (isPointwiseRescaling(info.getGateIdx())) {
+            return getChannel(info.getGateIdx(), 0);
+        }
         final RescaleMappings oldToNewMapping =
                 oldToNewMappings.computeIfAbsent(
                         info.getGateIdx(), idx -> channelMapping.getChannelMapping(idx).invert());
@@ -270,6 +344,10 @@ class InputChannelRecoveredStateHandler
                         + "one buffer is expected to be processed once by the same task.");
         return getChannel(info.getGateIdx(), mappedIndexes[0]);
     }
+
+    private boolean isPointwiseRescaling(int gateIdx) {
+        return channelMapping.getGateOrPartitionDescriptor(gateIdx).isPointwiseRescaling();
+    }
 }
 
 class ResultSubpartitionRecoveredStateHandler
@@ -277,19 +355,20 @@ class ResultSubpartitionRecoveredStateHandler
 
     private final ResultPartitionWriter[] writers;
     private final boolean notifyAndBlockOnCompletion;
+    private final InflightDataRescalingDescriptor channelMapping;
+    private final int subtaskIndex;
     private final ResultSubpartitionDistributor resultSubpartitionDistributor;
 
     ResultSubpartitionRecoveredStateHandler(
             ResultPartitionWriter[] writers,
             boolean notifyAndBlockOnCompletion,
-            InflightDataRescalingDescriptor channelMapping) {
+            InflightDataRescalingDescriptor channelMapping,
+            int subtaskIndex) {
         this.writers = writers;
+        this.channelMapping = channelMapping;
+        this.subtaskIndex = subtaskIndex;
         this.resultSubpartitionDistributor =
                 new ResultSubpartitionDistributor(channelMapping) {
-                    /**
-                     * Override the getSubpartitionInfo to perform type checking on the
-                     * ResultPartitionWriter.
-                     */
                     @Override
                     ResultSubpartitionInfo getSubpartitionInfo(
                             int partitionIndex, int subPartitionIdx) {
@@ -323,23 +402,78 @@ class ResultSubpartitionRecoveredStateHandler
             if (!bufferConsumer.isDataAvailable()) {
                 return;
             }
-            final List<ResultSubpartitionInfo> mappedSubpartitions =
-                    resultSubpartitionDistributor.getMappedSubpartitions(subpartitionInfo);
-            CheckpointedResultPartition checkpointedResultPartition =
-                    getCheckpointedResultPartition(subpartitionInfo.getPartitionIdx());
-            for (final ResultSubpartitionInfo mappedSubpartition : mappedSubpartitions) {
-                // channel selector is created from the downstream's point of view: the
-                // subtask of downstream = subpartition index of recovered buffer
-                final SubtaskConnectionDescriptor channelSelector =
-                        new SubtaskConnectionDescriptor(
-                                subpartitionInfo.getSubPartitionIdx(), oldSubtaskIndex);
-                checkpointedResultPartition.addRecovered(
-                        mappedSubpartition.getSubPartitionIdx(),
-                        EventSerializer.toBufferConsumer(channelSelector, false));
-                checkpointedResultPartition.addRecovered(
-                        mappedSubpartition.getSubPartitionIdx(), bufferConsumer.copy());
+            if (isPointwiseRescaling(subpartitionInfo.getPartitionIdx())) {
+                recoverPointwise(subpartitionInfo, oldSubtaskIndex, bufferConsumer);
+            } else {
+                recoverAllToAll(subpartitionInfo, oldSubtaskIndex, bufferConsumer);
             }
         }
+    }
+
+    private void recoverAllToAll(
+            ResultSubpartitionInfo subpartitionInfo,
+            int oldSubtaskIndex,
+            BufferConsumer bufferConsumer)
+            throws IOException {
+        final List<ResultSubpartitionInfo> mappedSubpartitions =
+                resultSubpartitionDistributor.getMappedSubpartitions(subpartitionInfo);
+        CheckpointedResultPartition checkpointedResultPartition =
+                getCheckpointedResultPartition(subpartitionInfo.getPartitionIdx());
+        for (final ResultSubpartitionInfo mappedSubpartition : mappedSubpartitions) {
+            final SubtaskConnectionDescriptor channelSelector =
+                    new SubtaskConnectionDescriptor(
+                            subpartitionInfo.getSubPartitionIdx(), oldSubtaskIndex);
+            checkpointedResultPartition.addRecovered(
+                    mappedSubpartition.getSubPartitionIdx(),
+                    EventSerializer.toBufferConsumer(channelSelector, false));
+            checkpointedResultPartition.addRecovered(
+                    mappedSubpartition.getSubPartitionIdx(), bufferConsumer.copy());
+        }
+    }
+
+    private void recoverPointwise(
+            ResultSubpartitionInfo subpartitionInfo,
+            int oldSubtaskIndex,
+            BufferConsumer bufferConsumer)
+            throws IOException {
+        PointwiseRescaleParams params =
+                channelMapping
+                        .getGateOrPartitionDescriptor(subpartitionInfo.getPartitionIdx())
+                        .getPointwiseRescaleParams();
+
+        int oldDownstreamSubtaskIndex =
+                PointwiseChannelMappingUtils.localIndexToGlobalSubtaskIndex(
+                        oldSubtaskIndex,
+                        subpartitionInfo.getSubPartitionIdx(),
+                        params.getOldUpParallelism(),
+                        params.getOldDownParallelism(),
+                        false,
+                        params.getOldDistributionPattern());
+
+        int newDownstreamSubtaskIndex =
+                PointwiseChannelMappingUtils.newSubtaskAssignedFrom(
+                        oldDownstreamSubtaskIndex, params.getNewDownParallelism());
+
+        int newLocalSubpartitionIndex =
+                PointwiseChannelMappingUtils.computeNewLocalSubpartitionIndex(
+                        newDownstreamSubtaskIndex, subtaskIndex, params);
+        // Primary upstream dedup: returns -1 if not primary or not connected, discard buffer
+        if (newLocalSubpartitionIndex < 0) {
+            return;
+        }
+
+        SubtaskConnectionDescriptor channelSelector =
+                new SubtaskConnectionDescriptor(oldDownstreamSubtaskIndex, oldSubtaskIndex);
+        CheckpointedResultPartition checkpointedResultPartition =
+                getCheckpointedResultPartition(subpartitionInfo.getPartitionIdx());
+        checkpointedResultPartition.addRecovered(
+                newLocalSubpartitionIndex,
+                EventSerializer.toBufferConsumer(channelSelector, false));
+        checkpointedResultPartition.addRecovered(newLocalSubpartitionIndex, bufferConsumer.copy());
+    }
+
+    private boolean isPointwiseRescaling(int partitionIdx) {
+        return channelMapping.getGateOrPartitionDescriptor(partitionIdx).isPointwiseRescaling();
     }
 
     private CheckpointedResultPartition getCheckpointedResultPartition(int partitionIndex) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/SequentialChannelStateReaderImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/SequentialChannelStateReaderImpl.java
@@ -52,9 +52,15 @@ public class SequentialChannelStateReaderImpl implements SequentialChannelStateR
     private final TaskStateSnapshot taskStateSnapshot;
     private final ChannelStateSerializer serializer;
     private final ChannelStateChunkReader chunkReader;
+    private final int subtaskIndex;
 
     public SequentialChannelStateReaderImpl(TaskStateSnapshot taskStateSnapshot) {
+        this(taskStateSnapshot, 0);
+    }
+
+    public SequentialChannelStateReaderImpl(TaskStateSnapshot taskStateSnapshot, int subtaskIndex) {
         this.taskStateSnapshot = taskStateSnapshot;
+        this.subtaskIndex = subtaskIndex;
         serializer = new ChannelStateSerializerImpl();
         chunkReader = new ChannelStateChunkReader(serializer);
     }
@@ -75,7 +81,8 @@ public class SequentialChannelStateReaderImpl implements SequentialChannelStateR
                                 inputGates,
                                 taskStateSnapshot.getInputRescalingDescriptor(),
                                 filteringHandler,
-                                filterContext.getMemorySegmentSize())) {
+                                filterContext.getMemorySegmentSize(),
+                                subtaskIndex)) {
             read(
                     stateHandler,
                     groupByDelegate(
@@ -102,7 +109,8 @@ public class SequentialChannelStateReaderImpl implements SequentialChannelStateR
                 new ResultSubpartitionRecoveredStateHandler(
                         writers,
                         notifyAndBlockOnCompletion,
-                        taskStateSnapshot.getOutputRescalingDescriptor())) {
+                        taskStateSnapshot.getOutputRescalingDescriptor(),
+                        subtaskIndex)) {
             read(
                     stateHandler,
                     groupByDelegate(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/writer/SubtaskStateMapper.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/writer/SubtaskStateMapper.java
@@ -173,6 +173,38 @@ public enum SubtaskStateMapper {
         }
     },
 
+    /**
+     * Rescaling mapper for POINTWISE upstream edges. Unlike other mappers, the old-to-new mapping
+     * depends on both upstream and downstream parallelisms and edge patterns (topology-aware), so
+     * {@link #getOldSubtasks} cannot compute it from parallelisms alone. Callers must use {@link
+     * org.apache.flink.runtime.checkpoint.PointwiseChannelMappingUtils#computeInheritedOldUpstreams
+     * PointwiseChannelMappingUtils.computeInheritedOldUpstreams} with the full {@link
+     * org.apache.flink.runtime.checkpoint.PointwiseRescaleParams PointwiseRescaleParams} instead.
+     *
+     * <p>The mapping is ambiguous: multiple new upstreams may claim the same old upstream's state
+     * (e.g. when scaling up, computeInheritedOldUpstreams produces overlapping sets). Only the
+     * primary upstream (producersOf(D)[0]) is responsible for recovery.
+     *
+     * <p>In {@link org.apache.flink.streaming.api.graph.StreamingJobGraphGenerator
+     * StreamingJobGraphGenerator}, {@link #UNSUPPORTED} (set by forward/rescale partitioners on PW
+     * edges) is replaced with this value to signal the output mapping builder to use the
+     * topology-aware rescale path.
+     */
+    POINTWISE_UPSTREAM {
+        @Override
+        public int[] getOldSubtasks(
+                int newSubtaskIndex, int oldNumberOfSubtasks, int newNumberOfSubtasks) {
+            throw new UnsupportedOperationException(
+                    "POINTWISE_UPSTREAM requires PointwiseRescaleParams; "
+                            + "use PointwiseChannelMappingUtils.computeInheritedOldUpstreams instead.");
+        }
+
+        @Override
+        public boolean isAmbiguous() {
+            return true;
+        }
+    },
+
     UNSUPPORTED {
         @Override
         public int[] getOldSubtasks(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/TaskStateManagerImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/TaskStateManagerImpl.java
@@ -113,7 +113,8 @@ public class TaskStateManagerImpl implements TaskStateManager {
                 new SequentialChannelStateReaderImpl(
                         jobManagerTaskRestore == null
                                 ? new TaskStateSnapshot()
-                                : jobManagerTaskRestore.getTaskStateSnapshot()));
+                                : jobManagerTaskRestore.getTaskStateSnapshot(),
+                        executionAttemptID.getSubtaskIndex()));
     }
 
     public TaskStateManagerImpl(

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/api/graph/EdgeDistributionPatternHook.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/api/graph/EdgeDistributionPatternHook.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.graph;
+
+import org.apache.flink.core.io.SimpleVersionedSerializer;
+import org.apache.flink.runtime.checkpoint.EdgeDistributionPatternSnapshot;
+import org.apache.flink.runtime.checkpoint.MasterTriggerRestoreHook;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+
+/**
+ * A {@link MasterTriggerRestoreHook} that persists the current job's edge {@link
+ * org.apache.flink.runtime.jobgraph.DistributionPattern}s into checkpoint metadata, so they are
+ * available when restoring after a shuffle-mode change.
+ */
+class EdgeDistributionPatternHook implements MasterTriggerRestoreHook<byte[]> {
+
+    private final byte[] snapshotBytes;
+
+    EdgeDistributionPatternHook(byte[] snapshotBytes) {
+        this.snapshotBytes = snapshotBytes;
+    }
+
+    @Override
+    public String getIdentifier() {
+        return EdgeDistributionPatternSnapshot.HOOK_IDENTIFIER;
+    }
+
+    @Nullable
+    @Override
+    public CompletableFuture<byte[]> triggerCheckpoint(
+            long checkpointId, long timestamp, Executor executor) {
+        return CompletableFuture.completedFuture(snapshotBytes);
+    }
+
+    @Override
+    public void restoreCheckpoint(long checkpointId, @Nullable byte[] checkpointData) {
+        // no-op: data is extracted directly from MasterState before assignStates()
+    }
+
+    @Nullable
+    @Override
+    public SimpleVersionedSerializer<byte[]> createCheckpointDataSerializer() {
+        return ByteArraySerializer.INSTANCE;
+    }
+
+    private static final class ByteArraySerializer implements SimpleVersionedSerializer<byte[]> {
+        static final ByteArraySerializer INSTANCE = new ByteArraySerializer();
+
+        @Override
+        public int getVersion() {
+            return 1;
+        }
+
+        @Override
+        public byte[] serialize(byte[] obj) throws IOException {
+            return obj;
+        }
+
+        @Override
+        public byte[] deserialize(int version, byte[] serialized) throws IOException {
+            return serialized;
+        }
+    }
+
+    static class Factory implements MasterTriggerRestoreHook.Factory {
+        private static final long serialVersionUID = 1L;
+
+        private final byte[] snapshotBytes;
+
+        Factory(EdgeDistributionPatternSnapshot snapshot) throws IOException {
+            this.snapshotBytes = snapshot.toBytes();
+        }
+
+        @SuppressWarnings("unchecked")
+        @Override
+        public <V> MasterTriggerRestoreHook<V> create() {
+            return (MasterTriggerRestoreHook<V>) new EdgeDistributionPatternHook(snapshotBytes);
+        }
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphGenerator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphGenerator.java
@@ -269,9 +269,14 @@ public class StreamGraphGenerator {
         LineageGraph lineageGraph = LineageGraphUtils.convertToLineageGraph(transformations);
         streamGraph.setLineageGraph(lineageGraph);
 
+        boolean forceUnaligned =
+                checkpointConfig.isForceUnalignedCheckpoints() && !streamGraph.isIterative();
         for (StreamNode node : streamGraph.getStreamNodes()) {
             if (node.getInEdges().stream()
-                    .anyMatch(e -> !e.getPartitioner().isSupportsUnalignedCheckpoint())) {
+                    .anyMatch(
+                            e ->
+                                    !e.getPartitioner()
+                                            .isSupportsUnalignedCheckpoint(forceUnaligned))) {
                 for (StreamEdge edge : node.getInEdges()) {
                     edge.setSupportsUnalignedCheckpoints(false);
                 }

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
@@ -1712,11 +1712,13 @@ public class StreamingJobGraphGenerator {
                         .isUnalignedCheckpointsEnabled()
                 && !partitioner.isSupportsUnalignedCheckpoint(false)
                 && partitioner.isSupportsUnalignedCheckpoint(true)) {
+            // PW edges: downstream via ROUND_ROBIN, upstream via POINTWISE_UPSTREAM
+            // (topology-aware)
             if (downstreamMapper == SubtaskStateMapper.UNSUPPORTED) {
                 downstreamMapper = SubtaskStateMapper.ROUND_ROBIN;
             }
             if (upstreamMapper == SubtaskStateMapper.UNSUPPORTED) {
-                upstreamMapper = SubtaskStateMapper.ROUND_ROBIN;
+                upstreamMapper = SubtaskStateMapper.POINTWISE_UPSTREAM;
             }
         }
 

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
@@ -34,6 +34,9 @@ import org.apache.flink.configuration.ExecutionOptions;
 import org.apache.flink.configuration.IllegalConfigurationException;
 import org.apache.flink.core.memory.ManagedMemoryUseCase;
 import org.apache.flink.runtime.OperatorIDPair;
+import org.apache.flink.runtime.checkpoint.EdgeDistributionPatternSnapshot;
+import org.apache.flink.runtime.checkpoint.MasterTriggerRestoreHook;
+import org.apache.flink.runtime.io.network.api.writer.SubtaskStateMapper;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
 import org.apache.flink.runtime.jobgraph.DistributionPattern;
 import org.apache.flink.runtime.jobgraph.InputOutputFormatVertex;
@@ -45,11 +48,11 @@ import org.apache.flink.runtime.jobgraph.JobType;
 import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobgraph.OperatorID;
-import org.apache.flink.runtime.io.network.api.writer.SubtaskStateMapper;
 import org.apache.flink.runtime.jobgraph.forwardgroup.ForwardGroup;
 import org.apache.flink.runtime.jobgraph.forwardgroup.ForwardGroupComputeUtil;
 import org.apache.flink.runtime.jobgraph.forwardgroup.JobVertexForwardGroup;
 import org.apache.flink.runtime.jobgraph.tasks.CheckpointCoordinatorConfiguration;
+import org.apache.flink.runtime.jobgraph.tasks.JobCheckpointingSettings;
 import org.apache.flink.runtime.jobgraph.tasks.TaskInvokable;
 import org.apache.flink.runtime.jobgraph.topology.DefaultLogicalPipelinedRegion;
 import org.apache.flink.runtime.jobgraph.topology.DefaultLogicalTopology;
@@ -254,7 +257,68 @@ public class StreamingJobGraphGenerator {
         // Wait for the serialization of operator coordinators and stream config.
         serializeOperatorCoordinatorsAndStreamConfig(serializationExecutor, jobVertexBuildContext);
 
+        configureEdgeDistributionPatternHook();
+
         return jobGraph;
+    }
+
+    @SuppressWarnings("unchecked")
+    private void configureEdgeDistributionPatternHook() {
+        if (!streamGraph.getCheckpointConfig().isUnalignedCheckpointsEnabled()
+                || !streamGraph.getCheckpointConfig().isForceUnalignedCheckpoints()) {
+            return;
+        }
+        JobCheckpointingSettings settings = jobGraph.getCheckpointingSettings();
+        if (settings == null) {
+            return;
+        }
+        try {
+            Map<OperatorID, DistributionPattern[]> outputPatterns = new HashMap<>();
+            for (JobVertex jv : jobGraph.getVerticesSortedTopologicallyFromSources()) {
+                OperatorID outputOpId = jv.getOperatorIDs().get(0).getGeneratedOperatorID();
+                List<IntermediateDataSet> outputs = jv.getProducedDataSets();
+                DistributionPattern[] patterns = new DistributionPattern[outputs.size()];
+                for (int i = 0; i < outputs.size(); i++) {
+                    IntermediateDataSet ds = outputs.get(i);
+                    patterns[i] =
+                            ds.getConsumers().isEmpty()
+                                    ? DistributionPattern.ALL_TO_ALL
+                                    : ds.getDistributionPattern();
+                }
+                outputPatterns.put(outputOpId, patterns);
+            }
+
+            MasterTriggerRestoreHook.Factory[] existingHooks;
+            SerializedValue<MasterTriggerRestoreHook.Factory[]> serializedHooks =
+                    settings.getMasterHooks();
+            if (serializedHooks != null) {
+                existingHooks =
+                        serializedHooks.deserializeValue(
+                                Thread.currentThread().getContextClassLoader());
+            } else {
+                existingHooks = new MasterTriggerRestoreHook.Factory[0];
+            }
+
+            MasterTriggerRestoreHook.Factory[] newHooks =
+                    new MasterTriggerRestoreHook.Factory[existingHooks.length + 1];
+            System.arraycopy(existingHooks, 0, newHooks, 0, existingHooks.length);
+            newHooks[existingHooks.length] =
+                    new EdgeDistributionPatternHook.Factory(
+                            new EdgeDistributionPatternSnapshot(outputPatterns));
+
+            JobCheckpointingSettings newSettings =
+                    new JobCheckpointingSettings(
+                            settings.getCheckpointCoordinatorConfiguration(),
+                            settings.getDefaultStateBackend(),
+                            settings.isChangelogStateBackendEnabled(),
+                            settings.getDefaultCheckpointStorage(),
+                            new SerializedValue<>(newHooks),
+                            settings.isStateBackendUseManagedMemory());
+            jobGraph.setSnapshotSettings(newSettings);
+        } catch (Exception e) {
+            throw new FlinkRuntimeException(
+                    "Failed to configure edge distribution pattern hook", e);
+        }
     }
 
     public static void serializeOperatorCoordinatorsAndStreamConfig(

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
@@ -45,6 +45,7 @@ import org.apache.flink.runtime.jobgraph.JobType;
 import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobgraph.OperatorID;
+import org.apache.flink.runtime.io.network.api.writer.SubtaskStateMapper;
 import org.apache.flink.runtime.jobgraph.forwardgroup.ForwardGroup;
 import org.apache.flink.runtime.jobgraph.forwardgroup.ForwardGroupComputeUtil;
 import org.apache.flink.runtime.jobgraph.forwardgroup.JobVertexForwardGroup;
@@ -1634,8 +1635,29 @@ public class StreamingJobGraphGenerator {
 
         // set strategy name so that web interface can show it.
         jobEdge.setShipStrategyName(partitioner.toString());
-        jobEdge.setDownstreamSubtaskStateMapper(partitioner.getDownstreamSubtaskStateMapper());
-        jobEdge.setUpstreamSubtaskStateMapper(partitioner.getUpstreamSubtaskStateMapper());
+        SubtaskStateMapper downstreamMapper = partitioner.getDownstreamSubtaskStateMapper();
+        SubtaskStateMapper upstreamMapper = partitioner.getUpstreamSubtaskStateMapper();
+
+        if (jobVertexBuildContext
+                        .getStreamGraph()
+                        .getCheckpointConfig()
+                        .isForceUnalignedCheckpoints()
+                && jobVertexBuildContext
+                        .getStreamGraph()
+                        .getCheckpointConfig()
+                        .isUnalignedCheckpointsEnabled()
+                && !partitioner.isSupportsUnalignedCheckpoint(false)
+                && partitioner.isSupportsUnalignedCheckpoint(true)) {
+            if (downstreamMapper == SubtaskStateMapper.UNSUPPORTED) {
+                downstreamMapper = SubtaskStateMapper.ROUND_ROBIN;
+            }
+            if (upstreamMapper == SubtaskStateMapper.UNSUPPORTED) {
+                upstreamMapper = SubtaskStateMapper.ROUND_ROBIN;
+            }
+        }
+
+        jobEdge.setDownstreamSubtaskStateMapper(downstreamMapper);
+        jobEdge.setUpstreamSubtaskStateMapper(upstreamMapper);
 
         if (LOG.isDebugEnabled()) {
             LOG.debug(

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/io/recovery/DemultiplexingRecordDeserializer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/io/recovery/DemultiplexingRecordDeserializer.java
@@ -19,6 +19,9 @@ package org.apache.flink.streaming.runtime.io.recovery;
 
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.runtime.checkpoint.InflightDataRescalingDescriptor;
+import org.apache.flink.runtime.checkpoint.InflightDataRescalingDescriptor.InflightDataGateOrPartitionRescalingDescriptor;
+import org.apache.flink.runtime.checkpoint.PointwiseChannelMappingUtils;
+import org.apache.flink.runtime.checkpoint.PointwiseRescaleParams;
 import org.apache.flink.runtime.checkpoint.channel.InputChannelInfo;
 import org.apache.flink.runtime.io.network.api.SubtaskConnectionDescriptor;
 import org.apache.flink.runtime.io.network.api.serialization.RecordDeserializer;
@@ -152,6 +155,21 @@ class DemultiplexingRecordDeserializer<T>
         if (oldSubtaskIndexes.length == 0) {
             return UNMAPPED;
         }
+
+        InflightDataGateOrPartitionRescalingDescriptor gateDesc =
+                rescalingDescriptor.getGateOrPartitionDescriptor(channelInfo.getGateIdx());
+
+        if (gateDesc.isPointwiseRescaling()) {
+            // PW edges: compute actual connected virtual channels via old/new topology
+            return createPointwise(
+                    channelInfo,
+                    rescalingDescriptor,
+                    gateDesc,
+                    deserializerFactory,
+                    recordFilterFactory,
+                    oldSubtaskIndexes);
+        }
+
         final int[] oldChannelIndexes =
                 rescalingDescriptor
                         .getChannelMapping(channelInfo.getGateIdx())
@@ -170,6 +188,56 @@ class DemultiplexingRecordDeserializer<T>
                         descriptor,
                         new VirtualChannel<>(
                                 deserializerFactory.apply(totalChannels),
+                                rescalingDescriptor.isAmbiguous(channelInfo.getGateIdx(), subtask)
+                                        ? recordFilterFactory.apply(channelInfo)
+                                        : RecordFilter.acceptAll()));
+            }
+        }
+
+        return new DemultiplexingRecordDeserializer(virtualChannels);
+    }
+
+    private static <T> DemultiplexingRecordDeserializer<T> createPointwise(
+            InputChannelInfo channelInfo,
+            InflightDataRescalingDescriptor rescalingDescriptor,
+            InflightDataGateOrPartitionRescalingDescriptor gateDesc,
+            Function<Integer, RecordDeserializer<DeserializationDelegate<StreamElement>>>
+                    deserializerFactory,
+            Function<InputChannelInfo, RecordFilter<T>> recordFilterFactory,
+            int[] oldSubtaskIndexes) {
+        PointwiseRescaleParams params = gateDesc.getPointwiseRescaleParams();
+
+        int totalVirtualChannels = 0;
+        for (int subtask : oldSubtaskIndexes) {
+            totalVirtualChannels +=
+                    PointwiseChannelMappingUtils.getOldLocalChannelCount(subtask, params);
+        }
+        if (totalVirtualChannels == 0) {
+            return UNMAPPED;
+        }
+
+        Map<SubtaskConnectionDescriptor, VirtualChannel<T>> virtualChannels =
+                Maps.newHashMapWithExpectedSize(totalVirtualChannels);
+        for (int subtask : oldSubtaskIndexes) {
+            int numLocalChannels =
+                    PointwiseChannelMappingUtils.getOldLocalChannelCount(subtask, params);
+            for (int localChannelIndex = 0;
+                    localChannelIndex < numLocalChannels;
+                    localChannelIndex++) {
+                int oldUpstreamSubtaskIndex =
+                        PointwiseChannelMappingUtils.localIndexToGlobalSubtaskIndex(
+                                subtask,
+                                localChannelIndex,
+                                params.getOldUpParallelism(),
+                                params.getOldDownParallelism(),
+                                true,
+                                params.getOldDistributionPattern());
+                SubtaskConnectionDescriptor descriptor =
+                        new SubtaskConnectionDescriptor(subtask, oldUpstreamSubtaskIndex);
+                virtualChannels.put(
+                        descriptor,
+                        new VirtualChannel<>(
+                                deserializerFactory.apply(totalVirtualChannels),
                                 rescalingDescriptor.isAmbiguous(channelInfo.getGateIdx(), subtask)
                                         ? recordFilterFactory.apply(channelInfo)
                                         : RecordFilter.acceptAll()));

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/partitioner/StreamPartitioner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/partitioner/StreamPartitioner.java
@@ -87,7 +87,11 @@ public abstract class StreamPartitioner<T>
     public abstract boolean isPointwise();
 
     public boolean isSupportsUnalignedCheckpoint() {
-        return supportsUnalignedCheckpoint && !isPointwise() && !isBroadcast();
+        return isSupportsUnalignedCheckpoint(false);
+    }
+
+    public boolean isSupportsUnalignedCheckpoint(boolean forceUnaligned) {
+        return supportsUnalignedCheckpoint && (forceUnaligned || !isPointwise()) && !isBroadcast();
     }
 
     public void disableUnalignedCheckpoints() {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/EdgeDistributionPatternSnapshotTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/EdgeDistributionPatternSnapshotTest.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.checkpoint;
+
+import org.apache.flink.runtime.jobgraph.DistributionPattern;
+import org.apache.flink.runtime.jobgraph.OperatorID;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Tests for {@link EdgeDistributionPatternSnapshot}. */
+class EdgeDistributionPatternSnapshotTest {
+
+    @Test
+    void roundTripSerialization() throws IOException {
+        Map<OperatorID, DistributionPattern[]> patterns = new HashMap<>();
+        OperatorID op1 = new OperatorID();
+        OperatorID op2 = new OperatorID();
+        patterns.put(op1, new DistributionPattern[] {DistributionPattern.POINTWISE});
+        patterns.put(
+                op2,
+                new DistributionPattern[] {
+                    DistributionPattern.ALL_TO_ALL, DistributionPattern.POINTWISE
+                });
+
+        EdgeDistributionPatternSnapshot original = new EdgeDistributionPatternSnapshot(patterns);
+        byte[] bytes = original.toBytes();
+        EdgeDistributionPatternSnapshot restored = EdgeDistributionPatternSnapshot.fromBytes(bytes);
+
+        assertThat(restored.getOutputPatterns(op1)).containsExactly(DistributionPattern.POINTWISE);
+        assertThat(restored.getOutputPatterns(op2))
+                .containsExactly(DistributionPattern.ALL_TO_ALL, DistributionPattern.POINTWISE);
+    }
+
+    @Test
+    void emptySnapshot() throws IOException {
+        EdgeDistributionPatternSnapshot original =
+                new EdgeDistributionPatternSnapshot(new HashMap<>());
+        byte[] bytes = original.toBytes();
+        EdgeDistributionPatternSnapshot restored = EdgeDistributionPatternSnapshot.fromBytes(bytes);
+
+        assertThat(restored.getOutputPatterns(new OperatorID())).isNull();
+    }
+
+    @Test
+    void getOutputPatternByIndex() throws IOException {
+        Map<OperatorID, DistributionPattern[]> patterns = new HashMap<>();
+        OperatorID op = new OperatorID();
+        patterns.put(
+                op,
+                new DistributionPattern[] {
+                    DistributionPattern.POINTWISE,
+                    DistributionPattern.ALL_TO_ALL,
+                    DistributionPattern.POINTWISE
+                });
+
+        EdgeDistributionPatternSnapshot snapshot = new EdgeDistributionPatternSnapshot(patterns);
+
+        assertThat(snapshot.getOutputPattern(op, 0)).isEqualTo(DistributionPattern.POINTWISE);
+        assertThat(snapshot.getOutputPattern(op, 1)).isEqualTo(DistributionPattern.ALL_TO_ALL);
+        assertThat(snapshot.getOutputPattern(op, 2)).isEqualTo(DistributionPattern.POINTWISE);
+        assertThat(snapshot.getOutputPattern(op, 3)).isNull();
+        assertThat(snapshot.getOutputPattern(new OperatorID(), 0)).isNull();
+    }
+
+    @Test
+    void unknownPatternByteRejected() throws IOException {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        DataOutputStream dos = new DataOutputStream(baos);
+        dos.writeInt(1); // version
+        dos.writeInt(1); // numOperators
+        dos.writeLong(0L); // opId lower
+        dos.writeLong(0L); // opId upper
+        dos.writeInt(1); // numPartitions
+        dos.writeByte(7); // unknown pattern byte
+        dos.flush();
+
+        assertThatThrownBy(() -> EdgeDistributionPatternSnapshot.fromBytes(baos.toByteArray()))
+                .isInstanceOf(IOException.class)
+                .hasMessageContaining("Unknown DistributionPattern byte");
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/PointwiseChannelMappingUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/PointwiseChannelMappingUtilsTest.java
@@ -1,0 +1,679 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.checkpoint;
+
+import org.apache.flink.runtime.jobgraph.DistributionPattern;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Tests for {@link PointwiseChannelMappingUtils}. */
+class PointwiseChannelMappingUtilsTest {
+
+    private static final DistributionPattern PW = DistributionPattern.POINTWISE;
+    private static final DistributionPattern A2A = DistributionPattern.ALL_TO_ALL;
+
+    private static PointwiseRescaleParams params(int oldUp, int oldDown, int newUp, int newDown) {
+        return new PointwiseRescaleParams(PW, PW, oldUp, oldDown, newUp, newDown);
+    }
+
+    private static PointwiseRescaleParams params(
+            DistributionPattern oldPat,
+            DistributionPattern newPat,
+            int oldUp,
+            int oldDown,
+            int newUp,
+            int newDown) {
+        return new PointwiseRescaleParams(oldPat, newPat, oldUp, oldDown, newUp, newDown);
+    }
+
+    // ======================== producersOf / consumersOf ========================
+
+    @Test
+    void producersOfAndConsumersOfAreInverses() {
+        for (int upPar = 1; upPar <= 8; upPar++) {
+            for (int downPar = 1; downPar <= 8; downPar++) {
+                for (int d = 0; d < downPar; d++) {
+                    int[] producers = PointwiseChannelMappingUtils.producersOf(d, upPar, downPar);
+                    for (int p : producers) {
+                        int[] consumers =
+                                PointwiseChannelMappingUtils.consumersOf(p, upPar, downPar);
+                        assertThat(consumers)
+                                .as(
+                                        "up=%d down=%d: d=%d should be in consumersOf(%d)",
+                                        upPar, downPar, d, p)
+                                .contains(d);
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    void producersOfCoversAllUpstream() {
+        for (int upPar = 1; upPar <= 8; upPar++) {
+            for (int downPar = 1; downPar <= 8; downPar++) {
+                Set<Integer> allProducers = new HashSet<>();
+                for (int d = 0; d < downPar; d++) {
+                    int[] producers = PointwiseChannelMappingUtils.producersOf(d, upPar, downPar);
+                    for (int p : producers) {
+                        allProducers.add(p);
+                    }
+                }
+                assertThat(allProducers)
+                        .as("up=%d down=%d: all upstream covered", upPar, downPar)
+                        .hasSize(upPar);
+            }
+        }
+    }
+
+    @Test
+    void consumersOfCoversAllDownstream() {
+        for (int upPar = 1; upPar <= 8; upPar++) {
+            for (int downPar = 1; downPar <= 8; downPar++) {
+                Set<Integer> allConsumers = new HashSet<>();
+                for (int u = 0; u < upPar; u++) {
+                    int[] consumers = PointwiseChannelMappingUtils.consumersOf(u, upPar, downPar);
+                    for (int c : consumers) {
+                        allConsumers.add(c);
+                    }
+                }
+                assertThat(allConsumers)
+                        .as("up=%d down=%d: all downstream covered", upPar, downPar)
+                        .hasSize(downPar);
+            }
+        }
+    }
+
+    @Test
+    void producersOfConcreteValues() {
+        // 2 upstream -> 4 downstream (upscale): each downstream has one producer
+        assertThat(PointwiseChannelMappingUtils.producersOf(0, 2, 4)).containsExactly(0);
+        assertThat(PointwiseChannelMappingUtils.producersOf(1, 2, 4)).containsExactly(0);
+        assertThat(PointwiseChannelMappingUtils.producersOf(2, 2, 4)).containsExactly(1);
+        assertThat(PointwiseChannelMappingUtils.producersOf(3, 2, 4)).containsExactly(1);
+
+        // 4 upstream -> 2 downstream (downscale): each downstream merges 2 producers
+        assertThat(PointwiseChannelMappingUtils.producersOf(0, 4, 2)).containsExactly(0, 1);
+        assertThat(PointwiseChannelMappingUtils.producersOf(1, 4, 2)).containsExactly(2, 3);
+
+        // 3 upstream -> 3 downstream (equal): identity
+        assertThat(PointwiseChannelMappingUtils.producersOf(0, 3, 3)).containsExactly(0);
+        assertThat(PointwiseChannelMappingUtils.producersOf(1, 3, 3)).containsExactly(1);
+        assertThat(PointwiseChannelMappingUtils.producersOf(2, 3, 3)).containsExactly(2);
+    }
+
+    @Test
+    void consumersOfConcreteValues() {
+        // 2 upstream -> 4 downstream (upscale): each upstream serves 2 consumers
+        assertThat(PointwiseChannelMappingUtils.consumersOf(0, 2, 4)).containsExactly(0, 1);
+        assertThat(PointwiseChannelMappingUtils.consumersOf(1, 2, 4)).containsExactly(2, 3);
+
+        // 4 upstream -> 2 downstream (downscale): each upstream feeds one consumer
+        assertThat(PointwiseChannelMappingUtils.consumersOf(0, 4, 2)).containsExactly(0);
+        assertThat(PointwiseChannelMappingUtils.consumersOf(1, 4, 2)).containsExactly(0);
+        assertThat(PointwiseChannelMappingUtils.consumersOf(2, 4, 2)).containsExactly(1);
+        assertThat(PointwiseChannelMappingUtils.consumersOf(3, 4, 2)).containsExactly(1);
+    }
+
+    // ======================== localIndexToGlobalSubtaskIndex ========================
+
+    @Test
+    void localIndexToGlobalSubtaskIndexPointwiseInputSide() {
+        // 4 upstream -> 2 downstream: d=0 has producers {0,1}, d=1 has producers {2,3}
+        assertThat(
+                        PointwiseChannelMappingUtils.localIndexToGlobalSubtaskIndex(
+                                0, 0, 4, 2, true, PW))
+                .isEqualTo(0);
+        assertThat(
+                        PointwiseChannelMappingUtils.localIndexToGlobalSubtaskIndex(
+                                0, 1, 4, 2, true, PW))
+                .isEqualTo(1);
+        assertThat(
+                        PointwiseChannelMappingUtils.localIndexToGlobalSubtaskIndex(
+                                1, 0, 4, 2, true, PW))
+                .isEqualTo(2);
+        assertThat(
+                        PointwiseChannelMappingUtils.localIndexToGlobalSubtaskIndex(
+                                1, 1, 4, 2, true, PW))
+                .isEqualTo(3);
+    }
+
+    @Test
+    void localIndexToGlobalSubtaskIndexPointwiseOutputSide() {
+        // 2 upstream -> 4 downstream: u=0 has consumers {0,1}, u=1 has consumers {2,3}
+        // consumers start at 0 and 2 (both % 2 == 0), so modulo == sequential here.
+        assertThat(
+                        PointwiseChannelMappingUtils.localIndexToGlobalSubtaskIndex(
+                                0, 0, 2, 4, false, PW))
+                .isEqualTo(0);
+        assertThat(
+                        PointwiseChannelMappingUtils.localIndexToGlobalSubtaskIndex(
+                                0, 1, 2, 4, false, PW))
+                .isEqualTo(1);
+        assertThat(
+                        PointwiseChannelMappingUtils.localIndexToGlobalSubtaskIndex(
+                                1, 0, 2, 4, false, PW))
+                .isEqualTo(2);
+        assertThat(
+                        PointwiseChannelMappingUtils.localIndexToGlobalSubtaskIndex(
+                                1, 1, 2, 4, false, PW))
+                .isEqualTo(3);
+
+        // 4 upstream -> 6 downstream: u=2 has consumers {3,4}
+        // consumers[0]=3, 3%2=1 ≠ 0, so modulo ≠ sequential:
+        // sp 0 → consumer 4 (4%2=0), sp 1 → consumer 3 (3%2=1)
+        assertThat(
+                        PointwiseChannelMappingUtils.localIndexToGlobalSubtaskIndex(
+                                2, 0, 4, 6, false, PW))
+                .isEqualTo(4);
+        assertThat(
+                        PointwiseChannelMappingUtils.localIndexToGlobalSubtaskIndex(
+                                2, 1, 4, 6, false, PW))
+                .isEqualTo(3);
+    }
+
+    @Test
+    void localIndexToGlobalSubtaskIndexBoundsCheck() {
+        assertThatThrownBy(
+                        () ->
+                                PointwiseChannelMappingUtils.localIndexToGlobalSubtaskIndex(
+                                        0, 5, 4, 2, true, PW))
+                .isInstanceOf(ArrayIndexOutOfBoundsException.class);
+    }
+
+    // ======================== getOldLocalChannelCount ========================
+
+    @Test
+    void getOldLocalChannelCountAllToAll() {
+        PointwiseRescaleParams p = new PointwiseRescaleParams(A2A, A2A, 5, 3, 5, 3);
+        assertThat(PointwiseChannelMappingUtils.getOldLocalChannelCount(0, p)).isEqualTo(5);
+        assertThat(PointwiseChannelMappingUtils.getOldLocalChannelCount(2, p)).isEqualTo(5);
+    }
+
+    @Test
+    void getOldLocalChannelCountPointwise() {
+        // 4 upstream -> 2 downstream: each downstream has 2 producers
+        PointwiseRescaleParams p = params(4, 2, 4, 2);
+        assertThat(PointwiseChannelMappingUtils.getOldLocalChannelCount(0, p)).isEqualTo(2);
+        assertThat(PointwiseChannelMappingUtils.getOldLocalChannelCount(1, p)).isEqualTo(2);
+    }
+
+    // ======================== computeNewLocalInputChannelIndex / SubpartitionIndex ===
+
+    @Test
+    void computeNewLocalInputChannelIndexAllToAll() {
+        PointwiseRescaleParams p = new PointwiseRescaleParams(PW, A2A, 4, 2, 4, 2);
+        assertThat(PointwiseChannelMappingUtils.computeNewLocalInputChannelIndex(3, 0, p))
+                .isEqualTo(3);
+    }
+
+    @Test
+    void computeNewLocalInputChannelIndexPointwise() {
+        // 4 upstream -> 2 downstream: d=0 connects to {0,1}, d=1 connects to {2,3}
+        PointwiseRescaleParams p = params(4, 2, 4, 2);
+        assertThat(PointwiseChannelMappingUtils.computeNewLocalInputChannelIndex(0, 0, p))
+                .isEqualTo(0);
+        assertThat(PointwiseChannelMappingUtils.computeNewLocalInputChannelIndex(1, 0, p))
+                .isEqualTo(1);
+        assertThat(PointwiseChannelMappingUtils.computeNewLocalInputChannelIndex(2, 1, p))
+                .isEqualTo(0);
+    }
+
+    @Test
+    void computeNewLocalSubpartitionIndexAllToAll() {
+        PointwiseRescaleParams p = new PointwiseRescaleParams(PW, A2A, 2, 4, 2, 4);
+        assertThat(PointwiseChannelMappingUtils.computeNewLocalSubpartitionIndex(3, 0, p))
+                .isEqualTo(3);
+    }
+
+    @Test
+    void computeNewLocalSubpartitionIndexPointwise() {
+        // 2 upstream -> 4 downstream: u=0 connects to {0,1}, u=1 connects to {2,3}
+        PointwiseRescaleParams p = params(2, 4, 2, 4);
+        assertThat(PointwiseChannelMappingUtils.computeNewLocalSubpartitionIndex(0, 0, p))
+                .isEqualTo(0);
+        assertThat(PointwiseChannelMappingUtils.computeNewLocalSubpartitionIndex(1, 0, p))
+                .isEqualTo(1);
+        assertThat(PointwiseChannelMappingUtils.computeNewLocalSubpartitionIndex(2, 1, p))
+                .isEqualTo(0);
+    }
+
+    // =============== oldSubtasksAssignedTo / newSubtaskAssignedFrom ===============
+
+    @Test
+    void oldSubtasksAssignedToAndNewSubtaskAssignedFromAreConsistent() {
+        for (int oldPar = 1; oldPar <= 8; oldPar++) {
+            for (int newPar = 1; newPar <= 8; newPar++) {
+                for (int newIdx = 0; newIdx < newPar; newIdx++) {
+                    int[] oldSubtasks =
+                            PointwiseChannelMappingUtils.oldSubtasksAssignedTo(
+                                    newIdx, oldPar, newPar);
+                    for (int oldIdx : oldSubtasks) {
+                        assertThat(
+                                        PointwiseChannelMappingUtils.newSubtaskAssignedFrom(
+                                                oldIdx, newPar))
+                                .as(
+                                        "old=%d,new=%d: newSubtaskAssignedFrom(%d) == %d",
+                                        oldPar, newPar, oldIdx, newIdx)
+                                .isEqualTo(newIdx);
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    void oldSubtasksAssignedToCoversAllOld() {
+        for (int oldPar = 1; oldPar <= 8; oldPar++) {
+            for (int newPar = 1; newPar <= 8; newPar++) {
+                Set<Integer> covered = new HashSet<>();
+                for (int newIdx = 0; newIdx < newPar; newIdx++) {
+                    for (int oldIdx :
+                            PointwiseChannelMappingUtils.oldSubtasksAssignedTo(
+                                    newIdx, oldPar, newPar)) {
+                        covered.add(oldIdx);
+                    }
+                }
+                assertThat(covered)
+                        .as("old=%d new=%d: all old subtasks assigned", oldPar, newPar)
+                        .hasSize(oldPar);
+            }
+        }
+    }
+
+    @Test
+    void newSubtaskAssignedFromIsModulo() {
+        assertThat(PointwiseChannelMappingUtils.newSubtaskAssignedFrom(5, 3)).isEqualTo(2);
+        assertThat(PointwiseChannelMappingUtils.newSubtaskAssignedFrom(0, 4)).isEqualTo(0);
+        assertThat(PointwiseChannelMappingUtils.newSubtaskAssignedFrom(7, 3)).isEqualTo(1);
+    }
+
+    // ======================== computeInheritedOldUpstreams ========================
+
+    @Test
+    void computeInheritedOldUpstreamsPwToPw() {
+        // 3 up -> 3 down (PW), rescale to 4 up -> 3 down (PW)
+        // newUp=0: consumers in new topo = consumersOf(0,4,3) = {0}
+        //   newDown=0: oldSubtasksAssignedTo(0,3,3) = {0}
+        //     oldDown=0: producersOf(0,3,3) = {0}
+        // result = {0}
+        PointwiseRescaleParams p = params(3, 3, 4, 3);
+        assertThat(PointwiseChannelMappingUtils.computeInheritedOldUpstreams(0, p))
+                .containsExactly(0);
+
+        // newUp=3: consumers in new topo = consumersOf(3,4,3) = {2}
+        //   newDown=2: oldSubtasksAssignedTo(2,3,3) = {2}
+        //     oldDown=2: producersOf(2,3,3) = {2}
+        // result = {2}
+        assertThat(PointwiseChannelMappingUtils.computeInheritedOldUpstreams(3, p))
+                .containsExactly(2);
+    }
+
+    @Test
+    void computeInheritedOldUpstreamsA2aToPw() {
+        // Old A2A (3 up, 3 down) -> New PW (4 up, 3 down)
+        // Any old downstream connects to all 3 old upstreams (A2A), so result = {0,1,2}
+        PointwiseRescaleParams p = params(A2A, PW, 3, 3, 4, 3);
+        for (int newUp = 0; newUp < 4; newUp++) {
+            assertThat(PointwiseChannelMappingUtils.computeInheritedOldUpstreams(newUp, p))
+                    .as("newUp=%d", newUp)
+                    .containsExactly(0, 1, 2);
+        }
+    }
+
+    @Test
+    void computeInheritedOldUpstreamsPwToA2a() {
+        // Old PW (3 up, 3 down) -> New A2A (4 up, 3 down)
+        // New A2A: every new upstream serves ALL new downstreams {0,1,2}
+        // oldSubtasksAssignedTo covers all 3 old downstreams → all old producers reached
+        PointwiseRescaleParams p = params(PW, A2A, 3, 3, 4, 3);
+        for (int newUp = 0; newUp < 4; newUp++) {
+            assertThat(PointwiseChannelMappingUtils.computeInheritedOldUpstreams(newUp, p))
+                    .as("newUp=%d", newUp)
+                    .containsExactly(0, 1, 2);
+        }
+    }
+
+    @Test
+    void computeInheritedOldUpstreamsCoversAllOldUpstreams() {
+        for (int oldUp = 1; oldUp <= 6; oldUp++) {
+            for (int oldDown = 1; oldDown <= 6; oldDown++) {
+                for (int newUp = 1; newUp <= 6; newUp++) {
+                    for (int newDown = 1; newDown <= 6; newDown++) {
+                        PointwiseRescaleParams p = params(oldUp, oldDown, newUp, newDown);
+                        Set<Integer> allClaimed = new HashSet<>();
+                        for (int u = 0; u < newUp; u++) {
+                            for (int oldU :
+                                    PointwiseChannelMappingUtils.computeInheritedOldUpstreams(
+                                            u, p)) {
+                                allClaimed.add(oldU);
+                            }
+                        }
+                        assertThat(allClaimed)
+                                .as(
+                                        "PW %d:%d->%d:%d: all old upstreams covered",
+                                        oldUp, oldDown, newUp, newDown)
+                                .hasSize(oldUp);
+                    }
+                }
+            }
+        }
+    }
+
+    // ======================== computePrimaryUpstreamMapping ========================
+
+    @Test
+    void computePrimaryUpstreamMappingPwToPw() {
+        // 3 up -> 3 down (PW), rescale to 4 up -> 3 down (PW)
+        // newDown=0: connected new upstreams = producersOf(0,4,3) = {0}
+        //   newUp=0: computeInheritedOldUpstreams = {0} → mapping[0] = 0
+        PointwiseRescaleParams p = params(3, 3, 4, 3);
+        int[] ownership = PointwiseChannelMappingUtils.computePrimaryUpstreamMapping(0, p);
+        assertThat(ownership).hasSize(3);
+        assertThat(ownership[0]).isEqualTo(0);
+    }
+
+    @Test
+    void computePrimaryUpstreamMappingNoUnclaimedForConnectedOldUpstreams() {
+        for (int oldUp = 1; oldUp <= 6; oldUp++) {
+            for (int oldDown = 1; oldDown <= 6; oldDown++) {
+                for (int newUp = 1; newUp <= 6; newUp++) {
+                    for (int newDown = 1; newDown <= 6; newDown++) {
+                        PointwiseRescaleParams p = params(oldUp, oldDown, newUp, newDown);
+                        for (int newD = 0; newD < newDown; newD++) {
+                            int[] ownership =
+                                    PointwiseChannelMappingUtils.computePrimaryUpstreamMapping(
+                                            newD, p);
+                            // Every old upstream that was connected to any old downstream
+                            // that maps to this new downstream must be claimed.
+                            int[] oldDownstreams =
+                                    PointwiseChannelMappingUtils.oldSubtasksAssignedTo(
+                                            newD, oldDown, newDown);
+                            for (int oldD : oldDownstreams) {
+                                int[] oldProducers =
+                                        PointwiseChannelMappingUtils.producersOf(
+                                                oldD, oldUp, oldDown);
+                                for (int oldU : oldProducers) {
+                                    assertThat(ownership[oldU])
+                                            .as(
+                                                    "%d:%d->%d:%d newD=%d oldD=%d oldU=%d must be claimed",
+                                                    oldUp, oldDown, newUp, newDown, newD, oldD,
+                                                    oldU)
+                                            .isGreaterThanOrEqualTo(0);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    void computePrimaryUpstreamMappingOwnerIsConnected() {
+        for (int oldUp = 1; oldUp <= 6; oldUp++) {
+            for (int oldDown = 1; oldDown <= 6; oldDown++) {
+                for (int newUp = 1; newUp <= 6; newUp++) {
+                    for (int newDown = 1; newDown <= 6; newDown++) {
+                        PointwiseRescaleParams p = params(oldUp, oldDown, newUp, newDown);
+                        for (int newD = 0; newD < newDown; newD++) {
+                            int[] ownership =
+                                    PointwiseChannelMappingUtils.computePrimaryUpstreamMapping(
+                                            newD, p);
+                            int[] connectedNewUp =
+                                    PointwiseChannelMappingUtils.producersOf(newD, newUp, newDown);
+                            for (int oldU = 0; oldU < oldUp; oldU++) {
+                                if (ownership[oldU] >= 0) {
+                                    assertThat(connectedNewUp)
+                                            .as(
+                                                    "%d:%d->%d:%d newD=%d: owner of oldU=%d should be connected",
+                                                    oldUp, oldDown, newUp, newDown, newD, oldU)
+                                            .contains(ownership[oldU]);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // ======================== Primary producer dedup ========================
+
+    @Test
+    void primaryProducerDedupExactlyOneWriterPerDownstream() {
+        // When newUpPar > newDownPar, multiple upstreams connect to the same downstream.
+        // computeNewLocalSubpartitionIndex must return non-negative for exactly one.
+        int[][] cases = {{4, 2}, {10, 3}, {11, 3}, {6, 2}, {7, 1}};
+        for (int[] c : cases) {
+            int newUp = c[0], newDown = c[1];
+            PointwiseRescaleParams p = params(newUp, newDown, newUp, newDown);
+            for (int d = 0; d < newDown; d++) {
+                int writerCount = 0;
+                int writerIndex = -1;
+                for (int u = 0; u < newUp; u++) {
+                    int sub =
+                            PointwiseChannelMappingUtils.computeNewLocalSubpartitionIndex(d, u, p);
+                    if (sub >= 0) {
+                        writerCount++;
+                        writerIndex = u;
+                    }
+                }
+                assertThat(writerCount)
+                        .as("%d:%d downstream %d: exactly one writer", newUp, newDown, d)
+                        .isEqualTo(1);
+                // The writer must be producersOf(d)[0] (primary producer)
+                int[] producers = PointwiseChannelMappingUtils.producersOf(d, newUp, newDown);
+                assertThat(writerIndex)
+                        .as("%d:%d downstream %d: writer is primary producer", newUp, newDown, d)
+                        .isEqualTo(producers[0]);
+            }
+        }
+    }
+
+    // ======================== Modulo-based subpartition/channel mapping ========================
+
+    /**
+     * The execution graph assigns subpartitions via {@code consumerSubtaskIndex % numConsumers}
+     * (see {@code VertexInputInfoComputationUtils.computeConsumedSubpartitionRange}). When
+     * consumers don't start at a multiple of numConsumers, this differs from sequential indexing
+     * ({@code D - consumers[0]}). Both {@code localIndexToGlobalSubtaskIndex} (output side) and
+     * {@code computeNewLocalSubpartitionIndex} must use modulo, not sequential offset.
+     *
+     * <p>Concrete example: 4 upstream → 6 downstream POINTWISE. Upstream 2 has consumers [3,4].
+     * Sequential would map sp0→D3, sp1→D4. But the execution graph assigns D3→sp(3%2=1),
+     * D4→sp(4%2=0). So sp0→D4, sp1→D3. Using sequential causes buffers to be routed to the wrong
+     * downstream, leading to "Cannot select SubtaskConnectionDescriptor" errors at the DEMUX layer.
+     */
+    @Test
+    void moduloMappingDiffersFromSequentialWhenOffsetNotAligned() {
+        // 4 up -> 6 down: upstream 2 has consumers [3,4]
+        int[] consumers = PointwiseChannelMappingUtils.consumersOf(2, 4, 6);
+        assertThat(consumers).containsExactly(3, 4);
+
+        // localIndexToGlobalSubtaskIndex output side: sp → consumer via modulo
+        // sp 0 → consumer where c%2==0 → 4 (NOT sequential consumers[0]=3)
+        assertThat(
+                        PointwiseChannelMappingUtils.localIndexToGlobalSubtaskIndex(
+                                2, 0, 4, 6, false, PW))
+                .isEqualTo(4);
+        // sp 1 → consumer where c%2==1 → 3 (NOT sequential consumers[1]=4)
+        assertThat(
+                        PointwiseChannelMappingUtils.localIndexToGlobalSubtaskIndex(
+                                2, 1, 4, 6, false, PW))
+                .isEqualTo(3);
+
+        // computeNewLocalSubpartitionIndex: consumer → sp via modulo
+        PointwiseRescaleParams p = params(4, 6, 4, 6);
+        // D=3 → sp 3%2=1 (NOT sequential 3-3=0)
+        assertThat(PointwiseChannelMappingUtils.computeNewLocalSubpartitionIndex(3, 2, p))
+                .isEqualTo(1);
+        // D=4 → sp 4%2=0 (NOT sequential 4-3=1)
+        assertThat(PointwiseChannelMappingUtils.computeNewLocalSubpartitionIndex(4, 2, p))
+                .isEqualTo(0);
+    }
+
+    @Test
+    void subpartitionIndexModuloForNonZeroOffset() {
+        // Subpartition assignment uses D % numConsumers (matching the execution graph),
+        // NOT D - consumers[0] (sequential offset). This distinction matters when
+        // consumers[0] % consumers.length != 0.
+
+        // 3 up -> 10 down (PW): upstream 1 has consumers [4,5,6]
+        // D=4 → sp 4%3=1, D=5 → sp 5%3=2, D=6 → sp 6%3=0
+        PointwiseRescaleParams p = params(3, 10, 3, 10);
+        int[] consumers = PointwiseChannelMappingUtils.consumersOf(1, 3, 10);
+        assertThat(consumers).startsWith(4); // sanity check: non-zero offset
+        for (int c : consumers) {
+            assertThat(PointwiseChannelMappingUtils.computeNewLocalSubpartitionIndex(c, 1, p))
+                    .as("3:10 upstream 1, D=%d → sp %d", c, c % consumers.length)
+                    .isEqualTo(c % consumers.length);
+        }
+
+        // 2 up -> 5 down (PW): upstream 1 has consumers [3,4]
+        // D=3 → sp 3%2=1, D=4 → sp 4%2=0
+        PointwiseRescaleParams p2 = params(2, 5, 2, 5);
+        int[] consumers2 = PointwiseChannelMappingUtils.consumersOf(1, 2, 5);
+        assertThat(consumers2).startsWith(3);
+        for (int c : consumers2) {
+            assertThat(PointwiseChannelMappingUtils.computeNewLocalSubpartitionIndex(c, 1, p2))
+                    .as("2:5 upstream 1, D=%d → sp %d", c, c % consumers2.length)
+                    .isEqualTo(c % consumers2.length);
+        }
+    }
+
+    @Test
+    void subpartitionIndexIsModuloForAllParallelisms() {
+        // Exhaustively verify D % numConsumers for all upPar x downPar up to 8.
+        for (int upPar = 1; upPar <= 8; upPar++) {
+            for (int downPar = 1; downPar <= 8; downPar++) {
+                PointwiseRescaleParams p = params(upPar, downPar, upPar, downPar);
+                for (int u = 0; u < upPar; u++) {
+                    int[] consumers = PointwiseChannelMappingUtils.consumersOf(u, upPar, downPar);
+                    for (int c : consumers) {
+                        int sp =
+                                PointwiseChannelMappingUtils.computeNewLocalSubpartitionIndex(
+                                        c, u, p);
+                        int[] producers =
+                                PointwiseChannelMappingUtils.producersOf(c, upPar, downPar);
+                        if (producers[0] == u) {
+                            assertThat(sp)
+                                    .as(
+                                            "up=%d down=%d u=%d D=%d: sp should be D %% numConsumers",
+                                            upPar, downPar, u, c)
+                                    .isEqualTo(c % consumers.length);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    void outputSideLocalIndexModuloForAllParallelisms() {
+        // Exhaustively verify modulo mapping on the output side of localIndexToGlobalSubtaskIndex.
+        for (int upPar = 1; upPar <= 8; upPar++) {
+            for (int downPar = 1; downPar <= 8; downPar++) {
+                for (int u = 0; u < upPar; u++) {
+                    int[] consumers = PointwiseChannelMappingUtils.consumersOf(u, upPar, downPar);
+                    for (int sp = 0; sp < consumers.length; sp++) {
+                        int globalD =
+                                PointwiseChannelMappingUtils.localIndexToGlobalSubtaskIndex(
+                                        u, sp, upPar, downPar, false, PW);
+                        assertThat(globalD % consumers.length)
+                                .as(
+                                        "up=%d down=%d u=%d sp=%d: D %% numConsumers should equal sp",
+                                        upPar, downPar, u, sp)
+                                .isEqualTo(sp);
+                    }
+                }
+            }
+        }
+    }
+
+    // =============== Round-trip: localIndexToGlobalSubtaskIndex ↔ subpartition index
+    // ===============
+
+    @Test
+    void localIndexToGlobalSubtaskIndexAndSubpartitionIndexAreInverses() {
+        for (int upPar = 1; upPar <= 6; upPar++) {
+            for (int downPar = 1; downPar <= 6; downPar++) {
+                PointwiseRescaleParams p = params(upPar, downPar, upPar, downPar);
+                for (int u = 0; u < upPar; u++) {
+                    int[] consumers = PointwiseChannelMappingUtils.consumersOf(u, upPar, downPar);
+                    // Only the primary producer can round-trip (others get -1)
+                    for (int localIndex = 0; localIndex < consumers.length; localIndex++) {
+                        int globalD =
+                                PointwiseChannelMappingUtils.localIndexToGlobalSubtaskIndex(
+                                        u, localIndex, upPar, downPar, false, PW);
+                        // Output side uses modulo mapping (D % numConsumers == localIndex),
+                        // not sequential consumers[localIndex].
+                        assertThat(consumers).contains(globalD);
+                        assertThat(globalD % consumers.length)
+                                .as("up=%d down=%d u=%d local=%d", upPar, downPar, u, localIndex)
+                                .isEqualTo(localIndex);
+                        int[] producers =
+                                PointwiseChannelMappingUtils.producersOf(globalD, upPar, downPar);
+                        if (producers[0] == u) {
+                            int backLocal =
+                                    PointwiseChannelMappingUtils.computeNewLocalSubpartitionIndex(
+                                            globalD, u, p);
+                            assertThat(backLocal)
+                                    .as(
+                                            "up=%d down=%d u=%d: round-trip localIndex=%d",
+                                            upPar, downPar, u, localIndex)
+                                    .isEqualTo(localIndex);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    void localIndexToGlobalSubtaskIndexAndInputChannelIndexAreInverses() {
+        for (int upPar = 1; upPar <= 6; upPar++) {
+            for (int downPar = 1; downPar <= 6; downPar++) {
+                PointwiseRescaleParams p = params(upPar, downPar, upPar, downPar);
+                for (int d = 0; d < downPar; d++) {
+                    int[] producers = PointwiseChannelMappingUtils.producersOf(d, upPar, downPar);
+                    for (int localIndex = 0; localIndex < producers.length; localIndex++) {
+                        int globalU =
+                                PointwiseChannelMappingUtils.localIndexToGlobalSubtaskIndex(
+                                        d, localIndex, upPar, downPar, true, PW);
+                        assertThat(globalU).isEqualTo(producers[localIndex]);
+                        int backLocal =
+                                PointwiseChannelMappingUtils.computeNewLocalInputChannelIndex(
+                                        globalU, d, p);
+                        assertThat(backLocal)
+                                .as(
+                                        "up=%d down=%d d=%d: round-trip localIndex=%d",
+                                        upPar, downPar, d, localIndex)
+                                .isEqualTo(localIndex);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/PointwiseRescalingDescriptorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/PointwiseRescalingDescriptorTest.java
@@ -1,0 +1,634 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.checkpoint;
+
+import org.apache.flink.runtime.JobException;
+import org.apache.flink.runtime.OperatorIDPair;
+import org.apache.flink.runtime.checkpoint.InflightDataRescalingDescriptor.InflightDataGateOrPartitionRescalingDescriptor;
+import org.apache.flink.runtime.client.JobExecutionException;
+import org.apache.flink.runtime.executiongraph.ExecutionGraph;
+import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
+import org.apache.flink.runtime.executiongraph.TestingDefaultExecutionGraphBuilder;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
+import org.apache.flink.runtime.jobgraph.DistributionPattern;
+import org.apache.flink.runtime.jobgraph.JobEdge;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.jobgraph.JobGraphTestUtils;
+import org.apache.flink.runtime.jobgraph.JobVertex;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.jobgraph.OperatorID;
+import org.apache.flink.runtime.testtasks.NoOpInvokable;
+import org.apache.flink.runtime.util.JobVertexConnectionUtils;
+import org.apache.flink.testutils.TestingUtils;
+import org.apache.flink.testutils.executor.TestExecutorExtension;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Random;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.stream.Collectors;
+
+import static org.apache.flink.runtime.checkpoint.StateHandleDummyUtil.createNewInputChannelStateHandle;
+import static org.apache.flink.runtime.checkpoint.StateHandleDummyUtil.createNewResultSubpartitionStateHandle;
+import static org.apache.flink.runtime.io.network.api.writer.SubtaskStateMapper.ROUND_ROBIN;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests for POINTWISE edge rescaling descriptor generation in {@link
+ * StateAssignmentOperation} and {@link TaskStateAssignment}.
+ */
+class PointwiseRescalingDescriptorTest {
+
+    @RegisterExtension
+    private static final TestExecutorExtension<ScheduledExecutorService> EXECUTOR_EXTENSION =
+            TestingUtils.defaultExecutorExtension();
+
+    private static final int MAX_P = 256;
+
+    // ===== Test 1: POINTWISE same parallelism => IDENTITY =====
+    @Test
+    void testPointwiseSameParallelismIsIdentity() throws Exception {
+        OperatorID sourceId = new OperatorID();
+        OperatorID sinkId = new OperatorID();
+        int oldPar = 3;
+        int newPar = 3;
+
+        JobVertex source = createJobVertex(sourceId, newPar);
+        JobVertex sink = createJobVertex(sinkId, newPar);
+        connectPointwise(source, sink);
+
+        Map<OperatorID, ExecutionJobVertex> vertices = toExecutionVertices(source, sink);
+        Map<OperatorID, OperatorState> states =
+                buildStatesWithChannelState(sourceId, sinkId, oldPar);
+
+        EdgeDistributionPatternSnapshot oldEdgePatterns =
+                buildEdgePatterns(sourceId, DistributionPattern.POINTWISE);
+
+        new StateAssignmentOperation(
+                        0, new HashSet<>(vertices.values()), states, false, true, oldEdgePatterns)
+                .assignStates();
+
+        // Same parallelism + same pattern => IDENTITY (NO_RESCALE)
+        for (int subtask = 0; subtask < newPar; subtask++) {
+            OperatorSubtaskState sinkState =
+                    getAssignedState(vertices.get(sinkId), sinkId, subtask);
+            assertThat(sinkState.getInputRescalingDescriptor())
+                    .isEqualTo(InflightDataRescalingDescriptor.NO_RESCALE);
+
+            OperatorSubtaskState sourceState =
+                    getAssignedState(vertices.get(sourceId), sourceId, subtask);
+            assertThat(sourceState.getOutputRescalingDescriptor())
+                    .isEqualTo(InflightDataRescalingDescriptor.NO_RESCALE);
+        }
+    }
+
+    // ===== Test 2: POINTWISE scale up - subtasks with old state get descriptors =====
+    @Test
+    void testPointwiseScaleUp() throws Exception {
+        // old: source(2) --PW--> sink(2), new: source(4) --PW--> sink(4)
+        OperatorID sourceId = new OperatorID();
+        OperatorID sinkId = new OperatorID();
+        int oldPar = 2;
+        int newPar = 4;
+
+        JobVertex source = createJobVertex(sourceId, newPar);
+        JobVertex sink = createJobVertex(sinkId, newPar);
+        connectPointwise(source, sink);
+
+        Map<OperatorID, ExecutionJobVertex> vertices = toExecutionVertices(source, sink);
+        Map<OperatorID, OperatorState> states =
+                buildStatesWithChannelState(sourceId, sinkId, oldPar);
+
+        EdgeDistributionPatternSnapshot oldEdgePatterns =
+                buildEdgePatterns(sourceId, DistributionPattern.POINTWISE);
+
+        new StateAssignmentOperation(
+                        0, new HashSet<>(vertices.values()), states, false, true, oldEdgePatterns)
+                .assignStates();
+
+        // Subtasks that absorb old state should get POINTWISE descriptors (newUpPar > 0)
+        int subtasksWithDescriptor = 0;
+        for (int subtask = 0; subtask < newPar; subtask++) {
+            OperatorSubtaskState sinkState =
+                    getAssignedState(vertices.get(sinkId), sinkId, subtask);
+            InflightDataRescalingDescriptor inputDesc = sinkState.getInputRescalingDescriptor();
+
+            if (!inputDesc.equals(InflightDataRescalingDescriptor.NO_RESCALE)) {
+                subtasksWithDescriptor++;
+                InflightDataGateOrPartitionRescalingDescriptor gateDesc =
+                        inputDesc.getGateOrPartitionDescriptor(0);
+                assertThat(gateDesc.getPointwiseRescaleParams().getNewUpParallelism())
+                        .isEqualTo(newPar);
+                assertThat(gateDesc.getPointwiseRescaleParams().getNewDownParallelism())
+                        .isEqualTo(newPar);
+                assertThat(gateDesc.getPointwiseRescaleParams().getOldUpParallelism())
+                        .isEqualTo(oldPar);
+                assertThat(gateDesc.getPointwiseRescaleParams().getOldDownParallelism())
+                        .isEqualTo(oldPar);
+                assertThat(gateDesc.getPointwiseRescaleParams().getOldDistributionPattern())
+                        .isEqualTo(DistributionPattern.POINTWISE);
+                assertThat(gateDesc.isIdentity()).isFalse();
+
+                int[] oldSubtaskIndexes = inputDesc.getOldSubtaskIndexes(0);
+                assertThat(oldSubtaskIndexes.length).isGreaterThan(0);
+            }
+        }
+        // At least the subtasks that got old state must have descriptors
+        assertThat(subtasksWithDescriptor).isGreaterThan(0);
+
+        // Verify output side similarly
+        int sourceSubtasksWithDescriptor = 0;
+        for (int subtask = 0; subtask < newPar; subtask++) {
+            OperatorSubtaskState sourceState =
+                    getAssignedState(vertices.get(sourceId), sourceId, subtask);
+            InflightDataRescalingDescriptor outputDesc = sourceState.getOutputRescalingDescriptor();
+
+            if (!outputDesc.equals(InflightDataRescalingDescriptor.NO_RESCALE)) {
+                sourceSubtasksWithDescriptor++;
+                InflightDataGateOrPartitionRescalingDescriptor partDesc =
+                        outputDesc.getGateOrPartitionDescriptor(0);
+                assertThat(partDesc.getPointwiseRescaleParams().getNewUpParallelism())
+                        .isEqualTo(newPar);
+                assertThat(partDesc.getPointwiseRescaleParams().getNewDownParallelism())
+                        .isEqualTo(newPar);
+                assertThat(partDesc.getPointwiseRescaleParams().getOldUpParallelism())
+                        .isEqualTo(oldPar);
+                assertThat(partDesc.getPointwiseRescaleParams().getOldDownParallelism())
+                        .isEqualTo(oldPar);
+                assertThat(partDesc.getPointwiseRescaleParams().getOldDistributionPattern())
+                        .isEqualTo(DistributionPattern.POINTWISE);
+            }
+        }
+        assertThat(sourceSubtasksWithDescriptor).isGreaterThan(0);
+    }
+
+    // ===== Test 3: POINTWISE scale down - all old subtasks covered =====
+    @Test
+    void testPointwiseScaleDown() throws Exception {
+        // old: source(4) --PW--> sink(4), new: source(2) --PW--> sink(2)
+        OperatorID sourceId = new OperatorID();
+        OperatorID sinkId = new OperatorID();
+        int oldPar = 4;
+        int newPar = 2;
+
+        JobVertex source = createJobVertex(sourceId, newPar);
+        JobVertex sink = createJobVertex(sinkId, newPar);
+        connectPointwise(source, sink);
+
+        Map<OperatorID, ExecutionJobVertex> vertices = toExecutionVertices(source, sink);
+        Map<OperatorID, OperatorState> states =
+                buildStatesWithChannelState(sourceId, sinkId, oldPar);
+
+        EdgeDistributionPatternSnapshot oldEdgePatterns =
+                buildEdgePatterns(sourceId, DistributionPattern.POINTWISE);
+
+        new StateAssignmentOperation(
+                        0, new HashSet<>(vertices.values()), states, false, true, oldEdgePatterns)
+                .assignStates();
+
+        // Scale down: every new subtask absorbs state from multiple old subtasks
+        boolean[] covered = new boolean[oldPar];
+        for (int subtask = 0; subtask < newPar; subtask++) {
+            OperatorSubtaskState sinkState =
+                    getAssignedState(vertices.get(sinkId), sinkId, subtask);
+            InflightDataRescalingDescriptor inputDesc = sinkState.getInputRescalingDescriptor();
+            assertThat(inputDesc)
+                    .as("subtask %d should have rescaling descriptor", subtask)
+                    .isNotEqualTo(InflightDataRescalingDescriptor.NO_RESCALE);
+
+            InflightDataGateOrPartitionRescalingDescriptor gateDesc =
+                    inputDesc.getGateOrPartitionDescriptor(0);
+            assertThat(gateDesc.getPointwiseRescaleParams().getOldUpParallelism())
+                    .isEqualTo(oldPar);
+            assertThat(gateDesc.getPointwiseRescaleParams().getOldDownParallelism())
+                    .isEqualTo(oldPar);
+            assertThat(gateDesc.getPointwiseRescaleParams().getNewUpParallelism())
+                    .isEqualTo(newPar);
+            assertThat(gateDesc.getPointwiseRescaleParams().getNewDownParallelism())
+                    .isEqualTo(newPar);
+            assertThat(gateDesc.getPointwiseRescaleParams().getOldDistributionPattern())
+                    .isEqualTo(DistributionPattern.POINTWISE);
+
+            int[] oldSubtaskIndexes = inputDesc.getOldSubtaskIndexes(0);
+            assertThat(oldSubtaskIndexes.length).isGreaterThan(0);
+            for (int oldIdx : oldSubtaskIndexes) {
+                covered[oldIdx] = true;
+            }
+        }
+        // Every old subtask must be assigned to some new subtask
+        for (int i = 0; i < oldPar; i++) {
+            assertThat(covered[i]).as("Old subtask %d should be covered", i).isTrue();
+        }
+    }
+
+    // ===== Test 4: A2A -> POINTWISE migration =====
+    @Test
+    void testAllToAllToPointwiseMigration() throws Exception {
+        // old: source(3) --A2A--> sink(3), new: source(3) --PW--> sink(3)
+        OperatorID sourceId = new OperatorID();
+        OperatorID sinkId = new OperatorID();
+        int oldPar = 3;
+        int newPar = 3;
+
+        JobVertex source = createJobVertex(sourceId, newPar);
+        JobVertex sink = createJobVertex(sinkId, newPar);
+        connectPointwise(source, sink);
+
+        Map<OperatorID, ExecutionJobVertex> vertices = toExecutionVertices(source, sink);
+        Map<OperatorID, OperatorState> states =
+                buildStatesWithChannelState(sourceId, sinkId, oldPar);
+
+        // Old pattern was A2A
+        EdgeDistributionPatternSnapshot oldEdgePatterns =
+                buildEdgePatterns(sourceId, DistributionPattern.ALL_TO_ALL);
+
+        new StateAssignmentOperation(
+                        0, new HashSet<>(vertices.values()), states, false, true, oldEdgePatterns)
+                .assignStates();
+
+        // A2A->PW same-par: new sink k reads from old sink k only (ROUND_ROBIN 1:1).
+        // TM-side recoverPointwise then routes each old upstream's buffer to the correct new
+        // upstream channel via computePrimaryUpstreamMapping, so reading the extra old sinks would
+        // cause each inflight record to be delivered to all new subtasks (3x duplicates).
+        for (int subtask = 0; subtask < newPar; subtask++) {
+            OperatorSubtaskState sinkState =
+                    getAssignedState(vertices.get(sinkId), sinkId, subtask);
+            InflightDataRescalingDescriptor inputDesc = sinkState.getInputRescalingDescriptor();
+            assertThat(inputDesc)
+                    .as("subtask %d", subtask)
+                    .isNotEqualTo(InflightDataRescalingDescriptor.NO_RESCALE);
+
+            int[] oldSubtaskIndexes = inputDesc.getOldSubtaskIndexes(0);
+            // ROUND_ROBIN 1:1 for same parallelism: new sink k -> old sink k
+            assertThat(oldSubtaskIndexes).isEqualTo(new int[] {subtask});
+
+            InflightDataGateOrPartitionRescalingDescriptor gateDesc =
+                    inputDesc.getGateOrPartitionDescriptor(0);
+            assertThat(gateDesc.getPointwiseRescaleParams().getOldDistributionPattern())
+                    .isEqualTo(DistributionPattern.ALL_TO_ALL);
+            assertThat(gateDesc.getPointwiseRescaleParams().getNewDistributionPattern())
+                    .isEqualTo(DistributionPattern.POINTWISE);
+            assertThat(gateDesc.getPointwiseRescaleParams().getNewUpParallelism())
+                    .isEqualTo(newPar);
+        }
+    }
+
+    // ===== Test 5: POINTWISE -> A2A migration =====
+    @Test
+    void testPointwiseToAllToAllMigration() throws Exception {
+        // old: source(3) --PW--> sink(3), new: source(3) --A2A--> sink(3)
+        OperatorID sourceId = new OperatorID();
+        OperatorID sinkId = new OperatorID();
+        int oldPar = 3;
+        int newPar = 3;
+
+        JobVertex source = createJobVertex(sourceId, newPar);
+        JobVertex sink = createJobVertex(sinkId, newPar);
+        connectAllToAll(source, sink);
+
+        Map<OperatorID, ExecutionJobVertex> vertices = toExecutionVertices(source, sink);
+        Map<OperatorID, OperatorState> states =
+                buildStatesWithChannelState(sourceId, sinkId, oldPar);
+
+        // Old pattern was POINTWISE
+        EdgeDistributionPatternSnapshot oldEdgePatterns =
+                buildEdgePatterns(sourceId, DistributionPattern.POINTWISE);
+
+        new StateAssignmentOperation(
+                        0, new HashSet<>(vertices.values()), states, false, true, oldEdgePatterns)
+                .assignStates();
+
+        // PW->A2A: enters the pointwise path (oldPattern != A2A)
+        for (int subtask = 0; subtask < newPar; subtask++) {
+            OperatorSubtaskState sinkState =
+                    getAssignedState(vertices.get(sinkId), sinkId, subtask);
+            InflightDataRescalingDescriptor inputDesc = sinkState.getInputRescalingDescriptor();
+            assertThat(inputDesc)
+                    .as("subtask %d", subtask)
+                    .isNotEqualTo(InflightDataRescalingDescriptor.NO_RESCALE);
+
+            InflightDataGateOrPartitionRescalingDescriptor gateDesc =
+                    inputDesc.getGateOrPartitionDescriptor(0);
+            assertThat(gateDesc.getPointwiseRescaleParams().getOldDistributionPattern())
+                    .isEqualTo(DistributionPattern.POINTWISE);
+            assertThat(gateDesc.getPointwiseRescaleParams().getNewDistributionPattern())
+                    .isEqualTo(DistributionPattern.ALL_TO_ALL);
+            // PW->A2A: newUpParallelism > 0 confirms pointwise path used
+            assertThat(gateDesc.getPointwiseRescaleParams().getNewUpParallelism())
+                    .isEqualTo(newPar);
+        }
+    }
+
+    // ===== Test 6: Pure A2A rescaling (regression - original path unchanged) =====
+    @Test
+    void testPureAllToAllRescalingRegression() throws Exception {
+        // old: source(2) --A2A--> sink(2), new: source(3) --A2A--> sink(3)
+        OperatorID sourceId = new OperatorID();
+        OperatorID sinkId = new OperatorID();
+        int oldPar = 2;
+        int newPar = 3;
+
+        JobVertex source = createJobVertex(sourceId, newPar);
+        JobVertex sink = createJobVertex(sinkId, newPar);
+        connectAllToAll(source, sink);
+
+        Map<OperatorID, ExecutionJobVertex> vertices = toExecutionVertices(source, sink);
+        Map<OperatorID, OperatorState> states =
+                buildStatesWithChannelState(sourceId, sinkId, oldPar);
+
+        // Old pattern was A2A (same as new)
+        EdgeDistributionPatternSnapshot oldEdgePatterns =
+                buildEdgePatterns(sourceId, DistributionPattern.ALL_TO_ALL);
+
+        new StateAssignmentOperation(
+                        0, new HashSet<>(vertices.values()), states, false, true, oldEdgePatterns)
+                .assignStates();
+
+        // A2A->A2A: should use the original all-to-all path
+        // The descriptor should have newUpParallelism == 0 (no pointwise fields)
+        for (int subtask = 0; subtask < newPar; subtask++) {
+            OperatorSubtaskState sinkState =
+                    getAssignedState(vertices.get(sinkId), sinkId, subtask);
+            InflightDataRescalingDescriptor inputDesc = sinkState.getInputRescalingDescriptor();
+
+            if (!inputDesc.equals(InflightDataRescalingDescriptor.NO_RESCALE)) {
+                InflightDataGateOrPartitionRescalingDescriptor gateDesc =
+                        inputDesc.getGateOrPartitionDescriptor(0);
+                // A2A->A2A uses 4-arg constructor, scalars all 0
+                assertThat(gateDesc.getPointwiseRescaleParams().getNewUpParallelism()).isEqualTo(0);
+                assertThat(gateDesc.getPointwiseRescaleParams().getOldUpParallelism()).isEqualTo(0);
+            }
+        }
+    }
+
+    // ===== Test 7: POINTWISE cross-parallelism =====
+    @Test
+    void testPointwiseCrossParallelism() throws Exception {
+        OperatorID sourceId = new OperatorID();
+        OperatorID sinkId = new OperatorID();
+        int oldSourcePar = 3;
+        int oldSinkPar = 2;
+        int newSourcePar = 4;
+        int newSinkPar = 3;
+
+        JobVertex source = createJobVertex(sourceId, newSourcePar);
+        JobVertex sink = createJobVertex(sinkId, newSinkPar);
+        connectPointwise(source, sink);
+
+        Map<OperatorID, ExecutionJobVertex> vertices = toExecutionVertices(source, sink);
+
+        Map<OperatorID, OperatorState> states = new HashMap<>();
+        Random random = new Random(42);
+
+        OperatorState sourceState = new OperatorState(null, null, sourceId, oldSourcePar, MAX_P);
+        for (int i = 0; i < oldSourcePar; i++) {
+            sourceState.putState(
+                    i,
+                    OperatorSubtaskState.builder()
+                            .setResultSubpartitionState(
+                                    new StateObjectCollection<>(
+                                            Collections.singletonList(
+                                                    createNewResultSubpartitionStateHandle(
+                                                            10, i, 0, 0, random))))
+                            .build());
+        }
+        states.put(sourceId, sourceState);
+
+        OperatorState sinkState = new OperatorState(null, null, sinkId, oldSinkPar, MAX_P);
+        for (int i = 0; i < oldSinkPar; i++) {
+            sinkState.putState(
+                    i,
+                    OperatorSubtaskState.builder()
+                            .setInputChannelState(
+                                    new StateObjectCollection<>(
+                                            Collections.singletonList(
+                                                    createNewInputChannelStateHandle(
+                                                            10, i, 0, random))))
+                            .build());
+        }
+        states.put(sinkId, sinkState);
+
+        EdgeDistributionPatternSnapshot oldEdgePatterns =
+                buildEdgePatterns(sourceId, DistributionPattern.POINTWISE);
+
+        new StateAssignmentOperation(
+                        0, new HashSet<>(vertices.values()), states, false, true, oldEdgePatterns)
+                .assignStates();
+
+        // Verify input descriptors carry correct cross-parallelism values
+        int subtasksWithDesc = 0;
+        for (int subtask = 0; subtask < newSinkPar; subtask++) {
+            OperatorSubtaskState assigned = getAssignedState(vertices.get(sinkId), sinkId, subtask);
+            InflightDataRescalingDescriptor inputDesc = assigned.getInputRescalingDescriptor();
+
+            if (!inputDesc.equals(InflightDataRescalingDescriptor.NO_RESCALE)) {
+                subtasksWithDesc++;
+                InflightDataGateOrPartitionRescalingDescriptor gateDesc =
+                        inputDesc.getGateOrPartitionDescriptor(0);
+                assertThat(gateDesc.getPointwiseRescaleParams().getOldUpParallelism())
+                        .isEqualTo(oldSourcePar);
+                assertThat(gateDesc.getPointwiseRescaleParams().getOldDownParallelism())
+                        .isEqualTo(oldSinkPar);
+                assertThat(gateDesc.getPointwiseRescaleParams().getNewUpParallelism())
+                        .isEqualTo(newSourcePar);
+                assertThat(gateDesc.getPointwiseRescaleParams().getNewDownParallelism())
+                        .isEqualTo(newSinkPar);
+                assertThat(gateDesc.getPointwiseRescaleParams().getOldDistributionPattern())
+                        .isEqualTo(DistributionPattern.POINTWISE);
+            }
+        }
+        assertThat(subtasksWithDesc).isGreaterThan(0);
+
+        // Verify output descriptors
+        int sourceSubtasksWithDesc = 0;
+        for (int subtask = 0; subtask < newSourcePar; subtask++) {
+            OperatorSubtaskState assigned =
+                    getAssignedState(vertices.get(sourceId), sourceId, subtask);
+            InflightDataRescalingDescriptor outputDesc = assigned.getOutputRescalingDescriptor();
+
+            if (!outputDesc.equals(InflightDataRescalingDescriptor.NO_RESCALE)) {
+                sourceSubtasksWithDesc++;
+                InflightDataGateOrPartitionRescalingDescriptor partDesc =
+                        outputDesc.getGateOrPartitionDescriptor(0);
+                assertThat(partDesc.getPointwiseRescaleParams().getOldUpParallelism())
+                        .isEqualTo(oldSourcePar);
+                assertThat(partDesc.getPointwiseRescaleParams().getOldDownParallelism())
+                        .isEqualTo(oldSinkPar);
+                assertThat(partDesc.getPointwiseRescaleParams().getNewUpParallelism())
+                        .isEqualTo(newSourcePar);
+                assertThat(partDesc.getPointwiseRescaleParams().getNewDownParallelism())
+                        .isEqualTo(newSinkPar);
+            }
+        }
+        assertThat(sourceSubtasksWithDesc).isGreaterThan(0);
+    }
+
+    // ===== Test 8: No EdgeDistributionPatternSnapshot -> treated as A2A (backward compat) =====
+    @Test
+    void testNullEdgePatternsDefaultsToAllToAll() throws Exception {
+        // old: source(2) --?--> sink(2), new: source(3) --A2A--> sink(3)
+        OperatorID sourceId = new OperatorID();
+        OperatorID sinkId = new OperatorID();
+        int oldPar = 2;
+        int newPar = 3;
+
+        JobVertex source = createJobVertex(sourceId, newPar);
+        JobVertex sink = createJobVertex(sinkId, newPar);
+        connectAllToAll(source, sink);
+
+        Map<OperatorID, ExecutionJobVertex> vertices = toExecutionVertices(source, sink);
+        Map<OperatorID, OperatorState> states =
+                buildStatesWithChannelState(sourceId, sinkId, oldPar);
+
+        // No edge pattern snapshot (null) - backward compatible
+        new StateAssignmentOperation(0, new HashSet<>(vertices.values()), states, false, true, null)
+                .assignStates();
+
+        // Should produce standard A2A descriptors (newUpParallelism == 0)
+        for (int subtask = 0; subtask < newPar; subtask++) {
+            OperatorSubtaskState sinkState =
+                    getAssignedState(vertices.get(sinkId), sinkId, subtask);
+            InflightDataRescalingDescriptor inputDesc = sinkState.getInputRescalingDescriptor();
+
+            if (!inputDesc.equals(InflightDataRescalingDescriptor.NO_RESCALE)) {
+                InflightDataGateOrPartitionRescalingDescriptor gateDesc =
+                        inputDesc.getGateOrPartitionDescriptor(0);
+                assertThat(gateDesc.getPointwiseRescaleParams().getNewUpParallelism()).isEqualTo(0);
+            }
+        }
+    }
+
+    // ===== Helper methods =====
+
+    private JobVertex createJobVertex(OperatorID operatorID, int parallelism) {
+        JobVertex jobVertex =
+                new JobVertex(
+                        operatorID.toHexString(),
+                        new JobVertexID(),
+                        Collections.singletonList(
+                                OperatorIDPair.of(operatorID, operatorID, null, null)));
+        jobVertex.setInvokableClass(NoOpInvokable.class);
+        jobVertex.setParallelism(parallelism);
+        return jobVertex;
+    }
+
+    private void connectPointwise(JobVertex upstream, JobVertex downstream) {
+        final JobEdge jobEdge =
+                JobVertexConnectionUtils.connectNewDataSetAsInput(
+                        downstream,
+                        upstream,
+                        DistributionPattern.POINTWISE,
+                        ResultPartitionType.PIPELINED);
+        jobEdge.setDownstreamSubtaskStateMapper(ROUND_ROBIN);
+        jobEdge.setUpstreamSubtaskStateMapper(ROUND_ROBIN);
+    }
+
+    private void connectAllToAll(JobVertex upstream, JobVertex downstream) {
+        final JobEdge jobEdge =
+                JobVertexConnectionUtils.connectNewDataSetAsInput(
+                        downstream,
+                        upstream,
+                        DistributionPattern.ALL_TO_ALL,
+                        ResultPartitionType.PIPELINED);
+        jobEdge.setDownstreamSubtaskStateMapper(ROUND_ROBIN);
+        jobEdge.setUpstreamSubtaskStateMapper(ROUND_ROBIN);
+    }
+
+    private Map<OperatorID, ExecutionJobVertex> toExecutionVertices(JobVertex... jobVertices)
+            throws JobException, JobExecutionException {
+        JobGraph jobGraph = JobGraphTestUtils.streamingJobGraph(jobVertices);
+        ExecutionGraph eg =
+                TestingDefaultExecutionGraphBuilder.newBuilder()
+                        .setJobGraph(jobGraph)
+                        .build(EXECUTOR_EXTENSION.getExecutor());
+        return Arrays.stream(jobVertices)
+                .collect(
+                        Collectors.toMap(
+                                jobVertex ->
+                                        jobVertex.getOperatorIDs().get(0).getGeneratedOperatorID(),
+                                jobVertex -> {
+                                    try {
+                                        return eg.getJobVertex(jobVertex.getID());
+                                    } catch (Exception e) {
+                                        throw new RuntimeException(e);
+                                    }
+                                }));
+    }
+
+    private Map<OperatorID, OperatorState> buildStatesWithChannelState(
+            OperatorID sourceId, OperatorID sinkId, int oldParallelism) {
+        Map<OperatorID, OperatorState> states = new HashMap<>();
+        Random random = new Random(42);
+
+        // For POINTWISE same parallelism: each subtask connects to exactly one downstream
+        // via subpartition 0
+        OperatorState sourceState = new OperatorState(null, null, sourceId, oldParallelism, MAX_P);
+        for (int i = 0; i < oldParallelism; i++) {
+            sourceState.putState(
+                    i,
+                    OperatorSubtaskState.builder()
+                            .setResultSubpartitionState(
+                                    new StateObjectCollection<>(
+                                            Collections.singletonList(
+                                                    createNewResultSubpartitionStateHandle(
+                                                            10, i, 0, 0, random))))
+                            .build());
+        }
+        states.put(sourceId, sourceState);
+
+        OperatorState sinkState = new OperatorState(null, null, sinkId, oldParallelism, MAX_P);
+        for (int i = 0; i < oldParallelism; i++) {
+            sinkState.putState(
+                    i,
+                    OperatorSubtaskState.builder()
+                            .setInputChannelState(
+                                    new StateObjectCollection<>(
+                                            Collections.singletonList(
+                                                    createNewInputChannelStateHandle(
+                                                            10, i, 0, random))))
+                            .build());
+        }
+        states.put(sinkId, sinkState);
+
+        return states;
+    }
+
+    private EdgeDistributionPatternSnapshot buildEdgePatterns(
+            OperatorID sourceId, DistributionPattern pattern) {
+        Map<OperatorID, DistributionPattern[]> patterns = new HashMap<>();
+        patterns.put(sourceId, new DistributionPattern[] {pattern});
+        return new EdgeDistributionPatternSnapshot(patterns);
+    }
+
+    private OperatorSubtaskState getAssignedState(
+            ExecutionJobVertex executionJobVertex, OperatorID operatorId, int subtaskIdx) {
+        return executionJobVertex
+                .getTaskVertices()[subtaskIdx]
+                .getCurrentExecutionAttempt()
+                .getTaskRestore()
+                .getTaskStateSnapshot()
+                .getSubtaskStateByOperatorID(operatorId);
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/StateAssignmentOperationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/StateAssignmentOperationTest.java
@@ -1908,6 +1908,225 @@ class StateAssignmentOperationTest {
     }
 
     /**
+     * Parameterized test for POINTWISE output state distribution.
+     *
+     * <p>Tests all combinations of:
+     *
+     * <ul>
+     *   <li>Old pattern: A2A or PW
+     *   <li>New pattern: A2A or PW
+     *   <li>Scale: upscale, downscale, noscale
+     * </ul>
+     *
+     * <p>Verifies that ALL upstream output state handles are distributed to downstream tasks (no
+     * state is silently dropped).
+     */
+    @ParameterizedTest
+    @ValueSource(
+            strings = {
+                "A2A_A2A_UP",
+                "A2A_A2A_DOWN",
+                "A2A_A2A_NO",
+                "A2A_PW_UP",
+                "A2A_PW_DOWN",
+                "A2A_PW_NO",
+                "PW_PW_UP",
+                "PW_PW_DOWN",
+                "PW_PW_NO",
+                "PW_A2A_UP",
+                "PW_A2A_DOWN",
+                "PW_A2A_NO"
+            })
+    void testPointwiseOutputStateDistribution(String testCase)
+            throws JobException, JobExecutionException {
+        // Parse test case
+        String[] parts = testCase.split("_");
+        DistributionPattern oldPattern =
+                parts[0].equals("A2A")
+                        ? DistributionPattern.ALL_TO_ALL
+                        : DistributionPattern.POINTWISE;
+        DistributionPattern newPattern =
+                parts[1].equals("A2A")
+                        ? DistributionPattern.ALL_TO_ALL
+                        : DistributionPattern.POINTWISE;
+        String scaleType = parts[2];
+
+        // Determine parallelisms
+        // For POINTWISE edges, we need oldUp > oldDown to trigger the bug where multiple
+        // upstreams map to the same downstream and primary producer dedup incorrectly drops state
+        int oldUpParallelism, newUpParallelism, oldDownParallelism, newDownParallelism;
+        switch (scaleType) {
+            case "UP":
+                oldUpParallelism = 4;
+                newUpParallelism = 6;
+                oldDownParallelism = 3;
+                newDownParallelism = 6;
+                break;
+            case "DOWN":
+                // Use 12->6 to ensure oldUp > oldDown, triggering multiple upstreams per downstream
+                oldUpParallelism = 12;
+                newUpParallelism = 4;
+                oldDownParallelism = 6;
+                newDownParallelism = 3;
+                break;
+            case "NO":
+            default:
+                // Use 12->6 to ensure oldUp > oldDown
+                oldUpParallelism = 12;
+                newUpParallelism = 12;
+                oldDownParallelism = 6;
+                newDownParallelism = 6;
+                break;
+        }
+
+        // Create upstream and downstream operators with appropriate parallelisms
+        OperatorID upstreamOpId = new OperatorID();
+        OperatorID downstreamOpId = new OperatorID();
+
+        JobVertex upstream = createJobVertex(upstreamOpId, upstreamOpId, newUpParallelism);
+        JobVertex downstream = createJobVertex(downstreamOpId, downstreamOpId, newDownParallelism);
+
+        // Connect with appropriate distribution pattern
+        if (newPattern == DistributionPattern.POINTWISE) {
+            connectVerticesPointwise(
+                    upstream, downstream, SubtaskStateMapper.POINTWISE_UPSTREAM, ROUND_ROBIN);
+        } else {
+            connectVertices(upstream, downstream, ROUND_ROBIN, ROUND_ROBIN);
+        }
+
+        Map<OperatorID, ExecutionJobVertex> vertices = toExecutionVertices(upstream, downstream);
+
+        // Build EdgeDistributionPatternSnapshot with old pattern
+        // The snapshot stores patterns keyed by the OUTPUT operator ID
+        // For output side, resolveOldDistributionPattern looks up using outputOperatorID
+        EdgeDistributionPatternSnapshot edgePatterns =
+                buildEdgePatternSnapshot(upstreamOpId, oldPattern);
+
+        // Create output state for upstream
+        Map<OperatorID, OperatorState> states = new HashMap<>();
+        Random random = new Random(42);
+
+        // Track all original output state handles
+        List<ResultSubpartitionStateHandle> allOriginalHandles = new ArrayList<>();
+
+        OperatorState upstreamState =
+                new OperatorState("", "", upstreamOpId, oldUpParallelism, MAX_P);
+        for (int subtask = 0; subtask < oldUpParallelism; subtask++) {
+            // Create output state for each subpartition this subtask connects to
+            List<ResultSubpartitionStateHandle> subtaskHandles = new ArrayList<>();
+
+            if (oldPattern == DistributionPattern.POINTWISE) {
+                // POINTWISE: each upstream connects to a subset of downstreams
+                int[] consumers =
+                        PointwiseChannelMappingUtils.consumersOf(
+                                subtask, oldUpParallelism, oldDownParallelism);
+                for (int localSP = 0; localSP < consumers.length; localSP++) {
+                    ResultSubpartitionStateHandle handle =
+                            createNewResultSubpartitionStateHandle(10, subtask, 0, localSP, random);
+                    subtaskHandles.add(handle);
+                    allOriginalHandles.add(handle);
+                }
+            } else {
+                // A2A: each upstream connects to all downstreams
+                for (int downstreamIdx = 0; downstreamIdx < oldDownParallelism; downstreamIdx++) {
+                    ResultSubpartitionStateHandle handle =
+                            createNewResultSubpartitionStateHandle(
+                                    10, subtask, 0, downstreamIdx, random);
+                    subtaskHandles.add(handle);
+                    allOriginalHandles.add(handle);
+                }
+            }
+
+            upstreamState.putState(
+                    subtask,
+                    OperatorSubtaskState.builder()
+                            .setResultSubpartitionState(
+                                    new StateObjectCollection<OutputStateHandle>(
+                                            new ArrayList<>(subtaskHandles)))
+                            .build());
+        }
+        states.put(upstreamOpId, upstreamState);
+
+        // Create empty state for downstream
+        OperatorState downstreamState =
+                new OperatorState("", "", downstreamOpId, oldDownParallelism, MAX_P);
+        for (int subtask = 0; subtask < oldDownParallelism; subtask++) {
+            downstreamState.putState(subtask, OperatorSubtaskState.builder().build());
+        }
+        states.put(downstreamOpId, downstreamState);
+
+        // Run state assignment with recoverOutputOnDownstreamTask=true
+        new StateAssignmentOperation(
+                        0, new HashSet<>(vertices.values()), states, false, true, edgePatterns)
+                .assignStates();
+
+        // Collect all distributed InputChannelStateHandles across all downstream subtasks
+        List<InputChannelStateHandle> allDistributedHandles = new ArrayList<>();
+        for (int subtask = 0; subtask < newDownParallelism; subtask++) {
+            OperatorSubtaskState assignedState =
+                    getAssignedState(vertices.get(downstreamOpId), downstreamOpId, subtask);
+            if (assignedState != null && assignedState.getUpstreamOutputBufferState() != null) {
+                for (InputChannelStateHandle handle :
+                        assignedState.getUpstreamOutputBufferState()) {
+                    allDistributedHandles.add(handle);
+                }
+            }
+        }
+
+        // CRITICAL ASSERTION: All original output state handles must be distributed
+        // This catches the bug where primary producer dedup silently drops state
+        assertThat(allDistributedHandles)
+                .as(
+                        "Test case %s: all %d original output state handles must be distributed to downstream (found %d)",
+                        testCase, allOriginalHandles.size(), allDistributedHandles.size())
+                .hasSize(allOriginalHandles.size());
+
+        // Verify each original handle appears exactly once fin distributed results
+        for (ResultSubpartitionStateHandle original : allOriginalHandles) {
+            long matchCount =
+                    allDistributedHandles.stream()
+                            .filter(
+                                    distributed ->
+                                            distributed.getDelegate() == original.getDelegate()
+                                                    && distributed
+                                                            .getOffsets()
+                                                            .equals(original.getOffsets())
+                                                    && distributed.getStateSize()
+                                                            == original.getStateSize())
+                            .count();
+            assertThat(matchCount)
+                    .as(
+                            "Test case %s: original handle from subtask %d subpartition %d must appear exactly once",
+                            testCase,
+                            original.getSubtaskIndex(),
+                            original.getInfo().getSubPartitionIdx())
+                    .isEqualTo(1);
+        }
+    }
+
+    private void connectVerticesPointwise(
+            JobVertex upstream,
+            JobVertex downstream,
+            SubtaskStateMapper upstreamRescaler,
+            SubtaskStateMapper downstreamRescaler) {
+        final JobEdge jobEdge =
+                connectNewDataSetAsInput(
+                        downstream,
+                        upstream,
+                        DistributionPattern.POINTWISE,
+                        ResultPartitionType.PIPELINED);
+        jobEdge.setDownstreamSubtaskStateMapper(downstreamRescaler);
+        jobEdge.setUpstreamSubtaskStateMapper(upstreamRescaler);
+    }
+
+    private EdgeDistributionPatternSnapshot buildEdgePatternSnapshot(
+            OperatorID outputOperatorId, DistributionPattern pattern) {
+        Map<OperatorID, DistributionPattern[]> map = new HashMap<>();
+        map.put(outputOperatorId, new DistributionPattern[] {pattern});
+        return new EdgeDistributionPatternSnapshot(map);
+    }
+
+    /**
      * Test utility class that manages ResultSubpartitionStateHandles for all operators in a job.
      */
     private static class JobResultSubpartitionHandlers {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/StateHandleDummyUtil.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/StateHandleDummyUtil.java
@@ -28,10 +28,12 @@ import org.apache.flink.runtime.state.OperatorStreamStateHandle;
 import org.apache.flink.runtime.state.ResultSubpartitionStateHandle;
 import org.apache.flink.runtime.state.SharedStateRegistry;
 import org.apache.flink.runtime.state.StateHandleID;
+import org.apache.flink.runtime.state.StreamStateHandle;
 import org.apache.flink.runtime.state.memory.ByteStreamStateHandle;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.UUID;
@@ -144,15 +146,23 @@ public class StateHandleDummyUtil {
 
     public static InputChannelStateHandle createNewInputChannelStateHandle(
             int numNamedStates, Random random) {
-        return createNewInputChannelStateHandle(numNamedStates, 0, random);
+        return createNewInputChannelStateHandle(numNamedStates, 0, 0, random);
     }
 
     public static InputChannelStateHandle createNewInputChannelStateHandle(
             int numNamedStates, int gateIndex, Random random) {
+        return createNewInputChannelStateHandle(numNamedStates, 0, gateIndex, random);
+    }
+
+    public static InputChannelStateHandle createNewInputChannelStateHandle(
+            int numNamedStates, int subtaskIndex, int gateIndex, Random random) {
+        StreamStateHandle delegate = createStreamStateHandle(numNamedStates, random);
         return new InputChannelStateHandle(
+                subtaskIndex,
                 new InputChannelInfo(gateIndex, random.nextInt()),
-                createStreamStateHandle(numNamedStates, random),
-                genOffsets(numNamedStates, random));
+                delegate,
+                genOffsets(numNamedStates, random),
+                delegate.getStateSize());
     }
 
     public static ResultSubpartitionStateHandle createNewResultSubpartitionStateHandle(
@@ -168,10 +178,24 @@ public class StateHandleDummyUtil {
 
     public static ResultSubpartitionStateHandle createNewResultSubpartitionStateHandle(
             int numNamedStates, int partitionIndex, int subPartitionIdx, Random random) {
+        return createNewResultSubpartitionStateHandle(
+                numNamedStates, 0, partitionIndex, subPartitionIdx, random);
+    }
+
+    public static ResultSubpartitionStateHandle createNewResultSubpartitionStateHandle(
+            int numNamedStates,
+            int subtaskIndex,
+            int partitionIndex,
+            int subPartitionIdx,
+            Random random) {
+        StreamStateHandle delegate = createStreamStateHandle(numNamedStates, random);
+        List<Long> offsets = genOffsets(numNamedStates, random);
         return new ResultSubpartitionStateHandle(
+                subtaskIndex,
                 new ResultSubpartitionInfo(partitionIndex, subPartitionIdx),
-                createStreamStateHandle(numNamedStates, random),
-                genOffsets(numNamedStates, random));
+                delegate,
+                offsets,
+                delegate.getStateSize());
     }
 
     private static ArrayList<Long> genOffsets(int size, Random random) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/InputChannelRecoveredStateHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/InputChannelRecoveredStateHandlerTest.java
@@ -83,7 +83,8 @@ class InputChannelRecoveredStateHandlerTest extends RecoveredChannelStateHandler
                                             .MappingType.IDENTITY)
                         }),
                 null,
-                MemoryManager.DEFAULT_PAGE_SIZE);
+                MemoryManager.DEFAULT_PAGE_SIZE,
+                0);
     }
 
     private InputChannelRecoveredStateHandler buildMultiChannelHandler() {
@@ -111,7 +112,8 @@ class InputChannelRecoveredStateHandlerTest extends RecoveredChannelStateHandler
                                             .MappingType.RESCALING)
                         }),
                 null,
-                MemoryManager.DEFAULT_PAGE_SIZE);
+                MemoryManager.DEFAULT_PAGE_SIZE,
+                0);
     }
 
     /** Builds a handler in filtering mode (non-null filtering handler, no-op stub). */
@@ -136,7 +138,8 @@ class InputChannelRecoveredStateHandlerTest extends RecoveredChannelStateHandler
                                             .MappingType.IDENTITY)
                         }),
                 stubFilteringHandler,
-                MemoryManager.DEFAULT_PAGE_SIZE);
+                MemoryManager.DEFAULT_PAGE_SIZE,
+                0);
     }
 
     @Test

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/ResultSubpartitionRecoveredStateHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/ResultSubpartitionRecoveredStateHandlerTest.java
@@ -70,7 +70,8 @@ class ResultSubpartitionRecoveredStateHandlerTest extends RecoveredChannelStateH
                                     InflightDataRescalingDescriptor
                                             .InflightDataGateOrPartitionRescalingDescriptor
                                             .MappingType.IDENTITY)
-                        }));
+                        }),
+                0);
     }
 
     @Test

--- a/flink-runtime/src/test/java/org/apache/flink/streaming/runtime/partitioner/ForceUnalignedSupportTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/streaming/runtime/partitioner/ForceUnalignedSupportTest.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.partitioner;
+
+import org.apache.flink.api.java.functions.KeySelector;
+import org.apache.flink.api.java.tuple.Tuple;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link StreamPartitioner#isSupportsUnalignedCheckpoint(boolean)} — specifically the
+ * {@code forceUnaligned} flag introduced to allow unaligned checkpoints on forward (pointwise)
+ * edges while keeping broadcast edges aligned.
+ */
+class ForceUnalignedSupportTest {
+
+    @Test
+    void testForwardPartitionerRespectsForceUnaligned() {
+        ForwardPartitioner<Tuple> partitioner = new ForwardPartitioner<>();
+
+        // Without force: pointwise edges block unaligned checkpoints.
+        assertThat(partitioner.isSupportsUnalignedCheckpoint(false)).isFalse();
+        // With force: pointwise edges are allowed to use unaligned checkpoints.
+        assertThat(partitioner.isSupportsUnalignedCheckpoint(true)).isTrue();
+    }
+
+    @Test
+    void testRescalePartitionerRespectsForceUnaligned() {
+        RescalePartitioner<Tuple> partitioner = new RescalePartitioner<>();
+
+        assertThat(partitioner.isSupportsUnalignedCheckpoint(false)).isFalse();
+        assertThat(partitioner.isSupportsUnalignedCheckpoint(true)).isTrue();
+    }
+
+    @Test
+    void testBroadcastPartitionerIgnoresForceUnaligned() {
+        BroadcastPartitioner<Tuple> partitioner = new BroadcastPartitioner<>();
+
+        // Broadcast edges must never support unaligned checkpoints, regardless of force.
+        assertThat(partitioner.isSupportsUnalignedCheckpoint(false)).isFalse();
+        assertThat(partitioner.isSupportsUnalignedCheckpoint(true)).isFalse();
+    }
+
+    @Test
+    void testRebalancePartitionerForceDoesNotFlipBehavior() {
+        RebalancePartitioner<Tuple> partitioner = new RebalancePartitioner<>();
+
+        boolean withoutForce = partitioner.isSupportsUnalignedCheckpoint(false);
+        boolean withForce = partitioner.isSupportsUnalignedCheckpoint(true);
+
+        assertThat(withoutForce).isTrue();
+        assertThat(withForce).isEqualTo(withoutForce);
+    }
+
+    @Test
+    void testKeyGroupPartitionerForceDoesNotFlipBehavior() {
+        KeyGroupStreamPartitioner<Tuple, Object> partitioner =
+                new KeyGroupStreamPartitioner<>((KeySelector<Tuple, Object>) value -> value, 128);
+
+        boolean withoutForce = partitioner.isSupportsUnalignedCheckpoint(false);
+        boolean withForce = partitioner.isSupportsUnalignedCheckpoint(true);
+
+        assertThat(withoutForce).isTrue();
+        assertThat(withForce).isEqualTo(withoutForce);
+    }
+}

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/UnalignedCheckpointShuffleChangeITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/UnalignedCheckpointShuffleChangeITCase.java
@@ -1,0 +1,312 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.test.checkpointing;
+
+import org.apache.flink.api.common.JobExecutionResult;
+import org.apache.flink.api.common.JobStatus;
+import org.apache.flink.api.common.eventtime.WatermarkStrategy;
+import org.apache.flink.api.common.state.ListState;
+import org.apache.flink.api.common.state.ListStateDescriptor;
+import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.api.connector.source.util.ratelimit.RateLimiterStrategy;
+import org.apache.flink.connector.datagen.source.DataGeneratorSource;
+import org.apache.flink.runtime.state.FunctionInitializationContext;
+import org.apache.flink.runtime.state.FunctionSnapshotContext;
+import org.apache.flink.streaming.api.checkpoint.CheckpointedFunction;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.sink.legacy.RichSinkFunction;
+import org.apache.flink.testutils.junit.extensions.parameterized.Parameter;
+import org.apache.flink.testutils.junit.extensions.parameterized.ParameterizedTestExtension;
+import org.apache.flink.testutils.junit.extensions.parameterized.Parameters;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.concurrent.ConcurrentSkipListSet;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration test for changing distribution patterns (POINTWISE / ALL_TO_ALL) and parallelism
+ * between runs when restoring from an unaligned checkpoint.
+ *
+ * <p>Each parameterized case is a 9-tuple: (desc, oldUpPar, oldDownPar, oldPattern, newUpPar,
+ * newDownPar, newPattern, recoverOutputOnDownstream, checkpointDuringRecovery). Run 1 emits a
+ * bounded monotonic sequence {@code [0, TOTAL_COUNT)} XORed with a header, takes an in-flight
+ * unaligned checkpoint, and is cancelled. Run 2 restores with the new topology and runs to
+ * completion. The verifying sink asserts: (a) no header corruption (mis-routed buffers), (b) no
+ * per-subtask duplicates after restore, and (c) every value in {@code [0, TOTAL_COUNT)} arrives at
+ * the sink.
+ *
+ * <p>The test is parameterized over three recovery configurations:
+ *
+ * <ul>
+ *   <li>Neither {@code UNALIGNED_RECOVER_OUTPUT_ON_DOWNSTREAM} nor {@code
+ *       CHECKPOINTING_DURING_RECOVERY_ENABLED} (both false)
+ *   <li>Only {@code UNALIGNED_RECOVER_OUTPUT_ON_DOWNSTREAM} enabled (true, false)
+ *   <li>Both enabled (true, true)
+ * </ul>
+ */
+@ExtendWith(ParameterizedTestExtension.class)
+class UnalignedCheckpointShuffleChangeITCase extends UnalignedCheckpointTestBase {
+
+    private static final int TOTAL_COUNT = 20_000;
+
+    private static final ConcurrentSkipListSet<Long> SEEN_GLOBAL = new ConcurrentSkipListSet<>();
+    private static final AtomicLong POST_RESTORE_DUPLICATES = new AtomicLong();
+    private static final AtomicLong CORRUPTIONS = new AtomicLong();
+
+    enum EdgePattern {
+        POINTWISE,
+        ALL_TO_ALL
+    }
+
+    @Parameter(0)
+    public String desc;
+
+    @Parameter(1)
+    public int oldUpPar;
+
+    @Parameter(2)
+    public int oldDownPar;
+
+    @Parameter(3)
+    public EdgePattern oldPattern;
+
+    @Parameter(4)
+    public int newUpPar;
+
+    @Parameter(5)
+    public int newDownPar;
+
+    @Parameter(6)
+    public EdgePattern newPattern;
+
+    @Parameter(7)
+    public boolean recoverOutputOnDownstream;
+
+    @Parameter(8)
+    public boolean checkpointDuringRecovery;
+
+    @Parameters(name = "{0}")
+    public static Collection<Object[]> parameters() {
+        EdgePattern a2a = EdgePattern.ALL_TO_ALL;
+        EdgePattern pw = EdgePattern.POINTWISE;
+
+        return Arrays.asList(
+                new Object[][] {
+                    // ---- A2A -> A2A ----
+                    {"A2A->A2A same", 3, 3, a2a, 3, 3, a2a},
+                    {"A2A->A2A up-up", 3, 3, a2a, 4, 3, a2a},
+                    {"A2A->A2A up-up wide", 3, 3, a2a, 11, 3, a2a},
+                    {"A2A->A2A up-down", 4, 3, a2a, 3, 3, a2a},
+                    {"A2A->A2A up-down wide", 11, 3, a2a, 3, 3, a2a},
+                    {"A2A->A2A down-up", 3, 3, a2a, 3, 4, a2a},
+                    {"A2A->A2A down-up wide", 3, 3, a2a, 3, 11, a2a},
+                    {"A2A->A2A down-down", 3, 4, a2a, 3, 3, a2a},
+                    {"A2A->A2A down-down wide", 3, 11, a2a, 3, 3, a2a},
+                    // ---- A2A -> PW ----
+                    {"A2A->PW same", 3, 3, a2a, 3, 3, pw},
+                    {"A2A->PW up-up", 3, 3, a2a, 4, 3, pw},
+                    {"A2A->PW up-up wide", 3, 3, a2a, 11, 3, pw},
+                    {"A2A->PW up-down", 4, 3, a2a, 3, 3, pw},
+                    {"A2A->PW up-down wide", 11, 3, a2a, 3, 3, pw},
+                    {"A2A->PW down-up", 3, 3, a2a, 3, 4, pw},
+                    {"A2A->PW down-up wide", 3, 3, a2a, 3, 11, pw},
+                    {"A2A->PW down-down", 3, 4, a2a, 3, 3, pw},
+                    {"A2A->PW down-down wide", 3, 11, a2a, 3, 3, pw},
+                    // ---- PW -> A2A ----
+                    {"PW->A2A same", 3, 3, pw, 3, 3, a2a},
+                    {"PW->A2A up-up", 3, 3, pw, 4, 3, a2a},
+                    {"PW->A2A up-up wide", 3, 3, pw, 11, 3, a2a},
+                    {"PW->A2A up-down", 4, 3, pw, 3, 3, a2a},
+                    {"PW->A2A up-down wide", 11, 3, pw, 3, 3, a2a},
+                    {"PW->A2A down-up", 3, 3, pw, 3, 4, a2a},
+                    {"PW->A2A down-up wide", 3, 3, pw, 3, 11, a2a},
+                    {"PW->A2A down-down", 3, 4, pw, 3, 3, a2a},
+                    {"PW->A2A down-down wide", 3, 11, pw, 3, 3, a2a},
+                    // ---- PW -> PW ----
+                    {"PW->PW same", 3, 3, pw, 3, 3, pw},
+                    {"PW->PW up-up", 3, 3, pw, 4, 3, pw},
+                    {"PW->PW up-up wide", 3, 3, pw, 11, 3, pw},
+                    {"PW->PW up-down", 4, 3, pw, 3, 3, pw},
+                    {"PW->PW up-down wide", 11, 3, pw, 3, 3, pw},
+                    {"PW->PW down-up", 3, 3, pw, 3, 4, pw},
+                    {"PW->PW down-up wide", 3, 3, pw, 3, 11, pw},
+                    {"PW->PW down-down", 3, 4, pw, 3, 3, pw},
+                    {"PW->PW down-down wide", 3, 11, pw, 3, 3, pw},
+                    {"PW->PW both-up", 3, 3, pw, 4, 4, pw},
+                    {"PW->PW both-down", 4, 4, pw, 3, 3, pw},
+                });
+    }
+
+    @BeforeEach
+    void setup() {
+        SEEN_GLOBAL.clear();
+        POST_RESTORE_DUPLICATES.set(0);
+        CORRUPTIONS.set(0);
+    }
+
+    @TestTemplate
+    void testShuffleChangeWithUnalignedCheckpoint(TestInfo testInfo) throws Exception {
+        // Phase 1: run with old topology, generate checkpoint, cancel
+        UnalignedSettings phase1Settings =
+                createSettings(oldPattern, oldUpPar, oldDownPar)
+                        .setCheckpointGenerationMode(
+                                CheckpointGenerationMode.WAIT_FOR_CHECKPOINT_AND_CANCEL);
+        String checkpointPath = super.execute(phase1Settings, testInfo);
+        assertThat(checkpointPath)
+                .as("Phase 1 must generate a checkpoint for restore test to be valid.")
+                .isNotNull();
+
+        // Phase 2: restore with new topology and run to completion
+        UnalignedSettings phase2Settings =
+                createSettings(newPattern, newUpPar, newDownPar)
+                        .setRestoreCheckpoint(checkpointPath)
+                        .setExpectedFinalJobStatus(JobStatus.FINISHED);
+        super.execute(phase2Settings, testInfo);
+
+        assertThat(CORRUPTIONS.get())
+                .as("records with bad header (mis-routed or wrongly-decoded buffers)")
+                .isZero();
+        assertThat(POST_RESTORE_DUPLICATES.get())
+                .as("post-restore duplicates (replayed buffer delivered twice to a sink subtask)")
+                .isZero();
+        assertThat(SEEN_GLOBAL)
+                .as("union of all sink output must cover [0, %d)", TOTAL_COUNT)
+                .hasSize(TOTAL_COUNT);
+        assertThat(SEEN_GLOBAL.first()).isZero();
+        assertThat(SEEN_GLOBAL.last()).isEqualTo((long) (TOTAL_COUNT - 1));
+    }
+
+    @Override
+    protected void checkCounters(JobExecutionResult result) {}
+
+    private UnalignedSettings createSettings(EdgePattern pattern, int upPar, int downPar) {
+        UnalignedSettings settings =
+                new UnalignedSettings(new ShuffleChangeDagCreator(pattern, upPar, downPar));
+        settings.setParallelism(Math.max(upPar, downPar));
+        settings.setChannelTypes(ChannelType.LOCAL);
+        return settings;
+    }
+
+    // -------------------------------------------------------------------------
+    //  DAG creation
+    // -------------------------------------------------------------------------
+
+    private static class ShuffleChangeDagCreator implements DagCreator {
+        private final EdgePattern pattern;
+        private final int upPar;
+        private final int downPar;
+
+        ShuffleChangeDagCreator(EdgePattern pattern, int upPar, int downPar) {
+            this.pattern = pattern;
+            this.upPar = upPar;
+            this.downPar = downPar;
+        }
+
+        @Override
+        public void create(
+                StreamExecutionEnvironment env,
+                int minCheckpoints,
+                boolean slotSharing,
+                int expectedFailuresUntilSourceFinishes,
+                long sourceSleepMs) {
+            env.disableOperatorChaining();
+
+            DataGeneratorSource<Long> source =
+                    new DataGeneratorSource<>(
+                            UnalignedCheckpointTestBase::withHeader,
+                            TOTAL_COUNT,
+                            RateLimiterStrategy.perSecond(5000),
+                            Types.LONG);
+
+            DataStream<Long> sourceStream =
+                    env.fromSource(source, WatermarkStrategy.noWatermarks(), "source")
+                            .uid("source")
+                            .setParallelism(upPar);
+
+            DataStream<Long> shuffled =
+                    (pattern == EdgePattern.POINTWISE)
+                            ? sourceStream.rescale()
+                            : sourceStream.rebalance();
+
+            shuffled.map(
+                            x -> {
+                                Thread.sleep(1);
+                                return x;
+                            })
+                    .returns(Types.LONG)
+                    .name("map")
+                    .uid("map")
+                    .setParallelism(downPar)
+                    .addSink(new VerifyingSink())
+                    .uid("sink")
+                    .name("sink")
+                    .setParallelism(downPar);
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    //  Verification sink
+    // -------------------------------------------------------------------------
+
+    private static class VerifyingSink extends RichSinkFunction<Long>
+            implements CheckpointedFunction {
+        private transient ListState<Long> seenState;
+        private transient HashSet<Long> seen;
+
+        @Override
+        public void initializeState(FunctionInitializationContext context) throws Exception {
+            seenState =
+                    context.getOperatorStateStore()
+                            .getListState(new ListStateDescriptor<>("seen", Types.LONG));
+            seen = new HashSet<>();
+            for (Long v : seenState.get()) {
+                seen.add(v);
+            }
+        }
+
+        @Override
+        public void snapshotState(FunctionSnapshotContext context) throws Exception {
+            seenState.update(new ArrayList<>(seen));
+        }
+
+        @Override
+        public void invoke(Long value, Context context) {
+            try {
+                long base = withoutHeader(value);
+                if (!seen.add(base)) {
+                    POST_RESTORE_DUPLICATES.incrementAndGet();
+                }
+                SEEN_GLOBAL.add(base);
+            } catch (IllegalArgumentException e) {
+                CORRUPTIONS.incrementAndGet();
+            }
+        }
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

This PR enables unaligned checkpoint on pointwise edges when users enable it explicitly, as long as handling the channel state recovery of pointwise edges.
The two issues are combined because neither makes sense as an independent change.

## Brief change log

  - Support unaligned checkpoint on forward edges with force-unaligned option
  - Introduce EdgeDistributionPatternHook to store edge patterns for channel mapping calculation during recovery
  - Handling channel state redistribution on both JM and TM sides for pointwise edges

## Verifying this change

This change is covered by existing unaligned checkpoint IT cases, because the original topologies contain pointwise edges and the jobs are already set FORCE_UNALIGNED.
This change also added an IT case that covers all parallelism and edge pattern changes on pointwise edges.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable