### PR TITLE
[hotfix][ci] Use correct property `steps.docker-cache.outputs.cache-hit`

### DIFF
--- a/.github/workflows/template.flink-ci.yml
+++ b/.github/workflows/template.flink-ci.yml
@@ -253,7 +253,7 @@ jobs:
           restore-keys: ${{ matrix.module }}-docker-${{ runner.os }}
 
       - name: "Load Docker images if not present in cache, yet"
-        if: ${{ !cancelled() && !steps.docker-cache.cache.hit }}
+        if: ${{ !cancelled() && steps.docker-cache.outputs.cache-hit != 'true' }}
         working-directory: ${{ env.CONTAINER_LOCAL_WORKING_DIR }}
         run: ./tools/azure-pipelines/cache_docker_images.sh load
 
@@ -312,7 +312,7 @@ jobs:
 
       - name: "Save Docker images to cache"
         working-directory: ${{ env.CONTAINER_LOCAL_WORKING_DIR }}
-        if: ${{ !cancelled() && (failure() || !steps.docker-cache.cache.hit) }}
+        if: ${{ !cancelled() && (failure() || steps.docker-cache.outputs.cache-hit != 'true') }}
         run: ./tools/azure-pipelines/cache_docker_images.sh save
 
   e2e:
@@ -416,7 +416,7 @@ jobs:
           key: e2e-${{ matrix.group }}-docker-${{ runner.os }}-${{ hashFiles('**/cache_docker_images.sh', '**/flink-test-utils-parent/**/DockerImageVersions.java') }}
 
       - name: "Load Docker images if not present in Cache, yet"
-        if: ${{ !cancelled() && !steps.docker-cache.cache.hit }}
+        if: ${{ !cancelled() && steps.docker-cache.outputs.cache-hit != 'true' }}
         run: ./tools/azure-pipelines/cache_docker_images.sh load
 
       - name: "Build Flink"
@@ -444,5 +444,5 @@ jobs:
           path: ${{ steps.test-run.outputs.debug-files-output-dir }}
 
       - name: "Save Docker images to Cache"
-        if: ${{ !cancelled() && (failure() || !steps.docker-cache.cache.hit) }}
+        if: ${{ !cancelled() && (failure() || steps.docker-cache.outputs.cache-hit != 'true') }}
         run: ./tools/azure-pipelines/cache_docker_images.sh save


### PR DESCRIPTION

## What is the purpose of the change

The PR makes using correct cache properties for docker cache

also some refs to docs
[- actions/cache — Outputs](https://github.com/actions/cache#outputs)
[- GitHub Docs — Using the cache-hit output](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/caching-dependencies-to-speed-up-workflows#using-the-cache-hit-output)
## Brief change log

gha


## Verifying this change

GHA

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change the checkbox below to `[X]` followed by the name of the tool, and uncomment the
"Generated-by" line. See the ASF Generative Tooling Guidance for details:
https://www.apache.org/legal/generative-tooling.html

You are responsible for the quality and correctness of every change in this PR
regardless of the tooling used. Low-effort AI-generated PRs will be closed. See
AGENTS.md for the full guidance.
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name and Version]
-->
