### PR TITLE
[FLINK-39687] [sql-gateway] Fix URI dependency conversion in SessionContext

### DIFF
--- a/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/service/context/SessionContext.java
+++ b/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/service/context/SessionContext.java
@@ -329,7 +329,7 @@ public class SessionContext {
     private static URL toURL(URI uri) {
         try {
             return uri.toURL();
-        } catch (MalformedURLException e) {
+        } catch (MalformedURLException | IllegalArgumentException e) {
             throw new SqlGatewayException(
                     String.format("Failed to convert dependency URI '%s' to URL.", uri), e);
         }

--- a/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/service/context/SessionContext.java
+++ b/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/service/context/SessionContext.java
@@ -56,6 +56,8 @@ import org.slf4j.LoggerFactory;
 import javax.annotation.Nullable;
 
 import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.nio.file.Path;
@@ -304,7 +306,7 @@ public class SessionContext {
                 initializeConfiguration(defaultContext, environment, sessionId);
         final MutableURLClassLoader userClassLoader =
                 FlinkUserCodeClassLoaders.create(
-                        defaultContext.getDependencies().toArray(new URL[0]),
+                        getDependencyURLs(defaultContext),
                         SessionContext.class.getClassLoader(),
                         configuration);
         final ResourceManager resourceManager = new ResourceManager(configuration, userClassLoader);
@@ -316,6 +318,21 @@ public class SessionContext {
                 userClassLoader,
                 initializeSessionState(environment, configuration, resourceManager),
                 new OperationManager(operationExecutorService));
+    }
+
+    private static URL[] getDependencyURLs(DefaultContext defaultContext) {
+        return defaultContext.getDependencies().stream()
+                .map(SessionContext::toURL)
+                .toArray(URL[]::new);
+    }
+
+    private static URL toURL(URI uri) {
+        try {
+            return uri.toURL();
+        } catch (MalformedURLException e) {
+            throw new SqlGatewayException(
+                    String.format("Failed to convert dependency URI '%s' to URL.", uri), e);
+        }
     }
 
     // ------------------------------------------------------------------------------------------------------------------

--- a/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/service/context/SessionContextTest.java
+++ b/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/service/context/SessionContextTest.java
@@ -147,6 +147,28 @@ class SessionContextTest {
     }
 
     @Test
+    void testCreateContextWithDependencies(@TempDir Path dependencyDirectory) throws Exception {
+        DefaultContext defaultContext =
+                new DefaultContext(
+                        new Configuration(),
+                        Collections.singletonList(dependencyDirectory.toUri()));
+        SessionEnvironment environment =
+                SessionEnvironment.newBuilder()
+                        .setSessionEndpointVersion(MockedEndpointVersion.V1)
+                        .build();
+
+        SessionContext context =
+                SessionContext.create(
+                        defaultContext, SessionHandle.create(), environment, EXECUTOR_SERVICE);
+        try {
+            assertThat(context.getUserClassloader().getURLs())
+                    .contains(dependencyDirectory.toUri().toURL());
+        } finally {
+            context.close();
+        }
+    }
+
+    @Test
     void testCreateContextWithListeners() {
         assertThat(
                         sessionContext

--- a/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/service/context/SessionContextTest.java
+++ b/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/service/context/SessionContextTest.java
@@ -32,6 +32,7 @@ import org.apache.flink.table.catalog.listener.CatalogListener2;
 import org.apache.flink.table.gateway.api.session.SessionEnvironment;
 import org.apache.flink.table.gateway.api.session.SessionHandle;
 import org.apache.flink.table.gateway.api.utils.MockedEndpointVersion;
+import org.apache.flink.table.gateway.api.utils.SqlGatewayException;
 import org.apache.flink.table.gateway.api.utils.ThreadUtils;
 
 import org.junit.jupiter.api.AfterAll;
@@ -40,6 +41,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
+import java.net.URI;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collections;
@@ -54,6 +56,7 @@ import static org.apache.flink.table.api.config.TableConfigOptions.TABLE_CATALOG
 import static org.apache.flink.table.api.config.TableConfigOptions.TABLE_SQL_DIALECT;
 import static org.apache.flink.table.catalog.CommonCatalogOptions.TABLE_CATALOG_STORE_KIND;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Test {@link SessionContext}. */
 class SessionContextTest {
@@ -166,6 +169,28 @@ class SessionContextTest {
         } finally {
             context.close();
         }
+    }
+
+    @Test
+    void testCreateContextWrapsSchemelessDependencyUri() {
+        DefaultContext defaultContext =
+                new DefaultContext(
+                        new Configuration(), Collections.singletonList(URI.create("foo.jar")));
+        SessionEnvironment environment =
+                SessionEnvironment.newBuilder()
+                        .setSessionEndpointVersion(MockedEndpointVersion.V1)
+                        .build();
+
+        assertThatThrownBy(
+                        () ->
+                                SessionContext.create(
+                                        defaultContext,
+                                        SessionHandle.create(),
+                                        environment,
+                                        EXECUTOR_SERVICE))
+                .isInstanceOf(SqlGatewayException.class)
+                .hasMessageContaining("Failed to convert dependency URI 'foo.jar' to URL.")
+                .hasCauseInstanceOf(IllegalArgumentException.class);
     }
 
     @Test


### PR DESCRIPTION
## What is the purpose of the change

This pull request fixes `SessionContext` creation when the default SQL Gateway context contains dependency URIs. The previous code passed `List<URI>` elements to `toArray(new URL[0])`, which throws `ArrayStoreException` as soon as the dependency list is non-empty.

## Brief change log

- Convert each dependency `URI` to a `URL` before creating the session user-code classloader.
- Add a `SessionContextTest` regression test that creates a session from a `DefaultContext` with a non-empty dependency list and verifies the dependency URL is available from the user-code classloader.

## Verifying this change

This change added tests and can be verified as follows:

- `./mvnw -pl flink-table/flink-sql-gateway -Dtest=SessionContextTest#testCreateContextWithDependencies -DfailIfNoTests=false -Dsurefire.failIfNoSpecifiedTests=false -Dfast test`
- `./mvnw -pl flink-table/flink-sql-gateway -Dtest=SessionContextTest -Dfast test`
- `./mvnw -pl flink-table/flink-sql-gateway spotless:check checkstyle:check`

I also verified that the new regression test fails against the previous production implementation with `java.lang.ArrayStoreException: java.net.URI`.

## Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): no
- The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
- The serializers: no
- The runtime per-record code paths (performance sensitive): no
- Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
- The S3 file system connector: no

## Documentation

- Does this pull request introduce a new feature? no
- If yes, how is the feature documented? not applicable

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (Hermes Agent / OpenAI GPT-5.5)

Generated-by: Hermes Agent / OpenAI GPT-5.5
