### PR TITLE
[FLINK-39132] [e2e] Stabilize Kubernetes materialized table test

### DIFF
--- a/flink-end-to-end-tests/run-nightly-tests.sh
+++ b/flink-end-to-end-tests/run-nightly-tests.sh
@@ -182,7 +182,7 @@ function run_group_3 {
     run_test "Streaming SQL end-to-end test using planner with Scala version" "$END_TO_END_DIR/test-scripts/test_streaming_sql.sh scala-planner" "skip_check_exceptions"
     run_test "Sql Jdbc Driver end-to-end test" "$END_TO_END_DIR/test-scripts/test_sql_jdbc_driver.sh" "skip_check_exceptions"
     run_test "Run kubernetes SQL application test" "$END_TO_END_DIR/test-scripts/test_kubernetes_sql_application.sh"
-    run_test "Run kubernetes Materialized Table test" "$END_TO_END_DIR/test-scripts/test_kubernetes_materialized_table.sh"
+    run_test "Run kubernetes Materialized Table test" "$END_TO_END_DIR/test-scripts/test_kubernetes_materialized_table.sh" "custom_check_exceptions" "$END_TO_END_DIR/test-scripts/test_kubernetes_materialized_table.sh check_exceptions"
 
     run_test "Streaming File Sink end-to-end test" "$END_TO_END_DIR/test-scripts/test_file_sink.sh local StreamingFileSink" "skip_check_exceptions"
     run_test "Streaming File Sink s3 end-to-end test" "$END_TO_END_DIR/test-scripts/test_file_sink.sh s3 StreamingFileSink" "skip_check_exceptions"

--- a/flink-end-to-end-tests/test-scripts/test_kubernetes_materialized_table.sh
+++ b/flink-end-to-end-tests/test-scripts/test_kubernetes_materialized_table.sh
@@ -19,6 +19,20 @@
 
 # This script aims to test Materialized Table and Kubernetes integration.
 
+ACTION="${1:-run_test}"
+
+if [ "${ACTION}" == "check_exceptions" ]; then
+    source "$(dirname "$0")"/common.sh
+
+    check_logs_for_errors
+    internal_check_logs_for_exceptions "stream_write_exceptions=0"
+    check_logs_for_non_empty_out_files
+    exit "${EXIT_CODE}"
+elif [ "${ACTION}" != "run_test" ]; then
+    echo "ERROR: Action ${ACTION} is unsupported for kubernetes materialized table test. Aborting..."
+    exit 1
+fi
+
 source "$(dirname "$0")"/common_kubernetes.sh
 
 CURRENT_DIR=`cd "$(dirname "$0")" && pwd -P`
@@ -196,7 +210,8 @@ session_options="{\"table.catalog-store.kind\": \"file\",
                  \"kubernetes.taskmanager.cpu\": \"0.5\",
                  \"kubernetes.rest-service.exposed.type\": \"NodePort\",
                  \"s3.endpoint\": \"$S3_ENDPOINT\",
-                 \"workflow-scheduler.type\": \"embedded\"}"
+                 \"workflow-scheduler.type\": \"embedded\",
+                 \"client.timeout\": \"5min\"}"
 
 session_handle=$(open_session "$session_options")
 echo "[INFO] Session Handle $session_handle"


### PR DESCRIPTION
## What is the purpose of the change

This pull request stabilizes the Kubernetes Materialized Table end-to-end test for FLINK-39132.

The test suspends a continuous materialized table by stopping the Kubernetes application job with a savepoint. The Jira evidence shows that this stop-with-savepoint operation can exceed the default 60s SQL Gateway client timeout. A later linked Azure failure also shows the same test failing during post-test log validation because Hadoop S3A emits a harmless statistics field named `stream_write_exceptions=0`, which the generic e2e exception grep treats as an exception.

## Brief change log

  - Configure the Kubernetes Materialized Table SQL Gateway session with `client.timeout = 5min` so the stop-with-savepoint operation has enough time in CI.
  - Use a custom log-check action for this test that still checks errors, real exceptions, and non-empty `.out` files, but allows the zero-valued S3A `stream_write_exceptions=0` statistics field.

## Verifying this change

This change added targeted validation for the e2e shell-script behavior and can be verified as follows:

  - `bash -n flink-end-to-end-tests/test-scripts/test_kubernetes_materialized_table.sh`
  - `bash -n flink-end-to-end-tests/run-nightly-tests.sh`
  - A focused shell harness verified that `test_kubernetes_materialized_table.sh check_exceptions` passes for the S3A `stream_write_exceptions=0` statistics line.
  - The same harness verified that `test_kubernetes_materialized_table.sh check_exceptions` still fails for a real `java.lang.RuntimeException` log line.
  - A focused static check verified that the test session options include `client.timeout = 5min`.
  - `git diff --check`

I did not run the full Kubernetes e2e test locally because it requires the full Flink distribution plus minikube/kubectl/sudo setup used by CI.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: yes, Kubernetes e2e test configuration only
  - The S3 file system connector: no, only the e2e log checker allow-list for a zero-valued S3A metric field

## Documentation

  - Does this pull request introduce a new feature? no

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: Hermes Agent
