### PR TITLE
[FLINK-39969] [runtime] Apply configured SSL protocols and algorithms

### DIFF
--- a/flink-rpc/flink-rpc-akka/src/main/java/org/apache/flink/runtime/rpc/pekko/PekkoUtils.java
+++ b/flink-rpc/flink-rpc-akka/src/main/java/org/apache/flink/runtime/rpc/pekko/PekkoUtils.java
@@ -361,6 +361,22 @@ class PekkoUtils {
 
         final String sslEngineProviderName = CustomSSLEngineProvider.class.getCanonicalName();
 
+        LOG.debug(
+                "Creating RPC SSL configuration with enabled={}, protocol={}, "
+                        + "enabledAlgorithms={}, keyStoreConfigured={}, keyStoreType={}, "
+                        + "trustStoreConfigured={}, trustStoreType={}, certFingerprintsConfigured={}, "
+                        + "requireMutualAuthentication={}, sslEngineProvider={}",
+                enableSSLConfig,
+                sslProtocol,
+                sslAlgorithmsString,
+                sslKeyStore != null,
+                sslKeyStoreType,
+                sslTrustStore != null,
+                sslTrustStoreType,
+                sslCertFingerprintString != null && !sslCertFingerprintString.isEmpty(),
+                true,
+                sslEngineProviderName);
+
         configBuilder
                 .add("pekko {")
                 .add("  remote.classic {")

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/net/SSLUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/net/SSLUtils.java
@@ -35,6 +35,9 @@ import org.apache.flink.shaded.netty4.io.netty.handler.ssl.SslContextBuilder;
 import org.apache.flink.shaded.netty4.io.netty.handler.ssl.SslProvider;
 import org.apache.flink.shaded.netty4.io.netty.handler.ssl.util.FingerprintTrustManagerFactory;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import javax.annotation.Nullable;
 import javax.net.ServerSocketFactory;
 import javax.net.SocketFactory;
@@ -42,6 +45,8 @@ import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLServerSocket;
 import javax.net.ssl.SSLServerSocketFactory;
+import javax.net.ssl.SSLSocket;
+import javax.net.ssl.SSLSocketFactory;
 import javax.net.ssl.TrustManagerFactory;
 
 import java.io.File;
@@ -49,6 +54,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.InetAddress;
 import java.net.ServerSocket;
+import java.net.Socket;
 import java.nio.file.Files;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
@@ -66,6 +72,8 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /** Common utilities to manage SSL transport settings. */
 public class SSLUtils {
+
+    private static final Logger LOG = LoggerFactory.getLogger(SSLUtils.class);
 
     /**
      * Creates a factory for SSL Server Sockets from the given configuration. SSL Server Sockets are
@@ -96,7 +104,11 @@ public class SSLUtils {
             throw new IllegalConfigurationException("SSL is not enabled");
         }
 
-        return sslContext.getSocketFactory();
+        String[] protocols = getEnabledProtocols(config);
+        String[] cipherSuites = getEnabledCipherSuites(config);
+
+        SSLSocketFactory factory = sslContext.getSocketFactory();
+        return new ConfiguringSSLSocketFactory(factory, protocols, cipherSuites);
     }
 
     /** Creates a SSLEngineFactory to be used by internal communication server endpoints. */
@@ -357,6 +369,17 @@ public class SSLUtils {
         int sessionCacheSize = config.get(SecurityOptions.SSL_INTERNAL_SESSION_CACHE_SIZE);
         int sessionTimeoutMs = config.get(SecurityOptions.SSL_INTERNAL_SESSION_TIMEOUT);
 
+        LOG.debug(
+                "Creating internal SSL context with provider={}, clientMode={}, clientAuth={}, "
+                        + "protocols={}, cipherSuites={}, sessionCacheSize={}, sessionTimeoutMs={}",
+                provider,
+                clientMode,
+                ClientAuth.REQUIRE,
+                Arrays.toString(sslProtocols),
+                ciphers,
+                sessionCacheSize,
+                sessionTimeoutMs);
+
         KeyManagerFactory kmf = getKeyManagerFactory(config, true, provider);
         ClientAuth clientAuth = ClientAuth.REQUIRE;
 
@@ -421,6 +444,16 @@ public class SSLUtils {
         String[] sslProtocols = getEnabledProtocols(config);
         List<String> ciphers = Arrays.asList(getEnabledCipherSuites(config));
 
+        LOG.debug(
+                "Creating REST SSL context with provider={}, clientMode={}, clientAuth={}, "
+                        + "protocols={}, cipherSuites={}, verifyHostname={}",
+                provider,
+                clientMode,
+                clientAuth,
+                Arrays.toString(sslProtocols),
+                ciphers,
+                clientMode ? config.get(SecurityOptions.SSL_REST_VERIFY_HOSTNAME) : null);
+
         final SslContextBuilder sslContextBuilder;
         if (clientMode) {
             sslContextBuilder = SslContextBuilder.forClient();
@@ -433,22 +466,21 @@ public class SSLUtils {
         } else {
             KeyManagerFactory kmf = getKeyManagerFactory(config, false, provider);
             sslContextBuilder = SslContextBuilder.forServer(kmf);
+            if (clientAuth != ClientAuth.NONE) {
+                sslContextBuilder.clientAuth(clientAuth);
+            }
         }
 
         if (clientMode || clientAuth != ClientAuth.NONE) {
             Optional<TrustManagerFactory> tmf = getTrustManagerFactory(config, false);
-            tmf.map(
-                    // Use specific ciphers and protocols if SSL is configured with self-signed
-                    // certificates (user-supplied truststore)
-                    tm ->
-                            sslContextBuilder
-                                    .trustManager(tm)
-                                    .protocols(sslProtocols)
-                                    .ciphers(ciphers)
-                                    .clientAuth(clientAuth));
+            tmf.ifPresent(sslContextBuilder::trustManager);
         }
 
-        return sslContextBuilder.sslProvider(provider).build();
+        return sslContextBuilder
+                .sslProvider(provider)
+                .protocols(sslProtocols)
+                .ciphers(ciphers)
+                .build();
     }
 
     // ------------------------------------------------------------------------
@@ -475,6 +507,72 @@ public class SSLUtils {
     // ------------------------------------------------------------------------
     //  Wrappers for socket factories that additionally configure the sockets
     // ------------------------------------------------------------------------
+
+    private static class ConfiguringSSLSocketFactory extends SSLSocketFactory {
+
+        private final SSLSocketFactory sslSocketFactory;
+        private final String[] protocols;
+        private final String[] cipherSuites;
+
+        ConfiguringSSLSocketFactory(
+                SSLSocketFactory sslSocketFactory, String[] protocols, String[] cipherSuites) {
+            this.sslSocketFactory = sslSocketFactory;
+            this.protocols = protocols;
+            this.cipherSuites = cipherSuites;
+        }
+
+        @Override
+        public String[] getDefaultCipherSuites() {
+            return sslSocketFactory.getDefaultCipherSuites();
+        }
+
+        @Override
+        public String[] getSupportedCipherSuites() {
+            return sslSocketFactory.getSupportedCipherSuites();
+        }
+
+        @Override
+        public Socket createSocket() throws IOException {
+            return configureSocket(sslSocketFactory.createSocket());
+        }
+
+        @Override
+        public Socket createSocket(Socket socket, String host, int port, boolean autoClose)
+                throws IOException {
+            return configureSocket(sslSocketFactory.createSocket(socket, host, port, autoClose));
+        }
+
+        @Override
+        public Socket createSocket(String host, int port) throws IOException {
+            return configureSocket(sslSocketFactory.createSocket(host, port));
+        }
+
+        @Override
+        public Socket createSocket(String host, int port, InetAddress localHost, int localPort)
+                throws IOException {
+            return configureSocket(sslSocketFactory.createSocket(host, port, localHost, localPort));
+        }
+
+        @Override
+        public Socket createSocket(InetAddress host, int port) throws IOException {
+            return configureSocket(sslSocketFactory.createSocket(host, port));
+        }
+
+        @Override
+        public Socket createSocket(
+                InetAddress address, int port, InetAddress localAddress, int localPort)
+                throws IOException {
+            return configureSocket(
+                    sslSocketFactory.createSocket(address, port, localAddress, localPort));
+        }
+
+        private Socket configureSocket(Socket socket) {
+            SSLSocket sslSocket = (SSLSocket) socket;
+            sslSocket.setEnabledProtocols(protocols);
+            sslSocket.setEnabledCipherSuites(cipherSuites);
+            return sslSocket;
+        }
+    }
 
     private static class ConfiguringSSLServerSocketFactory extends ServerSocketFactory {
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/net/SSLUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/net/SSLUtilsTest.java
@@ -33,11 +33,14 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLServerSocket;
+import javax.net.ssl.SSLSocket;
 
 import java.io.File;
 import java.io.InputStream;
 import java.net.ServerSocket;
+import java.net.Socket;
 import java.nio.file.Files;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
@@ -173,6 +176,27 @@ public class SSLUtilsTest {
         List<String> cipherSuites = checkNotNull(nettySSLContext).cipherSuites();
         assertThat(cipherSuites).hasSize(2);
         assertThat(cipherSuites).containsExactlyInAnyOrder(testSSLAlgorithms.split(","));
+    }
+
+    @Test
+    void testRestServerAppliesConfiguredProtocolsAndCipherSuites() throws Exception {
+        final Configuration config = createRestSslConfigWithKeyStore("JDK");
+        config.set(SecurityOptions.SSL_PROTOCOL, "TLSv1.2");
+        config.set(
+                SecurityOptions.SSL_ALGORITHMS,
+                "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384");
+
+        final JdkSslContext nettySSLContext =
+                (JdkSslContext)
+                        SSLUtils.createRestNettySSLContext(config, false, ClientAuth.NONE, JDK);
+        final SSLEngine sslEngine =
+                checkNotNull(nettySSLContext).newEngine(UnpooledByteBufAllocator.DEFAULT);
+
+        assertThat(sslEngine.getEnabledProtocols()).containsExactly("TLSv1.2");
+        assertThat(sslEngine.getEnabledCipherSuites())
+                .containsExactlyInAnyOrder(
+                        "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+                        "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384");
     }
 
     // ------------------------ server --------------------------
@@ -382,6 +406,29 @@ public class SSLUtilsTest {
             assertThat(algorithms).hasSize(2);
             assertThat(algorithms)
                     .contains(
+                            "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+                            "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384");
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void testSetSSLVersionAndCipherSuitesForSSLClientSocket(String sslProvider) throws Exception {
+        final Configuration clientConfig =
+                createInternalSslConfigWithKeyAndTrustStores(sslProvider);
+
+        clientConfig.set(SecurityOptions.SSL_PROTOCOL, "TLSv1.1");
+        clientConfig.set(
+                SecurityOptions.SSL_ALGORITHMS,
+                "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384");
+
+        try (Socket socket = SSLUtils.createSSLClientSocketFactory(clientConfig).createSocket()) {
+            assertThat(socket).isInstanceOf(SSLSocket.class);
+            final SSLSocket sslSocket = (SSLSocket) socket;
+
+            assertThat(sslSocket.getEnabledProtocols()).containsExactly("TLSv1.1");
+            assertThat(sslSocket.getEnabledCipherSuites())
+                    .containsExactlyInAnyOrder(
                             "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
                             "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384");
         }


### PR DESCRIPTION
## What is the purpose of the change

This pull request fixes FLINK-39969 so configured SSL protocols and cipher suites are consistently applied to Flink REST SSL services and internal SSL client sockets. Previously, REST server Netty SSL contexts skipped configured protocols/ciphers when no trust manager was installed, and `createSSLClientSocketFactory` returned the raw socket factory without applying Flink's configured SSL protocol and algorithms.

## Brief change log

- Apply configured REST SSL protocols, cipher suites, and client-auth mode directly on the Netty `SslContextBuilder` regardless of whether a trust manager is present.
- Wrap internal SSL client socket factories so each created `SSLSocket` receives the configured protocols and cipher suites, matching the existing server-side socket factory behavior.
- Add regression coverage for REST server Netty SSL context configuration and internal SSL client socket configuration.

## Verifying this change

This change added tests and can be verified as follows:

- `./mvnw -pl flink-runtime -Dtest=SSLUtilsTest#testRestServerAppliesConfiguredProtocolsAndCipherSuites+testSetSSLVersionAndCipherSuitesForSSLClientSocket -DfailIfNoTests=false -DskipITs -Dfast -Drat.skip=true -Dcheckstyle.skip=true -Dspotless.check.skip=true test`
  - Verified RED before the fix: the new focused tests failed because configured protocols were not applied.
  - Verified GREEN after the fix: `Tests run: 2, Failures: 0, Errors: 0, Skipped: 0`.
- `./mvnw -pl flink-runtime -Dtest=SSLUtilsTest -DfailIfNoTests=false -DskipITs -Dfast -Drat.skip=true -Dspotless.check.skip=true test`
  - `Tests run: 28, Failures: 0, Errors: 0, Skipped: 0`.
- `./mvnw -pl flink-runtime -DskipTests -DskipITs -Drat.skip=true spotless:check`
  - `BUILD SUCCESS`.

## Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): no
- The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
- The serializers: no
- The runtime per-record code paths (performance sensitive): no
- Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: yes, SSL setup for REST and internal runtime communication
- The S3 file system connector: no

## Documentation

- Does this pull request introduce a new feature? no
- If yes, how is the feature documented? not applicable

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (Hermes Agent, OpenAI GPT-5.5)

Generated-by: Hermes Agent (OpenAI GPT-5.5)
