### PR TITLE
[FLINK-39963][runtime/tests] Stabilize balanced input slow task detector test

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/slowtaskdetector/ExecutionTimeBasedSlowTaskDetectorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/slowtaskdetector/ExecutionTimeBasedSlowTaskDetectorTest.java
@@ -23,6 +23,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.SlowTaskDetectorOptions;
 import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutorServiceAdapter;
 import org.apache.flink.runtime.concurrent.NoMainThreadCheckComponentMainThreadExecutor;
+import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.executiongraph.ExecutionGraph;
 import org.apache.flink.runtime.executiongraph.ExecutionGraphTestUtils;
@@ -264,6 +265,11 @@ class ExecutionTimeBasedSlowTaskDetectorTest {
         ev23.setInputBytes(1024);
 
         ev23.getCurrentExecutionAttempt().markFinished();
+        final long currentTimeMillis = System.currentTimeMillis();
+        setStateTimestamp(ev21, ExecutionState.DEPLOYING, currentTimeMillis - 1000);
+        setStateTimestamp(ev22, ExecutionState.DEPLOYING, currentTimeMillis - 1000);
+        setStateTimestamp(ev23, ExecutionState.DEPLOYING, currentTimeMillis - 1);
+        setStateTimestamp(ev23, ExecutionState.FINISHED, currentTimeMillis);
 
         final Map<ExecutionVertexID, Collection<ExecutionAttemptID>> slowTasks =
                 slowTaskDetector.findSlowTasks(executionGraph);
@@ -501,5 +507,11 @@ class ExecutionTimeBasedSlowTaskDetectorTest {
         configuration.set(SlowTaskDetectorOptions.EXECUTION_TIME_BASELINE_RATIO, ratio);
         configuration.set(SlowTaskDetectorOptions.EXECUTION_TIME_BASELINE_MULTIPLIER, multiplier);
         return configuration;
+    }
+
+    private static void setStateTimestamp(
+            ExecutionVertex executionVertex, ExecutionState state, long timestamp) {
+        executionVertex.getCurrentExecutionAttempt().getStateTimestamps()[state.ordinal()] =
+                timestamp;
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

This pull request stabilizes `ExecutionTimeBasedSlowTaskDetectorTest.testBalancedInput` by making the execution-time relationship used by the assertion explicit instead of relying on wall-clock timing between task deployment and completion.

## Brief change log

- Sets deterministic `DEPLOYING` / `FINISHED` timestamps for the running and finished executions in `testBalancedInput`.
- Keeps the test focused on the balanced-input slow-task detection expectation: two still-running tasks should exceed the finished baseline.

## Verifying this change

This change is already covered by existing tests, such as:

- `./mvnw -pl flink-runtime -Dtest=ExecutionTimeBasedSlowTaskDetectorTest#testBalancedInput test`
- `./mvnw -pl flink-runtime -Dtest=ExecutionTimeBasedSlowTaskDetectorTest test`

## Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): no
- The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
- The serializers: no
- The runtime per-record code paths (performance sensitive): no
- Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
- The S3 file system connector: no

## Documentation

- Does this pull request introduce a new feature? no
- If yes, how is the feature documented? not applicable

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: OpenAI GPT-5.5 via Hermes Agent
