### PR TITLE
[FLINK-39962] [runtime] Fix flaky DeclarativeSlotPoolBridgeTest

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/DeclarativeSlotPoolBridgeTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/DeclarativeSlotPoolBridgeTest.java
@@ -18,8 +18,12 @@
 
 package org.apache.flink.runtime.jobmaster.slotpool;
 
+import org.apache.flink.core.testutils.ScheduledTask;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
+import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
+import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutorServiceAdapter;
+import org.apache.flink.runtime.concurrent.ManuallyTriggeredScheduledExecutorService;
 import org.apache.flink.runtime.executiongraph.utils.SimpleAckingTaskManagerGateway;
 import org.apache.flink.runtime.jobmaster.SlotInfo;
 import org.apache.flink.runtime.jobmaster.SlotRequestId;
@@ -28,6 +32,7 @@ import org.apache.flink.runtime.taskmanager.LocalTaskManagerLocation;
 import org.apache.flink.runtime.util.ResourceCounter;
 import org.apache.flink.testutils.junit.extensions.parameterized.ParameterizedTestExtension;
 import org.apache.flink.util.concurrent.FutureUtils;
+import org.apache.flink.util.concurrent.ScheduledExecutor;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
@@ -42,6 +47,8 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -224,8 +231,15 @@ class DeclarativeSlotPoolBridgeTest extends AbstractDeclarativeSlotPoolBridgeTes
 
     @TestTemplate
     void testAcceptingOfferedSlotsWithoutResourceManagerConnected() throws Exception {
+        final ManuallyTriggeredScheduledExecutorService scheduledExecutor =
+                new ManuallyTriggeredScheduledExecutorService();
+        final ComponentMainThreadExecutor mainThreadExecutor =
+                new ComponentMainThreadExecutorServiceAdapter(
+                        (ScheduledExecutor) scheduledExecutor, Thread.currentThread());
+
         try (DeclarativeSlotPoolBridge declarativeSlotPoolBridge =
-                createDeclarativeSlotPoolBridge(new DefaultDeclarativeSlotPoolFactory())) {
+                createDeclarativeSlotPoolBridge(
+                        new DefaultDeclarativeSlotPoolFactory(), mainThreadExecutor)) {
 
             declarativeSlotPoolBridge.start(JOB_MASTER_ID, "localhost");
 
@@ -234,6 +248,7 @@ class DeclarativeSlotPoolBridgeTest extends AbstractDeclarativeSlotPoolBridgeTes
                             PhysicalSlotRequestUtils.normalRequest(ResourceProfile.UNKNOWN),
                             RPC_TIMEOUT);
 
+            triggerDeferredSlotRequestDeclaration(scheduledExecutor);
             tryWaitSlotRequestIsDone(declarativeSlotPoolBridge);
 
             final LocalTaskManagerLocation localTaskManagerLocation =
@@ -248,6 +263,24 @@ class DeclarativeSlotPoolBridgeTest extends AbstractDeclarativeSlotPoolBridgeTes
 
             assertThat(slotFuture.join().getAllocationId()).isSameAs(allocationId);
         }
+    }
+
+    private void triggerDeferredSlotRequestDeclaration(
+            ManuallyTriggeredScheduledExecutorService scheduledExecutor) {
+        if (slotRequestMaxInterval.toMillis() <= 0L) {
+            return;
+        }
+
+        final List<ScheduledFuture<?>> slotRequestTasks =
+                scheduledExecutor.getActiveNonPeriodicScheduledTask().stream()
+                        .filter(
+                                scheduledTask ->
+                                        scheduledTask.getDelay(TimeUnit.MILLISECONDS)
+                                                == slotRequestMaxInterval.toMillis())
+                        .collect(Collectors.toList());
+
+        assertThat(slotRequestTasks).hasSize(1);
+        slotRequestTasks.forEach(scheduledTask -> ((ScheduledTask<?>) scheduledTask).execute());
     }
 
     @TestTemplate


### PR DESCRIPTION
## What is the purpose of the change

This pull request fixes the flaky `DeclarativeSlotPoolBridgeTest.testAcceptingOfferedSlotsWithoutResourceManagerConnected` reported in FLINK-39962.

The Jira describes a test-only threading race: the test used the regular `forMainThread()` test executor, whose scheduled timeout callbacks can run concurrently with the test thread while `close()` copies `pendingRequests`, intermittently producing `NegativeArraySizeException`.

## Brief change log

- Use a `ManuallyTriggeredScheduledExecutorService` for the affected test.
- Manually complete the deferred slot-request declaration task when `slotRequestMaxInterval` is positive.
- Keep production slot-pool code unchanged and avoid triggering unrelated request/idle/batch timeout tasks in this test.

## Verifying this change

This change is covered by the existing affected test and the containing test class:

- `./mvnw -pl flink-runtime -Dtest=DeclarativeSlotPoolBridgeTest#testAcceptingOfferedSlotsWithoutResourceManagerConnected -DfailIfNoTests=false -DskipITs -Dfast -Drat.skip=true -Dcheckstyle.skip=true -Dspotless.check.skip=true test`
- `./mvnw -pl flink-runtime -Dtest=DeclarativeSlotPoolBridgeTest -DfailIfNoTests=false -DskipITs -Dfast -Drat.skip=true -Dcheckstyle.skip=true -Dspotless.check.skip=true test`
- `./mvnw -pl flink-runtime -DskipTests -DskipITs -Drat.skip=true spotless:check`
- `./mvnw -pl flink-runtime -DskipTests -DskipITs -Drat.skip=true checkstyle:check`

## Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): no
- The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
- The serializers: no
- The runtime per-record code paths (performance sensitive): no
- Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
- The S3 file system connector: no

## Documentation

- Does this pull request introduce a new feature? no
- If yes, how is the feature documented? not applicable

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: Hermes Agent (OpenAI GPT-5.5)
