### PR TITLE
[FLINK-39357][docs] Correct documentation examples for ProcessTableFunctionTestHarness

### DIFF
--- a/docs/content.zh/docs/dev/table/functions/ptfs.md
+++ b/docs/content.zh/docs/dev/table/functions/ptfs.md
@@ -2112,7 +2112,7 @@ public class PassthroughPTF extends ProcessTableFunction<Integer> {
 
 @Test
 void testPassthrough() throws Exception {
-  try (ProcessTableFunctionTestHarness<Row> harness =
+  try (ProcessTableFunctionTestHarness<Integer> harness =
     ProcessTableFunctionTestHarness.ofClass(PassthroughPTF.class)
     .withTableArgument("input", DataTypes.of("ROW<value INT>"))
     .build()) {
@@ -2120,7 +2120,7 @@ void testPassthrough() throws Exception {
     harness.processElement(Row.of(42));
     harness.processElement(Row.of(100));
 
-    List<Row> output = harness.getOutput();
+    List<Integer> output = harness.getOutput();
     assertThat(output).containsExactly(42, 100);
   }
 }
@@ -2199,8 +2199,8 @@ void testMultiTable() throws Exception {
     harness.processElementForTable("right", Row.of(1, "Berlin"));
 
     List<Row> output = harness.getOutput();
-    assertThat(output.get(0)).isEqualTo(Row.of(1, null, "LEFT: +I[1, Alice]"));
-    assertThat(output.get(1)).isEqualTo(Row.of(null, 1, "RIGHT: +I[1, Berlin]"));
+    assertThat(output.get(0)).isEqualTo(Row.of(1, 1, "LEFT: +I[1, Alice]"));
+    assertThat(output.get(1)).isEqualTo(Row.of(1, 1, "RIGHT: +I[1, Berlin]"));
   }
 }
 ```
@@ -2218,7 +2218,7 @@ Use `.withScalarArgument()` to configure scalar parameter values:
 public class FilterPTF extends ProcessTableFunction<Row> {
   public void eval(
     @ArgumentHint(ArgumentTrait.ROW_SEMANTIC_TABLE) Row input,
-    int threshold) {
+    Integer threshold) {
     int value = input.getFieldAs("value");
     if (value > threshold) {
       collect(Row.of(value));
@@ -2252,7 +2252,7 @@ void testFilter() throws Exception {
 ```java
 @DataTypeHint("ROW<sum INT>")
 public class AddPTF extends ProcessTableFunction<Row> {
-  public void eval(int a, int b) {
+  public void eval(Integer a, Integer b) {
     collect(Row.of(a + b));
   }
 }
@@ -2536,7 +2536,7 @@ void testBuilderType() throws Exception {
     .build()) {
 
     harness.processElement(Row.of(5));
-    assertThat(harness.getOutput()).containsExactly(Row.of(10));
+    assertThat(harness.getOutput()).containsExactly(Row.of(10, 5));
   }
 }
 ```
@@ -2564,10 +2564,10 @@ public class CustomerPTF extends ProcessTableFunction<Customer> {
 void testPOJO() throws Exception {
   try (ProcessTableFunctionTestHarness<Customer> harness =
       ProcessTableFunctionTestHarness.ofClass(CustomerPTF.class)
-          .withTableArgument("input", DataTypes.of(Customer.class))
+          .withTableArgument("c", DataTypes.of(Customer.class))
           .build()) {
 
-    harness.processElement(Row.of("Alice", 30));
+    harness.processElement(Row.of(30, "Alice"));
 
     List<Customer> output = harness.getOutput();
     assertThat(output.get(0).name).isEqualTo("Alice");

--- a/docs/content/docs/dev/table/functions/ptfs.md
+++ b/docs/content/docs/dev/table/functions/ptfs.md
@@ -2115,7 +2115,7 @@ public class PassthroughPTF extends ProcessTableFunction<Integer> {
 
 @Test
 void testPassthrough() throws Exception {
-  try (ProcessTableFunctionTestHarness<Row> harness =
+  try (ProcessTableFunctionTestHarness<Integer> harness =
     ProcessTableFunctionTestHarness.ofClass(PassthroughPTF.class)
     .withTableArgument("input", DataTypes.of("ROW<value INT>"))
     .build()) {
@@ -2123,7 +2123,7 @@ void testPassthrough() throws Exception {
     harness.processElement(Row.of(42));
     harness.processElement(Row.of(100));
 
-    List<Row> output = harness.getOutput();
+    List<Integer> output = harness.getOutput();
     assertThat(output).containsExactly(42, 100);
   }
 }
@@ -2202,8 +2202,8 @@ void testMultiTable() throws Exception {
     harness.processElementForTable("right", Row.of(1, "Berlin"));
 
     List<Row> output = harness.getOutput();
-    assertThat(output.get(0)).isEqualTo(Row.of(1, null, "LEFT: +I[1, Alice]"));
-    assertThat(output.get(1)).isEqualTo(Row.of(null, 1, "RIGHT: +I[1, Berlin]"));
+    assertThat(output.get(0)).isEqualTo(Row.of(1, 1, "LEFT: +I[1, Alice]"));
+    assertThat(output.get(1)).isEqualTo(Row.of(1, 1, "RIGHT: +I[1, Berlin]"));
   }
 }
 ```
@@ -2221,7 +2221,7 @@ Use `.withScalarArgument()` to configure scalar parameter values:
 public class FilterPTF extends ProcessTableFunction<Row> {
   public void eval(
     @ArgumentHint(ArgumentTrait.ROW_SEMANTIC_TABLE) Row input,
-    int threshold) {
+    Integer threshold) {
     int value = input.getFieldAs("value");
     if (value > threshold) {
       collect(Row.of(value));
@@ -2255,7 +2255,7 @@ void testFilter() throws Exception {
 ```java
 @DataTypeHint("ROW<sum INT>")
 public class AddPTF extends ProcessTableFunction<Row> {
-  public void eval(int a, int b) {
+  public void eval(Integer a, Integer b) {
     collect(Row.of(a + b));
   }
 }
@@ -2539,7 +2539,7 @@ void testBuilderType() throws Exception {
     .build()) {
 
     harness.processElement(Row.of(5));
-    assertThat(harness.getOutput()).containsExactly(Row.of(10));
+    assertThat(harness.getOutput()).containsExactly(Row.of(10, 5));
   }
 }
 ```
@@ -2567,10 +2567,10 @@ public class CustomerPTF extends ProcessTableFunction<Customer> {
 void testPOJO() throws Exception {
   try (ProcessTableFunctionTestHarness<Customer> harness =
       ProcessTableFunctionTestHarness.ofClass(CustomerPTF.class)
-          .withTableArgument("input", DataTypes.of(Customer.class))
+          .withTableArgument("c", DataTypes.of(Customer.class))
           .build()) {
 
-    harness.processElement(Row.of("Alice", 30));
+    harness.processElement(Row.of(30, "Alice"));
 
     List<Customer> output = harness.getOutput();
     assertThat(output.get(0).name).isEqualTo("Alice");


### PR DESCRIPTION
## What is the purpose of the change

Some of the examples in the PTF documentation for the PTF Test Harness are incorrect or out of sync with the current harness behaviour. This PR fixes the examples.

## Brief change log

- *Corrected documentation examples for PTF Test Harness*


## Verifying this change

This change is a trivial rework (verified the examples by writing them as standalone tests)

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)