### PR TITLE
[FLINK-39994][table] Allow the use of primitive scalar arguments in ProcessTableFunctionTestHarness

### DIFF
--- a/flink-table/flink-table-test-utils/src/main/java/org/apache/flink/table/runtime/functions/ProcessTableFunctionTestHarness.java
+++ b/flink-table/flink-table-test-utils/src/main/java/org/apache/flink/table/runtime/functions/ProcessTableFunctionTestHarness.java
@@ -47,6 +47,8 @@ import org.apache.flink.types.Row;
 import org.apache.flink.types.RowKind;
 import org.apache.flink.util.Collector;
 
+import org.apache.commons.lang3.ClassUtils;
+
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;
@@ -871,7 +873,8 @@ public class ProcessTableFunctionTestHarness<OUT> implements AutoCloseable {
 
                 if (arg instanceof ScalarArgumentInfo) {
                     Object value = ((ScalarArgumentInfo) arg).value;
-                    if (value != null && !paramType.isAssignableFrom(value.getClass())) {
+                    Class<?> expectedType = ClassUtils.primitiveToWrapper(paramType);
+                    if (value != null && !expectedType.isAssignableFrom(value.getClass())) {
                         throw new IllegalStateException(
                                 String.format(
                                         "Type mismatch for scalar argument '%s' at position %d: "

--- a/flink-table/flink-table-test-utils/src/test/java/org/apache/flink/table/runtime/functions/ProcessTableFunctionTestHarnessTest.java
+++ b/flink-table/flink-table-test-utils/src/test/java/org/apache/flink/table/runtime/functions/ProcessTableFunctionTestHarnessTest.java
@@ -299,6 +299,14 @@ class ProcessTableFunctionTestHarnessTest {
         }
     }
 
+    /** PTF with primitive scalar arguments. */
+    @DataTypeHint("ROW<sum INT>")
+    public static class PrimitiveScalarPTF extends ProcessTableFunction<Row> {
+        public void eval(int a, int b) {
+            collect(Row.of(a + b));
+        }
+    }
+
     /** PTF with Context parameter - should be rejected by test harness. */
     @DataTypeHint("ROW<value INT>")
     public static class PTFWithContext extends ProcessTableFunction<Row> {
@@ -523,6 +531,22 @@ class ProcessTableFunctionTestHarnessTest {
 
             List<Row> output = harness.getOutput();
 
+            assertThat(output).hasSize(1);
+            assertThat(output.get(0).getField("sum")).isEqualTo(30);
+        }
+    }
+
+    @Test
+    void testPrimitiveScalarArguments() throws Exception {
+        try (ProcessTableFunctionTestHarness<Row> harness =
+                ProcessTableFunctionTestHarness.ofClass(PrimitiveScalarPTF.class)
+                        .withScalarArgument("a", 10)
+                        .withScalarArgument("b", 20)
+                        .build()) {
+
+            harness.process();
+
+            List<Row> output = harness.getOutput();
             assertThat(output).hasSize(1);
             assertThat(output.get(0).getField("sum")).isEqualTo(30);
         }


### PR DESCRIPTION
## What is the purpose of the change

When testing examples for the ProcessTableFunctionTestHarness, it was found that since `withScalarArguments` autoboxes the the input value (for example `int` to `Integer`), it was incompatible with PTFs that have primitive scalar input arguments, since `int` is not assignable from `Integer`. This was just an error in the preflight check, and would have worked without it.

This PR instead converts the expected primitive class to the wrapper class before checking assignability.

## Brief change log

- *Fixed bug that prevented users from using PTFs with primitive scalar arguments with the PTF test harness*


## Verifying this change

This change added tests and can be verified as follows:

- Added `testPrimitiveScalarArguments` in `ProcessTableFunctionTestHarnessTest.java`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)