### PR TITLE
[FLINK-39995][json] Add ISO-8601 timestamp format with explicit timezone offset support

### DIFF
--- a/docs/content/docs/connectors/table/formats/json.md
+++ b/docs/content/docs/connectors/table/formats/json.md
@@ -107,12 +107,14 @@ Format Options
       <td>yes</td>
       <td style="word-wrap: break-word;"><code>'SQL'</code></td>
       <td>String</td>
-      <td>Specify the input and output timestamp format for <code>TIMESTAMP</code> and <code>TIMESTAMP_LTZ</code> type. Currently supported values are <code>'SQL'</code> and <code>'ISO-8601'</code>:
+      <td>Specify the input and output timestamp format for <code>TIMESTAMP</code> and <code>TIMESTAMP_LTZ</code> type. Currently supported values are <code>'SQL'</code>, <code>'ISO-8601'</code>, and <code>'ISO-8601-WITH-OFFSET'</code>:
       <ul>
         <li>Option <code>'SQL'</code> will parse input TIMESTAMP values in "yyyy-MM-dd HH:mm:ss.s{precision}" format, e.g "2020-12-30 12:13:14.123", 
         parse input TIMESTAMP_LTZ values in "yyyy-MM-dd HH:mm:ss.s{precision}'Z'" format, e.g "2020-12-30 12:13:14.123Z" and output timestamp in the same format.</li>
         <li>Option <code>'ISO-8601'</code>will parse input TIMESTAMP in "yyyy-MM-ddTHH:mm:ss.s{precision}" format, e.g "2020-12-30T12:13:14.123" 
         parse input TIMESTAMP_LTZ in "yyyy-MM-ddTHH:mm:ss.s{precision}'Z'" format, e.g "2020-12-30T12:13:14.123Z" and output timestamp in the same format.</li>
+        <li>Option <code>'ISO-8601-WITH-OFFSET'</code> will parse input TIMESTAMP and TIMESTAMP_LTZ in "yyyy-MM-ddTHH:mm:ss.s{precision}±HH:mm" format with explicit timezone offset, e.g "2020-12-30T12:13:14.123+02:00", "2020-12-30T12:13:14.123+05:30". 
+        <strong>Note:</strong> All timestamps are normalized to UTC (±00:00) on output and serialized in "yyyy-MM-ddTHH:mm:ss.s{precision}Z" format, e.g "2020-12-30T10:13:14.123Z", regardless of the input timezone offset.</li>
       </ul>
       </td>
     </tr>

--- a/flink-formats/flink-format-common/src/main/java/org/apache/flink/formats/common/TimeFormats.java
+++ b/flink-formats/flink-format-common/src/main/java/org/apache/flink/formats/common/TimeFormats.java
@@ -63,6 +63,17 @@ public class TimeFormats {
                     .appendPattern("'Z'")
                     .toFormatter();
 
+    /**
+     * Formatter for ISO8601 string representation of a timestamp value (with explicit timezone
+     * offset).
+     */
+    public static final DateTimeFormatter ISO8601_TIMESTAMP_WITH_OFFSET_FORMAT =
+            new DateTimeFormatterBuilder()
+                    .append(DateTimeFormatter.ISO_LOCAL_DATE)
+                    .appendLiteral('T')
+                    .append(DateTimeFormatter.ISO_OFFSET_TIME)
+                    .toFormatter();
+
     /** Formatter for SQL string representation of a time value. */
     public static final DateTimeFormatter SQL_TIME_FORMAT =
             new DateTimeFormatterBuilder()

--- a/flink-formats/flink-format-common/src/main/java/org/apache/flink/formats/common/TimestampFormat.java
+++ b/flink-formats/flink-format-common/src/main/java/org/apache/flink/formats/common/TimestampFormat.java
@@ -35,5 +35,11 @@ public enum TimestampFormat {
      * "yyyy-MM-ddTHH:mm:ss.s{precision}" format, TIMESTAMP_WITH_LOCAL_TIMEZONE in
      * "yyyy-MM-ddTHH:mm:ss.s{precision}'Z'" and output in the same format.
      */
-    ISO_8601
+    ISO_8601,
+
+    /**
+     * Options to specify TIMESTAMP with explicit timezone offset format. It will parse TIMESTAMP in
+     * "yyyy-MM-ddTHH:mm:ss.s{precision}±HH:mm" format and output in the same format.
+     */
+    ISO_8601_WITH_OFFSET
 }

--- a/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/JsonFormatOptionsUtil.java
+++ b/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/JsonFormatOptionsUtil.java
@@ -45,9 +45,10 @@ public class JsonFormatOptionsUtil {
 
     public static final String SQL = "SQL";
     public static final String ISO_8601 = "ISO-8601";
+    public static final String ISO_8601_WITH_OFFSET = "ISO-8601-WITH-OFFSET";
 
     public static final Set<String> TIMESTAMP_FORMAT_ENUM =
-            new HashSet<>(Arrays.asList(SQL, ISO_8601));
+            new HashSet<>(Arrays.asList(SQL, ISO_8601, ISO_8601_WITH_OFFSET));
 
     // The handling mode of null key for map data
     public static final String JSON_MAP_NULL_KEY_MODE_FAIL = "FAIL";
@@ -65,6 +66,8 @@ public class JsonFormatOptionsUtil {
                 return TimestampFormat.SQL;
             case ISO_8601:
                 return TimestampFormat.ISO_8601;
+            case ISO_8601_WITH_OFFSET:
+                return TimestampFormat.ISO_8601_WITH_OFFSET;
             default:
                 throw new TableException(
                         String.format(
@@ -132,13 +135,13 @@ public class JsonFormatOptionsUtil {
         validateTimestampFormat(tableOptions);
     }
 
-    /** Validates timestamp format which value should be SQL or ISO-8601. */
+    /** Validates timestamp format which value should be SQL, ISO-8601, or ISO-8601-WITH-OFFSET. */
     static void validateTimestampFormat(ReadableConfig tableOptions) {
         String timestampFormat = tableOptions.get(TIMESTAMP_FORMAT);
         if (!TIMESTAMP_FORMAT_ENUM.contains(timestampFormat)) {
             throw new ValidationException(
                     String.format(
-                            "Unsupported value '%s' for %s. Supported values are [SQL, ISO-8601].",
+                            "Unsupported value '%s' for %s. Supported values are [SQL, ISO-8601, ISO-8601-WITH-OFFSET].",
                             timestampFormat, TIMESTAMP_FORMAT.key()));
         }
     }

--- a/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/JsonParserToRowDataConverters.java
+++ b/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/JsonParserToRowDataConverters.java
@@ -62,6 +62,7 @@ import java.util.Map;
 import static java.time.format.DateTimeFormatter.ISO_LOCAL_DATE;
 import static org.apache.flink.formats.common.TimeFormats.ISO8601_TIMESTAMP_FORMAT;
 import static org.apache.flink.formats.common.TimeFormats.ISO8601_TIMESTAMP_WITH_LOCAL_TIMEZONE_FORMAT;
+import static org.apache.flink.formats.common.TimeFormats.ISO8601_TIMESTAMP_WITH_OFFSET_FORMAT;
 import static org.apache.flink.formats.common.TimeFormats.SQL_TIMESTAMP_FORMAT;
 import static org.apache.flink.formats.common.TimeFormats.SQL_TIMESTAMP_WITH_LOCAL_TIMEZONE_FORMAT;
 import static org.apache.flink.formats.common.TimeFormats.SQL_TIME_FORMAT;
@@ -278,6 +279,17 @@ public class JsonParserToRowDataConverters implements Serializable {
             case ISO_8601:
                 parsedTimestamp = ISO8601_TIMESTAMP_FORMAT.parse(jp.getText());
                 break;
+            case ISO_8601_WITH_OFFSET:
+                parsedTimestamp = ISO8601_TIMESTAMP_WITH_OFFSET_FORMAT.parse(jp.getText());
+                ZoneOffset offset = parsedTimestamp.query(TemporalQueries.offset());
+                if (offset != null) {
+                    return TimestampData.fromInstant(
+                            LocalDateTime.of(
+                                            parsedTimestamp.query(TemporalQueries.localDate()),
+                                            parsedTimestamp.query(TemporalQueries.localTime()))
+                                    .toInstant(offset));
+                }
+                break;
             default:
                 throw new TableException(
                         String.format(
@@ -301,6 +313,10 @@ public class JsonParserToRowDataConverters implements Serializable {
                 parsedTimestampWithLocalZone =
                         ISO8601_TIMESTAMP_WITH_LOCAL_TIMEZONE_FORMAT.parse(jp.getText());
                 break;
+            case ISO_8601_WITH_OFFSET:
+                parsedTimestampWithLocalZone =
+                        ISO8601_TIMESTAMP_WITH_OFFSET_FORMAT.parse(jp.getText());
+                break;
             default:
                 throw new TableException(
                         String.format(
@@ -309,9 +325,11 @@ public class JsonParserToRowDataConverters implements Serializable {
         }
         LocalTime localTime = parsedTimestampWithLocalZone.query(TemporalQueries.localTime());
         LocalDate localDate = parsedTimestampWithLocalZone.query(TemporalQueries.localDate());
+        ZoneOffset offset = parsedTimestampWithLocalZone.query(TemporalQueries.offset());
 
         return TimestampData.fromInstant(
-                LocalDateTime.of(localDate, localTime).toInstant(ZoneOffset.UTC));
+                LocalDateTime.of(localDate, localTime)
+                        .toInstant(offset != null ? offset : ZoneOffset.UTC));
     }
 
     private StringData convertToString(JsonParser jp) throws IOException {

--- a/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/RowDataToJsonConverters.java
+++ b/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/RowDataToJsonConverters.java
@@ -49,7 +49,6 @@ import java.util.Arrays;
 import static java.time.format.DateTimeFormatter.ISO_LOCAL_DATE;
 import static org.apache.flink.formats.common.TimeFormats.ISO8601_TIMESTAMP_FORMAT;
 import static org.apache.flink.formats.common.TimeFormats.ISO8601_TIMESTAMP_WITH_LOCAL_TIMEZONE_FORMAT;
-import static org.apache.flink.formats.common.TimeFormats.ISO8601_TIMESTAMP_WITH_OFFSET_FORMAT;
 import static org.apache.flink.formats.common.TimeFormats.SQL_TIMESTAMP_FORMAT;
 import static org.apache.flink.formats.common.TimeFormats.SQL_TIMESTAMP_WITH_LOCAL_TIMEZONE_FORMAT;
 import static org.apache.flink.formats.common.TimeFormats.SQL_TIME_FORMAT;
@@ -202,7 +201,7 @@ public class RowDataToJsonConverters implements Serializable {
                     TimestampData timestamp = (TimestampData) value;
                     return mapper.getNodeFactory()
                             .textNode(
-                                    ISO8601_TIMESTAMP_WITH_OFFSET_FORMAT.format(
+                                    ISO8601_TIMESTAMP_WITH_LOCAL_TIMEZONE_FORMAT.format(
                                             timestamp.toInstant().atOffset(ZoneOffset.UTC)));
                 };
             default:
@@ -238,7 +237,7 @@ public class RowDataToJsonConverters implements Serializable {
                     TimestampData timestampWithLocalZone = (TimestampData) value;
                     return mapper.getNodeFactory()
                             .textNode(
-                                    ISO8601_TIMESTAMP_WITH_OFFSET_FORMAT.format(
+                                    ISO8601_TIMESTAMP_WITH_LOCAL_TIMEZONE_FORMAT.format(
                                             timestampWithLocalZone
                                                     .toInstant()
                                                     .atOffset(ZoneOffset.UTC)));

--- a/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/RowDataToJsonConverters.java
+++ b/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/RowDataToJsonConverters.java
@@ -49,6 +49,7 @@ import java.util.Arrays;
 import static java.time.format.DateTimeFormatter.ISO_LOCAL_DATE;
 import static org.apache.flink.formats.common.TimeFormats.ISO8601_TIMESTAMP_FORMAT;
 import static org.apache.flink.formats.common.TimeFormats.ISO8601_TIMESTAMP_WITH_LOCAL_TIMEZONE_FORMAT;
+import static org.apache.flink.formats.common.TimeFormats.ISO8601_TIMESTAMP_WITH_OFFSET_FORMAT;
 import static org.apache.flink.formats.common.TimeFormats.SQL_TIMESTAMP_FORMAT;
 import static org.apache.flink.formats.common.TimeFormats.SQL_TIMESTAMP_WITH_LOCAL_TIMEZONE_FORMAT;
 import static org.apache.flink.formats.common.TimeFormats.SQL_TIME_FORMAT;
@@ -196,6 +197,14 @@ public class RowDataToJsonConverters implements Serializable {
                     return mapper.getNodeFactory()
                             .textNode(SQL_TIMESTAMP_FORMAT.format(timestamp.toLocalDateTime()));
                 };
+            case ISO_8601_WITH_OFFSET:
+                return (mapper, reuse, value) -> {
+                    TimestampData timestamp = (TimestampData) value;
+                    return mapper.getNodeFactory()
+                            .textNode(
+                                    ISO8601_TIMESTAMP_WITH_OFFSET_FORMAT.format(
+                                            timestamp.toInstant().atOffset(ZoneOffset.UTC)));
+                };
             default:
                 throw new TableException(
                         "Unsupported timestamp format. Validator should have checked that.");
@@ -220,6 +229,16 @@ public class RowDataToJsonConverters implements Serializable {
                     return mapper.getNodeFactory()
                             .textNode(
                                     SQL_TIMESTAMP_WITH_LOCAL_TIMEZONE_FORMAT.format(
+                                            timestampWithLocalZone
+                                                    .toInstant()
+                                                    .atOffset(ZoneOffset.UTC)));
+                };
+            case ISO_8601_WITH_OFFSET:
+                return (mapper, reuse, value) -> {
+                    TimestampData timestampWithLocalZone = (TimestampData) value;
+                    return mapper.getNodeFactory()
+                            .textNode(
+                                    ISO8601_TIMESTAMP_WITH_OFFSET_FORMAT.format(
                                             timestampWithLocalZone
                                                     .toInstant()
                                                     .atOffset(ZoneOffset.UTC)));

--- a/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/JsonFormatFactoryTest.java
+++ b/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/JsonFormatFactoryTest.java
@@ -89,7 +89,7 @@ class JsonFormatFactoryTest {
                 .satisfies(
                         anyCauseMatches(
                                 ValidationException.class,
-                                "Unsupported value 'test' for timestamp-format.standard. Supported values are [SQL, ISO-8601]."));
+                                "Unsupported value 'test' for timestamp-format.standard. Supported values are [SQL, ISO-8601, ISO-8601-WITH-OFFSET]."));
     }
 
     @Test
@@ -102,7 +102,7 @@ class JsonFormatFactoryTest {
                 .satisfies(
                         anyCauseMatches(
                                 ValidationException.class,
-                                "Unsupported value 'iso-8601' for timestamp-format.standard. Supported values are [SQL, ISO-8601]."));
+                                "Unsupported value 'iso-8601' for timestamp-format.standard. Supported values are [SQL, ISO-8601, ISO-8601-WITH-OFFSET]."));
     }
 
     @Test

--- a/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/JsonParserRowDataDeSerSchemaTest.java
+++ b/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/JsonParserRowDataDeSerSchemaTest.java
@@ -49,6 +49,7 @@ import static org.apache.flink.table.api.DataTypes.MAP;
 import static org.apache.flink.table.api.DataTypes.ROW;
 import static org.apache.flink.table.api.DataTypes.SMALLINT;
 import static org.apache.flink.table.api.DataTypes.STRING;
+import static org.apache.flink.table.api.DataTypes.TIMESTAMP;
 import static org.apache.flink.table.api.DataTypes.TINYINT;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -342,5 +343,52 @@ public class JsonParserRowDataDeSerSchemaTest {
 
         RowData rowData = deserializationSchema.deserialize(serializedJson);
         assertThat(rowData).isEqualTo(expected);
+    }
+
+    /** Tests parsing timestamps with explicit timezone offsets. */
+    @Test
+    public void testTimestampWithTimezoneOffset() throws Exception {
+        ObjectMapper objectMapper = new ObjectMapper();
+
+        ObjectNode root = objectMapper.createObjectNode();
+        root.put("timestamp3", "1990-10-14T12:12:43.123+02:00");
+        root.put("timestamp_with_local_timezone3", "1990-10-14T12:12:43.123-05:00");
+
+        byte[] serializedJson = objectMapper.writeValueAsBytes(root);
+
+        DataType dataType =
+                ROW(
+                        FIELD("timestamp3", TIMESTAMP(3)),
+                        FIELD("timestamp_with_local_timezone3", TIMESTAMP_WITH_LOCAL_TIME_ZONE(3)));
+        RowType schema = (RowType) dataType.getLogicalType();
+        TypeInformation<RowData> resultTypeInfo = InternalTypeInfo.of(schema);
+
+        DeserializationSchema<RowData> deserializationSchema =
+                new JsonParserRowDataDeserializationSchema(
+                        schema, resultTypeInfo, false, false, TimestampFormat.ISO_8601_WITH_OFFSET);
+        open(deserializationSchema);
+
+        RowData rowData = deserializationSchema.deserialize(serializedJson);
+        Row actual = convertToExternal(rowData, dataType);
+
+        assertThat(actual.getField(0)).isNotNull();
+        assertThat(actual.getField(1)).isNotNull();
+
+        JsonRowDataSerializationSchema serializationSchema =
+                new JsonRowDataSerializationSchema(
+                        schema,
+                        TimestampFormat.ISO_8601_WITH_OFFSET,
+                        JsonFormatOptions.MapNullKeyMode.LITERAL,
+                        "null",
+                        true,
+                        false);
+        open(serializationSchema);
+
+        byte[] serialized = serializationSchema.serialize(rowData);
+        ObjectNode serializedNode = (ObjectNode) objectMapper.readTree(serialized);
+
+        assertThat(serializedNode.get("timestamp3").asText()).endsWith("+00:00");
+        assertThat(serializedNode.get("timestamp_with_local_timezone3").asText())
+                .endsWith("+00:00");
     }
 }

--- a/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/JsonParserRowDataDeSerSchemaTest.java
+++ b/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/JsonParserRowDataDeSerSchemaTest.java
@@ -50,6 +50,7 @@ import static org.apache.flink.table.api.DataTypes.ROW;
 import static org.apache.flink.table.api.DataTypes.SMALLINT;
 import static org.apache.flink.table.api.DataTypes.STRING;
 import static org.apache.flink.table.api.DataTypes.TIMESTAMP;
+import static org.apache.flink.table.api.DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE;
 import static org.apache.flink.table.api.DataTypes.TINYINT;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -353,13 +354,17 @@ public class JsonParserRowDataDeSerSchemaTest {
         ObjectNode root = objectMapper.createObjectNode();
         root.put("timestamp3", "1990-10-14T12:12:43.123+02:00");
         root.put("timestamp_with_local_timezone3", "1990-10-14T12:12:43.123-05:00");
+        root.put("timestamp_india", "1990-10-14T12:12:43.123+05:30");
+        root.put("timestamp_nepal", "1990-10-14T12:12:43.123+05:45");
 
         byte[] serializedJson = objectMapper.writeValueAsBytes(root);
 
         DataType dataType =
                 ROW(
                         FIELD("timestamp3", TIMESTAMP(3)),
-                        FIELD("timestamp_with_local_timezone3", TIMESTAMP_WITH_LOCAL_TIME_ZONE(3)));
+                        FIELD("timestamp_with_local_timezone3", TIMESTAMP_WITH_LOCAL_TIME_ZONE(3)),
+                        FIELD("timestamp_india", TIMESTAMP(3)),
+                        FIELD("timestamp_nepal", TIMESTAMP(3)));
         RowType schema = (RowType) dataType.getLogicalType();
         TypeInformation<RowData> resultTypeInfo = InternalTypeInfo.of(schema);
 
@@ -373,6 +378,8 @@ public class JsonParserRowDataDeSerSchemaTest {
 
         assertThat(actual.getField(0)).isNotNull();
         assertThat(actual.getField(1)).isNotNull();
+        assertThat(actual.getField(2)).isNotNull();
+        assertThat(actual.getField(3)).isNotNull();
 
         JsonRowDataSerializationSchema serializationSchema =
                 new JsonRowDataSerializationSchema(
@@ -387,8 +394,12 @@ public class JsonParserRowDataDeSerSchemaTest {
         byte[] serialized = serializationSchema.serialize(rowData);
         ObjectNode serializedNode = (ObjectNode) objectMapper.readTree(serialized);
 
-        assertThat(serializedNode.get("timestamp3").asText()).endsWith("+00:00");
+        assertThat(serializedNode.get("timestamp3").asText()).isEqualTo("1990-10-14T10:12:43.123Z");
         assertThat(serializedNode.get("timestamp_with_local_timezone3").asText())
-                .endsWith("+00:00");
+                .isEqualTo("1990-10-14T17:12:43.123Z");
+        assertThat(serializedNode.get("timestamp_india").asText())
+                .isEqualTo("1990-10-14T06:42:43.123Z");
+        assertThat(serializedNode.get("timestamp_nepal").asText())
+                .isEqualTo("1990-10-14T06:27:43.123Z");
     }
 }

--- a/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/canal/CanalJsonFormatFactoryTest.java
+++ b/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/canal/CanalJsonFormatFactoryTest.java
@@ -142,7 +142,7 @@ class CanalJsonFormatFactoryTest {
                         anyCauseMatches(
                                 ValidationException.class,
                                 "Unsupported value 'test' for timestamp-format.standard. "
-                                        + "Supported values are [SQL, ISO-8601]."));
+                                        + "Supported values are [SQL, ISO-8601, ISO-8601-WITH-OFFSET]."));
     }
 
     @Test

--- a/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/debezium/DebeziumJsonFormatFactoryTest.java
+++ b/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/debezium/DebeziumJsonFormatFactoryTest.java
@@ -157,7 +157,7 @@ class DebeziumJsonFormatFactoryTest {
                         anyCauseMatches(
                                 ValidationException.class,
                                 "Unsupported value 'test' for timestamp-format.standard. "
-                                        + "Supported values are [SQL, ISO-8601]."));
+                                        + "Supported values are [SQL, ISO-8601, ISO-8601-WITH-OFFSET]."));
     }
 
     @Test

--- a/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/maxwell/MaxwellJsonFormatFactoryTest.java
+++ b/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/maxwell/MaxwellJsonFormatFactoryTest.java
@@ -122,7 +122,7 @@ class MaxwellJsonFormatFactoryTest {
                         anyCauseMatches(
                                 ValidationException.class,
                                 "Unsupported value 'test' for timestamp-format.standard. "
-                                        + "Supported values are [SQL, ISO-8601]."));
+                                        + "Supported values are [SQL, ISO-8601, ISO-8601-WITH-OFFSET]."));
     }
 
     @Test

--- a/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/ogg/OggJsonFormatFactoryTest.java
+++ b/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/ogg/OggJsonFormatFactoryTest.java
@@ -94,7 +94,7 @@ class OggJsonFormatFactoryTest {
                         anyCauseMatches(
                                 ValidationException.class,
                                 "Unsupported value 'test' for timestamp-format.standard. "
-                                        + "Supported values are [SQL, ISO-8601]."));
+                                        + "Supported values are [SQL, ISO-8601, ISO-8601-WITH-OFFSET]."));
     }
 
     @Test


### PR DESCRIPTION

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

The current `ISO-8601` timestamp format option for `JSON` is misleading as it does not support timestamps with explicit timezone offsets (e.g., `2026-06-25T09:15:00+00:00`).

The existing `ISO-8601` format only handles timestamps with UTC 'Z' suffix: `yyyy-MM-ddTHH:mm:ss.s{precision}Z`

It cannot parse valid `ISO-8601` timestamps with explicit timezone offsets like `+02:00`, `-05:00`, etc.

This change adds a new timestamp format option `ISO-8601-WITH-OFFSET` that properly 
handles timestamps with explicit timezone offsets in the format:
`yyyy-MM-ddTHH:mm:ss.s{precision}±HH:mm`

## Brief change log

- Added `TimestampFormat.ISO_8601_WITH_OFFSET` enum value
- Added `ISO8601_TIMESTAMP_WITH_OFFSET_FORMAT` DateTimeFormatter
- Updated JSON format options to support `ISO-8601-WITH-OFFSET`

## Verifying this change

Added unit tests covering various offset formats and precisions

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? not documented
---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change the checkbox below to `[X]` followed by the name of the tool, and uncomment the
"Generated-by" line. See the ASF Generative Tooling Guidance for details:
https://www.apache.org/legal/generative-tooling.html

You are responsible for the quality and correctness of every change in this PR
regardless of the tooling used. Low-effort AI-generated PRs will be closed. See
AGENTS.md for the full guidance.
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name and Version]
-->
