### PR TITLE
[DISCUSS][FLIP-597][FLIP-598][FLIP-601][filesystem] Add common object storage stream abstractions

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/core/fs/BufferingInputStreamExtension.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/BufferingInputStreamExtension.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.core.fs;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.util.Preconditions;
+
+import javax.annotation.concurrent.Immutable;
+
+import java.io.BufferedInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * Default {@link InputStreamExtension} that opens the raw stream via an {@link InputStreamOpener}
+ * and wraps it with a {@link BufferedInputStream}.
+ */
+@Internal
+@Immutable
+final class BufferingInputStreamExtension implements InputStreamExtension {
+
+    private final InputStreamOpener opener;
+    private final int readBufferSize;
+
+    BufferingInputStreamExtension(final InputStreamOpener opener, final int readBufferSize) {
+        this.opener = Preconditions.checkNotNull(opener, "opener");
+        Preconditions.checkArgument(readBufferSize > 0, "readBufferSize must be positive");
+        this.readBufferSize = readBufferSize;
+    }
+
+    @Override
+    public RawAndWrappedInputStreams openStream(final InputStreamExtension.StreamContext ctx)
+            throws IOException {
+        final InputStream raw = opener.open(ReadContext.of(ctx.getPos()));
+        return new RawAndWrappedInputStreams(raw, new BufferedInputStream(raw, readBufferSize));
+    }
+}

--- a/flink-core/src/main/java/org/apache/flink/core/fs/InputStreamExtension.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/InputStreamExtension.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.core.fs;
+
+import org.apache.flink.annotation.Experimental;
+import org.apache.flink.annotation.Internal;
+
+import java.io.IOException;
+
+/**
+ * Extension point for {@link ObjectStorageInputStream}.
+ *
+ * <p>All methods are called with the stream's internal lock held.
+ *
+ * @see ObjectStorageInputStream
+ */
+@Internal
+@Experimental
+public interface InputStreamExtension {
+
+    /** Read-only view of stream state passed to extension callbacks. */
+    @Internal
+    @Experimental
+    interface StreamContext {
+
+        /** Returns the current byte position. */
+        long getPos();
+
+        /** Returns the total content length in bytes. */
+        long getContentLength();
+    }
+
+    /**
+     * Opens streams at the current {@linkplain StreamContext#getPos() read position}.
+     *
+     * <p>Called during lazy initialization (first read) and stream recovery (seek beyond
+     * threshold). The previous streams are closed by the base class before this call. The base
+     * class manages the lifecycle of the returned streams (reads, closes, reopens on seek).
+     *
+     * <p>If the underlying source cannot do range reads (e.g., encrypted streams opened at offset
+     * 0), open at offset 0 and skip forward to {@link StreamContext#getPos()} after wrapping.
+     *
+     * <p>On failure, close any streams opened during this call before rethrowing.
+     *
+     * @param ctx read-only view of the stream state at the time of opening
+     * @return the raw and wrapped stream pair
+     * @throws IOException if opening fails
+     */
+    RawAndWrappedInputStreams openStream(StreamContext ctx) throws IOException;
+
+    /**
+     * Returns the default extension that opens the raw stream via {@code opener} and wraps it with
+     * a {@link java.io.BufferedInputStream}.
+     *
+     * @param opener opens a raw stream at a given byte position
+     * @param readBufferSize the buffer size for the {@link java.io.BufferedInputStream}
+     */
+    static InputStreamExtension buffering(
+            final InputStreamOpener opener, final int readBufferSize) {
+        return new BufferingInputStreamExtension(opener, readBufferSize);
+    }
+}

--- a/flink-core/src/main/java/org/apache/flink/core/fs/InputStreamOpener.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/InputStreamOpener.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.core.fs;
+
+import org.apache.flink.annotation.Experimental;
+import org.apache.flink.annotation.Internal;
+
+import javax.annotation.concurrent.NotThreadSafe;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * Cloud-agnostic opener that returns an input stream starting at the position described by a {@link
+ * ReadContext}.
+ *
+ * <p>The implementation captures all cloud-specific state (client, path, bucket) in its closure,
+ * exposing only the read context to the caller.
+ *
+ * @see ReadContext
+ */
+@Internal
+@Experimental
+@NotThreadSafe
+@FunctionalInterface
+public interface InputStreamOpener {
+
+    /**
+     * Opens an input stream starting at the position indicated by {@code ctx}.
+     *
+     * @param ctx context for this read, including the byte offset to start from
+     * @return an input stream positioned at {@code ctx.getPos()}
+     * @throws IOException if the stream cannot be opened
+     */
+    InputStream open(ReadContext ctx) throws IOException;
+}

--- a/flink-core/src/main/java/org/apache/flink/core/fs/ObjectStorageInputStream.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/ObjectStorageInputStream.java
@@ -1,0 +1,436 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.core.fs;
+
+import org.apache.flink.annotation.Experimental;
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.util.Preconditions;
+
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.GuardedBy;
+import javax.annotation.concurrent.ThreadSafe;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Objects;
+import java.util.concurrent.locks.ReentrantLock;
+
+/**
+ * Object storage input stream with configurable read-ahead buffer and range-based requests for seek
+ * operations.
+ *
+ * <p>Thread-safety: all public methods are guarded by a {@link ReentrantLock}. {@link #close()} is
+ * non-interruptible and safe to call from any thread (e.g., task cancellation).
+ *
+ * <p>Extension: use {@link InputStreamExtension#buffering(InputStreamOpener, int)} for the default
+ * behavior. Pass a custom {@link InputStreamExtension} to customize stream opening.
+ *
+ * @see InputStreamExtension
+ */
+@Internal
+@Experimental
+@ThreadSafe
+public final class ObjectStorageInputStream extends FSDataInputStream {
+
+    private final long contentLength;
+    private final long skipOnSeekThreshold;
+
+    private final InputStreamExtension inputStreamExtension;
+    private final StreamContextImpl streamContext = new StreamContextImpl();
+
+    /** Lock guarding all mutable state. */
+    private final ReentrantLock lock = new ReentrantLock();
+
+    @Nullable
+    @GuardedBy("lock")
+    private InputStream sdkStream;
+
+    @Nullable
+    @GuardedBy("lock")
+    private InputStream wrappedStream;
+
+    /** Current byte position. Written and read under {@code lock}. */
+    @GuardedBy("lock")
+    private long position;
+
+    @GuardedBy("lock")
+    private boolean closed;
+
+    /**
+     * Creates a new object storage input stream.
+     *
+     * <p>Use {@link InputStreamExtension#buffering(InputStreamOpener, int)} for the default
+     * behavior (opens via the opener and wraps with {@link java.io.BufferedInputStream}).
+     *
+     * @param contentLength content length in bytes; must be &ge; 0
+     * @param skipOnSeekThreshold maximum forward seek distance (bytes) handled by read-and-discard
+     *     instead of close-and-reopen; must be non-negative (0 disables read-and-discard)
+     * @param inputStreamExtension extension for stream opening
+     */
+    public ObjectStorageInputStream(
+            final long contentLength,
+            final long skipOnSeekThreshold,
+            final InputStreamExtension inputStreamExtension) {
+        Preconditions.checkArgument(contentLength >= 0, "contentLength must be non-negative");
+        Preconditions.checkArgument(
+                skipOnSeekThreshold >= 0, "skipOnSeekThreshold must be non-negative");
+        this.contentLength = contentLength;
+        this.skipOnSeekThreshold = skipOnSeekThreshold;
+        this.inputStreamExtension = Preconditions.checkNotNull(inputStreamExtension, "extension");
+        this.position = 0;
+    }
+
+    @GuardedBy("lock")
+    private void lazyInitialize() throws IOException {
+        checkLocked();
+        if (sdkStream == null && !closed) {
+            openStream();
+        }
+    }
+
+    /**
+     * Closes the current streams and opens new ones at the current {@linkplain #getPos() position}.
+     *
+     * <p>If {@code openStream()} throws, the previous streams are already closed but no new streams
+     * are set — the next read will retry.
+     */
+    @GuardedBy("lock")
+    private void openStream() throws IOException {
+        checkLocked();
+        closeCurrentStream();
+        final RawAndWrappedInputStreams pair = inputStreamExtension.openStream(streamContext);
+        this.sdkStream = pair.sdk();
+        this.wrappedStream = pair.wrapped();
+    }
+
+    /**
+     * Closes the current underlying streams. If {@code wrappedStream} is present it is closed first
+     * (which also closes the wrapped {@code sdkStream}). If that close fails, a direct close of
+     * {@code sdkStream} is attempted so the remote connection is not leaked.
+     *
+     * @throws IOException if closing the stream(s) fails
+     */
+    @GuardedBy("lock")
+    private void closeCurrentStream() throws IOException {
+        checkLocked();
+        if (wrappedStream != null) {
+            try {
+                // Closing the wrapper typically closes the underlying stream as well.
+                wrappedStream.close();
+            } catch (final IOException e) {
+                // wrappedStream.close() may have failed before closing the underlying stream.
+                // Try closing it directly so we don't leak the connection.
+                if (sdkStream != null) {
+                    try {
+                        sdkStream.close();
+                    } catch (final IOException suppressed) {
+                        // Avoid self-suppression: the wrapper's close() delegates to
+                        // sdkStream.close(), so both may throw the same exception instance.
+                        if (suppressed != e) {
+                            e.addSuppressed(suppressed);
+                        }
+                    }
+                }
+                throw e;
+            } finally {
+                wrappedStream = null;
+                sdkStream = null;
+            }
+        } else if (sdkStream != null) {
+            try {
+                sdkStream.close();
+            } finally {
+                sdkStream = null;
+            }
+        }
+    }
+
+    /**
+     * Size of the throwaway buffer used in read-and-discard seek. The exact size does not matter
+     * much: actual I/O granularity is governed by the SDK's internal chunk buffer, not this array.
+     */
+    private static final int SKIP_BUFFER_SIZE = 8192;
+
+    /**
+     * Seeks to the specified position in the stream.
+     *
+     * <p>For forward seeks within {@code skipThreshold}, bytes are read-and-discarded from the
+     * current stream. This uses {@code read()} rather than {@code skip()} because {@link
+     * java.io.BufferedInputStream#skip} can delegate to the underlying SDK stream's {@code skip()},
+     * which discards its internal buffer even when the target falls within already-fetched data.
+     * Reading-and-discarding flows through the normal read path, consuming bytes from the SDK's
+     * existing buffer without additional HTTP requests.
+     *
+     * <p>For larger forward seeks or any backward seek, the stream is closed and reopened lazily
+     * with a range request at the new position — this costs one HTTP request regardless of
+     * distance.
+     *
+     * @param desired the position to seek to (byte offset from beginning)
+     * @throws IOException if the position is negative, beyond the file size, or the stream is
+     *     closed
+     */
+    @Override
+    public void seek(final long desired) throws IOException {
+        acquireLockInterruptibly();
+        try {
+            checkNotClosed();
+            if (desired < 0 || desired > contentLength) {
+                throw new IOException(
+                        "Cannot seek to position "
+                                + desired
+                                + " (file size: "
+                                + contentLength
+                                + ")");
+            }
+            seekInternal(desired);
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    @GuardedBy("lock")
+    private void seekInternal(final long desired) throws IOException {
+        checkLocked();
+        if (desired == position) {
+            return;
+        }
+        final long delta = desired - position;
+        if (delta > 0 && delta <= skipOnSeekThreshold && wrappedStream != null) {
+            readAndDiscard(delta);
+        } else {
+            position = desired;
+            closeCurrentStream();
+        }
+    }
+
+    /** Advances the stream by reading-and-discarding {@code delta} bytes. */
+    @GuardedBy("lock")
+    private void readAndDiscard(final long delta) throws IOException {
+        if (delta == 0) {
+            return;
+        }
+        checkLocked();
+        Preconditions.checkState(
+                wrappedStream != null, "readAndDiscard requires an open wrapped stream");
+        final byte[] skipBuf = new byte[(int) Math.min(delta, SKIP_BUFFER_SIZE)];
+        long remaining = delta;
+        while (remaining > 0L) {
+            final int toRead = (int) Math.min(remaining, skipBuf.length);
+            final int bytesRead = wrappedStream.read(skipBuf, 0, toRead);
+            if (bytesRead <= 0) {
+                break;
+            }
+            remaining -= bytesRead;
+            position += bytesRead;
+        }
+        if (remaining > 0L) {
+            throw new IOException(
+                    "Unexpected end of stream during read-and-discard seek: "
+                            + remaining
+                            + " bytes remaining");
+        }
+    }
+
+    /**
+     * Returns the current position in the stream.
+     *
+     * @return the byte offset from the beginning of the stream
+     */
+    @Override
+    public long getPos() {
+        lock.lock();
+        try {
+            return position;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * Reads a single byte from the stream.
+     *
+     * @return the byte read as an integer (0-255), or -1 if end of stream is reached
+     * @throws IOException if the stream is closed or an I/O error occurs
+     */
+    @Override
+    public int read() throws IOException {
+        acquireLockInterruptibly();
+        try {
+            checkNotClosed();
+            if (position >= contentLength) {
+                return -1;
+            }
+            lazyInitialize();
+            final int data = wrappedStream.read();
+            if (data != -1) {
+                position++;
+            }
+            return data;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * Reads bytes into a portion of a byte array.
+     *
+     * @param b the buffer into which the data is read
+     * @param off the start offset in array {@code b} at which the data is written
+     * @param len the maximum number of bytes to read
+     * @return the number of bytes read, or -1 if end of stream is reached
+     * @throws IOException if the stream is closed or an I/O error occurs
+     * @throws NullPointerException if {@code b} is null
+     * @throws IndexOutOfBoundsException if {@code off} or {@code len} is negative, or {@code len}
+     *     is greater than {@code b.length - off}
+     */
+    @Override
+    public int read(final byte[] b, final int off, final int len) throws IOException {
+        acquireLockInterruptibly();
+        try {
+            checkNotClosed();
+            Preconditions.checkNotNull(b, "buffer");
+            Objects.checkFromIndexSize(off, len, b.length);
+            if (len == 0) {
+                return 0;
+            }
+            if (position >= contentLength) {
+                return -1;
+            }
+            lazyInitialize();
+            final long remaining = contentLength - position;
+            final int toRead = (int) Math.min(len, remaining);
+            final int bytesRead = wrappedStream.read(b, off, toRead);
+            if (bytesRead > 0) {
+                position += bytesRead;
+            }
+            return bytesRead;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * Idempotently closes this stream and releases the underlying connection.
+     *
+     * <p>Uses non-interruptible {@code lock()} instead of {@code lockInterruptibly()} so that close
+     * always completes — stream cleanup must run to avoid resource leaks.
+     *
+     * @throws IOException if closing the underlying stream fails
+     */
+    @Override
+    public void close() throws IOException {
+        lock.lock();
+        try {
+            if (closed) {
+                return;
+            }
+            closed = true;
+            closeCurrentStream();
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * Returns an estimate of the number of bytes that can be read without blocking.
+     *
+     * @return the number of remaining bytes in the blob, capped at {@link Integer#MAX_VALUE}
+     * @throws IOException if the stream is closed
+     */
+    @Override
+    public int available() throws IOException {
+        acquireLockInterruptibly();
+        try {
+            checkNotClosed();
+            final long remaining = Math.max(0L, contentLength - position);
+            return (int) Math.min(remaining, Integer.MAX_VALUE);
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * Skips over and discards {@code n} bytes of data from this input stream.
+     *
+     * @param n the number of bytes to skip
+     * @return the actual number of bytes skipped (may be less if end of stream is reached)
+     * @throws IOException if the stream is closed or an I/O error occurs
+     */
+    @Override
+    public long skip(final long n) throws IOException {
+        acquireLockInterruptibly();
+        try {
+            checkNotClosed();
+            if (n <= 0) {
+                return 0;
+            }
+            final long newPos = Math.min(position + n, contentLength);
+            final long skipped = newPos - position;
+            seekInternal(newPos);
+            return skipped;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Private helpers
+    // -------------------------------------------------------------------------
+
+    private final class StreamContextImpl implements InputStreamExtension.StreamContext {
+
+        private StreamContextImpl() {}
+
+        @Override
+        public long getPos() {
+            checkLocked();
+            return position;
+        }
+
+        @Override
+        public long getContentLength() {
+            return contentLength;
+        }
+    }
+
+    /** Asserts that the current thread holds the lock. */
+    private void checkLocked() {
+        Preconditions.checkState(lock.isHeldByCurrentThread());
+    }
+
+    private void checkNotClosed() throws IOException {
+        checkLocked();
+        if (closed) {
+            throw new IOException("Stream is closed");
+        }
+    }
+
+    /**
+     * Acquires the lock, wrapping {@link InterruptedException} as {@link IOException} while
+     * restoring the interrupt flag.
+     */
+    private void acquireLockInterruptibly() throws IOException {
+        try {
+            lock.lockInterruptibly();
+        } catch (final InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IOException("Interrupted while waiting to acquire stream lock", e);
+        }
+    }
+}

--- a/flink-core/src/main/java/org/apache/flink/core/fs/ObjectStorageOutputStream.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/ObjectStorageOutputStream.java
@@ -1,0 +1,249 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.core.fs;
+
+import org.apache.flink.annotation.Experimental;
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.util.ExceptionUtils;
+import org.apache.flink.util.Preconditions;
+
+import javax.annotation.concurrent.GuardedBy;
+import javax.annotation.concurrent.ThreadSafe;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.Objects;
+import java.util.concurrent.locks.ReentrantLock;
+
+/**
+ * Object storage output stream that delegates writes to an underlying {@link OutputStream}.
+ *
+ * <p>The underlying stream may be a raw cloud stream or a wrapped stream (e.g., a compressing or
+ * encrypting stream). The delegate may buffer writes internally and upload blocks asynchronously.
+ * On {@link #close()} or {@link #sync()}, all buffered data is flushed and the stream is committed,
+ * making the file visible.
+ *
+ * <p>Thread-safety: all public methods are guarded by a {@link ReentrantLock}. {@link #close()} and
+ * {@link #sync()} use non-interruptible {@code lock()} so they always complete — stream cleanup
+ * must run to avoid resource leaks or silent data corruption. Other methods use {@code
+ * lockInterruptibly()} and throw {@link IOException} wrapping {@link InterruptedException} when
+ * interrupted.
+ *
+ * @see FSDataOutputStream
+ */
+@Internal
+@Experimental
+@ThreadSafe
+public final class ObjectStorageOutputStream extends FSDataOutputStream {
+
+    private final OutputStream delegate;
+
+    /** Path to the file within the storage system. Used in diagnostic messages. */
+    private final String filePath;
+
+    /** Lock guarding all mutable state. */
+    private final ReentrantLock lock = new ReentrantLock();
+
+    @GuardedBy("lock")
+    private long position;
+
+    @GuardedBy("lock")
+    private boolean closed;
+
+    /**
+     * Creates a new object storage output stream wrapping an already-opened delegate stream.
+     *
+     * @param delegate the underlying output stream (e.g., an SDK stream or a cipher-wrapped stream)
+     * @param filePath the path to the file within the storage system (used in diagnostic messages)
+     */
+    public ObjectStorageOutputStream(final OutputStream delegate, final String filePath) {
+        this.delegate = Preconditions.checkNotNull(delegate, "delegate");
+        this.filePath = Preconditions.checkNotNull(filePath, "filePath");
+        this.position = 0;
+    }
+
+    /**
+     * Returns the current position in the stream.
+     *
+     * @return the number of bytes written so far
+     * @throws IOException if interrupted while acquiring the lock, or if the stream is closed
+     */
+    @Override
+    public long getPos() throws IOException {
+        acquireLockInterruptibly();
+        try {
+            checkNotClosed();
+            return position;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * Writes a single byte to the stream.
+     *
+     * @param b the byte to write (only the low 8 bits are used)
+     * @throws IOException if interrupted while acquiring the lock, if the stream is closed, or if
+     *     an I/O error occurs
+     */
+    @Override
+    public void write(final int b) throws IOException {
+        acquireLockInterruptibly();
+        try {
+            checkNotClosed();
+            delegate.write(b);
+            position++;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * Writes bytes from the specified byte array to this output stream.
+     *
+     * @param b the data to write
+     * @param off the start offset in the data
+     * @param len the number of bytes to write
+     * @throws IOException if interrupted while acquiring the lock, if the stream is closed, or if
+     *     an I/O error occurs
+     * @throws NullPointerException if {@code b} is null
+     * @throws IndexOutOfBoundsException if {@code off} or {@code len} is out of bounds
+     */
+    @Override
+    public void write(final byte[] b, final int off, final int len) throws IOException {
+        acquireLockInterruptibly();
+        try {
+            checkNotClosed();
+            Preconditions.checkNotNull(b, "buffer");
+            Objects.checkFromIndexSize(off, len, b.length);
+            delegate.write(b, off, len);
+            position += len;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * Flushes this output stream and forces any buffered data to be uploaded.
+     *
+     * @throws IOException if interrupted while acquiring the lock, if the stream is closed, or if
+     *     an I/O error occurs
+     */
+    @Override
+    public void flush() throws IOException {
+        acquireLockInterruptibly();
+        try {
+            checkNotClosed();
+            delegate.flush();
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * Flushes all buffered data and commits the file, making it visible to readers.
+     *
+     * <p>This closes the underlying stream, triggering the commit. After this method returns
+     * successfully, the file is durable and visible. No further writes are possible — subsequent
+     * write or flush calls will throw {@link IOException}.
+     *
+     * <p>Calling {@code sync()} on an already-synced or closed stream is a no-op.
+     *
+     * <p>Uses non-interruptible {@code lock()} so that the commit always completes even if the
+     * calling thread is interrupted.
+     *
+     * @throws IOException if the commit fails
+     */
+    @Override
+    public void sync() throws IOException {
+        commitAndClose();
+    }
+
+    /**
+     * Closes this output stream and attempts to commit the file.
+     *
+     * <p>On the happy path, callers should use {@link #sync()} before close to guarantee data
+     * visibility. If {@code sync()} was already called, this method is a no-op.
+     *
+     * <p>This method is safe to call from any thread (e.g., task cancellation or safety-net
+     * cleanup). Uses non-interruptible {@code lock()} so that stream cleanup always completes.
+     *
+     * @throws IOException if closing the stream fails
+     */
+    @Override
+    public void close() throws IOException {
+        commitAndClose();
+    }
+
+    private void commitAndClose() throws IOException {
+        lock.lock();
+        try {
+            if (closed) {
+                return;
+            }
+            closed = true;
+            flushAndCloseDelegate();
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    private void flushAndCloseDelegate() throws IOException {
+        Exception primaryException = null;
+        try {
+            delegate.flush();
+        } catch (final Exception e) {
+            primaryException = e;
+        }
+        try {
+            delegate.close();
+        } catch (final Exception closeEx) {
+            if (primaryException != null) {
+                primaryException.addSuppressed(closeEx);
+            } else {
+                primaryException = closeEx;
+            }
+        }
+        if (primaryException != null) {
+            ExceptionUtils.rethrowIOException(primaryException);
+        }
+    }
+
+    @GuardedBy("lock")
+    private void checkNotClosed() throws IOException {
+        Preconditions.checkState(lock.isHeldByCurrentThread());
+        if (closed) {
+            throw new IOException("Stream already closed: " + filePath);
+        }
+    }
+
+    /**
+     * Acquires the lock, wrapping {@link InterruptedException} as {@link IOException} while
+     * restoring the interrupt flag.
+     */
+    private void acquireLockInterruptibly() throws IOException {
+        try {
+            lock.lockInterruptibly();
+        } catch (final InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IOException(
+                    "Interrupted while waiting to acquire stream lock: " + filePath, e);
+        }
+    }
+}

--- a/flink-core/src/main/java/org/apache/flink/core/fs/OutputStreamOpener.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/OutputStreamOpener.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.core.fs;
+
+import org.apache.flink.annotation.Experimental;
+import org.apache.flink.annotation.Internal;
+
+import javax.annotation.concurrent.NotThreadSafe;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+/**
+ * Cloud-agnostic opener that creates an output stream for a write operation.
+ *
+ * <p>The implementation captures all cloud-specific state (client, path, bucket) in its closure.
+ * The {@link WriteContext} provides metadata to attach to the cloud object before the stream is
+ * opened.
+ */
+@Internal
+@Experimental
+@NotThreadSafe
+@FunctionalInterface
+public interface OutputStreamOpener {
+
+    /**
+     * Opens an output stream for the write operation described by {@code ctx}.
+     *
+     * @param ctx context for this write, including metadata to attach to the cloud object
+     * @return an output stream for writing the file content
+     * @throws IOException if the stream cannot be opened
+     */
+    OutputStream open(WriteContext ctx) throws IOException;
+}

--- a/flink-core/src/main/java/org/apache/flink/core/fs/RawAndWrappedInputStreams.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/RawAndWrappedInputStreams.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.core.fs;
+
+import org.apache.flink.annotation.Experimental;
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.util.Preconditions;
+
+import java.io.InputStream;
+
+/**
+ * A pair of streams returned by {@link
+ * InputStreamExtension#openStream(InputStreamExtension.StreamContext)}.
+ */
+@Internal
+@Experimental
+public final class RawAndWrappedInputStreams {
+
+    private final InputStream sdk;
+    private final InputStream wrapped;
+
+    /**
+     * Creates a new stream pair.
+     *
+     * @param sdk the raw SDK stream
+     * @param wrapped the wrapped stream used for reads
+     */
+    public RawAndWrappedInputStreams(final InputStream sdk, final InputStream wrapped) {
+        this.sdk = Preconditions.checkNotNull(sdk, "sdk");
+        this.wrapped = Preconditions.checkNotNull(wrapped, "wrapped");
+    }
+
+    /** Returns the raw SDK stream. */
+    public InputStream sdk() {
+        return sdk;
+    }
+
+    /** Returns the wrapped stream used for reads. */
+    public InputStream wrapped() {
+        return wrapped;
+    }
+}

--- a/flink-core/src/main/java/org/apache/flink/core/fs/ReadContext.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/ReadContext.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.core.fs;
+
+import org.apache.flink.annotation.Experimental;
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.util.Preconditions;
+
+import javax.annotation.concurrent.Immutable;
+
+/**
+ * Context passed to {@link InputStreamOpener} describing the desired read position.
+ *
+ * @see InputStreamOpener
+ */
+@Internal
+@Experimental
+@Immutable
+public interface ReadContext {
+
+    /**
+     * Returns the byte offset at which the stream should start.
+     *
+     * @return byte offset; must be &ge; 0
+     */
+    long getPos();
+
+    /**
+     * Creates a {@link ReadContext} for the given byte position.
+     *
+     * @param pos byte offset; must be &ge; 0
+     * @return a {@link ReadContext} that returns {@code pos}
+     * @throws IllegalArgumentException if {@code pos} is negative
+     */
+    static ReadContext of(final long pos) {
+        Preconditions.checkArgument(pos >= 0, "pos must be >= 0");
+        return () -> pos;
+    }
+}

--- a/flink-core/src/main/java/org/apache/flink/core/fs/WriteContext.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/WriteContext.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.core.fs;
+
+import org.apache.flink.annotation.Experimental;
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.util.Preconditions;
+
+import javax.annotation.concurrent.Immutable;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Context passed to {@link OutputStreamOpener} describing the write operation, including metadata
+ * to be persisted with the cloud object.
+ *
+ * @see OutputStreamOpener
+ */
+@Internal
+@Experimental
+@Immutable
+public interface WriteContext {
+
+    /**
+     * Returns the metadata to attach to the cloud object (e.g., encryption headers).
+     *
+     * @return key-value metadata map; never {@code null}
+     */
+    Map<String, String> getMetadata();
+
+    /** Shared empty context — avoids allocation for plain writes without metadata. */
+    WriteContext EMPTY_WRITE_CONTEXT = Collections::emptyMap;
+
+    /**
+     * Creates a {@link WriteContext} backed by a defensive copy of the given metadata map.
+     *
+     * @param metadata the metadata to expose; must not be {@code null}
+     * @return a {@link WriteContext} that returns an unmodifiable copy of {@code metadata}
+     * @throws NullPointerException if {@code metadata} is {@code null}
+     */
+    static WriteContext of(final Map<String, String> metadata) {
+        Preconditions.checkNotNull(metadata, "metadata");
+        final Map<String, String> copy = Collections.unmodifiableMap(new HashMap<>(metadata));
+        return () -> copy;
+    }
+}

--- a/flink-core/src/test/java/org/apache/flink/core/fs/ObjectStorageInputStreamTest.java
+++ b/flink-core/src/test/java/org/apache/flink/core/fs/ObjectStorageInputStreamTest.java
@@ -1,0 +1,753 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.core.fs;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.io.BufferedInputStream;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Tests for {@link ObjectStorageInputStream}. */
+@Timeout(value = 10, unit = TimeUnit.MINUTES)
+class ObjectStorageInputStreamTest {
+
+    private static final int BUFFER_SIZE = 1024;
+    private static final long SKIP_THRESHOLD = 4 * 1024 * 1024;
+
+    /** Poll interval for {@link #awaitBlocked}. */
+    private static final long STATE_POLL_INTERVAL_MS = 100;
+
+    private ObjectStorageInputStream stream;
+
+    @AfterEach
+    void tearDown() throws Exception {
+        if (stream != null) {
+            stream.close();
+        }
+    }
+
+    /**
+     * Creates an opener that returns a {@link ByteArrayInputStream} starting at the requested
+     * position.
+     */
+    private static InputStreamOpener testOpener(final byte[] data) {
+        return ctx -> {
+            final int pos = (int) Math.min(ctx.getPos(), data.length);
+            return new ByteArrayInputStream(data, pos, data.length - pos);
+        };
+    }
+
+    private static InputStreamExtension buffering(final byte[] data) {
+        return InputStreamExtension.buffering(testOpener(data), BUFFER_SIZE);
+    }
+
+    private static InputStreamExtension buffering(final InputStreamOpener opener) {
+        return InputStreamExtension.buffering(opener, BUFFER_SIZE);
+    }
+
+    private ObjectStorageInputStream createStream(final byte[] data) {
+        stream = new ObjectStorageInputStream(data.length, SKIP_THRESHOLD, buffering(data));
+        return stream;
+    }
+
+    /** InputStream that tracks how many times {@link #close()} is called. */
+    private static final class TrackingInputStream extends ByteArrayInputStream {
+        private int closeCount;
+
+        TrackingInputStream(final byte[] data) {
+            super(data);
+        }
+
+        @Override
+        public void close() throws IOException {
+            closeCount++;
+            super.close();
+        }
+    }
+
+    /** Opener that tracks how many times it has been called. */
+    private static final class TrackingOpener implements InputStreamOpener {
+        private final byte[] data;
+        int openCount;
+
+        TrackingOpener(final byte[] data) {
+            this.data = data;
+        }
+
+        @Override
+        public InputStream open(final ReadContext ctx) {
+            openCount++;
+            final int pos = (int) Math.min(ctx.getPos(), data.length);
+            return new ByteArrayInputStream(data, pos, data.length - pos);
+        }
+    }
+
+    /** Extension for tests that opens streams via the provided opener. */
+    private static final class TestingExtension implements InputStreamExtension {
+        private final InputStreamOpener opener;
+
+        TestingExtension(final InputStreamOpener opener) {
+            this.opener = opener;
+        }
+
+        @Override
+        public RawAndWrappedInputStreams openStream(final StreamContext ctx) throws IOException {
+            final InputStream raw = opener.open(ReadContext.of(ctx.getPos()));
+            return new RawAndWrappedInputStreams(raw, new BufferedInputStream(raw, BUFFER_SIZE));
+        }
+    }
+
+    // --- Constructor validation ---
+
+    @Test
+    void shouldThrowOnNullExtension() {
+        assertThatThrownBy(() -> new ObjectStorageInputStream(100L, SKIP_THRESHOLD, null))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessageContaining("extension");
+    }
+
+    @Test
+    void shouldThrowOnNegativeContentLength() {
+        assertThatThrownBy(
+                        () ->
+                                new ObjectStorageInputStream(
+                                        -1L, SKIP_THRESHOLD, buffering(new byte[0])))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("non-negative");
+    }
+
+    @Test
+    void shouldThrowOnNegativeSkipThreshold() {
+        assertThatThrownBy(() -> new ObjectStorageInputStream(100L, -1L, buffering(new byte[0])))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("non-negative");
+    }
+
+    @Test
+    void shouldAcceptZeroSkipThresholdForEmptyFile() throws Exception {
+        stream = new ObjectStorageInputStream(0L, 0L, buffering(new byte[0]));
+        assertThat(stream.available()).isEqualTo(0);
+        assertThat(stream.read()).isEqualTo(-1);
+    }
+
+    // --- Lazy initialization ---
+
+    @Test
+    void shouldNotOpenStreamOnConstruction() {
+        final TrackingOpener opener = new TrackingOpener(new byte[0]);
+        stream = new ObjectStorageInputStream(100L, SKIP_THRESHOLD, buffering(opener));
+        assertThat(opener.openCount).isEqualTo(0);
+    }
+
+    @Test
+    void shouldOpenStreamOnFirstRead() throws Exception {
+        final byte[] data = {42};
+        final TrackingOpener opener = new TrackingOpener(data);
+
+        stream = new ObjectStorageInputStream(data.length, SKIP_THRESHOLD, buffering(opener));
+        assertThat(opener.openCount).isEqualTo(0);
+        stream.read();
+        assertThat(opener.openCount).isEqualTo(1);
+    }
+
+    // --- Single byte read ---
+
+    @Test
+    void shouldReadSingleByte() throws Exception {
+        createStream(new byte[] {42});
+        assertThat(stream.read()).isEqualTo(42);
+    }
+
+    @ParameterizedTest
+    @MethodSource("eofScenarios")
+    void shouldReturnMinusOneAtEof(final byte[] data) throws Exception {
+        createStream(data);
+        for (int i = 0; i < data.length; i++) {
+            stream.read();
+        }
+        assertThat(stream.read()).isEqualTo(-1);
+    }
+
+    private static Stream<Arguments> eofScenarios() {
+        return Stream.of(Arguments.of((Object) new byte[] {1}), Arguments.of((Object) new byte[0]));
+    }
+
+    // --- Byte array read ---
+
+    @Test
+    void shouldReadByteArray() throws Exception {
+        final byte[] data = {1, 2, 3, 4, 5};
+        createStream(data);
+        final byte[] buf = new byte[5];
+        final int read = stream.read(buf, 0, 5);
+        assertThat(read).isEqualTo(5);
+        assertThat(buf).isEqualTo(data);
+    }
+
+    @Test
+    void shouldReturnMinusOneForByteArrayReadAtEof() throws Exception {
+        final byte[] data = {1};
+        createStream(data);
+        final byte[] buf = new byte[1];
+        stream.read(buf, 0, 1);
+        assertThat(stream.read(buf, 0, 1)).isEqualTo(-1);
+    }
+
+    @Test
+    void shouldReturnZeroForZeroLengthRead() throws Exception {
+        createStream(new byte[] {1, 2, 3});
+        final byte[] buf = new byte[3];
+        assertThat(stream.read(buf, 0, 0)).isEqualTo(0);
+    }
+
+    @Test
+    void shouldThrowOnNullArrayRead() throws Exception {
+        createStream(new byte[0]);
+        assertThatThrownBy(() -> stream.read(null, 0, 1))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessageContaining("buffer");
+    }
+
+    @ParameterizedTest
+    @MethodSource("boundsViolations")
+    void shouldThrowOnBoundsViolation(final int bufLen, final int off, final int len)
+            throws Exception {
+        createStream(new byte[0]);
+        final byte[] buf = new byte[bufLen];
+        assertThatThrownBy(() -> stream.read(buf, off, len))
+                .isInstanceOf(IndexOutOfBoundsException.class);
+    }
+
+    private static Stream<Arguments> boundsViolations() {
+        return Stream.of(
+                Arguments.of(5, -1, 1),
+                Arguments.of(5, 0, -1),
+                Arguments.of(5, 3, 5),
+                Arguments.of(5, 6, 1));
+    }
+
+    // --- Position tracking ---
+
+    @Test
+    void shouldTrackPositionAfterSingleByteReads() throws Exception {
+        createStream(new byte[] {1, 2, 3});
+        assertThat(stream.getPos()).isEqualTo(0);
+        stream.read();
+        assertThat(stream.getPos()).isEqualTo(1);
+        stream.read();
+        assertThat(stream.getPos()).isEqualTo(2);
+    }
+
+    @Test
+    void shouldTrackPositionAfterArrayRead() throws Exception {
+        createStream(new byte[] {1, 2, 3, 4, 5});
+        final byte[] buf = new byte[3];
+        stream.read(buf, 0, 3);
+        assertThat(stream.getPos()).isEqualTo(3);
+    }
+
+    // --- Seek ---
+
+    @Test
+    void shouldSeekForward() throws Exception {
+        final byte[] data = {1, 2, 3, 4, 5};
+        createStream(data);
+        stream.read(); // initialize
+        stream.seek(3);
+        assertThat(stream.getPos()).isEqualTo(3);
+        assertThat(stream.read()).isEqualTo(4);
+    }
+
+    @Test
+    void shouldSeekBackward() throws Exception {
+        final byte[] data = {1, 2, 3, 4, 5};
+        createStream(data);
+        stream.read();
+        stream.read();
+        stream.read();
+        assertThat(stream.getPos()).isEqualTo(3);
+
+        stream.seek(1);
+        assertThat(stream.getPos()).isEqualTo(1);
+        assertThat(stream.read()).isEqualTo(2);
+    }
+
+    @Test
+    void shouldNotReopenStreamOnSeekToSamePosition() throws Exception {
+        final byte[] data = {1, 2, 3};
+        final TrackingOpener opener = new TrackingOpener(data);
+
+        stream = new ObjectStorageInputStream(data.length, SKIP_THRESHOLD, buffering(opener));
+        stream.read(); // initialize, position=1
+        stream.seek(1); // same position — should not reopen
+        assertThat(opener.openCount).isEqualTo(1);
+    }
+
+    @Test
+    void shouldThrowOnNegativeSeek() throws Exception {
+        createStream(new byte[0]);
+        assertThatThrownBy(() -> stream.seek(-1)).isInstanceOf(IOException.class);
+    }
+
+    @Test
+    void shouldThrowOnSeekAfterClose() throws Exception {
+        createStream(new byte[0]);
+        stream.close();
+        assertThatThrownBy(() -> stream.seek(0)).isInstanceOf(IOException.class);
+    }
+
+    // --- Skip ---
+
+    @Test
+    void shouldSkipForward() throws Exception {
+        createStream(new byte[] {1, 2, 3, 4, 5});
+        final long skipped = stream.skip(3);
+        assertThat(skipped).isEqualTo(3);
+        assertThat(stream.getPos()).isEqualTo(3);
+    }
+
+    @Test
+    void shouldCapSkipAtContentLength() throws Exception {
+        createStream(new byte[] {1, 2, 3});
+        final long skipped = stream.skip(100);
+        assertThat(skipped).isEqualTo(3);
+        assertThat(stream.getPos()).isEqualTo(3);
+    }
+
+    @Test
+    void shouldReturnZeroForNonPositiveSkip() throws Exception {
+        stream = new ObjectStorageInputStream(100L, SKIP_THRESHOLD, buffering(new byte[0]));
+        assertThat(stream.skip(0)).isEqualTo(0);
+        assertThat(stream.skip(-5)).isEqualTo(0);
+    }
+
+    @Test
+    void shouldSkipAfterSeek() throws Exception {
+        final byte[] data = {1, 2, 3, 4, 5};
+        createStream(data);
+        stream.seek(2);
+        final long skipped = stream.skip(2);
+        assertThat(skipped).isEqualTo(2);
+        assertThat(stream.getPos()).isEqualTo(4);
+        assertThat(stream.read()).isEqualTo(5);
+    }
+
+    // --- Seek optimization ---
+
+    @Test
+    void shouldUseBufferForSmallForwardSeek() throws Exception {
+        final byte[] data = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+        final TrackingOpener opener = new TrackingOpener(data);
+
+        stream = new ObjectStorageInputStream(data.length, SKIP_THRESHOLD, buffering(opener));
+        stream.read(); // trigger initialization, openCount=1
+        assertThat(opener.openCount).isEqualTo(1);
+
+        stream.seek(3); // small forward delta (2 bytes), should NOT reopen
+        assertThat(opener.openCount).isEqualTo(1);
+        assertThat(stream.getPos()).isEqualTo(3);
+        assertThat(stream.read()).isEqualTo(4);
+    }
+
+    @Test
+    void shouldReopenForLargeForwardSeek() throws Exception {
+        final int fileSize = (int) (SKIP_THRESHOLD + 1024);
+        final byte[] data = new byte[fileSize];
+        for (int i = 0; i < data.length; i++) {
+            data[i] = (byte) (i & 0xFF);
+        }
+        final TrackingOpener opener = new TrackingOpener(data);
+
+        stream = new ObjectStorageInputStream(data.length, SKIP_THRESHOLD, buffering(opener));
+        stream.read(); // trigger initialization, openCount=1
+        assertThat(opener.openCount).isEqualTo(1);
+
+        // delta > SKIP_THRESHOLD, closes stream
+        stream.seek(SKIP_THRESHOLD + 512);
+        assertThat(stream.getPos()).isEqualTo(SKIP_THRESHOLD + 512);
+        stream.read(); // lazy reopen on read
+        assertThat(opener.openCount).isEqualTo(2);
+    }
+
+    @Test
+    void shouldReopenForBackwardSeek() throws Exception {
+        final byte[] data = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+        final TrackingOpener opener = new TrackingOpener(data);
+
+        stream = new ObjectStorageInputStream(data.length, SKIP_THRESHOLD, buffering(opener));
+        stream.read();
+        stream.read();
+        stream.read(); // position=3, openCount=1
+
+        stream.seek(1); // backward seek, closes stream
+        assertThat(stream.read()).isEqualTo(2); // lazy reopen on read
+        assertThat(opener.openCount).isEqualTo(2);
+    }
+
+    @Test
+    void shouldThrowWhenReadAndDiscardEncountersTruncatedStream() throws Exception {
+        final byte[] fullData = {1, 2, 3, 4, 5, 6, 7, 8};
+        final int bufferSize = 8;
+        // Opener returns only 2 bytes regardless of position
+        final InputStreamOpener opener =
+                ctx ->
+                        new ByteArrayInputStream(
+                                fullData, (int) ctx.getPos(), 2 - (int) ctx.getPos());
+
+        stream =
+                new ObjectStorageInputStream(
+                        fullData.length,
+                        SKIP_THRESHOLD,
+                        InputStreamExtension.buffering(opener, bufferSize));
+        stream.read(); // position=1, buffer has 1 byte from truncated stream
+
+        // Seek forward within threshold triggers read-and-discard, which hits EOF prematurely
+        assertThatThrownBy(() -> stream.seek(3))
+                .isInstanceOf(IOException.class)
+                .hasMessageContaining("Unexpected end of stream during read-and-discard seek");
+    }
+
+    // --- Close ---
+
+    @Test
+    void shouldCloseUnderlyingStreams() throws Exception {
+        final byte[] data = {1, 2, 3};
+        final TrackingInputStream tracking = new TrackingInputStream(data);
+        final InputStreamOpener opener = ctx -> tracking;
+
+        stream = new ObjectStorageInputStream(data.length, SKIP_THRESHOLD, buffering(opener));
+        stream.read(); // trigger initialization
+        stream.close();
+        // BufferedInputStream.close() closes the underlying stream once.
+        assertThat(tracking.closeCount).isEqualTo(1);
+    }
+
+    @Test
+    void shouldCloseSuccessfullyWhenThreadIsInterrupted() throws Exception {
+        createStream(new byte[] {1, 2, 3});
+        stream.read();
+
+        Thread.currentThread().interrupt();
+        stream.close();
+
+        assertThat(Thread.interrupted()).isTrue();
+        assertThatThrownBy(stream::read).isInstanceOf(IOException.class);
+    }
+
+    @Test
+    void shouldHandleDoubleCloseGracefully() throws Exception {
+        stream = new ObjectStorageInputStream(100L, SKIP_THRESHOLD, buffering(new byte[0]));
+        stream.close();
+        stream.close(); // should not throw
+    }
+
+    @ParameterizedTest
+    @MethodSource("closedStreamOperations")
+    void shouldThrowOnOperationAfterClose(final StreamOperation operation) throws Exception {
+        stream = new ObjectStorageInputStream(100L, SKIP_THRESHOLD, buffering(new byte[0]));
+        stream.close();
+        assertThatThrownBy(() -> operation.execute(stream)).isInstanceOf(IOException.class);
+    }
+
+    @FunctionalInterface
+    interface StreamOperation {
+        void execute(ObjectStorageInputStream stream) throws Exception;
+    }
+
+    private static Stream<Arguments> closedStreamOperations() {
+        return Stream.of(
+                Arguments.of((StreamOperation) ObjectStorageInputStream::read),
+                Arguments.of((StreamOperation) s -> s.read(new byte[1], 0, 1)),
+                Arguments.of((StreamOperation) s -> s.seek(0)),
+                Arguments.of((StreamOperation) s -> s.skip(1)),
+                Arguments.of((StreamOperation) ObjectStorageInputStream::available));
+    }
+
+    // --- Concurrency ---
+
+    @Test
+    void shouldInterruptLockAcquisitionAndThrowIOException() throws Exception {
+        final CountDownLatch openerBlocked = new CountDownLatch(1);
+        final CountDownLatch openerRelease = new CountDownLatch(1);
+        final InputStreamOpener blockingOpener =
+                blockingOpener(new byte[] {1, 2, 3}, openerBlocked, openerRelease);
+        stream = new ObjectStorageInputStream(3L, SKIP_THRESHOLD, buffering(blockingOpener));
+
+        // First thread: holds the lock while blocked inside the opener.
+        final CompletableFuture<Void> holder =
+                CompletableFuture.runAsync(
+                        () -> {
+                            try {
+                                stream.read();
+                            } catch (final IOException ignored) {
+                            }
+                        });
+        openerBlocked.await();
+
+        // Second thread: blocks on lock acquisition — we need the raw Thread for interrupt().
+        final AtomicReference<Throwable> readerError = new AtomicReference<>();
+        final Thread readerThread =
+                new Thread(
+                        () -> {
+                            try {
+                                stream.read();
+                            } catch (final IOException e) {
+                                readerError.set(e);
+                            }
+                        });
+        readerThread.start();
+        awaitBlocked(readerThread);
+
+        readerThread.interrupt();
+        readerThread.join();
+
+        openerRelease.countDown();
+        holder.join();
+
+        assertThat(readerThread.isAlive()).isFalse();
+        assertThat(readerError.get())
+                .isInstanceOf(IOException.class)
+                .hasMessageContaining("Interrupted");
+    }
+
+    /**
+     * Creates an opener that blocks on {@code blocked}/{@code release} latches on first call,
+     * allowing tests to hold the stream's lock from a background thread.
+     */
+    private static InputStreamOpener blockingOpener(
+            final byte[] data, final CountDownLatch blocked, final CountDownLatch release) {
+        return ctx -> {
+            blocked.countDown();
+            try {
+                release.await();
+            } catch (final InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new IOException("Interrupted in blocking opener", e);
+            }
+            final int pos = (int) Math.min(ctx.getPos(), data.length);
+            return new ByteArrayInputStream(data, pos, data.length - pos);
+        };
+    }
+
+    private static void awaitBlocked(final Thread thread) throws InterruptedException {
+        while (thread.getState() != Thread.State.WAITING) {
+            Thread.sleep(STATE_POLL_INTERVAL_MS);
+        }
+    }
+
+    // --- Available ---
+
+    @Test
+    void shouldReturnRemainingBytesFromAvailable() throws Exception {
+        final byte[] data = {1, 2, 3, 4, 5};
+        createStream(data);
+        assertThat(stream.available()).isEqualTo(5);
+        stream.read();
+        assertThat(stream.available()).isEqualTo(4);
+    }
+
+    @Test
+    void shouldCapAvailableAtIntegerMaxValue() throws Exception {
+        stream =
+                new ObjectStorageInputStream(
+                        Long.MAX_VALUE, SKIP_THRESHOLD, buffering(new byte[0]));
+        assertThat(stream.available()).isEqualTo(Integer.MAX_VALUE);
+    }
+
+    @Test
+    void shouldReturnZeroAvailableAfterSeekToEof() throws Exception {
+        final byte[] data = {1, 2, 3};
+        createStream(data);
+        stream.seek(data.length);
+        assertThat(stream.available()).isEqualTo(0);
+    }
+
+    @Test
+    void shouldThrowOnSeekBeyondContentLength() throws Exception {
+        final byte[] data = {1, 2, 3};
+        createStream(data);
+        assertThatThrownBy(() -> stream.seek(data.length + 1))
+                .isInstanceOf(IOException.class)
+                .hasMessageContaining("file size");
+    }
+
+    @Test
+    void shouldThrowOnAvailableAfterClose() throws Exception {
+        stream = new ObjectStorageInputStream(100L, SKIP_THRESHOLD, buffering(new byte[0]));
+        stream.close();
+        assertThatThrownBy(stream::available).isInstanceOf(IOException.class);
+    }
+
+    // --- Opener failure ---
+
+    @Test
+    void shouldPropagateOpenerIOException() {
+        final InputStreamOpener failingOpener =
+                ctx -> {
+                    throw new IOException("connection refused");
+                };
+        stream = new ObjectStorageInputStream(100L, SKIP_THRESHOLD, buffering(failingOpener));
+        assertThatThrownBy(stream::read).isInstanceOf(IOException.class);
+    }
+
+    @Test
+    void shouldPropagateOpenerRuntimeException() {
+        final RuntimeException expectedException = new RuntimeException("unexpected");
+        final InputStreamOpener failingOpener =
+                ctx -> {
+                    throw expectedException;
+                };
+        stream = new ObjectStorageInputStream(100L, SKIP_THRESHOLD, buffering(failingOpener));
+        assertThatThrownBy(stream::read)
+                .isInstanceOf(RuntimeException.class)
+                .isSameAs(expectedException);
+    }
+
+    // --- Edge cases ---
+
+    @Test
+    void shouldHandleZeroContentLength() throws Exception {
+        createStream(new byte[0]);
+        assertThat(stream.available()).isEqualTo(0);
+        assertThat(stream.read()).isEqualTo(-1);
+        final byte[] buf = new byte[1];
+        assertThat(stream.read(buf, 0, 1)).isEqualTo(-1);
+    }
+
+    @Test
+    void shouldNotOpenStreamWhenAlreadyAtEof() throws Exception {
+        final TrackingOpener opener = new TrackingOpener(new byte[0]);
+        stream = new ObjectStorageInputStream(0L, SKIP_THRESHOLD, buffering(opener));
+        stream.read();
+        assertThat(opener.openCount).isEqualTo(0);
+    }
+
+    // --- Truncated stream (contentLength exceeds actual data) ---
+
+    @Test
+    void shouldReturnMinusOneFromSingleByteReadWhenStreamTruncated() throws Exception {
+        final byte[] actualData = {1, 2};
+        final long reportedLength = 10;
+        stream =
+                new ObjectStorageInputStream(reportedLength, SKIP_THRESHOLD, buffering(actualData));
+        assertThat(stream.read()).isEqualTo(1);
+        assertThat(stream.read()).isEqualTo(2);
+        assertThat(stream.read()).isEqualTo(-1);
+        assertThat(stream.getPos()).isEqualTo(2);
+    }
+
+    @Test
+    void shouldReturnMinusOneFromArrayReadWhenStreamTruncated() throws Exception {
+        final byte[] actualData = {1, 2};
+        final long reportedLength = 10;
+        stream =
+                new ObjectStorageInputStream(reportedLength, SKIP_THRESHOLD, buffering(actualData));
+        final byte[] buf = new byte[5];
+        final int firstRead = stream.read(buf, 0, 5);
+        assertThat(firstRead).isEqualTo(2);
+        assertThat(stream.read(buf, 0, 5)).isEqualTo(-1);
+        assertThat(stream.getPos()).isEqualTo(2);
+    }
+
+    // --- closeCurrentStream error handling ---
+
+    @Test
+    void shouldPropagateCloseExceptionFromUnderlyingStream() throws Exception {
+        final IOException closeFailure = new IOException("close failed");
+        final InputStreamOpener opener =
+                ctx ->
+                        new ByteArrayInputStream(new byte[] {1, 2, 3}) {
+                            @Override
+                            public void close() throws IOException {
+                                throw closeFailure;
+                            }
+                        };
+
+        stream = new ObjectStorageInputStream(3L, SKIP_THRESHOLD, buffering(opener));
+        stream.read(); // trigger lazy init
+
+        assertThatThrownBy(stream::close).isInstanceOf(IOException.class).isSameAs(closeFailure);
+    }
+
+    // --- InputStreamExtension: openStream ---
+
+    @Test
+    void shouldCallExtensionOpenStreamOnInit() throws Exception {
+        final byte[] data = {1, 2, 3};
+        final TrackingOpener opener = new TrackingOpener(data);
+        final InputStreamExtension extension = new TestingExtension(opener);
+
+        stream = new ObjectStorageInputStream(data.length, SKIP_THRESHOLD, extension);
+        assertThat(opener.openCount).isEqualTo(0);
+        final int ignore = stream.read();
+        assertThat(opener.openCount).isEqualTo(1);
+    }
+
+    @Test
+    void shouldCallExtensionOpenStreamOnReopen() throws Exception {
+        final byte[] data = {1, 2, 3, 4, 5};
+        final TrackingOpener opener = new TrackingOpener(data);
+        final InputStreamExtension extension = new TestingExtension(opener);
+
+        stream = new ObjectStorageInputStream(data.length, SKIP_THRESHOLD, extension);
+        stream.read(); // triggers init, openCount=1
+        stream.seek(0); // backward seek forces reopen on next read
+        stream.read(); // triggers reopen, openCount=2
+        assertThat(opener.openCount).isEqualTo(2);
+    }
+
+    @Test
+    void shouldUseDefaultBufferingExtension() throws Exception {
+        final byte[] data = {1, 2, 3, 4, 5};
+        stream = new ObjectStorageInputStream(data.length, SKIP_THRESHOLD, buffering(data));
+        final byte[] buf = new byte[5];
+        final int read = stream.read(buf, 0, 5);
+        assertThat(read).isEqualTo(5);
+        assertThat(buf).isEqualTo(data);
+        assertThat(stream.getPos()).isEqualTo(5);
+    }
+
+    @Test
+    void shouldPropagateExtensionOpenStreamException() {
+        final IOException openFailure = new IOException("open failed");
+        final InputStreamExtension extension =
+                new TestingExtension(
+                        ctx -> {
+                            throw openFailure;
+                        });
+
+        stream = new ObjectStorageInputStream(1L, SKIP_THRESHOLD, extension);
+        assertThatThrownBy(stream::read).isSameAs(openFailure);
+    }
+}

--- a/flink-core/src/test/java/org/apache/flink/core/fs/ObjectStorageOutputStreamTest.java
+++ b/flink-core/src/test/java/org/apache/flink/core/fs/ObjectStorageOutputStreamTest.java
@@ -1,0 +1,543 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.core.fs;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Tests for {@link ObjectStorageOutputStream}. */
+@Timeout(value = 10, unit = TimeUnit.MINUTES)
+class ObjectStorageOutputStreamTest {
+
+    private static final String FILE_PATH = "test/output.txt";
+
+    private ObjectStorageOutputStream stream;
+
+    @AfterEach
+    void tearDown() throws Exception {
+        if (stream != null) {
+            try {
+                stream.close();
+            } catch (final Exception ignored) {
+                // stream may already be closed or in a failed state
+            }
+        }
+    }
+
+    /** Test double that records writes and captures the written content. */
+    private static final class RecordingOutputStream extends OutputStream {
+        private final ByteArrayOutputStream delegate = new ByteArrayOutputStream();
+        private final List<String> operations = new ArrayList<>();
+        private boolean flushed;
+        private boolean closed;
+
+        @Override
+        public void write(final int b) throws IOException {
+            delegate.write(b);
+        }
+
+        @Override
+        public void write(final byte[] b, final int off, final int len) throws IOException {
+            delegate.write(b, off, len);
+        }
+
+        @Override
+        public void flush() throws IOException {
+            flushed = true;
+            operations.add("flush");
+            delegate.flush();
+        }
+
+        @Override
+        public void close() throws IOException {
+            closed = true;
+            operations.add("close");
+            delegate.close();
+        }
+
+        byte[] getWrittenData() {
+            return delegate.toByteArray();
+        }
+    }
+
+    private ObjectStorageOutputStream createStream() {
+        return createStream(new ByteArrayOutputStream());
+    }
+
+    private ObjectStorageOutputStream createStream(final OutputStream outputStream) {
+        stream = new ObjectStorageOutputStream(outputStream, FILE_PATH);
+        return stream;
+    }
+
+    // --- Constructor validation ---
+
+    @Test
+    void shouldThrowOnNullDelegate() {
+        assertThatThrownBy(() -> new ObjectStorageOutputStream(null, FILE_PATH))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessageContaining("delegate");
+    }
+
+    @Test
+    void shouldThrowOnNullFilePath() {
+        assertThatThrownBy(() -> new ObjectStorageOutputStream(new ByteArrayOutputStream(), null))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessageContaining("filePath");
+    }
+
+    // --- Write operations ---
+
+    @Test
+    void shouldWriteSingleByte() throws Exception {
+        createStream();
+        stream.write(42);
+        assertThat(stream.getPos()).isEqualTo(1);
+    }
+
+    @Test
+    void shouldWriteByteArray() throws Exception {
+        final byte[] data = {1, 2, 3, 4, 5};
+        createStream();
+        stream.write(data, 0, data.length);
+        assertThat(stream.getPos()).isEqualTo(5);
+    }
+
+    @Test
+    void shouldWriteByteArrayWithOffset() throws Exception {
+        final byte[] data = {1, 2, 3, 4, 5};
+        createStream();
+        stream.write(data, 2, 3);
+        assertThat(stream.getPos()).isEqualTo(3);
+    }
+
+    @Test
+    void shouldTrackPositionAcrossMultipleWrites() throws Exception {
+        createStream();
+        stream.write(1);
+        stream.write(new byte[] {2, 3, 4}, 0, 3);
+        assertThat(stream.getPos()).isEqualTo(4);
+    }
+
+    @Test
+    void shouldDelegateSingleArgWriteToDelegateStream() throws Exception {
+        // tests the inherited write(byte[]) -> write(byte[], 0, len) delegation
+        createStream();
+        final byte[] data = {1, 2, 3};
+        stream.write(data);
+        assertThat(stream.getPos()).isEqualTo(3);
+    }
+
+    @Test
+    void shouldHandleZeroLengthWrite() throws Exception {
+        createStream();
+        stream.write(new byte[5], 0, 0);
+        assertThat(stream.getPos()).isEqualTo(0);
+    }
+
+    @Test
+    void shouldThrowOnNullArrayWrite() throws Exception {
+        createStream();
+        assertThatThrownBy(() -> stream.write(null, 0, 1))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessageContaining("buffer");
+    }
+
+    @Test
+    void shouldThrowOnBoundsViolation() throws Exception {
+        createStream();
+        final byte[] buf = new byte[5];
+        assertThatThrownBy(() -> stream.write(buf, 3, 5))
+                .isInstanceOf(IndexOutOfBoundsException.class);
+    }
+
+    @ParameterizedTest
+    @MethodSource("closedWriteOperations")
+    void shouldThrowOnWriteAfterClose(final WriteOperation operation) throws Exception {
+        createStream();
+        stream.close();
+        assertThatThrownBy(() -> operation.execute(stream)).isInstanceOf(IOException.class);
+    }
+
+    @FunctionalInterface
+    interface WriteOperation {
+        void execute(ObjectStorageOutputStream stream) throws Exception;
+    }
+
+    private static Stream<Arguments> closedWriteOperations() {
+        return Stream.of(
+                Arguments.of((WriteOperation) s -> s.write(42)),
+                Arguments.of((WriteOperation) s -> s.write(new byte[] {1}, 0, 1)),
+                Arguments.of((WriteOperation) ObjectStorageOutputStream::flush),
+                Arguments.of((WriteOperation) ObjectStorageOutputStream::getPos));
+    }
+
+    // --- Write content verification ---
+
+    @Test
+    void shouldDelegateWritesToDelegateStream() throws Exception {
+        final RecordingOutputStream recordingOut = new RecordingOutputStream();
+        createStream(recordingOut);
+
+        final byte[] data = {1, 2, 3};
+        stream.write(data, 0, data.length);
+        stream.close();
+
+        assertThat(recordingOut.getWrittenData()).isEqualTo(data);
+    }
+
+    @Test
+    void shouldDelegateSingleByteWritesToDelegateStream() throws Exception {
+        final RecordingOutputStream recordingOut = new RecordingOutputStream();
+        createStream(recordingOut);
+
+        stream.write(42);
+        stream.write(99);
+        stream.close();
+
+        assertThat(recordingOut.getWrittenData()).isEqualTo(new byte[] {42, 99});
+    }
+
+    // --- Flush and sync ---
+
+    @Test
+    void shouldFlushWithoutError() throws Exception {
+        createStream();
+        stream.write(1);
+        stream.flush();
+    }
+
+    @Test
+    void shouldFlushDelegateToDelegateStream() throws Exception {
+        final RecordingOutputStream recordingOut = new RecordingOutputStream();
+        createStream(recordingOut);
+
+        stream.write(1);
+        stream.flush();
+
+        assertThat(recordingOut.flushed).isTrue();
+    }
+
+    @Test
+    void shouldSyncFlushAndCloseDelegateStream() throws Exception {
+        final RecordingOutputStream recordingOut = new RecordingOutputStream();
+        createStream(recordingOut);
+
+        stream.write(1);
+        stream.sync();
+
+        assertThat(recordingOut.flushed).isTrue();
+        assertThat(recordingOut.closed).isTrue();
+        assertThat(recordingOut.operations).containsExactly("flush", "close");
+    }
+
+    @Test
+    void shouldSyncBeIdempotent() throws Exception {
+        final RecordingOutputStream recordingOut = new RecordingOutputStream();
+        createStream(recordingOut);
+
+        stream.write(1);
+        stream.sync();
+        stream.sync(); // second call is a no-op
+
+        assertThat(recordingOut.operations).containsExactly("flush", "close");
+    }
+
+    @Test
+    void shouldThrowOnWriteAfterSync() throws Exception {
+        createStream();
+        stream.write(1);
+        stream.sync();
+
+        assertThatThrownBy(() -> stream.write(42)).isInstanceOf(IOException.class);
+        assertThatThrownBy(() -> stream.flush()).isInstanceOf(IOException.class);
+        assertThatThrownBy(() -> stream.getPos()).isInstanceOf(IOException.class);
+    }
+
+    @Test
+    void shouldCloseBeNoOpAfterSync() throws Exception {
+        final RecordingOutputStream recordingOut = new RecordingOutputStream();
+        createStream(recordingOut);
+
+        stream.write(1);
+        stream.sync();
+        stream.close(); // should be no-op — already closed by sync
+
+        assertThat(recordingOut.operations).containsExactly("flush", "close");
+    }
+
+    // --- Close ---
+
+    @Test
+    void shouldCloseDelegateStreamOnClose() throws Exception {
+        final RecordingOutputStream recordingOut = new RecordingOutputStream();
+        createStream(recordingOut);
+
+        stream.write(1);
+        stream.close();
+
+        assertThat(recordingOut.closed).isTrue();
+    }
+
+    @Test
+    void shouldFlushBeforeClosingDelegateStream() throws Exception {
+        final RecordingOutputStream recordingOut = new RecordingOutputStream();
+        createStream(recordingOut);
+
+        stream.write(1);
+        stream.close();
+
+        assertThat(recordingOut.operations).containsExactly("flush", "close");
+    }
+
+    @Test
+    void shouldAllowCloseFromDifferentThread() throws Exception {
+        final RecordingOutputStream recordingOut = new RecordingOutputStream();
+        createStream(recordingOut);
+        stream.write(1);
+
+        final Thread closer =
+                new Thread(
+                        () -> {
+                            try {
+                                stream.close();
+                            } catch (final Exception e) {
+                                throw new RuntimeException(e);
+                            }
+                        });
+        closer.start();
+        closer.join();
+        assertThat(recordingOut.closed).isTrue();
+    }
+
+    @Test
+    void shouldHandleDoubleCloseGracefully() throws Exception {
+        final RecordingOutputStream recordingOut = new RecordingOutputStream();
+        createStream(recordingOut);
+        stream.write(1);
+        stream.close();
+        stream.close(); // should not throw or close the delegate again
+        assertThat(recordingOut.closed).isTrue();
+    }
+
+    @Test
+    void shouldCloseEmptyStreamWithoutError() throws Exception {
+        final RecordingOutputStream recordingOut = new RecordingOutputStream();
+        createStream(recordingOut);
+        stream.close();
+        assertThat(recordingOut.closed).isTrue();
+        assertThat(recordingOut.getWrittenData()).isEmpty();
+    }
+
+    @Test
+    void shouldCloseDelegateStreamEvenIfFlushThrows() throws Exception {
+        final IOException flushFailure = new IOException("flush failed");
+        final boolean[] closeCalled = {false};
+        final OutputStream failingStream =
+                new OutputStream() {
+                    @Override
+                    public void write(final int b) {}
+
+                    @Override
+                    public void flush() throws IOException {
+                        throw flushFailure;
+                    }
+
+                    @Override
+                    public void close() {
+                        closeCalled[0] = true;
+                    }
+                };
+
+        createStream(failingStream);
+        assertThatThrownBy(stream::close).isInstanceOf(IOException.class).isSameAs(flushFailure);
+        assertThat(closeCalled[0]).isTrue();
+    }
+
+    @Test
+    void shouldPropagateCloseException() throws Exception {
+        final IOException closeFailure = new IOException("close failed");
+        final OutputStream failingStream =
+                new OutputStream() {
+                    @Override
+                    public void write(final int b) {}
+
+                    @Override
+                    public void close() throws IOException {
+                        throw closeFailure;
+                    }
+                };
+
+        createStream(failingStream);
+        assertThatThrownBy(stream::close).isInstanceOf(IOException.class).isSameAs(closeFailure);
+    }
+
+    @Test
+    void shouldChainCloseExceptionAsSuppressedWhenFlushAlsoFails() throws Exception {
+        final IOException flushFailure = new IOException("flush failed");
+        final IOException closeFailure = new IOException("close failed");
+        final OutputStream failingStream =
+                new OutputStream() {
+                    @Override
+                    public void write(final int b) {}
+
+                    @Override
+                    public void flush() throws IOException {
+                        throw flushFailure;
+                    }
+
+                    @Override
+                    public void close() throws IOException {
+                        throw closeFailure;
+                    }
+                };
+
+        createStream(failingStream);
+        assertThatThrownBy(stream::close)
+                .isInstanceOf(IOException.class)
+                .isSameAs(flushFailure)
+                .satisfies(
+                        ex ->
+                                assertThat(ex.getSuppressed())
+                                        .hasSize(1)
+                                        .allSatisfy(s -> assertThat(s).isSameAs(closeFailure)));
+    }
+
+    // --- Thread-safety ---
+
+    /**
+     * Verifies that {@code close()} blocks until a concurrent write completes.
+     *
+     * <p>A blocking write holds the lock; close() must wait until the write releases it.
+     */
+    @Test
+    void shouldBlockConcurrentWriteDuringClose() throws Exception {
+        final CountDownLatch writeStarted = new CountDownLatch(1);
+        final CountDownLatch writePermit = new CountDownLatch(1);
+        final RecordingOutputStream recordingOut = new RecordingOutputStream();
+        final OutputStream blockingDelegate =
+                new OutputStream() {
+                    @Override
+                    public void write(final int b) throws IOException {
+                        writeStarted.countDown();
+                        try {
+                            writePermit.await();
+                        } catch (final InterruptedException e) {
+                            Thread.currentThread().interrupt();
+                            throw new IOException(e);
+                        }
+                        recordingOut.write(b);
+                    }
+
+                    @Override
+                    public void flush() throws IOException {
+                        recordingOut.flush();
+                    }
+
+                    @Override
+                    public void close() throws IOException {
+                        recordingOut.close();
+                    }
+                };
+
+        createStream(blockingDelegate);
+
+        final AtomicReference<Throwable> writeError = new AtomicReference<>();
+        final Thread writer =
+                new Thread(
+                        () -> {
+                            try {
+                                stream.write(1);
+                            } catch (final Throwable t) {
+                                writeError.set(t);
+                            }
+                        });
+        writer.start();
+
+        // Wait until the write has the lock and is blocked inside the delegate.
+        writeStarted.await();
+
+        // close() must wait for the write to finish.
+        final CountDownLatch closeEntered = new CountDownLatch(1);
+        final AtomicReference<Throwable> closeError = new AtomicReference<>();
+        final Thread closer =
+                new Thread(
+                        () -> {
+                            closeEntered.countDown();
+                            try {
+                                stream.close();
+                            } catch (final Throwable t) {
+                                closeError.set(t);
+                            }
+                        });
+        closer.start();
+        closeEntered.await();
+
+        // Writer is still blocked inside the delegate — nothing written yet.
+        assertThat(recordingOut.getWrittenData()).isEmpty();
+
+        // Allow the write to complete, then close() should proceed.
+        writePermit.countDown();
+
+        writer.join();
+        closer.join();
+
+        assertThat(writeError.get()).isNull();
+        assertThat(closeError.get()).isNull();
+        assertThat(recordingOut.closed).isTrue();
+        assertThat(recordingOut.getWrittenData()).isEqualTo(new byte[] {1});
+    }
+
+    /**
+     * Verifies that setting the interrupt flag before calling {@link
+     * ObjectStorageOutputStream#write(int)} causes an {@link IOException} wrapping {@link
+     * InterruptedException}.
+     */
+    @Test
+    void shouldInterruptWriteOnInterrupt() throws Exception {
+        createStream();
+
+        Thread.currentThread().interrupt();
+        try {
+            assertThatThrownBy(() -> stream.write(1))
+                    .isInstanceOf(IOException.class)
+                    .hasMessageContaining("Interrupted")
+                    .hasCauseInstanceOf(InterruptedException.class);
+        } finally {
+            // Clear interrupt flag to avoid contaminating subsequent tests.
+            Thread.interrupted();
+        }
+    }
+}

--- a/flink-filesystems/flink-azure-fs-native/pom.xml
+++ b/flink-filesystems/flink-azure-fs-native/pom.xml
@@ -413,6 +413,11 @@ under the License.
                                     <shadedPattern>org.apache.flink.fs.azurefs.shaded.org.objectweb.asm</shadedPattern>
                                 </relocation>
                             </relocations>
+                            <transformers combine.children="append">
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.DontIncludeResourceTransformer">
+                                    <resource>publicsuffix/NOTICE</resource>
+                                </transformer>
+                            </transformers>
                             <filters combine.children="append">
                                 <!-- Module-specific excludes (signatures, maven poms,
                                      and NOTICE merging handled by parent pom) -->

--- a/flink-filesystems/flink-azure-fs-native/pom.xml
+++ b/flink-filesystems/flink-azure-fs-native/pom.xml
@@ -1,0 +1,480 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.flink</groupId>
+        <artifactId>flink-filesystems</artifactId>
+        <version>2.4-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>flink-azure-fs-native</artifactId>
+    <name>Flink : FileSystems : Azure FS Native</name>
+
+    <packaging>jar</packaging>
+
+    <properties>
+        <!-- Prepend JaCoCo agent to surefire argLine -->
+        <flink.surefire.baseArgLine>@{argLine} -XX:+UseG1GC -Xms256m -XX:+IgnoreUnrecognizedVMOptions ${surefire.module.config}</flink.surefire.baseArgLine>
+        <!-- Azure SDK versions -->
+        <azure.sdk.version>12.29.1</azure.sdk.version>
+        <azure.identity.version>1.14.2</azure.identity.version>
+        <msal4j.version>1.17.2</msal4j.version>
+        <azure.core.version>1.55.2</azure.core.version>
+        <azure.storage.common.version>12.28.1</azure.storage.common.version>
+        <azure.datalake.version>12.22.0</azure.datalake.version>
+        <!-- OkHttp versions (overrides root pom's 3.14.9; azure-core-http-okhttp requires 4.x) -->
+        <azure.core.http.okhttp.version>1.12.5</azure.core.http.okhttp.version>
+        <okhttp.version>4.12.0</okhttp.version>
+        <!-- Aligned transitive versions (okhttp and azure-core-http-okhttp pull different versions) -->
+        <okio.version>3.9.1</okio.version>
+        <kotlin.version>1.9.25</kotlin.version>
+        <!-- Reactor version -->
+        <reactor.core.version>3.5.20</reactor.core.version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- Align Okio versions (okhttp pulls 3.6.0, azure-core-http-okhttp pulls 3.9.1) -->
+            <dependency>
+                <groupId>com.squareup.okio</groupId>
+                <artifactId>okio</artifactId>
+                <version>${okio.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.squareup.okio</groupId>
+                <artifactId>okio-jvm</artifactId>
+                <version>${okio.version}</version>
+            </dependency>
+            <!-- Align Kotlin stdlib version (okio pulls 1.9.25, okhttp pulls 1.8.21).
+                 Since Kotlin 1.8, jdk7/jdk8 extensions are merged into kotlin-stdlib
+                 and the separate artifacts are empty — only kotlin-stdlib is needed. -->
+            <dependency>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-stdlib</artifactId>
+                <version>${kotlin.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <!-- Flink core -->
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-core</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-shaded-guava</artifactId>
+        </dependency>
+
+        <!-- Azure Storage Blob SDK v12 -->
+        <dependency>
+            <groupId>com.azure</groupId>
+            <artifactId>azure-storage-blob</artifactId>
+            <version>${azure.sdk.version}</version>
+            <optional>${flink.markBundledAsOptional}</optional>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.azure</groupId>
+                    <artifactId>azure-core-http-netty</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <!-- Azure Storage File DataLake SDK for ADLS Gen2 (abfss://) support -->
+        <dependency>
+            <groupId>com.azure</groupId>
+            <artifactId>azure-storage-file-datalake</artifactId>
+            <version>${azure.datalake.version}</version>
+            <optional>${flink.markBundledAsOptional}</optional>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.azure</groupId>
+                    <artifactId>azure-core-http-netty</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <!-- Azure Identity for credential management -->
+        <dependency>
+            <groupId>com.azure</groupId>
+            <artifactId>azure-identity</artifactId>
+            <version>${azure.identity.version}</version>
+            <optional>${flink.markBundledAsOptional}</optional>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.azure</groupId>
+                    <artifactId>azure-core-http-netty</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <!-- MSAL4J for Azure authentication (transitive optional from azure-identity, must be explicit) -->
+        <dependency>
+            <groupId>com.microsoft.azure</groupId>
+            <artifactId>msal4j</artifactId>
+            <version>${msal4j.version}</version>
+            <optional>${flink.markBundledAsOptional}</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>io.projectreactor</groupId>
+            <artifactId>reactor-core</artifactId>
+            <version>${reactor.core.version}</version>
+            <optional>${flink.markBundledAsOptional}</optional>
+        </dependency>
+
+        <!-- Azure SDK transitive dependencies - must be explicitly marked optional -->
+        <dependency>
+            <groupId>com.azure</groupId>
+            <artifactId>azure-core</artifactId>
+            <version>${azure.core.version}</version>
+            <optional>${flink.markBundledAsOptional}</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>com.azure</groupId>
+            <artifactId>azure-core-http-okhttp</artifactId>
+            <version>${azure.core.http.okhttp.version}</version>
+            <optional>${flink.markBundledAsOptional}</optional>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.jetbrains</groupId>
+                    <artifactId>annotations</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>com.azure</groupId>
+            <artifactId>azure-storage-common</artifactId>
+            <version>${azure.storage.common.version}</version>
+            <optional>${flink.markBundledAsOptional}</optional>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.azure</groupId>
+                    <artifactId>azure-core-http-netty</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <!-- OkHttp HTTP client (override root pom's managed 3.14.9) -->
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>okhttp</artifactId>
+            <version>${okhttp.version}</version>
+            <optional>${flink.markBundledAsOptional}</optional>
+            <exclusions>
+                <!-- CLASS retention only, not needed at runtime -->
+                <exclusion>
+                    <groupId>org.jetbrains</groupId>
+                    <artifactId>annotations</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <!-- Jackson dependencies - must be explicitly marked optional -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <optional>${flink.markBundledAsOptional}</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <optional>${flink.markBundledAsOptional}</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <optional>${flink.markBundledAsOptional}</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
+            <optional>${flink.markBundledAsOptional}</optional>
+        </dependency>
+
+        <!-- Logging -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- Test dependencies -->
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-core</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-runtime</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-runtime</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-streaming-java</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-streaming-java</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-statebackend-rocksdb</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-clients</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Flink Web UI for debugging integration tests -->
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-runtime-web</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- CSE abstractions: CseStreamFactory, KeyProvider, EncryptedReadContext, etc. -->
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-fs-cse-common</artifactId>
+            <version>${project.version}</version>
+            <optional>${flink.markBundledAsOptional}</optional>
+        </dependency>
+
+        <!-- CSE implementation: AesGcmCseStreamFactory -->
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-fs-cse-aes-gcm</artifactId>
+            <version>${project.version}</version>
+            <optional>${flink.markBundledAsOptional}</optional>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>shade-flink</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <artifactSet>
+                                <includes>
+                                    <include>com.azure:azure-storage-blob</include>
+                                    <include>com.azure:azure-storage-file-datalake</include>
+                                    <include>com.azure:azure-storage-common</include>
+                                    <include>com.azure:azure-identity</include>
+                                    <include>com.azure:azure-core</include>
+                                    <include>com.azure:azure-core-http-okhttp</include>
+                                    <include>com.azure:azure-json</include>
+                                    <include>com.azure:azure-xml</include>
+                                    <include>com.azure:azure-storage-internal-avro</include>
+                                    <include>io.projectreactor:*</include>
+                                    <include>com.fasterxml.jackson.core:*</include>
+                                    <include>com.fasterxml.jackson.datatype:*</include>
+                                    <include>org.reactivestreams:*</include>
+                                    <!-- OkHttp for Azure SDK HTTP client -->
+                                    <include>com.squareup.okhttp3:*</include>
+                                    <include>com.squareup.okio:okio*</include>
+                                    <include>org.jetbrains.kotlin:kotlin-stdlib</include>
+                                    <!-- MSAL4J for Azure authentication -->
+                                    <include>com.microsoft.azure:msal4j</include>
+                                    <include>com.nimbusds:*</include>
+                                    <include>net.minidev:*</include>
+                                    <include>org.ow2.asm:asm</include>
+                                    <include>com.github.stephenc.jcip:jcip-annotations</include>
+                                    <!-- CSE modules shaded into the uber-jar -->
+                                    <include>org.apache.flink:flink-fs-cse-common</include>
+                                    <include>org.apache.flink:flink-fs-cse-aes-gcm</include>
+                                </includes>
+                            </artifactSet>
+                            <relocations>
+                                <relocation>
+                                    <pattern>com.azure</pattern>
+                                    <shadedPattern>org.apache.flink.fs.azurefs.shaded.com.azure</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>reactor</pattern>
+                                    <shadedPattern>org.apache.flink.fs.azurefs.shaded.reactor</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>com.fasterxml.jackson</pattern>
+                                    <shadedPattern>org.apache.flink.fs.azurefs.shaded.com.fasterxml.jackson</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.reactivestreams</pattern>
+                                    <shadedPattern>org.apache.flink.fs.azurefs.shaded.org.reactivestreams</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>okhttp3</pattern>
+                                    <shadedPattern>org.apache.flink.fs.azurefs.shaded.okhttp3</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>okio</pattern>
+                                    <shadedPattern>org.apache.flink.fs.azurefs.shaded.okio</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>kotlin</pattern>
+                                    <shadedPattern>org.apache.flink.fs.azurefs.shaded.kotlin</shadedPattern>
+                                </relocation>
+                                <!-- MSAL4J and dependencies -->
+                                <relocation>
+                                    <pattern>com.microsoft.aad.msal4j</pattern>
+                                    <shadedPattern>org.apache.flink.fs.azurefs.shaded.com.microsoft.aad.msal4j</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>com.nimbusds</pattern>
+                                    <shadedPattern>org.apache.flink.fs.azurefs.shaded.com.nimbusds</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>net.minidev</pattern>
+                                    <shadedPattern>org.apache.flink.fs.azurefs.shaded.net.minidev</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>net.jcip</pattern>
+                                    <shadedPattern>org.apache.flink.fs.azurefs.shaded.net.jcip</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.objectweb.asm</pattern>
+                                    <shadedPattern>org.apache.flink.fs.azurefs.shaded.org.objectweb.asm</shadedPattern>
+                                </relocation>
+                            </relocations>
+                            <filters combine.children="append">
+                                <!-- Module-specific excludes (signatures, maven poms,
+                                     and NOTICE merging handled by parent pom) -->
+                                <filter>
+                                    <artifact>*:*</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/DEPENDENCIES</exclude>
+                                        <exclude>META-INF/proguard/**</exclude>
+                                        <exclude>META-INF/kotlin-project-structure-metadata.json</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.12</version>
+                <executions>
+                    <execution>
+                        <id>prepare-agent</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>report</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>check</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <rule>
+                                    <element>BUNDLE</element>
+                                    <limits>
+                                        <limit>
+                                            <counter>LINE</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.80</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>BRANCH</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.80</minimum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/flink-filesystems/flink-azure-fs-native/src/main/java/org/apache/flink/fs/azurefs/AbfssFileSystemFactory.java
+++ b/flink-filesystems/flink-azure-fs-native/src/main/java/org/apache/flink/fs/azurefs/AbfssFileSystemFactory.java
@@ -1,0 +1,200 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.fs.azurefs;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.MemorySize;
+import org.apache.flink.core.fs.FileSystem;
+import org.apache.flink.core.fs.FileSystemFactory;
+import org.apache.flink.fs.cse.CseOptions;
+import org.apache.flink.fs.cse.CseStreamFactory;
+import org.apache.flink.fs.cse.KeyProvider;
+import org.apache.flink.fs.cse.KeyProviders;
+import org.apache.flink.fs.cse.aes.gcm.AesGcmCseStreamFactory;
+import org.apache.flink.util.Preconditions;
+
+import com.azure.storage.file.datalake.DataLakeFileSystemClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.NotThreadSafe;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.Map;
+
+/**
+ * Factory for Azure Data Lake Storage Gen2 (ADLS Gen2) with the "abfss" scheme.
+ *
+ * <p>This factory creates {@link AzureDataLakeFileSystem} instances backed by the native Azure SDK.
+ * It registers with the "abfss" URI scheme. To select this factory, configure {@code
+ * fs.abfss.priority.org.apache.flink.fs.azurefs.AbfssFileSystemFactory: 100} in flink-conf.yaml.
+ *
+ * <h3>Authentication</h3>
+ *
+ * <p>Two authentication modes are supported:
+ *
+ * <ul>
+ *   <li><b>SharedKey</b>: when {@code fs.azure.account-key} is configured, SharedKey authentication
+ *       is used.
+ *   <li><b>DefaultAzureCredential</b>: when no account key is configured, the Azure SDK's {@code
+ *       DefaultAzureCredential} chain is used. This auto-detects workload identity, managed
+ *       identity, environment variables, and other credential sources. This mode is required in
+ *       environments where storage accounts are accessed via managed identity.
+ * </ul>
+ *
+ * <p>This class is NOT thread-safe during configuration, but the configured factory is safe to use
+ * from multiple threads.
+ *
+ * @see AzureFileSystemOptions
+ * @see CseOptions
+ */
+@NotThreadSafe
+public class AbfssFileSystemFactory implements FileSystemFactory {
+
+    private static final Logger LOG = LoggerFactory.getLogger(AbfssFileSystemFactory.class);
+
+    @Nullable private Configuration config;
+
+    /**
+     * Returns the URI scheme supported by this factory.
+     *
+     * @return "abfss" for Azure Data Lake Storage Gen2 with SSL
+     */
+    @Override
+    public String getScheme() {
+        return "abfss";
+    }
+
+    @Override
+    public int getPriority() {
+        // Deprioritized by default
+        return -1;
+    }
+
+    @Override
+    public void configure(final Configuration config) {
+        this.config = config;
+    }
+
+    @Override
+    public FileSystem create(final URI fsUri) throws IOException {
+        final Configuration config = this.config != null ? this.config : new Configuration();
+
+        final String accountName = AzureDataLakeClientProvider.extractAccountNameFromUri(fsUri);
+
+        final MemorySize readBufferMemory = config.get(AzureFileSystemOptions.READ_BUFFER_SIZE);
+        final int readBufferSize = Math.toIntExact(readBufferMemory.getBytes());
+        if (readBufferSize <= 0) {
+            throw new IOException(
+                    "Read buffer size must be positive. Got: "
+                            + readBufferMemory
+                            + ". Configure '"
+                            + AzureFileSystemOptions.READ_BUFFER_SIZE.key()
+                            + "'.");
+        }
+
+        // Account key is optional. When present, SharedKey authentication is used.
+        // When absent, the Azure SDK falls back to DefaultAzureCredential which
+        // auto-detects workload identity, managed identity, etc. This fallback is
+        // required in environments where storage accounts are accessed via managed
+        // identity rather than an explicit account key (e.g., HA recovery storage).
+        final AzureDataLakeClientProvider.Builder providerBuilder =
+                AzureDataLakeClientProvider.builder()
+                        .accountName(accountName)
+                        .maxRetries(config.get(AzureFileSystemOptions.RETRY_MAX_RETRIES))
+                        .baseDelay(config.get(AzureFileSystemOptions.RETRY_BASE_DELAY))
+                        .maxDelay(config.get(AzureFileSystemOptions.RETRY_MAX_DELAY))
+                        .connectionTimeout(config.get(AzureFileSystemOptions.CONNECTION_TIMEOUT))
+                        .readTimeout(config.get(AzureFileSystemOptions.READ_TIMEOUT))
+                        .maxIdleConnections(
+                                config.get(AzureFileSystemOptions.HTTP_MAX_IDLE_CONNECTIONS))
+                        .keepAliveDuration(
+                                config.get(AzureFileSystemOptions.HTTP_KEEP_ALIVE_DURATION));
+
+        final String accountKey = config.get(AzureFileSystemOptions.ACCOUNT_KEY);
+        if (accountKey != null) {
+            providerBuilder.accountKey(accountKey);
+        }
+
+        final MemorySize writeRequestMemory = config.get(AzureFileSystemOptions.WRITE_REQUEST_SIZE);
+        final long writeRequestSize = writeRequestMemory.getBytes();
+        if (writeRequestSize <= 0) {
+            throw new IOException(
+                    "Write request size must be positive. Got: "
+                            + writeRequestMemory
+                            + ". Configure '"
+                            + AzureFileSystemOptions.WRITE_REQUEST_SIZE.key()
+                            + "'.");
+        }
+
+        final AzureDataLakeClientProvider clientProvider = providerBuilder.build();
+        final String fileSystemName = AzureDataLakeFileSystem.getFileSystemNameFromUri(fsUri);
+        final DataLakeFileSystemClient fsClient =
+                clientProvider.getFileSystemClient(fileSystemName);
+
+        final String writeKeyId = config.get(CseOptions.WRITE_KEY_ID);
+        final CseStreamFactory cseFactory = createCseStreamFactory(config);
+
+        Preconditions.checkArgument(
+                cseFactory != null || writeKeyId == null,
+                "'%s' is configured but '%s' is absent. CSE writes require both options.",
+                CseOptions.WRITE_KEY_ID.key(),
+                CseOptions.KEY_PROVIDER_FACTORY_CLASS.key());
+
+        LOG.info(
+                "Creating Azure DataLake FileSystem - account: {}, CSE: {}, writeRequestSize: {} bytes",
+                accountName,
+                cseFactory != null ? (writeKeyId != null ? "read+write" : "read-only") : "disabled",
+                writeRequestSize);
+
+        return AzureDataLakeFileSystem.builder(new DataLakeStorageOperationsImpl(fsClient), fsUri)
+                .readBufferSize(readBufferSize)
+                .writeRequestSize(writeRequestSize)
+                .cseFactory(cseFactory)
+                .encryptWrites(writeKeyId != null)
+                .build();
+    }
+
+    /**
+     * Creates a {@link CseStreamFactory} if {@link CseOptions#KEY_PROVIDER_FACTORY_CLASS} is
+     * configured.
+     *
+     * @param config the filesystem configuration
+     * @return a configured factory, or {@code null} if CSE is disabled
+     * @throws IOException if the key provider factory cannot be instantiated
+     */
+    @Nullable
+    private static CseStreamFactory createCseStreamFactory(final Configuration config)
+            throws IOException {
+        final String factoryClassName = config.get(CseOptions.KEY_PROVIDER_FACTORY_CLASS);
+        if (factoryClassName == null) {
+            return null;
+        }
+        // TODO: CseStreamFactory is leaked — FileSystem has no close() lifecycle hook.
+        // Fix requires AzureDataLakeFileSystem to implement Closeable (closing the
+        // CseStreamFactory, which in turn closes the KeyProvider) and Flink's FileSystem
+        // base class to gain a close/dispose lifecycle callback.
+        final KeyProvider keyProvider = KeyProviders.instantiate(factoryClassName, config);
+        final Map<String, String> encryptionContext = CseOptions.extractEncryptionContext(config);
+        final String writeKeyId = config.get(CseOptions.WRITE_KEY_ID);
+        return new AesGcmCseStreamFactory(keyProvider, writeKeyId, encryptionContext);
+    }
+}

--- a/flink-filesystems/flink-azure-fs-native/src/main/java/org/apache/flink/fs/azurefs/AzureDataLakeClientProvider.java
+++ b/flink-filesystems/flink-azure-fs-native/src/main/java/org/apache/flink/fs/azurefs/AzureDataLakeClientProvider.java
@@ -1,0 +1,394 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.fs.azurefs;
+
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.util.StringUtils;
+
+import com.azure.core.http.HttpClient;
+import com.azure.core.http.okhttp.OkHttpAsyncHttpClientBuilder;
+import com.azure.core.http.policy.ExponentialBackoffOptions;
+import com.azure.core.http.policy.RetryOptions;
+import com.azure.identity.DefaultAzureCredentialBuilder;
+import com.azure.storage.common.StorageSharedKeyCredential;
+import com.azure.storage.file.datalake.DataLakeFileSystemClient;
+import com.azure.storage.file.datalake.DataLakeServiceClient;
+import com.azure.storage.file.datalake.DataLakeServiceClientBuilder;
+import okhttp3.ConnectionPool;
+import okhttp3.OkHttpClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.NotThreadSafe;
+import javax.annotation.concurrent.ThreadSafe;
+
+import java.net.URI;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * Handles credential management and connection configuration. The underlying {@link
+ * DataLakeServiceClient} is thread-safe and does not require explicit close.
+ *
+ * <p>This provider manages an {@link OkHttpClient} that owns background threads (connection pool
+ * cleanup and dispatcher executor service). The OkHttpClient uses daemon threads by default, so it
+ * will not prevent JVM shutdown. Since Flink caches FileSystem instances globally (typically one
+ * per scheme+authority), the resource footprint is bounded by {@link
+ * AzureFileSystemOptions#HTTP_MAX_IDLE_CONNECTIONS} and {@link
+ * AzureFileSystemOptions#HTTP_KEEP_ALIVE_DURATION}. Flink's FileSystem base class does not have a
+ * close lifecycle hook, so the OkHttpClient is not explicitly closed.
+ */
+@ThreadSafe
+final class AzureDataLakeClientProvider {
+
+    private static final Logger LOG = LoggerFactory.getLogger(AzureDataLakeClientProvider.class);
+
+    /** Default Azure public cloud DFS endpoint URL format. */
+    static final String DEFAULT_DFS_ENDPOINT_FORMAT = "https://%s.dfs.core.windows.net";
+
+    private final DataLakeServiceClient dataLakeServiceClient;
+
+    private AzureDataLakeClientProvider(final DataLakeServiceClient dataLakeServiceClient) {
+        this.dataLakeServiceClient = checkNotNull(dataLakeServiceClient);
+    }
+
+    /**
+     * Returns the account URL configured on the underlying service client.
+     *
+     * @return the account URL
+     */
+    String getAccountUrl() {
+        return dataLakeServiceClient.getAccountUrl();
+    }
+
+    /**
+     * Returns a synchronous DataLake file system client for the specified file system (container).
+     *
+     * @param fileSystemName the name of the file system (container)
+     * @return the sync DataLake file system client
+     */
+    DataLakeFileSystemClient getFileSystemClient(final String fileSystemName) {
+        return dataLakeServiceClient.getFileSystemClient(fileSystemName);
+    }
+
+    /**
+     * Creates a new builder for configuring an Azure DataLake client provider.
+     *
+     * @return a new builder instance
+     */
+    static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Extracts the storage account name from an ABFSS URI.
+     *
+     * <p>Expected format: {@code abfss://container@account.dfs.core.windows.net/path}
+     *
+     * <p>Only the {@code abfss} (TLS-enabled) scheme is supported. The plain {@code abfs} scheme is
+     * not supported. The storage account must have Hierarchical Namespace (HNS) enabled.
+     *
+     * @param fsUri the filesystem URI with the "abfss" scheme
+     * @return the account name extracted from the URI host (substring before the first dot)
+     * @throws NullPointerException if {@code fsUri} is null
+     * @throws IllegalArgumentException if the scheme is not "abfss", the host is null, or the host
+     *     contains no dot
+     * @see <a
+     *     href="https://learn.microsoft.com/en-us/azure/storage/blobs/data-lake-storage-introduction-abfs-uri">
+     *     Azure Data Lake Storage Gen2 URI scheme</a>
+     */
+    @VisibleForTesting
+    static String extractAccountNameFromUri(final URI fsUri) {
+        checkNotNull(fsUri, "fsUri must not be null");
+        checkArgument(
+                "abfss".equals(fsUri.getScheme()),
+                "Expected abfss scheme, got: %s",
+                fsUri.getScheme());
+        checkArgument(fsUri.getHost() != null, "URI host must not be null: %s", fsUri);
+        final String host = fsUri.getHost();
+        final int dotIndex = host.indexOf('.');
+        checkArgument(dotIndex > 0, "URI host must contain a dot: %s", host);
+        return host.substring(0, dotIndex);
+    }
+
+    /** Builder for creating {@link AzureDataLakeClientProvider} instances. */
+    @NotThreadSafe
+    static final class Builder {
+
+        @Nullable private String accountName;
+        @Nullable private String accountKey;
+
+        private int maxRetries = AzureFileSystemOptions.RETRY_MAX_RETRIES.defaultValue();
+        private Duration baseDelay = AzureFileSystemOptions.RETRY_BASE_DELAY.defaultValue();
+        private Duration maxDelay = AzureFileSystemOptions.RETRY_MAX_DELAY.defaultValue();
+
+        private Duration connectionTimeout =
+                AzureFileSystemOptions.CONNECTION_TIMEOUT.defaultValue();
+        private Duration readTimeout = AzureFileSystemOptions.READ_TIMEOUT.defaultValue();
+
+        private int maxIdleConnections =
+                AzureFileSystemOptions.HTTP_MAX_IDLE_CONNECTIONS.defaultValue();
+        private Duration keepAliveDuration =
+                AzureFileSystemOptions.HTTP_KEEP_ALIVE_DURATION.defaultValue();
+
+        /**
+         * Sets the Azure Storage account name.
+         *
+         * @param accountName the account name
+         * @return this builder
+         * @throws IllegalArgumentException if {@code accountName} is blank
+         */
+        Builder accountName(final String accountName) {
+            this.accountName = requireNonBlankStripped(accountName, "accountName");
+            return this;
+        }
+
+        /**
+         * Sets the Azure Storage account key.
+         *
+         * @param accountKey the account key
+         * @return this builder
+         * @throws IllegalArgumentException if {@code accountKey} is blank
+         */
+        Builder accountKey(final String accountKey) {
+            this.accountKey = requireNonBlankStripped(accountKey, "accountKey");
+            return this;
+        }
+
+        /**
+         * Sets the maximum number of retry attempts for transient failures.
+         *
+         * @param maxRetries the maximum number of retries (0 to disable)
+         * @return this builder
+         * @throws IllegalArgumentException if maxRetries is negative
+         */
+        Builder maxRetries(final int maxRetries) {
+            checkArgument(maxRetries >= 0, "maxRetries must be non-negative, got: %s", maxRetries);
+            this.maxRetries = maxRetries;
+            return this;
+        }
+
+        /**
+         * Sets the base delay for exponential backoff retry strategy.
+         *
+         * @param baseDelay the base delay
+         * @return this builder
+         * @throws IllegalArgumentException if baseDelay is not positive
+         */
+        Builder baseDelay(final Duration baseDelay) {
+            this.baseDelay = requirePositiveDuration(baseDelay, "baseDelay");
+            return this;
+        }
+
+        /**
+         * Sets the maximum delay between retry attempts.
+         *
+         * @param maxDelay the maximum delay
+         * @return this builder
+         * @throws IllegalArgumentException if maxDelay is not positive
+         */
+        Builder maxDelay(final Duration maxDelay) {
+            this.maxDelay = requirePositiveDuration(maxDelay, "maxDelay");
+            return this;
+        }
+
+        /**
+         * Sets the connection timeout for the HTTP client.
+         *
+         * @param connectionTimeout the connection timeout
+         * @return this builder
+         * @throws IllegalArgumentException if connectionTimeout is not positive
+         */
+        Builder connectionTimeout(final Duration connectionTimeout) {
+            this.connectionTimeout =
+                    requirePositiveDuration(connectionTimeout, "connectionTimeout");
+            return this;
+        }
+
+        /**
+         * Sets the read timeout for the HTTP client.
+         *
+         * @param readTimeout the read timeout
+         * @return this builder
+         * @throws IllegalArgumentException if readTimeout is not positive
+         */
+        Builder readTimeout(final Duration readTimeout) {
+            this.readTimeout = requirePositiveDuration(readTimeout, "readTimeout");
+            return this;
+        }
+
+        /**
+         * Sets the maximum number of idle connections in the HTTP connection pool.
+         *
+         * @param maxIdleConnections the maximum number of idle connections
+         * @return this builder
+         * @throws IllegalArgumentException if maxIdleConnections is negative
+         */
+        Builder maxIdleConnections(final int maxIdleConnections) {
+            checkArgument(
+                    maxIdleConnections >= 0,
+                    "maxIdleConnections must be non-negative, got: %s",
+                    maxIdleConnections);
+            this.maxIdleConnections = maxIdleConnections;
+            return this;
+        }
+
+        /**
+         * Sets the keep-alive duration for idle HTTP connections. Connections idle longer than this
+         * are evicted.
+         *
+         * @param keepAliveDuration the keep-alive duration
+         * @return this builder
+         * @throws IllegalArgumentException if keepAliveDuration is not positive
+         */
+        Builder keepAliveDuration(final Duration keepAliveDuration) {
+            this.keepAliveDuration =
+                    requirePositiveDuration(keepAliveDuration, "keepAliveDuration");
+            return this;
+        }
+
+        /**
+         * Builds the Azure DataLake client provider with the configured settings.
+         *
+         * <p>Two authentication modes are supported:
+         *
+         * <ul>
+         *   <li>{@code accountName + accountKey} — SharedKey authentication
+         *   <li>{@code accountName} only — DefaultAzureCredential (auto-detects workload identity,
+         *       managed identity, etc.)
+         * </ul>
+         *
+         * @return a new client provider instance
+         * @throws IllegalArgumentException if no valid credentials are configured
+         */
+        AzureDataLakeClientProvider build() {
+            checkArgument(
+                    baseDelay.compareTo(maxDelay) <= 0,
+                    "baseDelay (%s) must not exceed maxDelay (%s)",
+                    baseDelay,
+                    maxDelay);
+
+            checkArgument(
+                    accountName != null,
+                    "Azure Storage credentials not configured. "
+                            + "Provide account-name + account-key for SharedKey auth, "
+                            + "or account-name alone for DefaultAzureCredential.");
+
+            final ConnectionPool connectionPool =
+                    new ConnectionPool(
+                            maxIdleConnections,
+                            keepAliveDuration.toMillis(),
+                            TimeUnit.MILLISECONDS);
+
+            final OkHttpClient okHttpClient =
+                    new OkHttpClient.Builder().connectionPool(connectionPool).build();
+
+            // Disable overall response timeout (Duration.ZERO = no timeout).
+            //
+            // Why: non-zero values cause OkHttp to allocate a Watchdog AsyncTimeout
+            // per request. Under high request volume this leads to OOM.
+            //
+            // Safety: stalled requests are still terminated by readTimeout (no bytes
+            // received within the deadline) and connectionTimeout (TCP handshake
+            // stalls). The Azure SDK retry policy (maxRetries + exponential backoff)
+            // provides an additional upper bound. The only unprotected scenario is a
+            // "slow drip" where the server sends just enough bytes to reset the
+            // readTimeout indefinitely — this does not occur with Azure Storage.
+            final HttpClient httpClient =
+                    new OkHttpAsyncHttpClientBuilder(okHttpClient)
+                            .connectionTimeout(connectionTimeout)
+                            .readTimeout(readTimeout)
+                            .responseTimeout(Duration.ZERO)
+                            .build();
+
+            final RetryOptions retryOptions =
+                    new RetryOptions(
+                            new ExponentialBackoffOptions()
+                                    .setMaxRetries(maxRetries)
+                                    .setBaseDelay(baseDelay)
+                                    .setMaxDelay(maxDelay));
+
+            LOG.debug(
+                    "Configured HTTP client - retries: {}, baseDelay: {}, maxDelay: {}, "
+                            + "maxIdleConnections: {}, keepAliveDuration: {}",
+                    maxRetries,
+                    baseDelay,
+                    maxDelay,
+                    maxIdleConnections,
+                    keepAliveDuration);
+
+            final DataLakeServiceClient dataLakeClient =
+                    buildDataLakeClient(httpClient, retryOptions);
+
+            LOG.info("Created Azure DataLake client provider - account: {}", accountName);
+
+            return new AzureDataLakeClientProvider(dataLakeClient);
+        }
+
+        private DataLakeServiceClient buildDataLakeClient(
+                final HttpClient httpClient, final RetryOptions retryOptions) {
+            final DataLakeServiceClientBuilder builder =
+                    new DataLakeServiceClientBuilder()
+                            .httpClient(httpClient)
+                            .retryOptions(retryOptions)
+                            .endpoint(String.format(DEFAULT_DFS_ENDPOINT_FORMAT, accountName));
+
+            if (accountKey != null) {
+                final StorageSharedKeyCredential credential =
+                        new StorageSharedKeyCredential(accountName, accountKey);
+                builder.credential(credential);
+            } else {
+                LOG.info(
+                        "No account key provided, using DefaultAzureCredential "
+                                + "(auto-detects workload identity, managed identity, etc.)");
+                builder.credential(new DefaultAzureCredentialBuilder().build());
+            }
+
+            return builder.buildClient();
+        }
+    }
+
+    /**
+     * Validates that a Duration value is non-null and positive (greater than zero).
+     *
+     * @param value the value to validate
+     * @param name the parameter name for error messages
+     * @return the validated duration
+     * @throws NullPointerException if {@code value} is null
+     * @throws IllegalArgumentException if {@code value} is zero or negative
+     */
+    private static Duration requirePositiveDuration(final Duration value, final String name) {
+        checkNotNull(value, "%s must not be null", name);
+        checkArgument(
+                !value.isNegative() && !value.isZero(),
+                "%s must be positive, got: %s",
+                name,
+                value);
+        return value;
+    }
+
+    private static String requireNonBlankStripped(final String value, final String name) {
+        checkArgument(!StringUtils.isNullOrWhitespaceOnly(value), "%s must not be blank", name);
+        return value.strip();
+    }
+}

--- a/flink-filesystems/flink-azure-fs-native/src/main/java/org/apache/flink/fs/azurefs/AzureDataLakeFileStatus.java
+++ b/flink-filesystems/flink-azure-fs-native/src/main/java/org/apache/flink/fs/azurefs/AzureDataLakeFileStatus.java
@@ -1,0 +1,163 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.fs.azurefs;
+
+import org.apache.flink.core.fs.FileStatus;
+import org.apache.flink.core.fs.Path;
+
+import javax.annotation.concurrent.Immutable;
+
+import java.util.Objects;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * File status implementation for Azure Data Lake Storage Gen2.
+ *
+ * <p>Use the factory methods {@link #forDirectory(Path, long)} and {@link #forFile(Path, long,
+ * long, long)} to create instances.
+ */
+@Immutable
+final class AzureDataLakeFileStatus implements FileStatus {
+
+    /**
+     * Azure Data Lake Storage does not track access time. This constant is used as the default
+     * until access-time support is added.
+     */
+    private static final long DEFAULT_ACCESS_TIME = 0L;
+
+    private final long length;
+    private final long blockSize;
+    private final long modificationTime;
+    private final boolean isDir;
+    private final Path path;
+
+    private AzureDataLakeFileStatus(
+            final Path path,
+            final long length,
+            final long blockSize,
+            final long modificationTime,
+            final boolean isDir) {
+        checkNotNull(path, "path must not be null");
+        checkArgument(length >= 0, "length must be non-negative, got %s", length);
+        checkArgument(blockSize >= 0, "blockSize must be non-negative, got %s", blockSize);
+        checkArgument(
+                modificationTime >= 0,
+                "modificationTime must be non-negative, got %s",
+                modificationTime);
+        this.path = path;
+        this.length = length;
+        this.blockSize = blockSize;
+        this.modificationTime = modificationTime;
+        this.isDir = isDir;
+    }
+
+    /**
+     * Creates a file status for a directory.
+     *
+     * <p>Directories have zero length and zero block size.
+     *
+     * @param path the directory path
+     * @param modificationTime the last-modified timestamp in milliseconds since epoch
+     * @return the file status
+     */
+    static AzureDataLakeFileStatus forDirectory(final Path path, final long modificationTime) {
+        return new AzureDataLakeFileStatus(path, 0L, 0L, modificationTime, true);
+    }
+
+    /**
+     * Creates a file status for a regular file.
+     *
+     * @param path the file path
+     * @param size the file size in bytes (must be non-negative)
+     * @param blockSize the block size in bytes (must be non-negative)
+     * @param modificationTime the last-modified timestamp in milliseconds since epoch
+     * @return the file status
+     */
+    static AzureDataLakeFileStatus forFile(
+            final Path path, final long size, final long blockSize, final long modificationTime) {
+        return new AzureDataLakeFileStatus(path, size, blockSize, modificationTime, false);
+    }
+
+    @Override
+    public long getLen() {
+        return length;
+    }
+
+    @Override
+    public long getBlockSize() {
+        return blockSize;
+    }
+
+    /** Azure Data Lake Storage manages replication internally, so this always returns 1. */
+    @Override
+    public short getReplication() {
+        return 1;
+    }
+
+    @Override
+    public long getModificationTime() {
+        return modificationTime;
+    }
+
+    @Override
+    public long getAccessTime() {
+        return DEFAULT_ACCESS_TIME;
+    }
+
+    @Override
+    public boolean isDir() {
+        return isDir;
+    }
+
+    @Override
+    public Path getPath() {
+        return path;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof AzureDataLakeFileStatus)) {
+            return false;
+        }
+        final AzureDataLakeFileStatus that = (AzureDataLakeFileStatus) o;
+        return length == that.length
+                && modificationTime == that.modificationTime
+                && isDir == that.isDir
+                && blockSize == that.blockSize
+                && Objects.equals(path, that.path);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(path, length, blockSize, modificationTime, isDir);
+    }
+
+    @Override
+    public String toString() {
+        return String.format(
+                "AzureDataLakeFileStatus{path=%s, length=%d, blockSize=%d, isDir=%b,"
+                        + " modTime=%d, accessTime=%d}",
+                path, length, blockSize, isDir, modificationTime, DEFAULT_ACCESS_TIME);
+    }
+}

--- a/flink-filesystems/flink-azure-fs-native/src/main/java/org/apache/flink/fs/azurefs/AzureDataLakeFileSystem.java
+++ b/flink-filesystems/flink-azure-fs-native/src/main/java/org/apache/flink/fs/azurefs/AzureDataLakeFileSystem.java
@@ -1,0 +1,687 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.fs.azurefs;
+
+import org.apache.flink.core.fs.BlockLocation;
+import org.apache.flink.core.fs.FSDataInputStream;
+import org.apache.flink.core.fs.FSDataOutputStream;
+import org.apache.flink.core.fs.FileStatus;
+import org.apache.flink.core.fs.FileSystem;
+import org.apache.flink.core.fs.InputStreamExtension;
+import org.apache.flink.core.fs.InputStreamOpener;
+import org.apache.flink.core.fs.ObjectStorageInputStream;
+import org.apache.flink.core.fs.ObjectStorageOutputStream;
+import org.apache.flink.core.fs.OutputStreamOpener;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.core.fs.RecoverableWriter;
+import org.apache.flink.core.fs.WriteContext;
+import org.apache.flink.core.fs.local.LocalBlockLocation;
+import org.apache.flink.fs.cse.CseStreamFactory;
+import org.apache.flink.fs.cse.EncryptedReadContext;
+import org.apache.flink.fs.cse.EncryptedWriteContext;
+
+import com.azure.storage.file.datalake.models.DataLakeStorageException;
+import com.azure.storage.file.datalake.models.ListPathsOptions;
+import com.azure.storage.file.datalake.models.PathItem;
+import com.azure.storage.file.datalake.models.PathProperties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.ThreadSafe;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * Native Azure DataLake FileSystem implementation using Azure Storage File DataLake SDK v12.
+ *
+ * <p>This implementation uses the DataLake (ADLS Gen2) API which provides native hierarchical
+ * namespace support. Directory detection uses {@link PathProperties#isDirectory()}.
+ *
+ * <p>This class is thread-safe. The FileSystem instance can be shared across multiple threads.
+ * Input streams returned by {@link #open} are thread-safe. Output streams returned by {@link
+ * #create} are thread-safe — all public methods are guarded by a {@link
+ * java.util.concurrent.locks.ReentrantLock}.
+ */
+@ThreadSafe
+class AzureDataLakeFileSystem extends FileSystem {
+
+    private static final Logger LOG = LoggerFactory.getLogger(AzureDataLakeFileSystem.class);
+
+    private static final int BYTES_PER_KB = 1024;
+    private static final int HTTP_NOT_FOUND = 404;
+    private static final int HTTP_CONFLICT = 409;
+    private static final int HTTP_PRECONDITION_FAILED = 412;
+
+    /**
+     * Azure SDK's default read chunk size (4 MB). Each HTTP GET fetches this many bytes into the
+     * SDK's internal buffer. Forward seeks within this distance consume already-fetched data;
+     * beyond it, reopening the stream at the target position is cheaper.
+     */
+    static final int SDK_READ_CHUNK_SIZE = 4 * 1024 * 1024;
+
+    private final DataLakeStorageOperations fsClient;
+    private final URI uri;
+    private final String fileSystemName;
+    private final int readBufferSize;
+    private final long writeRequestSize;
+    @Nullable private final CseStreamFactory cseFactory;
+    private final boolean encryptWrites;
+
+    private AzureDataLakeFileSystem(
+            final DataLakeStorageOperations fsClient,
+            final URI uri,
+            final int readBufferSize,
+            final long writeRequestSize,
+            @Nullable final CseStreamFactory cseFactory,
+            final boolean encryptWrites) {
+        this.fsClient = fsClient;
+        this.uri = uri;
+        this.fileSystemName = getFileSystemNameFromUri(uri);
+        this.readBufferSize = readBufferSize;
+        this.writeRequestSize = writeRequestSize;
+        this.cseFactory = cseFactory;
+        this.encryptWrites = encryptWrites;
+
+        LOG.info(
+                "Created Azure DataLake FileSystem for fileSystem: {}, read buffer: {} KB, "
+                        + "write request size: {} KB",
+                fileSystemName,
+                readBufferSize / BYTES_PER_KB,
+                writeRequestSize / BYTES_PER_KB);
+    }
+
+    /**
+     * Creates a builder for {@link AzureDataLakeFileSystem}.
+     *
+     * @param fsClient the abstraction over Azure DataLake storage operations
+     * @param uri the base URI for this filesystem
+     * @return a new builder
+     */
+    static Builder builder(final DataLakeStorageOperations fsClient, final URI uri) {
+        return new Builder(fsClient, uri);
+    }
+
+    /** Builder for {@link AzureDataLakeFileSystem}. */
+    static final class Builder {
+        private final DataLakeStorageOperations fsClient;
+        private final URI uri;
+        private int readBufferSize;
+        private long writeRequestSize;
+        @Nullable private CseStreamFactory cseFactory;
+        private boolean encryptWrites;
+
+        private Builder(final DataLakeStorageOperations fsClient, final URI uri) {
+            this.fsClient = checkNotNull(fsClient, "fsClient");
+            this.uri = checkNotNull(uri, "uri");
+        }
+
+        Builder readBufferSize(final int readBufferSize) {
+            this.readBufferSize = readBufferSize;
+            return this;
+        }
+
+        Builder writeRequestSize(final long writeRequestSize) {
+            this.writeRequestSize = writeRequestSize;
+            return this;
+        }
+
+        Builder cseFactory(@Nullable final CseStreamFactory cseFactory) {
+            this.cseFactory = cseFactory;
+            return this;
+        }
+
+        Builder encryptWrites(final boolean encryptWrites) {
+            this.encryptWrites = encryptWrites;
+            return this;
+        }
+
+        AzureDataLakeFileSystem build() {
+            checkArgument(readBufferSize > 0, "readBufferSize must be > 0");
+            checkArgument(writeRequestSize > 0, "writeRequestSize must be > 0");
+            checkArgument(
+                    !encryptWrites || cseFactory != null,
+                    "encryptWrites requires a CseStreamFactory");
+            return new AzureDataLakeFileSystem(
+                    fsClient, uri, readBufferSize, writeRequestSize, cseFactory, encryptWrites);
+        }
+    }
+
+    /**
+     * Extracts the container name from an abfss:// URI. The expected format is: {@code
+     * abfss://container@account.dfs.core.windows.net/path}. The container name is in the userInfo
+     * part (before @).
+     *
+     * @param uri Azure blob storage path URI
+     * @return Container name extracted from URI
+     * @throws IllegalArgumentException if the URI does not contain a container name in the userInfo
+     */
+    static String getFileSystemNameFromUri(final URI uri) {
+        checkArgument(
+                uri.getUserInfo() != null,
+                "URI must contain a container name in the userInfo part "
+                        + "(e.g., abfss://container@account.dfs.core.windows.net). Got: %s",
+                uri);
+        return uri.getUserInfo();
+    }
+
+    /**
+     * Returns the URI that identifies this filesystem.
+     *
+     * @return the filesystem URI (e.g., abfss://container@account.dfs.core.windows.net)
+     */
+    @Override
+    public URI getUri() {
+        return uri;
+    }
+
+    /**
+     * Returns the current working directory for this filesystem.
+     *
+     * @return the base path of this filesystem
+     */
+    @Override
+    public Path getWorkingDirectory() {
+        return new Path(uri);
+    }
+
+    /**
+     * Returns the home directory for this filesystem.
+     *
+     * @return the base path of this filesystem
+     */
+    @Override
+    public Path getHomeDirectory() {
+        return new Path(uri);
+    }
+
+    /**
+     * Returns the status of a file or directory at the given path.
+     *
+     * <p>Uses DataLake API's native directory detection via {@link PathProperties#isDirectory()}.
+     *
+     * @param path the path to check
+     * @return the file status containing metadata about the file or directory
+     * @throws FileNotFoundException if the path does not exist
+     * @throws IOException if an Azure storage error occurs
+     */
+    @Override
+    public FileStatus getFileStatus(final Path path) throws IOException {
+        final String filePath = toRelativePathString(path);
+
+        LOG.debug("Getting file status for {}://{}/{}", uri.getScheme(), fileSystemName, filePath);
+
+        // Handle root path
+        if (filePath.isEmpty()) {
+            return AzureDataLakeFileStatus.forDirectory(path, 0L);
+        }
+
+        try {
+            final PathProperties properties = fsClient.getFileClient(filePath).getProperties();
+            final long modificationTime =
+                    ensureLastModifiedMillis(properties.getLastModified(), path.toString());
+
+            if (Boolean.TRUE.equals(properties.isDirectory())) {
+                return AzureDataLakeFileStatus.forDirectory(path, modificationTime);
+            }
+
+            final long size = properties.getFileSize();
+
+            LOG.trace(
+                    "File properties for {} - size: {}, lastModified: {}",
+                    filePath,
+                    size,
+                    modificationTime);
+
+            return AzureDataLakeFileStatus.forFile(path, size, size, modificationTime);
+        } catch (DataLakeStorageException e) {
+            if (e.getStatusCode() == HTTP_NOT_FOUND) {
+                // With ADLS Gen2 (HNS enabled), directories are real objects.
+                // If getProperties() returns 404, the path doesn't exist.
+                throw new FileNotFoundException("File not found: " + path);
+            }
+            throw new IOException("Failed to get file status: " + path, e);
+        }
+    }
+
+    /**
+     * Returns the block locations for a file.
+     *
+     * @param file the file status to get block locations for
+     * @param start the starting offset (ignored for Azure)
+     * @param len the length of the region (ignored for Azure)
+     * @return an array containing a single block location covering the entire file
+     */
+    @Override
+    public BlockLocation[] getFileBlockLocations(
+            final FileStatus file, final long start, final long len) {
+        return new BlockLocation[] {new LocalBlockLocation(file.getLen())};
+    }
+
+    /**
+     * Opens a file for reading with the specified buffer size.
+     *
+     * <p>If a {@link CseStreamFactory} is configured and the blob's metadata indicates it is
+     * encrypted, returns a decrypting stream. Otherwise, returns a plain stream.
+     *
+     * @param path the path of the file to open
+     * @param bufferSize the buffer size in bytes for read operations
+     * @return an input stream for reading the file
+     * @throws FileNotFoundException if the file does not exist
+     * @throws IOException if an Azure storage error occurs
+     */
+    @Override
+    public FSDataInputStream open(final Path path, final int bufferSize) throws IOException {
+        final String filePath = toRelativePathString(path);
+
+        try {
+            final PathProperties properties = fsClient.getFileClient(filePath).getProperties();
+
+            if (Boolean.TRUE.equals(properties.isDirectory())) {
+                throw new IOException("Cannot open directory as file: " + path);
+            }
+
+            final InputStreamOpener opener =
+                    AzureInputStreamFactory.createOpener(fsClient, filePath, SDK_READ_CHUNK_SIZE);
+            final long fileSize = properties.getFileSize();
+
+            if (cseFactory != null) {
+                final Map<String, String> blobMetadata = properties.getMetadata();
+                if (blobMetadata != null && cseFactory.isEncrypted(blobMetadata)) {
+                    return cseFactory.openEncryptedRead(
+                            opener,
+                            EncryptedReadContext.of(blobMetadata, filePath, fileSize, bufferSize));
+                }
+            }
+
+            return new ObjectStorageInputStream(
+                    fileSize,
+                    SDK_READ_CHUNK_SIZE, // skipOnSeekThreshold
+                    InputStreamExtension.buffering(opener, bufferSize));
+        } catch (DataLakeStorageException e) {
+            if (e.getStatusCode() == HTTP_NOT_FOUND) {
+                throw new FileNotFoundException("File not found: " + path);
+            }
+            throw new IOException("Failed to open file: " + path, e);
+        }
+    }
+
+    /**
+     * Opens a file for reading using the default buffer size.
+     *
+     * @param path the path of the file to open
+     * @return an input stream for reading the file
+     * @throws FileNotFoundException if the file does not exist
+     * @throws IOException if an Azure storage error occurs
+     */
+    @Override
+    public FSDataInputStream open(final Path path) throws IOException {
+        return open(path, readBufferSize);
+    }
+
+    /**
+     * Lists the contents of a directory.
+     *
+     * <p>Uses DataLake API's native directory support for accurate directory detection.
+     *
+     * <p>Per Flink's {@link FileSystem} contract (see {@code LocalFileSystem}): if the path refers
+     * to a regular file, returns a single-element array with its status.
+     *
+     * @param path the directory path to list
+     * @return an array of file status objects for each item in the directory
+     * @throws FileNotFoundException if the path does not exist
+     * @throws IOException if an Azure storage error occurs
+     */
+    @Override
+    public FileStatus[] listStatus(final Path path) throws IOException {
+        final String dirPath = toRelativePathString(path);
+
+        // Per Flink FileSystem contract (see LocalFileSystem): if the path is a regular
+        // file, return a single-element array with its status rather than throwing
+        if (!dirPath.isEmpty()) {
+            try {
+                final PathProperties properties = fsClient.getFileClient(dirPath).getProperties();
+                if (!Boolean.TRUE.equals(properties.isDirectory())) {
+                    final long modTime =
+                            ensureLastModifiedMillis(properties.getLastModified(), path.toString());
+                    final long size = properties.getFileSize();
+                    return new FileStatus[] {
+                        AzureDataLakeFileStatus.forFile(path, size, size, modTime)
+                    };
+                }
+            } catch (DataLakeStorageException e) {
+                if (e.getStatusCode() == HTTP_NOT_FOUND) {
+                    throw new FileNotFoundException("Path not found: " + path);
+                }
+                throw new IOException("Failed to get path properties: " + path, e);
+            }
+        }
+
+        final List<FileStatus> results = new ArrayList<>();
+        final ListPathsOptions options = new ListPathsOptions();
+        // Empty dirPath means root — omitting setPath lists the root directory
+        if (!dirPath.isEmpty()) {
+            options.setPath(dirPath);
+        }
+        // Non-recursive: Flink's listStatus contract lists only immediate children
+        options.setRecursive(false);
+
+        try {
+            for (final PathItem item : fsClient.listPaths(options, null)) {
+                final Path itemPath = AzurePathUtils.buildDataLakePath(uri, item);
+                final long modTime =
+                        ensureLastModifiedMillis(item.getLastModified(), item.getName());
+
+                if (item.isDirectory()) {
+                    results.add(AzureDataLakeFileStatus.forDirectory(itemPath, modTime));
+                } else {
+                    final long size = item.getContentLength();
+                    results.add(AzureDataLakeFileStatus.forFile(itemPath, size, size, modTime));
+                }
+            }
+        } catch (DataLakeStorageException e) {
+            if (e.getStatusCode() == HTTP_NOT_FOUND) {
+                throw new FileNotFoundException("Directory not found: " + path);
+            }
+            throw new IOException("Failed to list directory: " + path, e);
+        }
+
+        // Empty result is valid: directory exists but contains no items
+        return results.toArray(new FileStatus[0]);
+    }
+
+    /**
+     * Deletes a file or directory at the given path.
+     *
+     * @param path the path to delete
+     * @param recursive if true, recursively delete all contents of a directory
+     * @return {@code true} if the deletion was successful, {@code false} if the path did not exist
+     * @throws IOException if an error occurs
+     */
+    @Override
+    public boolean delete(final Path path, final boolean recursive) throws IOException {
+        final String filePath = toRelativePathString(path);
+
+        if (filePath.isEmpty()) {
+            throw new IOException("Cannot delete root directory");
+        }
+
+        try {
+            final PathProperties properties = fsClient.getFileClient(filePath).getProperties();
+
+            if (Boolean.TRUE.equals(properties.isDirectory())) {
+                final DataLakeStorageOperations.DirectoryClient dirClient =
+                        fsClient.getDirectoryClient(filePath);
+                if (recursive) {
+                    dirClient.deleteRecursively();
+                } else {
+                    try {
+                        dirClient.delete();
+                    } catch (DataLakeStorageException e) {
+                        if (e.getStatusCode() == HTTP_CONFLICT) {
+                            throw new IOException(
+                                    "Directory is not empty: "
+                                            + path
+                                            + ". Use recursive=true to delete non-empty directories.",
+                                    e);
+                        }
+                        throw e;
+                    }
+                }
+            } else {
+                fsClient.getFileClient(filePath).delete();
+            }
+            return true;
+        } catch (DataLakeStorageException e) {
+            if (e.getStatusCode() == HTTP_NOT_FOUND) {
+                return false;
+            }
+            throw new IOException("Failed to delete: " + path, e);
+        }
+    }
+
+    /**
+     * Creates all directories in the given path.
+     *
+     * @param path the directory path to create
+     * @return {@code true} if the directory was created successfully
+     * @throws IOException if an error occurs
+     */
+    @Override
+    public boolean mkdirs(final Path path) throws IOException {
+        final String dirPath = toRelativePathString(path);
+
+        // Root directory always exists in ADLS Gen2
+        if (dirPath.isEmpty()) {
+            return true;
+        }
+
+        try {
+            fsClient.getDirectoryClient(dirPath).createIfNotExists();
+            checkNotExistingFile(dirPath, path);
+            return true;
+        } catch (DataLakeStorageException e) {
+            throw new IOException("Failed to create directory: " + path, e);
+        }
+    }
+
+    /**
+     * Creates a new file at the given path for writing.
+     *
+     * <p>For {@link WriteMode#OVERWRITE}, the SDK's {@code getOutputStream()} natively overwrites
+     * existing files — no pre-delete is needed.
+     *
+     * <p>For {@link WriteMode#NO_OVERWRITE}, the server-side conditional write ({@code
+     * If-None-Match: *}) guarantees atomic rejection when the file already exists — no client-side
+     * TOCTOU window.
+     *
+     * <p>If {@link CseStreamFactory} is configured and {@code writeKeyId} is set, writes are
+     * encrypted. When {@code writeKeyId} is absent (read-only decryption mode), writes are
+     * plaintext.
+     *
+     * @param path the path of the file to create
+     * @param overwriteMode determines behavior if the file already exists
+     * @return an output stream for writing the file content
+     * @throws IOException if the file already exists (NO_OVERWRITE), the path is a directory, or
+     *     another error occurs
+     */
+    @Override
+    public FSDataOutputStream create(final Path path, final WriteMode overwriteMode)
+            throws IOException {
+        final String filePath = toRelativePathString(path);
+
+        try {
+            final OutputStreamOpener sdkOpener =
+                    AzureOutputStreamFactory.createOpener(
+                            fsClient, filePath, writeRequestSize, overwriteMode);
+            final OutputStream delegate;
+            if (encryptWrites) {
+                delegate =
+                        cseFactory.openEncryptedWrite(
+                                sdkOpener, EncryptedWriteContext.of(filePath));
+            } else {
+                delegate = sdkOpener.open(WriteContext.EMPTY_WRITE_CONTEXT);
+            }
+            return new ObjectStorageOutputStream(delegate, filePath);
+        } catch (DataLakeStorageException e) {
+            if (overwriteMode == WriteMode.NO_OVERWRITE
+                    && (e.getStatusCode() == HTTP_CONFLICT
+                            || e.getStatusCode() == HTTP_PRECONDITION_FAILED)) {
+                throw new IOException("File already exists: " + path, e);
+            }
+            throw new IOException("Failed to create file: " + path, e);
+        }
+    }
+
+    /**
+     * Renames (moves) a file or directory from source to destination path.
+     *
+     * <p>Follows Hadoop semantics: if the destination is an existing directory, the source is moved
+     * <em>into</em> that directory (i.e., {@code rename(src, dst)} becomes {@code rename(src,
+     * dst/src.getName())}). This matches the behavior of the Hadoop-based ABFS implementation that
+     * this filesystem replaces.
+     *
+     * <p>The destination parent directory is created if it does not exist, matching Hadoop {@code
+     * FileSystem} behavior.
+     *
+     * <p>For directories, ADLS Gen2 performs an atomic metadata-level rename that moves the entire
+     * directory tree — no per-file copying is needed.
+     *
+     * @param src the source path
+     * @param dst the destination path
+     * @return {@code true} if the rename was successful, {@code false} if the source does not exist
+     * @throws IOException if an error occurs
+     */
+    @Override
+    public boolean rename(final Path src, final Path dst) throws IOException {
+        final String srcPath = toRelativePathString(src);
+        String dstPath = toRelativePathString(dst);
+
+        if (srcPath.isEmpty() || dstPath.isEmpty()) {
+            throw new IOException("Cannot rename root directory");
+        }
+
+        try {
+            // If dst exists, check its type (Hadoop semantics):
+            // - directory → move src INTO dst
+            // - file → return false (refuse to overwrite)
+            try {
+                final PathProperties dstProperties =
+                        fsClient.getFileClient(dstPath).getProperties();
+                if (Boolean.TRUE.equals(dstProperties.isDirectory())) {
+                    dstPath = dstPath + "/" + src.getName();
+                } else {
+                    return false;
+                }
+            } catch (DataLakeStorageException e) {
+                if (e.getStatusCode() != HTTP_NOT_FOUND) {
+                    throw e;
+                }
+                // dst does not exist — proceed with rename as-is
+            }
+
+            // Ensure destination parent directory exists
+            final int lastSlash = dstPath.lastIndexOf('/');
+            if (lastSlash > 0) {
+                final String parentPath = dstPath.substring(0, lastSlash);
+                fsClient.getDirectoryClient(parentPath).createIfNotExists();
+            }
+
+            final DataLakeStorageOperations.FileClient fileClient = fsClient.getFileClient(srcPath);
+            final PathProperties properties = fileClient.getProperties();
+
+            if (Boolean.TRUE.equals(properties.isDirectory())) {
+                fsClient.getDirectoryClient(srcPath).rename(fileSystemName, dstPath);
+            } else {
+                fileClient.rename(fileSystemName, dstPath);
+            }
+            return true;
+        } catch (DataLakeStorageException e) {
+            if (e.getStatusCode() == HTTP_NOT_FOUND) {
+                return false;
+            }
+            throw new IOException("Failed to rename " + src + " to " + dst, e);
+        }
+    }
+
+    /**
+     * Returns whether this filesystem is a distributed filesystem.
+     *
+     * @return always {@code true}
+     */
+    @Override
+    public boolean isDistributedFS() {
+        return true;
+    }
+
+    /**
+     * Recoverable writer is not supported in this iteration of the native Azure FS.
+     *
+     * <p>Checkpoint metadata writes fall back to {@code FSDataOutputStreamWrapper} which uses plain
+     * {@code create()} + {@code close()}.
+     *
+     * @throws UnsupportedOperationException always
+     */
+    @Override
+    public RecoverableWriter createRecoverableWriter() {
+        throw new UnsupportedOperationException(
+                "Recoverable writer is not supported by the native Azure filesystem. "
+                        + "Checkpoint metadata uses the atomic create()+close() fallback.");
+    }
+
+    /**
+     * Converts a Flink {@link Path} to a relative path string suitable for Azure SDK calls,
+     * stripping the leading slash if present.
+     *
+     * @param path the Flink Path
+     * @return the relative path string without leading slash
+     */
+    static String toRelativePathString(final Path path) {
+        final String pathStr = path.toUri().getPath();
+        if (pathStr.startsWith("/")) {
+            return pathStr.substring(1);
+        }
+        return pathStr;
+    }
+
+    /**
+     * Checks that the target path is not an existing file. ADLS Gen2 with HNS guarantees that
+     * ancestors of an existing path are directories, so only the target itself needs checking.
+     */
+    private void checkNotExistingFile(final String dirPath, final Path path) throws IOException {
+        try {
+            final PathProperties props = fsClient.getFileClient(dirPath).getProperties();
+            if (!Boolean.TRUE.equals(props.isDirectory())) {
+                throw new IOException("Cannot create directory — path exists as a file: " + path);
+            }
+        } catch (DataLakeStorageException e) {
+            if (e.getStatusCode() == HTTP_NOT_FOUND) {
+                return;
+            }
+            throw new IOException("Failed to check path: " + path, e);
+        }
+    }
+
+    /**
+     * Extracts modification time in milliseconds from an Azure timestamp.
+     *
+     * @param lastModified the timestamp from Azure SDK
+     * @param pathIdentifier identifier for the path (used in error messages)
+     * @return the modification time in epoch milliseconds
+     * @throws IOException if the timestamp is null
+     */
+    private static long ensureLastModifiedMillis(
+            @Nullable final java.time.OffsetDateTime lastModified, final String pathIdentifier)
+            throws IOException {
+        if (lastModified == null) {
+            throw new IOException(
+                    "Azure Storage returned null modification time for path: " + pathIdentifier);
+        }
+        return lastModified.toInstant().toEpochMilli();
+    }
+}

--- a/flink-filesystems/flink-azure-fs-native/src/main/java/org/apache/flink/fs/azurefs/AzureFileSystemOptions.java
+++ b/flink-filesystems/flink-azure-fs-native/src/main/java/org/apache/flink/fs/azurefs/AzureFileSystemOptions.java
@@ -1,0 +1,149 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.fs.azurefs;
+
+import org.apache.flink.annotation.Experimental;
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.ConfigOptions;
+import org.apache.flink.configuration.MemorySize;
+
+import javax.annotation.concurrent.Immutable;
+
+import java.time.Duration;
+
+/**
+ * Configuration options for the native Azure Data Lake Storage Gen2 filesystem.
+ *
+ * <p>This is the single source of truth for all config keys and defaults used by both {@link
+ * AbfssFileSystemFactory} and {@link AzureDataLakeClientProvider}.
+ */
+@Experimental
+@Immutable
+public final class AzureFileSystemOptions {
+
+    private AzureFileSystemOptions() {}
+
+    // -------------------------------------------------------------------------
+    // Core credentials
+    // -------------------------------------------------------------------------
+
+    /** Azure Storage account key for SharedKey authentication. */
+    public static final ConfigOption<String> ACCOUNT_KEY =
+            ConfigOptions.key("fs.azure.account-key")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("Azure Storage account key");
+
+    // -------------------------------------------------------------------------
+    // Retry policy
+    // -------------------------------------------------------------------------
+
+    /** Maximum number of retry attempts for transient failures. */
+    public static final ConfigOption<Integer> RETRY_MAX_RETRIES =
+            ConfigOptions.key("fs.azure.retry.max-retries")
+                    .intType()
+                    .defaultValue(4)
+                    .withDescription(
+                            "Maximum number of retry attempts for transient failures. "
+                                    + "Set to 0 to disable retries.");
+
+    /** Base delay for exponential backoff retry strategy. */
+    public static final ConfigOption<Duration> RETRY_BASE_DELAY =
+            ConfigOptions.key("fs.azure.retry.base-delay")
+                    .durationType()
+                    .defaultValue(Duration.ofMillis(100))
+                    .withDescription("Base delay for exponential backoff retry strategy.");
+
+    /** Maximum delay between retry attempts. */
+    public static final ConfigOption<Duration> RETRY_MAX_DELAY =
+            ConfigOptions.key("fs.azure.retry.max-delay")
+                    .durationType()
+                    .defaultValue(Duration.ofSeconds(20))
+                    .withDescription("Maximum delay between retry attempts.");
+
+    // -------------------------------------------------------------------------
+    // HTTP timeouts
+    // -------------------------------------------------------------------------
+
+    /** Connection timeout for Azure HTTP client. */
+    public static final ConfigOption<Duration> CONNECTION_TIMEOUT =
+            ConfigOptions.key("fs.azure.http.connection-timeout")
+                    .durationType()
+                    .defaultValue(Duration.ofSeconds(60))
+                    .withDescription("Connection timeout for Azure HTTP client.");
+
+    /** Read timeout for Azure HTTP client. */
+    public static final ConfigOption<Duration> READ_TIMEOUT =
+            ConfigOptions.key("fs.azure.http.read-timeout")
+                    .durationType()
+                    .defaultValue(Duration.ofSeconds(60))
+                    .withDescription("Read timeout for Azure HTTP client.");
+
+    /** Maximum number of idle connections in the HTTP connection pool. */
+    public static final ConfigOption<Integer> HTTP_MAX_IDLE_CONNECTIONS =
+            ConfigOptions.key("fs.azure.http.max-idle-connections")
+                    .intType()
+                    .defaultValue(5)
+                    .withDescription(
+                            "Maximum number of idle connections in the HTTP connection pool.");
+
+    /** Keep-alive duration for idle HTTP connections. */
+    public static final ConfigOption<Duration> HTTP_KEEP_ALIVE_DURATION =
+            ConfigOptions.key("fs.azure.http.keep-alive-duration")
+                    .durationType()
+                    .defaultValue(Duration.ofSeconds(30))
+                    .withDescription(
+                            "Keep-alive duration for idle HTTP connections. "
+                                    + "Connections idle longer than this are evicted.");
+
+    // -------------------------------------------------------------------------
+    // Write / upload
+    // -------------------------------------------------------------------------
+
+    /**
+     * Size of each write request (block size). Controls both the block size for multi-block uploads
+     * and the maximum single-upload threshold. Files larger than this are uploaded in blocks.
+     */
+    public static final ConfigOption<MemorySize> WRITE_REQUEST_SIZE =
+            ConfigOptions.key("fs.azure.write.request-size")
+                    .memoryType()
+                    .defaultValue(MemorySize.ofMebiBytes(8))
+                    .withDescription(
+                            "Block size for uploads. Also sets the single-upload threshold: "
+                                    + "files larger than this are uploaded in blocks.");
+
+    // -------------------------------------------------------------------------
+    // Read
+    // -------------------------------------------------------------------------
+
+    /**
+     * Read buffer size for input streams.
+     *
+     * <p>Controls how much data is fetched per HTTP GET range request. Smaller buffers increase
+     * round trips; larger buffers waste bandwidth on small or random reads. The default (256 KB)
+     * balances latency and throughput for typical checkpoint/state file access patterns. This is
+     * independent of {@link #WRITE_REQUEST_SIZE} which uses larger blocks (default 8 MB) to
+     * amortize HTTP overhead on sequential uploads.
+     */
+    public static final ConfigOption<MemorySize> READ_BUFFER_SIZE =
+            ConfigOptions.key("fs.azure.read.buffer-size")
+                    .memoryType()
+                    .defaultValue(new MemorySize(256 * 1024L))
+                    .withDescription("Read buffer size for input streams.");
+}

--- a/flink-filesystems/flink-azure-fs-native/src/main/java/org/apache/flink/fs/azurefs/AzureInputStreamFactory.java
+++ b/flink-filesystems/flink-azure-fs-native/src/main/java/org/apache/flink/fs/azurefs/AzureInputStreamFactory.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.fs.azurefs;
+
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.core.fs.InputStreamOpener;
+import org.apache.flink.util.Preconditions;
+
+import com.azure.storage.file.datalake.models.FileRange;
+import com.azure.storage.file.datalake.options.DataLakeFileInputStreamOptions;
+
+import javax.annotation.concurrent.Immutable;
+
+/** Factory for {@link InputStreamOpener} and related Azure SDK stream configuration. */
+@Immutable
+final class AzureInputStreamFactory {
+
+    private AzureInputStreamFactory() {}
+
+    /**
+     * Creates an {@link InputStreamOpener} that opens range requests on the given file.
+     *
+     * <p>SDK exceptions from the returned opener include the Azure request URL (which contains
+     * {@code filePath}), hence no additional path wrapping.
+     *
+     * @param fsClient the DataLake storage operations abstraction
+     * @param filePath relative path of the file within the file system
+     * @param blockSize SDK read chunk size in bytes
+     * @return an opener that captures {@code fsClient}, {@code filePath} and {@code blockSize} in
+     *     its closure
+     */
+    static InputStreamOpener createOpener(
+            final DataLakeStorageOperations fsClient, final String filePath, final int blockSize) {
+        Preconditions.checkNotNull(fsClient, "fsClient");
+        Preconditions.checkNotNull(filePath, "filePath");
+        Preconditions.checkArgument(blockSize > 0, "blockSize must be positive");
+        return ctx -> {
+            final DataLakeFileInputStreamOptions options =
+                    buildInputStreamOptions(ctx.getPos(), blockSize);
+            return fsClient.getFileClient(filePath).openInputStream(options);
+        };
+    }
+
+    /**
+     * Builds {@link DataLakeFileInputStreamOptions} for a range request starting at {@code
+     * position}.
+     *
+     * @param position byte offset to start reading from; non-positive values omit the range header
+     * @param blockSize SDK read chunk size in bytes
+     * @return configured options
+     */
+    @VisibleForTesting
+    static DataLakeFileInputStreamOptions buildInputStreamOptions(
+            final long position, final int blockSize) {
+        final DataLakeFileInputStreamOptions options = new DataLakeFileInputStreamOptions();
+        options.setBlockSize(blockSize);
+        if (position > 0) {
+            options.setRange(new FileRange(position));
+        }
+        return options;
+    }
+}

--- a/flink-filesystems/flink-azure-fs-native/src/main/java/org/apache/flink/fs/azurefs/AzureOutputStreamFactory.java
+++ b/flink-filesystems/flink-azure-fs-native/src/main/java/org/apache/flink/fs/azurefs/AzureOutputStreamFactory.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.fs.azurefs;
+
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.core.fs.FileSystem.WriteMode;
+import org.apache.flink.core.fs.OutputStreamOpener;
+import org.apache.flink.util.Preconditions;
+
+import com.azure.storage.blob.models.ParallelTransferOptions;
+import com.azure.storage.file.datalake.models.DataLakeRequestConditions;
+import com.azure.storage.file.datalake.models.PathHttpHeaders;
+import com.azure.storage.file.datalake.options.DataLakeFileOutputStreamOptions;
+
+import javax.annotation.concurrent.Immutable;
+
+import java.util.Map;
+
+/** Factory for {@link OutputStreamOpener} and related Azure SDK stream configuration. */
+@Immutable
+final class AzureOutputStreamFactory {
+
+    private static final String CONTENT_TYPE_OCTET_STREAM = "application/octet-stream";
+
+    private AzureOutputStreamFactory() {}
+
+    /**
+     * Creates an {@link OutputStreamOpener} that opens an SDK output stream on the given file.
+     *
+     * <p>The returned opener captures {@code fsClient}, {@code filePath}, {@code writeRequestSize}
+     * and {@code writeMode} in its closure. When invoked, it attaches any metadata from the {@link
+     * org.apache.flink.core.fs.WriteContext} to the Azure blob options before opening the stream.
+     *
+     * @param fsClient the DataLake storage operations abstraction
+     * @param filePath relative path of the file within the file system
+     * @param writeRequestSize the block size and single-upload threshold in bytes
+     * @param writeMode the write mode
+     * @return an opener that creates an SDK output stream for the specified file
+     */
+    static OutputStreamOpener createOpener(
+            final DataLakeStorageOperations fsClient,
+            final String filePath,
+            final long writeRequestSize,
+            final WriteMode writeMode) {
+        Preconditions.checkNotNull(fsClient, "fsClient");
+        Preconditions.checkNotNull(filePath, "filePath");
+        Preconditions.checkArgument(writeRequestSize > 0, "writeRequestSize must be positive");
+        Preconditions.checkNotNull(writeMode, "writeMode");
+        return ctx -> {
+            final DataLakeFileOutputStreamOptions options =
+                    buildOutputStreamOptions(writeRequestSize, writeMode, ctx.getMetadata());
+            return fsClient.getFileClient(filePath).getOutputStream(options);
+        };
+    }
+
+    /**
+     * Builds SDK output stream options for the given write request size, write mode, and metadata.
+     *
+     * @param writeRequestSize the block size and single-upload threshold in bytes
+     * @param writeMode the write mode
+     * @param metadata metadata to attach to the blob (e.g., encryption headers); may be empty
+     * @return configured output stream options
+     */
+    @VisibleForTesting
+    static DataLakeFileOutputStreamOptions buildOutputStreamOptions(
+            final long writeRequestSize,
+            final WriteMode writeMode,
+            final Map<String, String> metadata) {
+        final DataLakeFileOutputStreamOptions options = new DataLakeFileOutputStreamOptions();
+        options.setHeaders(new PathHttpHeaders().setContentType(CONTENT_TYPE_OCTET_STREAM));
+        options.setParallelTransferOptions(
+                new ParallelTransferOptions()
+                        .setBlockSizeLong(writeRequestSize)
+                        .setMaxSingleUploadSizeLong(writeRequestSize));
+        if (writeMode == WriteMode.NO_OVERWRITE) {
+            options.setRequestConditions(new DataLakeRequestConditions().setIfNoneMatch("*"));
+        }
+        if (metadata != null && !metadata.isEmpty()) {
+            options.setMetadata(metadata);
+        }
+        return options;
+    }
+}

--- a/flink-filesystems/flink-azure-fs-native/src/main/java/org/apache/flink/fs/azurefs/AzurePathUtils.java
+++ b/flink-filesystems/flink-azure-fs-native/src/main/java/org/apache/flink/fs/azurefs/AzurePathUtils.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.fs.azurefs;
+
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.util.Preconditions;
+
+import com.azure.storage.file.datalake.models.PathItem;
+
+import java.net.URI;
+
+/** Utility methods for constructing Flink {@link Path} instances from DataLake SDK objects. */
+final class AzurePathUtils {
+
+    private AzurePathUtils() {}
+
+    /**
+     * Constructs a Flink {@link Path} from a DataLake {@link PathItem}.
+     *
+     * <p>The resulting path uses the scheme and authority from {@code filesystemUri} (e.g. {@code
+     * abfss://container@account.dfs.core.windows.net}) combined with the item name from the
+     * DataLake listing. The item name is stripped of leading and trailing whitespace and may be
+     * specified with or without a leading slash; this method normalizes it by ensuring a single
+     * leading slash before constructing the path.
+     *
+     * @param filesystemUri the base filesystem URI providing scheme and authority
+     * @param pathItem the DataLake path item whose name becomes the path component
+     * @return the fully qualified Flink path
+     */
+    static Path buildDataLakePath(final URI filesystemUri, final PathItem pathItem) {
+        Preconditions.checkNotNull(filesystemUri, "filesystemUri must not be null");
+        Preconditions.checkNotNull(pathItem, "pathItem must not be null");
+        final String name = pathItem.getName().strip();
+        final String absolutePath = name.startsWith("/") ? name : "/" + name;
+        return new Path(filesystemUri.getScheme(), filesystemUri.getAuthority(), absolutePath);
+    }
+}

--- a/flink-filesystems/flink-azure-fs-native/src/main/java/org/apache/flink/fs/azurefs/DataLakeStorageOperations.java
+++ b/flink-filesystems/flink-azure-fs-native/src/main/java/org/apache/flink/fs/azurefs/DataLakeStorageOperations.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.fs.azurefs;
+
+import com.azure.storage.file.datalake.models.DataLakeStorageException;
+import com.azure.storage.file.datalake.models.ListPathsOptions;
+import com.azure.storage.file.datalake.models.PathItem;
+import com.azure.storage.file.datalake.models.PathProperties;
+import com.azure.storage.file.datalake.options.DataLakeFileInputStreamOptions;
+import com.azure.storage.file.datalake.options.DataLakeFileOutputStreamOptions;
+
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.ThreadSafe;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.time.Duration;
+
+/**
+ * Abstraction over Azure DataLake storage operations for testability.
+ *
+ * <p>Mirrors the Azure SDK's client structure: {@code getFileClient(path).xxx()} and {@code
+ * getDirectoryClient(path).xxx()}.
+ *
+ * <p>Implementations should be thread-safe — {@link AzureDataLakeFileSystem} shares a single
+ * instance across threads.
+ */
+@ThreadSafe
+interface DataLakeStorageOperations {
+
+    /** Client for file operations on a specific path. */
+    interface FileClient {
+        /** Returns the properties (size, modification time, metadata) of the file. */
+        PathProperties getProperties() throws DataLakeStorageException;
+
+        /** Deletes the file. */
+        void delete() throws DataLakeStorageException;
+
+        /**
+         * Renames the file to a new path within the given file system.
+         *
+         * @param fileSystem the destination file system (container) name
+         * @param destinationPath the new path for the file
+         */
+        void rename(String fileSystem, String destinationPath) throws DataLakeStorageException;
+
+        /**
+         * Opens an output stream for writing to the file.
+         *
+         * @param options stream options (block size, request conditions, metadata)
+         * @return an output stream for writing
+         */
+        OutputStream getOutputStream(DataLakeFileOutputStreamOptions options)
+                throws DataLakeStorageException;
+
+        /**
+         * Opens an input stream for reading from the file.
+         *
+         * @param options stream options (range, block size)
+         * @return an input stream for reading
+         */
+        InputStream openInputStream(DataLakeFileInputStreamOptions options)
+                throws DataLakeStorageException;
+    }
+
+    /** Client for directory operations on a specific path. */
+    interface DirectoryClient {
+        /** Deletes the directory if it is empty. */
+        void delete() throws DataLakeStorageException;
+
+        /** Deletes the directory and all its contents recursively. */
+        void deleteRecursively() throws DataLakeStorageException;
+
+        /** Creates the directory if it does not already exist. */
+        void createIfNotExists() throws DataLakeStorageException;
+
+        /**
+         * Renames the directory to a new path within the given file system.
+         *
+         * @param fileSystem the destination file system (container) name
+         * @param destinationPath the new path for the directory
+         */
+        void rename(String fileSystem, String destinationPath) throws DataLakeStorageException;
+    }
+
+    /** Returns a client for file operations on the specified path. */
+    FileClient getFileClient(String path);
+
+    /** Returns a client for directory operations on the specified path. */
+    DirectoryClient getDirectoryClient(String path);
+
+    /**
+     * Lists paths under the specified options.
+     *
+     * <p>The returned iterable may throw {@link DataLakeStorageException} during iteration (e.g.,
+     * on network errors during pagination).
+     *
+     * @param options listing options (path, recursive flag)
+     * @param timeout optional timeout for the operation
+     * @return an iterable of path items matching the listing criteria
+     */
+    Iterable<PathItem> listPaths(ListPathsOptions options, @Nullable Duration timeout)
+            throws DataLakeStorageException;
+}

--- a/flink-filesystems/flink-azure-fs-native/src/main/java/org/apache/flink/fs/azurefs/DataLakeStorageOperationsImpl.java
+++ b/flink-filesystems/flink-azure-fs-native/src/main/java/org/apache/flink/fs/azurefs/DataLakeStorageOperationsImpl.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.fs.azurefs;
+
+import com.azure.storage.file.datalake.DataLakeDirectoryClient;
+import com.azure.storage.file.datalake.DataLakeFileClient;
+import com.azure.storage.file.datalake.DataLakeFileSystemClient;
+import com.azure.storage.file.datalake.models.DataLakeStorageException;
+import com.azure.storage.file.datalake.models.ListPathsOptions;
+import com.azure.storage.file.datalake.models.PathItem;
+import com.azure.storage.file.datalake.models.PathProperties;
+import com.azure.storage.file.datalake.options.DataLakeFileInputStreamOptions;
+import com.azure.storage.file.datalake.options.DataLakeFileOutputStreamOptions;
+
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.ThreadSafe;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.time.Duration;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * Production implementation of {@link DataLakeStorageOperations} backed by Azure SDK's {@link
+ * DataLakeFileSystemClient}.
+ */
+@ThreadSafe
+final class DataLakeStorageOperationsImpl implements DataLakeStorageOperations {
+
+    private final DataLakeFileSystemClient fsClient;
+
+    DataLakeStorageOperationsImpl(final DataLakeFileSystemClient fsClient) {
+        this.fsClient = checkNotNull(fsClient, "fsClient");
+    }
+
+    @Override
+    public FileClient getFileClient(final String path) {
+        final DataLakeFileClient fileClient = fsClient.getFileClient(path);
+        return new FileClient() {
+            @Override
+            public PathProperties getProperties() throws DataLakeStorageException {
+                return fileClient.getProperties();
+            }
+
+            @Override
+            public void delete() throws DataLakeStorageException {
+                fileClient.delete();
+            }
+
+            @Override
+            public void rename(final String fileSystem, final String destinationPath)
+                    throws DataLakeStorageException {
+                fileClient.rename(fileSystem, destinationPath);
+            }
+
+            @Override
+            public OutputStream getOutputStream(final DataLakeFileOutputStreamOptions options)
+                    throws DataLakeStorageException {
+                return fileClient.getOutputStream(options);
+            }
+
+            @Override
+            public InputStream openInputStream(final DataLakeFileInputStreamOptions options)
+                    throws DataLakeStorageException {
+                return fileClient.openInputStream(options).getInputStream();
+            }
+        };
+    }
+
+    @Override
+    public DirectoryClient getDirectoryClient(final String path) {
+        final DataLakeDirectoryClient directoryClient = fsClient.getDirectoryClient(path);
+        return new DirectoryClient() {
+            @Override
+            public void delete() throws DataLakeStorageException {
+                directoryClient.delete();
+            }
+
+            @Override
+            public void deleteRecursively() throws DataLakeStorageException {
+                directoryClient.deleteRecursively();
+            }
+
+            @Override
+            public void createIfNotExists() throws DataLakeStorageException {
+                directoryClient.createIfNotExists();
+            }
+
+            @Override
+            public void rename(final String fileSystem, final String destinationPath)
+                    throws DataLakeStorageException {
+                directoryClient.rename(fileSystem, destinationPath);
+            }
+        };
+    }
+
+    @Override
+    public Iterable<PathItem> listPaths(
+            final ListPathsOptions options, @Nullable final Duration timeout)
+            throws DataLakeStorageException {
+        return fsClient.listPaths(options, timeout);
+    }
+}

--- a/flink-filesystems/flink-azure-fs-native/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-azure-fs-native/src/main/resources/META-INF/NOTICE
@@ -24,7 +24,7 @@ This project bundles the following dependencies under the Apache Software Licens
 
 - com.fasterxml.jackson.core:jackson-core:2.21.3
 - com.fasterxml.jackson.core:jackson-databind:2.21.3
-- com.fasterxml.jackson.core:jackson-annotations:2.21.3
+- com.fasterxml.jackson.core:jackson-annotations:2.21
 - com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.21.3
 - com.github.stephenc.jcip:jcip-annotations:1.0-1
 - com.nimbusds:content-type:2.3

--- a/flink-filesystems/flink-azure-fs-native/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-azure-fs-native/src/main/resources/META-INF/NOTICE
@@ -1,0 +1,44 @@
+flink-azure-fs-native
+Copyright 2014-2026 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+This project bundles the following dependencies under the MIT License.
+See bundled license files for details.
+
+- com.azure:azure-storage-blob:12.29.1
+- com.azure:azure-storage-file-datalake:12.22.0
+- com.azure:azure-identity:1.14.2
+- com.azure:azure-core:1.55.2
+- com.azure:azure-core-http-okhttp:1.12.5
+- com.azure:azure-storage-common:12.28.1
+- com.azure:azure-storage-internal-avro:12.14.1
+- com.azure:azure-json:1.3.0
+- com.azure:azure-xml:1.2.0
+- com.microsoft.azure:msal4j:1.17.2
+- io.projectreactor:reactor-core:3.5.20
+- org.reactivestreams:reactive-streams:1.0.4
+
+This project bundles the following dependencies under the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+- com.fasterxml.jackson.core:jackson-core:2.21.3
+- com.fasterxml.jackson.core:jackson-databind:2.21.3
+- com.fasterxml.jackson.core:jackson-annotations:2.21.3
+- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.21.3
+- com.github.stephenc.jcip:jcip-annotations:1.0-1
+- com.nimbusds:content-type:2.3
+- com.nimbusds:lang-tag:1.7
+- com.nimbusds:nimbus-jose-jwt:9.40
+- com.nimbusds:oauth2-oidc-sdk:11.18
+- com.squareup.okhttp3:okhttp:4.12.0
+- com.squareup.okio:okio:3.9.1
+- com.squareup.okio:okio-jvm:3.9.1
+- net.minidev:accessors-smart:2.5.0
+- net.minidev:json-smart:2.5.0
+- org.jetbrains.kotlin:kotlin-stdlib:1.9.25
+
+This project bundles the following dependencies under the BSD 3-Clause License.
+
+- org.ow2.asm:asm:9.3
+

--- a/flink-filesystems/flink-azure-fs-native/src/main/resources/META-INF/services/org.apache.flink.core.fs.FileSystemFactory
+++ b/flink-filesystems/flink-azure-fs-native/src/main/resources/META-INF/services/org.apache.flink.core.fs.FileSystemFactory
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+org.apache.flink.fs.azurefs.AbfssFileSystemFactory

--- a/flink-filesystems/flink-azure-fs-native/src/test/java/org/apache/flink/fs/azurefs/AbfssFileSystemFactoryTest.java
+++ b/flink-filesystems/flink-azure-fs-native/src/test/java/org/apache/flink/fs/azurefs/AbfssFileSystemFactoryTest.java
@@ -1,0 +1,167 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.fs.azurefs;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.MemorySize;
+import org.apache.flink.fs.cse.CseOptions;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+import java.net.URI;
+import java.time.Duration;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Tests for {@link AbfssFileSystemFactory}. */
+class AbfssFileSystemFactoryTest {
+
+    private static final String FAKE_ACCOUNT_KEY = "dGVzdGtleWZvcmF6dXJlc3RvcmFnZWFjY291bnQ=";
+    private static final URI TEST_URI =
+            URI.create("abfss://container@myaccount.dfs.core.windows.net/");
+
+    private AbfssFileSystemFactory factory;
+
+    @BeforeEach
+    void setUp() {
+        factory = new AbfssFileSystemFactory();
+    }
+
+    @Test
+    void shouldReturnAbfssScheme() {
+        assertThat(factory.getScheme()).isEqualTo("abfss");
+    }
+
+    @Test
+    void shouldReturnNegativePriority() {
+        assertThat(factory.getPriority()).isEqualTo(-1);
+    }
+
+    /** Verifies factory wiring, not actual Azure connectivity (SDK defers authentication). */
+    @ParameterizedTest
+    @MethodSource("validConfigurations")
+    void shouldCreateFileSystemWithValidConfiguration(@Nullable final Configuration config)
+            throws Exception {
+        if (config != null) {
+            factory.configure(config);
+        }
+        final AzureDataLakeFileSystem fs = (AzureDataLakeFileSystem) factory.create(TEST_URI);
+        assertThat(fs).isNotNull();
+        assertThat(fs.getUri()).isEqualTo(TEST_URI);
+    }
+
+    private static Stream<Arguments> validConfigurations() {
+        final Configuration sharedKeyAuth = new Configuration();
+        sharedKeyAuth.set(AzureFileSystemOptions.ACCOUNT_KEY, FAKE_ACCOUNT_KEY);
+
+        final Configuration defaultAzureCredential = new Configuration();
+        // No account key — should use DefaultAzureCredential
+
+        final Configuration customRetry = new Configuration();
+        customRetry.set(AzureFileSystemOptions.ACCOUNT_KEY, FAKE_ACCOUNT_KEY);
+        customRetry.set(AzureFileSystemOptions.RETRY_MAX_RETRIES, 10);
+        customRetry.set(AzureFileSystemOptions.RETRY_BASE_DELAY, Duration.ofMillis(200));
+        customRetry.set(AzureFileSystemOptions.RETRY_MAX_DELAY, Duration.ofSeconds(30));
+
+        final Configuration customHttpTimeouts = new Configuration();
+        customHttpTimeouts.set(AzureFileSystemOptions.ACCOUNT_KEY, FAKE_ACCOUNT_KEY);
+        customHttpTimeouts.set(AzureFileSystemOptions.CONNECTION_TIMEOUT, Duration.ofSeconds(120));
+        customHttpTimeouts.set(AzureFileSystemOptions.READ_TIMEOUT, Duration.ofSeconds(120));
+
+        final Configuration customReadBuffer = new Configuration();
+        customReadBuffer.set(AzureFileSystemOptions.ACCOUNT_KEY, FAKE_ACCOUNT_KEY);
+        customReadBuffer.set(AzureFileSystemOptions.READ_BUFFER_SIZE, new MemorySize(512 * 1024));
+
+        return Stream.of(
+                Arguments.of(sharedKeyAuth), // shared key auth
+                Arguments.of(defaultAzureCredential), // default Azure credential
+                Arguments.of((Configuration) null), // unconfigured defaults
+                Arguments.of(customRetry), // custom retry settings
+                Arguments.of(customHttpTimeouts), // custom HTTP timeouts
+                Arguments.of(customReadBuffer)); // custom read buffer size
+    }
+
+    @Test
+    void shouldThrowWhenReadBufferSizeIsZero() {
+        final Configuration config = new Configuration();
+        config.set(AzureFileSystemOptions.READ_BUFFER_SIZE, new MemorySize(0));
+
+        factory.configure(config);
+
+        assertThatThrownBy(() -> factory.create(TEST_URI))
+                .isInstanceOf(IOException.class)
+                .hasMessageContaining("Read buffer size must be positive");
+    }
+
+    @Test
+    void shouldThrowWhenWriteRequestSizeIsZero() {
+        final Configuration config = new Configuration();
+        config.set(AzureFileSystemOptions.WRITE_REQUEST_SIZE, new MemorySize(0));
+
+        factory.configure(config);
+
+        assertThatThrownBy(() -> factory.create(TEST_URI))
+                .isInstanceOf(IOException.class)
+                .hasMessageContaining("Write request size must be positive");
+    }
+
+    @Test
+    void shouldThrowWhenKeyIdSetWithoutKeyProviderFactoryClass() {
+        final Configuration config = new Configuration();
+        config.setString(CseOptions.WRITE_KEY_ID.key(), "test-key-id");
+        factory.configure(config);
+
+        assertThatThrownBy(() -> factory.create(TEST_URI))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining(CseOptions.WRITE_KEY_ID.key())
+                .hasMessageContaining(CseOptions.KEY_PROVIDER_FACTORY_CLASS.key());
+    }
+
+    /** Verifies that an invalid key-provider-factory-class yields an {@link IOException}. */
+    @ParameterizedTest
+    @MethodSource("invalidFactoryClasses")
+    void shouldThrowWhenKeyProviderFactoryClassInvalid(final String factoryClass) {
+        final Configuration config = new Configuration();
+        config.setString(CseOptions.KEY_PROVIDER_FACTORY_CLASS.key(), factoryClass);
+        config.setString(CseOptions.WRITE_KEY_ID.key(), "test-key");
+        factory.configure(config);
+
+        assertThatThrownBy(() -> factory.create(TEST_URI))
+                .isInstanceOf(IOException.class)
+                .hasMessageContaining("Failed to instantiate KeyProviderFactory class")
+                .hasMessageContaining(factoryClass);
+    }
+
+    private static Stream<Arguments> invalidFactoryClasses() {
+        return Stream.of(
+                // class not on classpath
+                Arguments.of("com.example.NonExistent"),
+                // class exists but is not a KeyProviderFactory
+                Arguments.of("java.lang.String"));
+    }
+}

--- a/flink-filesystems/flink-azure-fs-native/src/test/java/org/apache/flink/fs/azurefs/AzureDataLakeClientProviderTest.java
+++ b/flink-filesystems/flink-azure-fs-native/src/test/java/org/apache/flink/fs/azurefs/AzureDataLakeClientProviderTest.java
@@ -1,0 +1,230 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.fs.azurefs;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.net.URI;
+import java.time.Duration;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Tests for {@link AzureDataLakeClientProvider}. */
+class AzureDataLakeClientProviderTest {
+
+    private static final String FAKE_ACCOUNT = "myaccount";
+    private static final String EXPECTED_ACCOUNT_URL =
+            "https://" + FAKE_ACCOUNT + ".dfs.core.windows.net";
+    // Base64-encoded fake key (Azure SDK requires valid base64 for SharedKey)
+    private static final String FAKE_KEY = "dGVzdGtleWZvcmF6dXJlc3RvcmFnZWFjY291bnQ=";
+
+    // --- Account name extraction from URI ---
+
+    static Stream<Arguments> validAbfssUris() {
+        return Stream.of(
+                Arguments.of(
+                        "abfss://container@mystorageaccount.dfs.core.windows.net/path",
+                        "mystorageaccount",
+                        "ABFSS URI (Azure Data Lake Gen2)"),
+                Arguments.of(
+                        "abfss://container@govaccount.dfs.core.usgovcloudapi.net/path",
+                        "govaccount",
+                        "Azure Government cloud"),
+                Arguments.of(
+                        "abfss://container@chinaaccount.dfs.core.chinacloudapi.cn/path",
+                        "chinaaccount",
+                        "Azure China cloud"));
+    }
+
+    @ParameterizedTest(name = "{2}")
+    @MethodSource("validAbfssUris")
+    void shouldExtractAccountNameFromUri(
+            final String uriString, final String expectedAccount, final String description)
+            throws Exception {
+        final URI uri = new URI(uriString);
+        final String accountName = AzureDataLakeClientProvider.extractAccountNameFromUri(uri);
+        assertThat(accountName).isEqualTo(expectedAccount);
+    }
+
+    @Test
+    void shouldThrowForNullUri() {
+        assertThatThrownBy(() -> AzureDataLakeClientProvider.extractAccountNameFromUri(null))
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void shouldThrowForHttpsScheme() throws Exception {
+        final URI uri = new URI("https://devaccount.blob.core.windows.net/container/blob.txt");
+        assertThatThrownBy(() -> AzureDataLakeClientProvider.extractAccountNameFromUri(uri))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Expected abfss scheme");
+    }
+
+    @Test
+    void shouldThrowForUriWithoutHost() throws Exception {
+        final URI uri = new URI("abfss:///path/to/file");
+        assertThatThrownBy(() -> AzureDataLakeClientProvider.extractAccountNameFromUri(uri))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("host must not be null");
+    }
+
+    @Test
+    void shouldThrowForHostWithoutDots() throws Exception {
+        final URI uri = new URI("abfss://container@storageaccount/path");
+        assertThatThrownBy(() -> AzureDataLakeClientProvider.extractAccountNameFromUri(uri))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("must contain a dot");
+    }
+
+    // --- Validation / negative tests ---
+
+    @Test
+    void shouldThrowWhenNoCredentialsConfigured() {
+        assertThatThrownBy(() -> AzureDataLakeClientProvider.builder().build())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("credentials not configured");
+    }
+
+    // --- Successful construction tests ---
+
+    @Test
+    void shouldBuildWithSharedKey() {
+        final AzureDataLakeClientProvider provider =
+                AzureDataLakeClientProvider.builder()
+                        .accountName(FAKE_ACCOUNT)
+                        .accountKey(FAKE_KEY)
+                        .build();
+
+        assertThat(provider.getAccountUrl()).isEqualTo(EXPECTED_ACCOUNT_URL);
+    }
+
+    @Test
+    void shouldBuildWithDefaultCredentialWhenOnlyAccountName() {
+        final AzureDataLakeClientProvider provider =
+                AzureDataLakeClientProvider.builder().accountName(FAKE_ACCOUNT).build();
+
+        assertThat(provider.getAccountUrl()).isEqualTo(EXPECTED_ACCOUNT_URL);
+    }
+
+    // --- getFileSystemClient tests ---
+
+    @Test
+    void shouldReturnFileSystemClientForValidContainer() {
+        final AzureDataLakeClientProvider provider =
+                AzureDataLakeClientProvider.builder()
+                        .accountName(FAKE_ACCOUNT)
+                        .accountKey(FAKE_KEY)
+                        .build();
+
+        assertThat(provider.getFileSystemClient("mycontainer").getFileSystemName())
+                .isEqualTo("mycontainer");
+    }
+
+    // --- Retry configuration tests ---
+
+    @Test
+    void shouldRejectNegativeMaxRetries() {
+        assertThatThrownBy(() -> AzureDataLakeClientProvider.builder().maxRetries(-1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("non-negative");
+    }
+
+    @Test
+    void shouldRejectNonPositiveBaseDelay() {
+        assertThatThrownBy(() -> AzureDataLakeClientProvider.builder().baseDelay(Duration.ZERO))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("positive");
+    }
+
+    @Test
+    void shouldRejectNonPositiveMaxDelay() {
+        assertThatThrownBy(() -> AzureDataLakeClientProvider.builder().maxDelay(Duration.ZERO))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("positive");
+    }
+
+    @Test
+    void shouldRejectBaseDelayExceedingMaxDelay() {
+        assertThatThrownBy(
+                        () ->
+                                AzureDataLakeClientProvider.builder()
+                                        .accountName(FAKE_ACCOUNT)
+                                        .accountKey(FAKE_KEY)
+                                        .baseDelay(Duration.ofSeconds(5))
+                                        .maxDelay(Duration.ofSeconds(1))
+                                        .build())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("baseDelay")
+                .hasMessageContaining("must not exceed")
+                .hasMessageContaining("maxDelay");
+    }
+
+    // --- Timeout configuration tests ---
+
+    @Test
+    void shouldRejectNonPositiveConnectionTimeout() {
+        assertThatThrownBy(
+                        () ->
+                                AzureDataLakeClientProvider.builder()
+                                        .connectionTimeout(Duration.ZERO))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("positive");
+    }
+
+    @Test
+    void shouldRejectNonPositiveReadTimeout() {
+        assertThatThrownBy(() -> AzureDataLakeClientProvider.builder().readTimeout(Duration.ZERO))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("positive");
+    }
+
+    // --- HTTP connection pool configuration tests ---
+
+    @Test
+    void shouldRejectNegativeMaxIdleConnections() {
+        assertThatThrownBy(() -> AzureDataLakeClientProvider.builder().maxIdleConnections(-1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("non-negative");
+    }
+
+    @Test
+    void shouldRejectNonPositiveKeepAliveDuration() {
+        assertThatThrownBy(
+                        () ->
+                                AzureDataLakeClientProvider.builder()
+                                        .keepAliveDuration(Duration.ZERO))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("positive");
+    }
+
+    @Test
+    void shouldRejectNegativeKeepAliveDuration() {
+        assertThatThrownBy(
+                        () ->
+                                AzureDataLakeClientProvider.builder()
+                                        .keepAliveDuration(Duration.ofSeconds(-1)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("positive");
+    }
+}

--- a/flink-filesystems/flink-azure-fs-native/src/test/java/org/apache/flink/fs/azurefs/AzureDataLakeFileStatusTest.java
+++ b/flink-filesystems/flink-azure-fs-native/src/test/java/org/apache/flink/fs/azurefs/AzureDataLakeFileStatusTest.java
@@ -1,0 +1,177 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.fs.azurefs;
+
+import org.apache.flink.core.fs.Path;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Tests for {@link AzureDataLakeFileStatus}. */
+class AzureDataLakeFileStatusTest {
+
+    private static final Path TEST_DIR_PATH =
+            new Path("abfss://container@account.dfs.core.windows.net/dir");
+    private static final Path TEST_FILE_PATH =
+            new Path("abfss://container@account.dfs.core.windows.net/dir/file.txt");
+    private static final Path TEST_ROOT_FILE_PATH =
+            new Path("abfss://container@account.dfs.core.windows.net/root.txt");
+
+    @Test
+    void forDirectorySetsExpectedValues() {
+        final AzureDataLakeFileStatus status =
+                AzureDataLakeFileStatus.forDirectory(TEST_DIR_PATH, 1700000000000L);
+
+        assertThat(status.isDir()).isTrue();
+        assertThat(status.getPath()).isEqualTo(TEST_DIR_PATH);
+        assertThat(status.getLen()).isZero();
+        assertThat(status.getBlockSize()).isZero();
+        assertThat(status.getModificationTime()).isEqualTo(1700000000000L);
+        assertThat(status.getAccessTime()).isZero();
+    }
+
+    static Stream<Arguments> fileCases() {
+        return Stream.of(
+                Arguments.of(TEST_FILE_PATH, 1024L, 256L, 1700000000000L),
+                Arguments.of(TEST_ROOT_FILE_PATH, 0L, 0L, 0L));
+    }
+
+    @ParameterizedTest
+    @MethodSource("fileCases")
+    void forFileSetsExpectedValues(
+            final Path path, final long size, final long blockSize, final long modTime) {
+        final AzureDataLakeFileStatus status =
+                AzureDataLakeFileStatus.forFile(path, size, blockSize, modTime);
+
+        assertThat(status.isDir()).isFalse();
+        assertThat(status.getPath()).isEqualTo(path);
+        assertThat(status.getLen()).isEqualTo(size);
+        assertThat(status.getBlockSize()).isEqualTo(blockSize);
+        assertThat(status.getModificationTime()).isEqualTo(modTime);
+        assertThat(status.getAccessTime()).isZero();
+    }
+
+    @Test
+    void forDirectoryWithNullPathThrows() {
+        assertThatThrownBy(() -> AzureDataLakeFileStatus.forDirectory(null, 0L))
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void forFileWithNullPathThrows() {
+        assertThatThrownBy(() -> AzureDataLakeFileStatus.forFile(null, 0L, 0L, 0L))
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    @ParameterizedTest
+    @MethodSource("negativeValueCases")
+    void shouldRejectNegativeValues(final Runnable action) {
+        assertThatThrownBy(action::run).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    private static Stream<Arguments> negativeValueCases() {
+        return Stream.of(
+                // negative file size
+                Arguments.of(
+                        (Runnable)
+                                () -> AzureDataLakeFileStatus.forFile(TEST_FILE_PATH, -1L, 0L, 0L)),
+                // negative block size
+                Arguments.of(
+                        (Runnable)
+                                () -> AzureDataLakeFileStatus.forFile(TEST_FILE_PATH, 0L, -1L, 0L)),
+                // negative file modification time
+                Arguments.of(
+                        (Runnable)
+                                () -> AzureDataLakeFileStatus.forFile(TEST_FILE_PATH, 0L, 0L, -1L)),
+                // negative directory modification time
+                Arguments.of(
+                        (Runnable) () -> AzureDataLakeFileStatus.forDirectory(TEST_DIR_PATH, -1L)));
+    }
+
+    @Test
+    void replicationAlwaysReturnsOne() {
+        final AzureDataLakeFileStatus dir = AzureDataLakeFileStatus.forDirectory(TEST_DIR_PATH, 0L);
+        final AzureDataLakeFileStatus file =
+                AzureDataLakeFileStatus.forFile(TEST_FILE_PATH, 100L, 64L, 0L);
+
+        assertThat(dir.getReplication()).isEqualTo((short) 1);
+        assertThat(file.getReplication()).isEqualTo((short) 1);
+    }
+
+    @Test
+    void toStringContainsAllFields() {
+        final AzureDataLakeFileStatus status =
+                AzureDataLakeFileStatus.forFile(TEST_FILE_PATH, 1024L, 256L, 99L);
+
+        assertThat(status.toString())
+                .contains("path=" + TEST_FILE_PATH)
+                .contains("length=1024")
+                .contains("blockSize=256")
+                .contains("isDir=false")
+                .contains("modTime=99")
+                .contains("accessTime=0");
+    }
+
+    @Test
+    void equalObjectsHaveEqualHashCodes() {
+        final AzureDataLakeFileStatus a =
+                AzureDataLakeFileStatus.forFile(TEST_FILE_PATH, 1024L, 256L, 100L);
+        final AzureDataLakeFileStatus b =
+                AzureDataLakeFileStatus.forFile(TEST_FILE_PATH, 1024L, 256L, 100L);
+
+        assertThat(a).isEqualTo(b);
+        assertThat(a.hashCode()).isEqualTo(b.hashCode());
+    }
+
+    @Test
+    void differentLengthIsNotEqual() {
+        final AzureDataLakeFileStatus a =
+                AzureDataLakeFileStatus.forFile(TEST_FILE_PATH, 1024L, 256L, 100L);
+        final AzureDataLakeFileStatus b =
+                AzureDataLakeFileStatus.forFile(TEST_FILE_PATH, 2048L, 256L, 100L);
+
+        assertThat(a).isNotEqualTo(b);
+    }
+
+    @Test
+    void fileAndDirectoryAreNotEqual() {
+        final AzureDataLakeFileStatus file =
+                AzureDataLakeFileStatus.forFile(TEST_DIR_PATH, 0L, 0L, 100L);
+        final AzureDataLakeFileStatus dir =
+                AzureDataLakeFileStatus.forDirectory(TEST_DIR_PATH, 100L);
+
+        assertThat(file).isNotEqualTo(dir);
+    }
+
+    @Test
+    void notEqualToNullOrDifferentType() {
+        final AzureDataLakeFileStatus status =
+                AzureDataLakeFileStatus.forFile(TEST_FILE_PATH, 1024L, 256L, 100L);
+
+        assertThat(status).isNotEqualTo(null);
+        assertThat(status).isNotEqualTo("not a file status");
+    }
+}

--- a/flink-filesystems/flink-azure-fs-native/src/test/java/org/apache/flink/fs/azurefs/AzureDataLakeFileSystemCseTest.java
+++ b/flink-filesystems/flink-azure-fs-native/src/test/java/org/apache/flink/fs/azurefs/AzureDataLakeFileSystemCseTest.java
@@ -1,0 +1,178 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.flink.fs.azurefs;
+
+import org.apache.flink.core.fs.FSDataInputStream;
+import org.apache.flink.core.fs.FSDataOutputStream;
+import org.apache.flink.core.fs.FileSystem.WriteMode;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.fs.cse.TestingKeyProvider;
+import org.apache.flink.fs.cse.aes.gcm.AesGcmCseStreamFactory;
+import org.apache.flink.util.function.BiConsumerWithException;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import javax.annotation.Nullable;
+
+import java.net.URI;
+import java.time.OffsetDateTime;
+import java.util.Map;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Round-trip CSE integration tests for {@link AzureDataLakeFileSystem}.
+ *
+ * <p>Verifies that the FS layer correctly routes writes through {@link
+ * AesGcmCseStreamFactory#openEncryptedWrite}, detects encrypted blobs via {@link
+ * AesGcmCseStreamFactory#isEncrypted}, and routes reads through {@link
+ * AesGcmCseStreamFactory#openEncryptedRead}. Also verifies the plaintext fallback when no
+ * encryption metadata is present.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class AzureDataLakeFileSystemCseTest {
+
+    private static final URI TEST_URI =
+            URI.create("abfss://mycontainer@myaccount.dfs.core.windows.net");
+
+    private static final int READ_BUFFER_SIZE = 256 * 1024;
+    private static final long WRITE_REQUEST_SIZE = 8 * 1024 * 1024L;
+    private static final String WRITE_KEY_ID = "test-key";
+
+    private TestingDataLakeStorageOperations storageOps;
+    private TestingKeyProvider keyProvider;
+    private AesGcmCseStreamFactory cseFactory;
+
+    @BeforeEach
+    void setUp() {
+        storageOps = new TestingDataLakeStorageOperations();
+        keyProvider = new TestingKeyProvider();
+        cseFactory = new AesGcmCseStreamFactory(keyProvider, WRITE_KEY_ID, Map.of());
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private static byte[] randomBytes(final int size) {
+        final byte[] bytes = new byte[size];
+        ThreadLocalRandom.current().nextBytes(bytes);
+        return bytes;
+    }
+
+    private AzureDataLakeFileSystem buildFs(
+            @Nullable final AesGcmCseStreamFactory factory, final boolean encryptWrites) {
+        final AzureDataLakeFileSystem.Builder builder =
+                AzureDataLakeFileSystem.builder(storageOps, TEST_URI)
+                        .readBufferSize(READ_BUFFER_SIZE)
+                        .writeRequestSize(WRITE_REQUEST_SIZE);
+        if (factory != null) {
+            builder.cseFactory(factory);
+        }
+        builder.encryptWrites(encryptWrites);
+        return builder.build();
+    }
+
+    /** Writes content through a CSE-enabled FS so the blob gets encryption metadata. */
+    private void writeEncrypted(final String relativePath, final byte[] content) throws Exception {
+        final AzureDataLakeFileSystem writeFs = buildFs(cseFactory, true);
+        final Path path = new Path(TEST_URI + "/" + relativePath);
+        try (FSDataOutputStream out = writeFs.create(path, WriteMode.OVERWRITE)) {
+            out.write(content);
+        }
+    }
+
+    /** Pre-adds a plaintext file directly into storage (no encryption metadata). */
+    private void addPlaintext(final String relativePath, final byte[] content) {
+        storageOps.addFile(relativePath, content, OffsetDateTime.now());
+    }
+
+    private byte[] readFile(final AzureDataLakeFileSystem fileSystem, final String relativePath)
+            throws Exception {
+        final Path path = new Path(TEST_URI + "/" + relativePath);
+        try (FSDataInputStream in = fileSystem.open(path)) {
+            return in.readAllBytes();
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // CSE routing matrix
+    // -------------------------------------------------------------------------
+
+    Stream<Arguments> cseRoutingMatrix() {
+        final byte[] content = randomBytes(256);
+        final byte[] empty = new byte[0];
+        final BiConsumerWithException<String, byte[], Exception> encrypted = this::writeEncrypted;
+        final BiConsumerWithException<String, byte[], Exception> plaintext = this::addPlaintext;
+        return Stream.of(
+                // cseFactory=present, encryptWrites=true, blob=encrypted
+                Arguments.of("encrypted", content, true, encrypted),
+                Arguments.of("encrypted_empty", empty, true, encrypted),
+                // cseFactory=present, encryptWrites=true, blob=plaintext
+                Arguments.of("plaintext_cse_enabled", content, true, plaintext),
+                // cseFactory=present, encryptWrites=false, blob=encrypted
+                Arguments.of("encrypted_read_only", content, false, encrypted),
+                // cseFactory=present, encryptWrites=false, blob=plaintext
+                Arguments.of("plaintext_read_only", content, false, plaintext));
+    }
+
+    @ParameterizedTest
+    @MethodSource("cseRoutingMatrix")
+    void shouldRouteReadCorrectly(
+            final String caseName,
+            final byte[] content,
+            final boolean encryptWrites,
+            final BiConsumerWithException<String, byte[], Exception> contentCreator)
+            throws Exception {
+
+        final String filePath = caseName + ".bin";
+        contentCreator.accept(filePath, content);
+
+        final AzureDataLakeFileSystem readFs = buildFs(cseFactory, encryptWrites);
+
+        assertThat(readFile(readFs, filePath)).as(caseName).isEqualTo(content);
+    }
+
+    // -------------------------------------------------------------------------
+    // Key version selection from metadata
+    // -------------------------------------------------------------------------
+
+    @Test
+    void shouldDecryptUsingKeyVersionFromMetadata() throws Exception {
+        final byte[] content1 = randomBytes(128);
+        final byte[] content2 = randomBytes(128);
+
+        writeEncrypted("file1.bin", content1);
+        keyProvider.rotateKey();
+        writeEncrypted("file2.bin", content2);
+
+        final AzureDataLakeFileSystem readFs = buildFs(cseFactory, true);
+
+        assertThat(readFile(readFs, "file1.bin")).isEqualTo(content1);
+        assertThat(readFile(readFs, "file2.bin")).isEqualTo(content2);
+    }
+}

--- a/flink-filesystems/flink-azure-fs-native/src/test/java/org/apache/flink/fs/azurefs/AzureDataLakeFileSystemTest.java
+++ b/flink-filesystems/flink-azure-fs-native/src/test/java/org/apache/flink/fs/azurefs/AzureDataLakeFileSystemTest.java
@@ -1,0 +1,810 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.fs.azurefs;
+
+import org.apache.flink.core.fs.BlockLocation;
+import org.apache.flink.core.fs.FSDataInputStream;
+import org.apache.flink.core.fs.FSDataOutputStream;
+import org.apache.flink.core.fs.FileStatus;
+import org.apache.flink.core.fs.FileSystem.WriteMode;
+import org.apache.flink.core.fs.Path;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.net.URI;
+import java.time.OffsetDateTime;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Tests for {@link AzureDataLakeFileSystem}. */
+class AzureDataLakeFileSystemTest {
+
+    private static final int DEFAULT_BUFFER_SIZE = 256 * 1024;
+    private static final long DEFAULT_WRITE_REQUEST_SIZE = 8 * 1024 * 1024L;
+
+    private static final URI TEST_URI =
+            URI.create("abfss://mycontainer@myaccount.dfs.core.windows.net");
+
+    private static final AzureDataLakeFileSystem DEFAULT_FS =
+            createTestFileSystem(new TestingDataLakeStorageOperations());
+
+    private static AzureDataLakeFileSystem createTestFileSystem(
+            final TestingDataLakeStorageOperations storageOperations) {
+        return AzureDataLakeFileSystem.builder(storageOperations, TEST_URI)
+                .readBufferSize(DEFAULT_BUFFER_SIZE)
+                .writeRequestSize(DEFAULT_WRITE_REQUEST_SIZE)
+                .build();
+    }
+
+    // --- getUri ---
+
+    @Test
+    void shouldReturnUri() {
+        assertThat(DEFAULT_FS.getUri()).isEqualTo(TEST_URI);
+    }
+
+    // --- getWorkingDirectory ---
+
+    @Test
+    void shouldReturnWorkingDirectory() {
+        assertThat(DEFAULT_FS.getWorkingDirectory()).isEqualTo(new Path(TEST_URI));
+    }
+
+    // --- getHomeDirectory ---
+
+    @Test
+    void shouldReturnHomeDirectory() {
+        assertThat(DEFAULT_FS.getHomeDirectory()).isEqualTo(new Path(TEST_URI));
+    }
+
+    // --- isDistributedFS ---
+
+    @Test
+    void shouldBeDistributedFileSystem() {
+        assertThat(DEFAULT_FS.isDistributedFS()).isTrue();
+    }
+
+    // --- createRecoverableWriter ---
+
+    @Test
+    void shouldThrowOnCreateRecoverableWriter() {
+        assertThatThrownBy(DEFAULT_FS::createRecoverableWriter)
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessageContaining("Recoverable writer is not supported");
+    }
+
+    // --- getFileBlockLocations ---
+
+    @Test
+    void shouldReturnSingleBlockLocation() {
+        final long fileSize = 1024L;
+        final FileStatus status =
+                AzureDataLakeFileStatus.forFile(
+                        new Path(TEST_URI + "/test.txt"), fileSize, fileSize, 0L);
+
+        final BlockLocation[] locations = DEFAULT_FS.getFileBlockLocations(status, 0, fileSize);
+
+        assertThat(locations).hasSize(1);
+        assertThat(locations[0].getLength()).isEqualTo(fileSize);
+        assertThat(locations[0].getOffset()).isZero();
+    }
+
+    // --- toRelativePathString ---
+
+    static Stream<Arguments> toRelativePathStringCases() {
+        return Stream.of(
+                Arguments.of(
+                        new Path("abfss://c@a.dfs.core.windows.net/dir/file.txt"), "dir/file.txt"),
+                Arguments.of(new Path("abfss://c@a.dfs.core.windows.net/file.txt"), "file.txt"),
+                Arguments.of(new Path("abfss://c@a.dfs.core.windows.net/"), ""),
+                Arguments.of(
+                        new Path("abfss://c@a.dfs.core.windows.net/a/b/c/d.parquet"),
+                        "a/b/c/d.parquet"),
+                Arguments.of(new Path("/some/path"), "some/path"),
+                Arguments.of(new Path("relative/path"), "relative/path"));
+    }
+
+    @ParameterizedTest
+    @MethodSource("toRelativePathStringCases")
+    void shouldConvertToRelativePathString(final Path input, final String expected) {
+        assertThat(AzureDataLakeFileSystem.toRelativePathString(input)).isEqualTo(expected);
+    }
+
+    // --- getFileSystemNameFromUri ---
+
+    @Test
+    void shouldExtractFileSystemNameFromUserInfo() {
+        final URI uri = URI.create("abfss://mycontainer@myaccount.dfs.core.windows.net/path");
+        assertThat(AzureDataLakeFileSystem.getFileSystemNameFromUri(uri)).isEqualTo("mycontainer");
+    }
+
+    @Test
+    void shouldThrowWhenNoUserInfoInUri() {
+        final URI uri = URI.create("abfss://myaccount.dfs.core.windows.net/path");
+        assertThatThrownBy(() -> AzureDataLakeFileSystem.getFileSystemNameFromUri(uri))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("container name");
+    }
+
+    // --- Constructor validation ---
+
+    @ParameterizedTest
+    @MethodSource("invalidConstructorArgs")
+    void shouldRejectInvalidConstructorArgs(
+            final DataLakeStorageOperations ops,
+            final URI uri,
+            final Class<? extends Exception> expectedExceptionType) {
+        assertThatThrownBy(
+                        () ->
+                                AzureDataLakeFileSystem.builder(ops, uri)
+                                        .readBufferSize(DEFAULT_BUFFER_SIZE)
+                                        .writeRequestSize(DEFAULT_WRITE_REQUEST_SIZE)
+                                        .build())
+                .isInstanceOf(expectedExceptionType);
+    }
+
+    private static Stream<Arguments> invalidConstructorArgs() {
+        return Stream.of(
+                // null storage operations
+                Arguments.of(null, TEST_URI, NullPointerException.class),
+                // null URI
+                Arguments.of(
+                        new TestingDataLakeStorageOperations(), null, NullPointerException.class),
+                // URI without container
+                Arguments.of(
+                        new TestingDataLakeStorageOperations(),
+                        URI.create("abfss://myaccount.dfs.core.windows.net/path"),
+                        IllegalArgumentException.class));
+    }
+
+    // --- getFileStatus for root ---
+
+    @Test
+    void shouldReturnDirectoryStatusForRootPath() throws Exception {
+        final Path rootPath = new Path("abfss://mycontainer@myaccount.dfs.core.windows.net/");
+
+        final FileStatus status = DEFAULT_FS.getFileStatus(rootPath);
+
+        assertThat(status.isDir()).isTrue();
+        assertThat(status.getLen()).isZero();
+    }
+
+    // --- getFileStatus (non-root paths) ---
+
+    @Test
+    void shouldReturnFileStatusForExistingFile() throws Exception {
+        final TestingDataLakeStorageOperations delegate = new TestingDataLakeStorageOperations();
+        final long fileSize = 1024L;
+        final OffsetDateTime modTime = OffsetDateTime.now();
+        delegate.addFile("dir/file.txt", new byte[(int) fileSize], modTime);
+
+        final AzureDataLakeFileSystem fs = createTestFileSystem(delegate);
+        final Path path = new Path(TEST_URI + "/dir/file.txt");
+
+        final FileStatus status = fs.getFileStatus(path);
+
+        assertThat(status.isDir()).isFalse();
+        assertThat(status.getLen()).isEqualTo(fileSize);
+        assertThat(status.getPath()).isEqualTo(path);
+        assertThat(status.getModificationTime()).isEqualTo(modTime.toInstant().toEpochMilli());
+    }
+
+    @Test
+    void shouldReturnDirectoryStatusForExistingDirectory() throws Exception {
+        final TestingDataLakeStorageOperations delegate = new TestingDataLakeStorageOperations();
+        final OffsetDateTime modTime = OffsetDateTime.now();
+        delegate.addDirectory("mydir", modTime);
+
+        final AzureDataLakeFileSystem fs = createTestFileSystem(delegate);
+        final Path path = new Path(TEST_URI + "/mydir");
+
+        final FileStatus status = fs.getFileStatus(path);
+
+        assertThat(status.isDir()).isTrue();
+        assertThat(status.getLen()).isZero();
+        assertThat(status.getPath()).isEqualTo(path);
+        assertThat(status.getModificationTime()).isEqualTo(modTime.toInstant().toEpochMilli());
+    }
+
+    @Test
+    void shouldThrowFileNotFoundExceptionWhenPathDoesNotExist() {
+        final TestingDataLakeStorageOperations delegate = new TestingDataLakeStorageOperations();
+        final AzureDataLakeFileSystem fs = createTestFileSystem(delegate);
+        final Path path = new Path(TEST_URI + "/nonexistent");
+
+        assertThatThrownBy(() -> fs.getFileStatus(path))
+                .isInstanceOf(FileNotFoundException.class)
+                .hasMessageContaining("File not found");
+    }
+
+    @Test
+    void shouldThrowIOExceptionWhenAzureReturnsOtherError() {
+        final TestingDataLakeStorageOperations delegate = new TestingDataLakeStorageOperations();
+        delegate.injectError("somefile", 500);
+
+        final AzureDataLakeFileSystem fs = createTestFileSystem(delegate);
+        final Path path = new Path(TEST_URI + "/somefile");
+
+        assertThatThrownBy(() -> fs.getFileStatus(path))
+                .isInstanceOf(IOException.class)
+                .hasMessageContaining("Failed to get file status");
+    }
+
+    @Test
+    void shouldThrowIOExceptionWhenLastModifiedIsNull() {
+        final TestingDataLakeStorageOperations delegate = new TestingDataLakeStorageOperations();
+        delegate.addFile("nulltime", new byte[10], null);
+
+        final AzureDataLakeFileSystem fs = createTestFileSystem(delegate);
+        final Path path = new Path(TEST_URI + "/nulltime");
+
+        assertThatThrownBy(() -> fs.getFileStatus(path))
+                .isInstanceOf(IOException.class)
+                .hasMessageContaining("null modification time");
+    }
+
+    // --- open ---
+
+    @Test
+    void shouldOpenFileForReadingAndReturnNonNullStream() throws Exception {
+        // Verifies that open() succeeds for a registered file and returns a non-null stream.
+        // Stream data content is validated at the ObjectStorageInputStreamBase level.
+        final byte[] content = {1, 2, 3, 4, 5};
+        final TestingDataLakeStorageOperations delegate = new TestingDataLakeStorageOperations();
+        delegate.addFile("data.bin", content, OffsetDateTime.now());
+
+        final AzureDataLakeFileSystem fs = createTestFileSystem(delegate);
+        final Path path = new Path(TEST_URI + "/data.bin");
+
+        try (FSDataInputStream stream = fs.open(path)) {
+            assertThat(stream).isNotNull();
+            // Stream is lazily initialized; getPos() verifies it is in a valid initial state.
+            assertThat(stream.getPos()).isEqualTo(0L);
+        }
+    }
+
+    @Test
+    void shouldThrowWhenOpeningDirectory() {
+        final TestingDataLakeStorageOperations delegate = new TestingDataLakeStorageOperations();
+        delegate.addDirectory("mydir", OffsetDateTime.now());
+
+        final AzureDataLakeFileSystem fs = createTestFileSystem(delegate);
+        final Path path = new Path(TEST_URI + "/mydir");
+
+        assertThatThrownBy(() -> fs.open(path))
+                .isInstanceOf(IOException.class)
+                .hasMessageContaining("Cannot open directory");
+    }
+
+    @Test
+    void shouldThrowFileNotFoundExceptionWhenOpeningNonexistentFile() {
+        final TestingDataLakeStorageOperations delegate = new TestingDataLakeStorageOperations();
+        final AzureDataLakeFileSystem fs = createTestFileSystem(delegate);
+        final Path path = new Path(TEST_URI + "/nonexistent");
+
+        assertThatThrownBy(() -> fs.open(path)).isInstanceOf(FileNotFoundException.class);
+    }
+
+    @Test
+    void shouldThrowIOExceptionOnOtherAzureErrorDuringOpen() {
+        final TestingDataLakeStorageOperations delegate = new TestingDataLakeStorageOperations();
+        delegate.injectError("failfile", 500);
+
+        final AzureDataLakeFileSystem fs = createTestFileSystem(delegate);
+        final Path path = new Path(TEST_URI + "/failfile");
+
+        assertThatThrownBy(() -> fs.open(path))
+                .isInstanceOf(IOException.class)
+                .hasMessageContaining("Failed to open file");
+    }
+
+    // --- create ---
+
+    @Test
+    void shouldCreateFileAndReturnOutputStream() throws Exception {
+        final TestingDataLakeStorageOperations delegate = new TestingDataLakeStorageOperations();
+        final AzureDataLakeFileSystem fs = createTestFileSystem(delegate);
+        final Path path = new Path(TEST_URI + "/newfile.bin");
+
+        try (FSDataOutputStream stream = fs.create(path, WriteMode.OVERWRITE)) {
+            assertThat(stream).isNotNull();
+            assertThat(stream.getPos()).isEqualTo(0L);
+        }
+    }
+
+    /**
+     * Error-path cases for {@link AzureDataLakeFileSystem#create}. The key distinction: 409/412 map
+     * to "File already exists" only with {@link WriteMode#NO_OVERWRITE}; with {@link
+     * WriteMode#OVERWRITE} the same codes fall through to the generic error path.
+     */
+    static Stream<Arguments> createErrorCases() {
+        return Stream.of(
+                // NO_OVERWRITE + conflict codes → "File already exists"
+                Arguments.of(WriteMode.NO_OVERWRITE, 409, "File already exists"),
+                Arguments.of(WriteMode.NO_OVERWRITE, 412, "File already exists"),
+                // NO_OVERWRITE + non-conflict codes → generic error
+                Arguments.of(WriteMode.NO_OVERWRITE, 500, "Failed to create file"),
+                // OVERWRITE + any error → generic "Failed to create file"
+                Arguments.of(WriteMode.OVERWRITE, 409, "Failed to create file"),
+                Arguments.of(WriteMode.OVERWRITE, 500, "Failed to create file"));
+    }
+
+    @ParameterizedTest
+    @MethodSource("createErrorCases")
+    void shouldMapCreateErrorToCorrectIOException(
+            final WriteMode writeMode, final int statusCode, final String expectedMessage) {
+        final TestingDataLakeStorageOperations delegate = new TestingDataLakeStorageOperations();
+        delegate.injectCreateError("file.bin", statusCode);
+
+        final AzureDataLakeFileSystem fs = createTestFileSystem(delegate);
+        final Path path = new Path(TEST_URI + "/file.bin");
+
+        assertThatThrownBy(() -> fs.create(path, writeMode))
+                .isInstanceOf(IOException.class)
+                .hasMessageContaining(expectedMessage);
+    }
+
+    // --- listStatus ---
+
+    @Test
+    void shouldListDirectoryContents() throws Exception {
+        final TestingDataLakeStorageOperations delegate = new TestingDataLakeStorageOperations();
+        final OffsetDateTime now = OffsetDateTime.now();
+        delegate.addDirectory("dir", now);
+        delegate.addFile("dir/file1.txt", new byte[100], now);
+        delegate.addFile("dir/file2.txt", new byte[200], now);
+        delegate.addDirectory("dir/subdir", now);
+
+        final AzureDataLakeFileSystem fs = createTestFileSystem(delegate);
+        final Path path = new Path(TEST_URI + "/dir");
+
+        final FileStatus[] statuses = fs.listStatus(path);
+
+        assertThat(statuses).hasSize(3);
+        assertThat(statuses)
+                .extracting(FileStatus::getPath)
+                .extracting(Path::getName)
+                .containsExactlyInAnyOrder("file1.txt", "file2.txt", "subdir");
+    }
+
+    @Test
+    void shouldReturnEmptyArrayForEmptyDirectory() throws Exception {
+        final TestingDataLakeStorageOperations delegate = new TestingDataLakeStorageOperations();
+        delegate.addDirectory("emptydir", OffsetDateTime.now());
+
+        final AzureDataLakeFileSystem fs = createTestFileSystem(delegate);
+        final Path path = new Path(TEST_URI + "/emptydir");
+
+        final FileStatus[] statuses = fs.listStatus(path);
+
+        assertThat(statuses).isEmpty();
+    }
+
+    @Test
+    void shouldReturnSingleElementArrayWhenListingRegularFile() throws Exception {
+        final TestingDataLakeStorageOperations delegate = new TestingDataLakeStorageOperations();
+        final OffsetDateTime now = OffsetDateTime.now();
+        delegate.addFile("somefile", new byte[50], now);
+
+        final AzureDataLakeFileSystem fs = createTestFileSystem(delegate);
+        final Path path = new Path(TEST_URI + "/somefile");
+
+        final FileStatus[] statuses = fs.listStatus(path);
+
+        assertThat(statuses).hasSize(1);
+        assertThat(statuses[0].isDir()).isFalse();
+        assertThat(statuses[0].getLen()).isEqualTo(50);
+    }
+
+    @Test
+    void shouldThrowFileNotFoundExceptionWhenListingNonexistentPath() {
+        final TestingDataLakeStorageOperations delegate = new TestingDataLakeStorageOperations();
+        final AzureDataLakeFileSystem fs = createTestFileSystem(delegate);
+        final Path path = new Path(TEST_URI + "/nonexistent");
+
+        assertThatThrownBy(() -> fs.listStatus(path)).isInstanceOf(FileNotFoundException.class);
+    }
+
+    @Test
+    void shouldThrowIOExceptionOnAzureErrorDuringInitialGetProperties() {
+        final TestingDataLakeStorageOperations delegate = new TestingDataLakeStorageOperations();
+        delegate.injectError("failpath", 500);
+
+        final AzureDataLakeFileSystem fs = createTestFileSystem(delegate);
+        final Path path = new Path(TEST_URI + "/failpath");
+
+        assertThatThrownBy(() -> fs.listStatus(path))
+                .isInstanceOf(IOException.class)
+                .hasMessageContaining("Failed to get path properties");
+    }
+
+    @Test
+    void shouldListRootDirectory() throws Exception {
+        final TestingDataLakeStorageOperations delegate = new TestingDataLakeStorageOperations();
+        final OffsetDateTime now = OffsetDateTime.now();
+        delegate.addFile("rootfile", new byte[10], now);
+        delegate.addDirectory("rootdir", now);
+
+        final AzureDataLakeFileSystem fs = createTestFileSystem(delegate);
+        final Path path = new Path(TEST_URI + "/");
+
+        final FileStatus[] statuses = fs.listStatus(path);
+
+        assertThat(statuses).hasSize(2);
+    }
+
+    @Test
+    void shouldThrowFileNotFoundExceptionWhenListPathsReturns404() {
+        final TestingDataLakeStorageOperations delegate = new TestingDataLakeStorageOperations();
+        delegate.injectListError("", 404);
+
+        final AzureDataLakeFileSystem fs = createTestFileSystem(delegate);
+        final Path path = new Path(TEST_URI + "/");
+
+        assertThatThrownBy(() -> fs.listStatus(path))
+                .isInstanceOf(FileNotFoundException.class)
+                .hasMessageContaining("Directory not found");
+    }
+
+    @Test
+    void shouldThrowIOExceptionWhenListPathsReturnsNon404Error() {
+        final TestingDataLakeStorageOperations delegate = new TestingDataLakeStorageOperations();
+        delegate.injectListError("", 500);
+
+        final AzureDataLakeFileSystem fs = createTestFileSystem(delegate);
+        final Path path = new Path(TEST_URI + "/");
+
+        assertThatThrownBy(() -> fs.listStatus(path))
+                .isInstanceOf(IOException.class)
+                .hasMessageContaining("Failed to list directory");
+    }
+
+    // --- delete ---
+
+    @Test
+    void shouldDeleteFile() throws Exception {
+        final TestingDataLakeStorageOperations delegate = new TestingDataLakeStorageOperations();
+        delegate.addFile("deleteme", new byte[10], OffsetDateTime.now());
+
+        final AzureDataLakeFileSystem fs = createTestFileSystem(delegate);
+        final Path path = new Path(TEST_URI + "/deleteme");
+
+        final boolean deleted = fs.delete(path, false);
+
+        assertThat(deleted).isTrue();
+        assertThat(delegate.exists("deleteme")).isFalse();
+    }
+
+    @Test
+    void shouldDeleteEmptyDirectoryNonRecursive() throws Exception {
+        final TestingDataLakeStorageOperations delegate = new TestingDataLakeStorageOperations();
+        delegate.addDirectory("emptydir", OffsetDateTime.now());
+
+        final AzureDataLakeFileSystem fs = createTestFileSystem(delegate);
+        final Path path = new Path(TEST_URI + "/emptydir");
+
+        final boolean deleted = fs.delete(path, false);
+
+        assertThat(deleted).isTrue();
+        assertThat(delegate.exists("emptydir")).isFalse();
+    }
+
+    @Test
+    void shouldDeleteNonEmptyDirectoryRecursive() throws Exception {
+        final TestingDataLakeStorageOperations delegate = new TestingDataLakeStorageOperations();
+        final OffsetDateTime now = OffsetDateTime.now();
+        delegate.addDirectory("parent", now);
+        delegate.addFile("parent/child.txt", new byte[10], now);
+
+        final AzureDataLakeFileSystem fs = createTestFileSystem(delegate);
+        final Path path = new Path(TEST_URI + "/parent");
+
+        final boolean deleted = fs.delete(path, true);
+
+        assertThat(deleted).isTrue();
+        assertThat(delegate.exists("parent")).isFalse();
+        assertThat(delegate.exists("parent/child.txt")).isFalse();
+    }
+
+    @Test
+    void shouldThrowWhenDeletingNonEmptyDirectoryNonRecursive() {
+        final TestingDataLakeStorageOperations delegate = new TestingDataLakeStorageOperations();
+        final OffsetDateTime now = OffsetDateTime.now();
+        delegate.addDirectory("parent", now);
+        delegate.addFile("parent/child.txt", new byte[10], now);
+
+        final AzureDataLakeFileSystem fs = createTestFileSystem(delegate);
+        final Path path = new Path(TEST_URI + "/parent");
+
+        assertThatThrownBy(() -> fs.delete(path, false))
+                .isInstanceOf(IOException.class)
+                .hasMessageContaining("not empty");
+    }
+
+    @Test
+    void shouldReturnFalseWhenDeletingNonexistentPath() throws Exception {
+        final TestingDataLakeStorageOperations delegate = new TestingDataLakeStorageOperations();
+        final AzureDataLakeFileSystem fs = createTestFileSystem(delegate);
+        final Path path = new Path(TEST_URI + "/nonexistent");
+
+        final boolean deleted = fs.delete(path, false);
+
+        assertThat(deleted).isFalse();
+    }
+
+    @Test
+    void shouldThrowIOExceptionOnAzureErrorDuringDelete() {
+        final TestingDataLakeStorageOperations delegate = new TestingDataLakeStorageOperations();
+        delegate.addFile("failfile", new byte[10], OffsetDateTime.now());
+        delegate.injectDeleteError("failfile", 500);
+
+        final AzureDataLakeFileSystem fs = createTestFileSystem(delegate);
+        final Path path = new Path(TEST_URI + "/failfile");
+
+        assertThatThrownBy(() -> fs.delete(path, false))
+                .isInstanceOf(IOException.class)
+                .hasMessageContaining("Failed to delete");
+    }
+
+    @Test
+    void shouldRethrowNonConflictErrorOnNonRecursiveDirectoryDelete() {
+        final TestingDataLakeStorageOperations delegate = new TestingDataLakeStorageOperations();
+        delegate.addDirectory("dir", OffsetDateTime.now());
+        delegate.injectDeleteError("dir", 500);
+
+        final AzureDataLakeFileSystem fs = createTestFileSystem(delegate);
+        final Path path = new Path(TEST_URI + "/dir");
+
+        assertThatThrownBy(() -> fs.delete(path, false))
+                .isInstanceOf(IOException.class)
+                .hasMessageContaining("Failed to delete");
+    }
+
+    // --- mkdirs ---
+
+    @Test
+    void shouldCreateDirectory() throws Exception {
+        final TestingDataLakeStorageOperations delegate = new TestingDataLakeStorageOperations();
+        final AzureDataLakeFileSystem fs = createTestFileSystem(delegate);
+        final Path path = new Path(TEST_URI + "/newdir");
+
+        final boolean created = fs.mkdirs(path);
+
+        assertThat(created).isTrue();
+        assertThat(delegate.exists("newdir")).isTrue();
+    }
+
+    @Test
+    void shouldSucceedWhenMkdirsOnExistingDirectory() throws Exception {
+        final TestingDataLakeStorageOperations delegate = new TestingDataLakeStorageOperations();
+        delegate.addDirectory("existingdir", OffsetDateTime.now());
+        final AzureDataLakeFileSystem fs = createTestFileSystem(delegate);
+
+        assertThat(fs.mkdirs(new Path(TEST_URI + "/existingdir"))).isTrue();
+    }
+
+    @ParameterizedTest
+    @MethodSource("mkdirsOnExistingFileCases")
+    void shouldThrowWhenMkdirsOnExistingFile(final String filePath, final String mkdirsPath)
+            throws Exception {
+        final TestingDataLakeStorageOperations delegate = new TestingDataLakeStorageOperations();
+        delegate.addFile(filePath, new byte[10], OffsetDateTime.now());
+        final AzureDataLakeFileSystem fs = createTestFileSystem(delegate);
+
+        assertThatThrownBy(() -> fs.mkdirs(new Path(TEST_URI + "/" + mkdirsPath)))
+                .isInstanceOf(IOException.class)
+                .hasMessageContaining("path exists as a file");
+    }
+
+    private static Stream<Arguments> mkdirsOnExistingFileCases() {
+        return Stream.of(
+                Arguments.of("existingfile", "existingfile"),
+                Arguments.of("dir/existingfile", "dir/existingfile"));
+    }
+
+    @Test
+    void shouldThrowIOExceptionOnAzureErrorDuringMkdirs() {
+        final TestingDataLakeStorageOperations delegate = new TestingDataLakeStorageOperations();
+        delegate.injectError("faildir", 500);
+
+        final AzureDataLakeFileSystem fs = createTestFileSystem(delegate);
+        final Path path = new Path(TEST_URI + "/faildir");
+
+        assertThatThrownBy(() -> fs.mkdirs(path))
+                .isInstanceOf(IOException.class)
+                .hasMessageContaining("Failed to create directory");
+    }
+
+    // --- rename ---
+
+    @Test
+    void shouldRenameFile() throws Exception {
+        final TestingDataLakeStorageOperations delegate = new TestingDataLakeStorageOperations();
+        delegate.addFile("oldname", new byte[10], OffsetDateTime.now());
+
+        final AzureDataLakeFileSystem fs = createTestFileSystem(delegate);
+        final Path src = new Path(TEST_URI + "/oldname");
+        final Path dst = new Path(TEST_URI + "/newname");
+
+        final boolean renamed = fs.rename(src, dst);
+
+        assertThat(renamed).isTrue();
+        assertThat(delegate.exists("oldname")).isFalse();
+        assertThat(delegate.exists("newname")).isTrue();
+    }
+
+    @Test
+    void shouldRenameFileIntoExistingDirectory() throws Exception {
+        final TestingDataLakeStorageOperations delegate = new TestingDataLakeStorageOperations();
+        final OffsetDateTime now = OffsetDateTime.now();
+        delegate.addFile("file.txt", new byte[10], now);
+        delegate.addDirectory("targetdir", now);
+
+        final AzureDataLakeFileSystem fs = createTestFileSystem(delegate);
+        final Path src = new Path(TEST_URI + "/file.txt");
+        final Path dst = new Path(TEST_URI + "/targetdir");
+
+        final boolean renamed = fs.rename(src, dst);
+
+        assertThat(renamed).isTrue();
+        assertThat(delegate.exists("file.txt")).isFalse();
+        assertThat(delegate.exists("targetdir/file.txt")).isTrue();
+    }
+
+    @Test
+    void shouldRenameDirectory() throws Exception {
+        final TestingDataLakeStorageOperations delegate = new TestingDataLakeStorageOperations();
+        final OffsetDateTime now = OffsetDateTime.now();
+        delegate.addDirectory("olddir", now);
+        delegate.addFile("olddir/file.txt", new byte[10], now);
+
+        final AzureDataLakeFileSystem fs = createTestFileSystem(delegate);
+        final Path src = new Path(TEST_URI + "/olddir");
+        final Path dst = new Path(TEST_URI + "/newdir");
+
+        final boolean renamed = fs.rename(src, dst);
+
+        assertThat(renamed).isTrue();
+        assertThat(delegate.exists("olddir")).isFalse();
+        assertThat(delegate.exists("newdir")).isTrue();
+        assertThat(delegate.exists("newdir/file.txt")).isTrue();
+    }
+
+    @Test
+    void shouldCreateParentDirectoryWhenRenamingIfNotExists() throws Exception {
+        final TestingDataLakeStorageOperations delegate = new TestingDataLakeStorageOperations();
+        delegate.addFile("file.txt", new byte[10], OffsetDateTime.now());
+
+        final AzureDataLakeFileSystem fs = createTestFileSystem(delegate);
+        final Path src = new Path(TEST_URI + "/file.txt");
+        final Path dst = new Path(TEST_URI + "/newdir/file.txt");
+
+        final boolean renamed = fs.rename(src, dst);
+
+        assertThat(renamed).isTrue();
+        assertThat(delegate.exists("newdir")).isTrue();
+        assertThat(delegate.exists("newdir/file.txt")).isTrue();
+    }
+
+    @ParameterizedTest
+    @MethodSource("renameOverExistingFileCases")
+    void shouldReturnFalseWhenRenamingOverExistingFile(final String srcPath, final String dstPath)
+            throws Exception {
+        final TestingDataLakeStorageOperations delegate = new TestingDataLakeStorageOperations();
+        final OffsetDateTime now = OffsetDateTime.now();
+        delegate.addFile(srcPath, new byte[10], now);
+        delegate.addFile(dstPath, new byte[5], now);
+
+        final AzureDataLakeFileSystem fs = createTestFileSystem(delegate);
+
+        final boolean renamed =
+                fs.rename(new Path(TEST_URI + "/" + srcPath), new Path(TEST_URI + "/" + dstPath));
+
+        assertThat(renamed).isFalse();
+        assertThat(delegate.exists(srcPath)).isTrue();
+        assertThat(delegate.exists(dstPath)).isTrue();
+    }
+
+    private static Stream<Arguments> renameOverExistingFileCases() {
+        return Stream.of(
+                Arguments.of("src.txt", "dst.txt"), Arguments.of("dir/src.txt", "dir/dst.txt"));
+    }
+
+    @Test
+    void shouldThrowWhenDstLookupFailsWithNon404Error() {
+        final TestingDataLakeStorageOperations delegate = new TestingDataLakeStorageOperations();
+        delegate.addFile("source", new byte[10], OffsetDateTime.now());
+        delegate.injectError("dest", 500);
+
+        final AzureDataLakeFileSystem fs = createTestFileSystem(delegate);
+        final Path src = new Path(TEST_URI + "/source");
+        final Path dst = new Path(TEST_URI + "/dest");
+
+        assertThatThrownBy(() -> fs.rename(src, dst))
+                .isInstanceOf(IOException.class)
+                .hasMessageContaining("Failed to rename");
+    }
+
+    @Test
+    void shouldReturnFalseWhenRenamingNonexistentPath() throws Exception {
+        final TestingDataLakeStorageOperations delegate = new TestingDataLakeStorageOperations();
+        final AzureDataLakeFileSystem fs = createTestFileSystem(delegate);
+        final Path src = new Path(TEST_URI + "/nonexistent");
+        final Path dst = new Path(TEST_URI + "/destination");
+
+        final boolean renamed = fs.rename(src, dst);
+
+        assertThat(renamed).isFalse();
+    }
+
+    @Test
+    void shouldThrowIOExceptionOnAzureErrorDuringRename() {
+        final TestingDataLakeStorageOperations delegate = new TestingDataLakeStorageOperations();
+        delegate.addFile("source", new byte[10], OffsetDateTime.now());
+        delegate.injectError("source", 500);
+
+        final AzureDataLakeFileSystem fs = createTestFileSystem(delegate);
+        final Path src = new Path(TEST_URI + "/source");
+        final Path dst = new Path(TEST_URI + "/dest");
+
+        assertThatThrownBy(() -> fs.rename(src, dst))
+                .isInstanceOf(IOException.class)
+                .hasMessageContaining("Failed to rename");
+    }
+
+    // --- Root path guards ---
+
+    private static final Path ROOT_PATH =
+            new Path("abfss://mycontainer@myaccount.dfs.core.windows.net/");
+
+    private static final Path NON_ROOT_PATH =
+            new Path("abfss://mycontainer@myaccount.dfs.core.windows.net/file");
+
+    @Test
+    void shouldThrowWhenDeletingRootPath() {
+        assertThatThrownBy(() -> DEFAULT_FS.delete(ROOT_PATH, false))
+                .isInstanceOf(IOException.class)
+                .hasMessageContaining("Cannot delete root directory");
+    }
+
+    static Stream<Arguments> renameRootPathCases() {
+        return Stream.of(
+                Arguments.of(ROOT_PATH, NON_ROOT_PATH), Arguments.of(NON_ROOT_PATH, ROOT_PATH));
+    }
+
+    @ParameterizedTest
+    @MethodSource("renameRootPathCases")
+    void shouldThrowWhenRenamingRootPath(final Path src, final Path dst) {
+        assertThatThrownBy(() -> DEFAULT_FS.rename(src, dst))
+                .isInstanceOf(IOException.class)
+                .hasMessageContaining("Cannot rename root directory");
+    }
+
+    @Test
+    void shouldReturnTrueWhenMkdirsOnRootPath() throws Exception {
+        assertThat(DEFAULT_FS.mkdirs(ROOT_PATH)).isTrue();
+    }
+}

--- a/flink-filesystems/flink-azure-fs-native/src/test/java/org/apache/flink/fs/azurefs/AzureInputStreamFactoryTest.java
+++ b/flink-filesystems/flink-azure-fs-native/src/test/java/org/apache/flink/fs/azurefs/AzureInputStreamFactoryTest.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.fs.azurefs;
+
+import com.azure.storage.file.datalake.models.FileRange;
+import com.azure.storage.file.datalake.options.DataLakeFileInputStreamOptions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Tests for {@link AzureInputStreamFactory}. */
+class AzureInputStreamFactoryTest {
+
+    // --- buildInputStreamOptions ---
+
+    private static final int BLOCK_SIZE = AzureDataLakeFileSystem.SDK_READ_CHUNK_SIZE;
+
+    @ParameterizedTest
+    @ValueSource(longs = {0L, -1L})
+    void buildInputStreamOptionsShouldNotSetRangeForNonPositivePosition(final long position) {
+        final DataLakeFileInputStreamOptions options =
+                AzureInputStreamFactory.buildInputStreamOptions(position, BLOCK_SIZE);
+        assertThat(options.getRange()).isNull();
+        assertThat(options.getBlockSize()).isEqualTo(BLOCK_SIZE);
+    }
+
+    @ParameterizedTest
+    @ValueSource(longs = {1L, 42L, Long.MAX_VALUE})
+    void buildInputStreamOptionsShouldSetRangeForPositivePosition(final long position) {
+        final DataLakeFileInputStreamOptions options =
+                AzureInputStreamFactory.buildInputStreamOptions(position, BLOCK_SIZE);
+        final FileRange range = options.getRange();
+        assertThat(range).isNotNull();
+        assertThat(range.getOffset()).isEqualTo(position);
+        assertThat(options.getBlockSize()).isEqualTo(BLOCK_SIZE);
+    }
+
+    @Test
+    void buildInputStreamOptionsShouldUseCustomBlockSize() {
+        final int customBlockSize = 8 * 1024 * 1024;
+        final DataLakeFileInputStreamOptions options =
+                AzureInputStreamFactory.buildInputStreamOptions(0L, customBlockSize);
+        assertThat(options.getBlockSize()).isEqualTo(customBlockSize);
+    }
+
+    // --- createOpener null checks ---
+
+    @Test
+    void shouldThrowOnNullClient() {
+        assertThatThrownBy(
+                        () ->
+                                AzureInputStreamFactory.createOpener(
+                                        null, "path/to/file", BLOCK_SIZE))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessageContaining("fsClient");
+    }
+
+    @Test
+    void shouldThrowOnNullFilePath() {
+        assertThatThrownBy(
+                        () ->
+                                AzureInputStreamFactory.createOpener(
+                                        new TestingDataLakeStorageOperations(), null, BLOCK_SIZE))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessageContaining("filePath");
+    }
+}

--- a/flink-filesystems/flink-azure-fs-native/src/test/java/org/apache/flink/fs/azurefs/AzureOutputStreamFactoryTest.java
+++ b/flink-filesystems/flink-azure-fs-native/src/test/java/org/apache/flink/fs/azurefs/AzureOutputStreamFactoryTest.java
@@ -1,0 +1,173 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.fs.azurefs;
+
+import org.apache.flink.core.fs.FileSystem.WriteMode;
+
+import com.azure.storage.file.datalake.models.DataLakeRequestConditions;
+import com.azure.storage.file.datalake.options.DataLakeFileOutputStreamOptions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Tests for {@link AzureOutputStreamFactory}. */
+class AzureOutputStreamFactoryTest {
+
+    private static final long WRITE_REQUEST_SIZE = 8 * 1024 * 1024L;
+
+    // --- buildOutputStreamOptions: content type ---
+
+    @ParameterizedTest
+    @EnumSource(WriteMode.class)
+    void shouldSetContentTypeToOctetStream(final WriteMode writeMode) {
+        final DataLakeFileOutputStreamOptions options =
+                AzureOutputStreamFactory.buildOutputStreamOptions(
+                        WRITE_REQUEST_SIZE, writeMode, Collections.emptyMap());
+
+        assertThat(options.getHeaders().getContentType()).isEqualTo("application/octet-stream");
+    }
+
+    // --- buildOutputStreamOptions: block size and single-upload threshold ---
+
+    @ParameterizedTest
+    @EnumSource(WriteMode.class)
+    void shouldSetTransferOptionsToWriteRequestSize(final WriteMode writeMode) {
+        final DataLakeFileOutputStreamOptions options =
+                AzureOutputStreamFactory.buildOutputStreamOptions(
+                        WRITE_REQUEST_SIZE, writeMode, Collections.emptyMap());
+
+        assertThat(options.getParallelTransferOptions().getBlockSizeLong())
+                .isEqualTo(WRITE_REQUEST_SIZE);
+        assertThat(options.getParallelTransferOptions().getMaxSingleUploadSizeLong())
+                .isEqualTo(WRITE_REQUEST_SIZE);
+    }
+
+    // --- buildOutputStreamOptions: request conditions ---
+
+    @ParameterizedTest
+    @MethodSource("requestConditionsCases")
+    void shouldSetRequestConditionsBasedOnWriteMode(
+            final WriteMode writeMode, final String expectedIfNoneMatch) {
+        final DataLakeFileOutputStreamOptions options =
+                AzureOutputStreamFactory.buildOutputStreamOptions(
+                        WRITE_REQUEST_SIZE, writeMode, Collections.emptyMap());
+
+        final DataLakeRequestConditions conditions = options.getRequestConditions();
+        if (expectedIfNoneMatch == null) {
+            assertThat(conditions).isNull();
+        } else {
+            assertThat(conditions).isNotNull();
+            assertThat(conditions.getIfNoneMatch()).isEqualTo(expectedIfNoneMatch);
+        }
+    }
+
+    private static Stream<Arguments> requestConditionsCases() {
+        return Stream.of(
+                Arguments.of(WriteMode.OVERWRITE, null), Arguments.of(WriteMode.NO_OVERWRITE, "*"));
+    }
+
+    // --- buildOutputStreamOptions: metadata ---
+
+    @Test
+    void shouldNotSetMetadataWhenEmpty() {
+        final DataLakeFileOutputStreamOptions options =
+                AzureOutputStreamFactory.buildOutputStreamOptions(
+                        WRITE_REQUEST_SIZE, WriteMode.OVERWRITE, Collections.emptyMap());
+
+        assertThat(options.getMetadata()).isNull();
+    }
+
+    @Test
+    void shouldAttachMetadataWhenPresent() {
+        final Map<String, String> metadata = Map.of("x_cse_key_id", "key-123");
+        final DataLakeFileOutputStreamOptions options =
+                AzureOutputStreamFactory.buildOutputStreamOptions(
+                        WRITE_REQUEST_SIZE, WriteMode.OVERWRITE, metadata);
+
+        assertThat(options.getMetadata()).containsEntry("x_cse_key_id", "key-123");
+    }
+
+    // --- createOpener: argument validation ---
+
+    static Stream<Arguments> invalidCreateOpenerArgs() {
+        final DataLakeStorageOperations ops = new TestingDataLakeStorageOperations();
+        return Stream.of(
+                Arguments.of(
+                        null,
+                        "path/file.txt",
+                        WRITE_REQUEST_SIZE,
+                        WriteMode.OVERWRITE,
+                        NullPointerException.class,
+                        "fsClient"),
+                Arguments.of(
+                        ops,
+                        null,
+                        WRITE_REQUEST_SIZE,
+                        WriteMode.OVERWRITE,
+                        NullPointerException.class,
+                        "filePath"),
+                Arguments.of(
+                        ops,
+                        "path/file.txt",
+                        0L,
+                        WriteMode.OVERWRITE,
+                        IllegalArgumentException.class,
+                        "writeRequestSize must be positive"),
+                Arguments.of(
+                        ops,
+                        "path/file.txt",
+                        -1L,
+                        WriteMode.OVERWRITE,
+                        IllegalArgumentException.class,
+                        "writeRequestSize must be positive"),
+                Arguments.of(
+                        ops,
+                        "path/file.txt",
+                        WRITE_REQUEST_SIZE,
+                        null,
+                        NullPointerException.class,
+                        "writeMode"));
+    }
+
+    @ParameterizedTest
+    @MethodSource("invalidCreateOpenerArgs")
+    void shouldRejectInvalidCreateOpenerArgs(
+            final DataLakeStorageOperations fsClient,
+            final String filePath,
+            final long writeRequestSize,
+            final WriteMode writeMode,
+            final Class<? extends Throwable> expectedType,
+            final String expectedMessage) {
+        assertThatThrownBy(
+                        () ->
+                                AzureOutputStreamFactory.createOpener(
+                                        fsClient, filePath, writeRequestSize, writeMode))
+                .isInstanceOf(expectedType)
+                .hasMessageContaining(expectedMessage);
+    }
+}

--- a/flink-filesystems/flink-azure-fs-native/src/test/java/org/apache/flink/fs/azurefs/AzurePathUtilsTest.java
+++ b/flink-filesystems/flink-azure-fs-native/src/test/java/org/apache/flink/fs/azurefs/AzurePathUtilsTest.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.fs.azurefs;
+
+import org.apache.flink.core.fs.Path;
+
+import com.azure.storage.file.datalake.models.PathItem;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.net.URI;
+import java.time.OffsetDateTime;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Tests for {@link AzurePathUtils}. */
+class AzurePathUtilsTest {
+
+    private static final URI FILESYSTEM_URI =
+            URI.create("abfss://container@account.dfs.core.windows.net/");
+
+    static Stream<Arguments> pathCases() {
+        return Stream.of(
+                Arguments.of(
+                        "dir/file.txt",
+                        "abfss://container@account.dfs.core.windows.net/dir/file.txt"),
+                Arguments.of("file.txt", "abfss://container@account.dfs.core.windows.net/file.txt"),
+                Arguments.of(
+                        "a/b/c/deep.parquet",
+                        "abfss://container@account.dfs.core.windows.net/a/b/c/deep.parquet"),
+                Arguments.of(
+                        "dir/file with spaces.txt",
+                        "abfss://container@account.dfs.core.windows.net/dir/file with spaces.txt"),
+                Arguments.of(
+                        "special-chars/a=1/b=2/part-00000.parquet",
+                        "abfss://container@account.dfs.core.windows.net/special-chars/a=1/b=2/part-00000.parquet"));
+    }
+
+    @ParameterizedTest
+    @MethodSource("pathCases")
+    void buildDataLakePathConstructsCorrectPath(final String itemName, final String expectedPath) {
+        final PathItem pathItem = createPathItem(itemName);
+
+        final Path result = AzurePathUtils.buildDataLakePath(FILESYSTEM_URI, pathItem);
+
+        assertThat(result.toString()).isEqualTo(expectedPath);
+    }
+
+    @Test
+    void buildDataLakePathHandlesLeadingSlash() {
+        final PathItem pathItem = createPathItem("/already/absolute");
+
+        final Path result = AzurePathUtils.buildDataLakePath(FILESYSTEM_URI, pathItem);
+
+        assertThat(result.toString())
+                .isEqualTo("abfss://container@account.dfs.core.windows.net/already/absolute");
+    }
+
+    @Test
+    void buildDataLakePathHandlesEmptyName() {
+        final PathItem pathItem = createPathItem("");
+
+        final Path result = AzurePathUtils.buildDataLakePath(FILESYSTEM_URI, pathItem);
+
+        assertThat(result.toString()).isEqualTo("abfss://container@account.dfs.core.windows.net/");
+    }
+
+    @Test
+    void buildDataLakePathStripsLeadingAndTrailingSpaces() {
+        final PathItem pathItem = createPathItem("  dir/file.txt  ");
+
+        final Path result = AzurePathUtils.buildDataLakePath(FILESYSTEM_URI, pathItem);
+
+        assertThat(result.toString())
+                .isEqualTo("abfss://container@account.dfs.core.windows.net/dir/file.txt");
+    }
+
+    @Test
+    void buildDataLakePathWorksWithoutAuthority() {
+        final URI noAuthorityUri = URI.create("abfss:///");
+        final PathItem pathItem = createPathItem("root-folder/checkpoints");
+
+        final Path result = AzurePathUtils.buildDataLakePath(noAuthorityUri, pathItem);
+
+        assertThat(result.toString()).isEqualTo("abfss:/root-folder/checkpoints");
+    }
+
+    @Test
+    void buildDataLakePathThrowsOnNullUri() {
+        final PathItem pathItem = createPathItem("file.txt");
+
+        assertThatThrownBy(() -> AzurePathUtils.buildDataLakePath(null, pathItem))
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void buildDataLakePathThrowsOnNullPathItem() {
+        assertThatThrownBy(() -> AzurePathUtils.buildDataLakePath(FILESYSTEM_URI, null))
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    private static PathItem createPathItem(final String name) {
+        return new PathItem(
+                (String) null, // eTag
+                (OffsetDateTime) null, // lastModified
+                0L, // contentLength
+                (String) null, // group
+                false, // isDirectory
+                name,
+                (String) null, // owner
+                (String) null); // permissions
+    }
+}

--- a/flink-filesystems/flink-azure-fs-native/src/test/java/org/apache/flink/fs/azurefs/TestingDataLakeStorageOperations.java
+++ b/flink-filesystems/flink-azure-fs-native/src/test/java/org/apache/flink/fs/azurefs/TestingDataLakeStorageOperations.java
@@ -1,0 +1,555 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.fs.azurefs;
+
+import com.azure.core.http.HttpResponse;
+import com.azure.storage.file.datalake.models.AccessTier;
+import com.azure.storage.file.datalake.models.ArchiveStatus;
+import com.azure.storage.file.datalake.models.CopyStatusType;
+import com.azure.storage.file.datalake.models.DataLakeStorageException;
+import com.azure.storage.file.datalake.models.LeaseDurationType;
+import com.azure.storage.file.datalake.models.LeaseStateType;
+import com.azure.storage.file.datalake.models.LeaseStatusType;
+import com.azure.storage.file.datalake.models.ListPathsOptions;
+import com.azure.storage.file.datalake.models.PathItem;
+import com.azure.storage.file.datalake.models.PathProperties;
+import com.azure.storage.file.datalake.options.DataLakeFileInputStreamOptions;
+import com.azure.storage.file.datalake.options.DataLakeFileOutputStreamOptions;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.ThreadSafe;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
+import java.time.Duration;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * In-memory implementation of {@link DataLakeStorageOperations} for testing.
+ *
+ * <p>This implementation uses a {@link ConcurrentHashMap} to store path metadata and supports error
+ * injection for simulating Azure Storage failures.
+ */
+@ThreadSafe
+final class TestingDataLakeStorageOperations implements DataLakeStorageOperations {
+
+    private static final String HDI_IS_FOLDER = "hdi_isfolder";
+
+    private final Map<String, PathEntry> paths = new ConcurrentHashMap<>();
+    private final Map<String, Integer> errorInjections = new ConcurrentHashMap<>();
+    private final Map<String, Integer> listErrorInjections = new ConcurrentHashMap<>();
+    private final Map<String, Integer> deleteErrorInjections = new ConcurrentHashMap<>();
+    private final Map<String, Integer> createErrorInjections = new ConcurrentHashMap<>();
+
+    private static final class PathEntry {
+        final boolean isDirectory;
+        @Nullable final byte[] content; // null for directories
+        @Nullable final OffsetDateTime lastModified;
+        @Nullable final Map<String, String> metadata;
+
+        PathEntry(
+                final boolean isDirectory,
+                @Nullable final byte[] content,
+                @Nullable final OffsetDateTime lastModified,
+                @Nullable final Map<String, String> metadata) {
+            this.isDirectory = isDirectory;
+            this.content = content;
+            this.lastModified = lastModified;
+            this.metadata = metadata;
+        }
+    }
+
+    /**
+     * Adds a file to the storage.
+     *
+     * @param path the file path (without leading slash)
+     * @param content the file content
+     * @param lastModified the modification time
+     * @return this instance for chaining
+     */
+    TestingDataLakeStorageOperations addFile(
+            final String path, final byte[] content, @Nullable final OffsetDateTime lastModified) {
+        return addFile(path, content, lastModified, null);
+    }
+
+    /**
+     * Adds a file to the storage with optional blob metadata.
+     *
+     * @param path the file path (without leading slash)
+     * @param content the file content
+     * @param lastModified the modification time
+     * @param metadata the blob metadata (e.g., encryption headers); may be {@code null}
+     * @return this instance for chaining
+     */
+    TestingDataLakeStorageOperations addFile(
+            final String path,
+            final byte[] content,
+            @Nullable final OffsetDateTime lastModified,
+            @Nullable final Map<String, String> metadata) {
+        paths.put(path, new PathEntry(false, content, lastModified, metadata));
+        return this;
+    }
+
+    /**
+     * Adds a directory to the storage.
+     *
+     * @param path the directory path (without leading slash)
+     * @param lastModified the modification time
+     * @return this instance for chaining
+     */
+    TestingDataLakeStorageOperations addDirectory(
+            final String path, final OffsetDateTime lastModified) {
+        paths.put(path, new PathEntry(true, null, lastModified, null));
+        return this;
+    }
+
+    /**
+     * Injects an error for the specified path.
+     *
+     * @param path the path that should fail
+     * @param statusCode the HTTP status code to return
+     * @return this instance for chaining
+     */
+    TestingDataLakeStorageOperations injectError(final String path, final int statusCode) {
+        errorInjections.put(path, statusCode);
+        return this;
+    }
+
+    /**
+     * Injects an error for listPaths operations on the specified path.
+     *
+     * @param path the path that should fail during listing
+     * @param statusCode the HTTP status code to return
+     * @return this instance for chaining
+     */
+    TestingDataLakeStorageOperations injectListError(final String path, final int statusCode) {
+        listErrorInjections.put(path, statusCode);
+        return this;
+    }
+
+    /**
+     * Injects an error for delete operations on the specified path.
+     *
+     * @param path the path that should fail during delete
+     * @param statusCode the HTTP status code to return
+     * @return this instance for chaining
+     */
+    TestingDataLakeStorageOperations injectDeleteError(final String path, final int statusCode) {
+        deleteErrorInjections.put(path, statusCode);
+        return this;
+    }
+
+    /**
+     * Injects an error for create (getOutputStream) operations on the specified path.
+     *
+     * @param path the path that should fail during create
+     * @param statusCode the HTTP status code to return
+     * @return this instance for chaining
+     */
+    TestingDataLakeStorageOperations injectCreateError(final String path, final int statusCode) {
+        createErrorInjections.put(path, statusCode);
+        return this;
+    }
+
+    /** Checks if a path exists in the storage. */
+    boolean exists(final String path) {
+        return paths.containsKey(path);
+    }
+
+    /**
+     * Creates a {@link PathProperties} instance for testing.
+     *
+     * <p>The SDK PathProperties constructor has 26 parameters. To mark a path as a directory,
+     * metadata must contain "hdi_isfolder" = "true" (position 26 in constructor).
+     */
+    private static PathProperties createPathProperties(
+            final boolean isDirectory,
+            final long fileSize,
+            @Nullable final OffsetDateTime lastModified,
+            @Nullable final Map<String, String> metadata) {
+        final Map<String, String> effectiveMetadata;
+        if (isDirectory) {
+            if (metadata != null && !metadata.isEmpty()) {
+                final Map<String, String> merged = new HashMap<>(metadata);
+                merged.put(HDI_IS_FOLDER, "true");
+                effectiveMetadata = merged;
+            } else {
+                effectiveMetadata = Map.of(HDI_IS_FOLDER, "true");
+            }
+        } else {
+            effectiveMetadata = metadata;
+        }
+        return new PathProperties(
+                (OffsetDateTime) null, // creationTime
+                lastModified,
+                (String) null, // eTag
+                fileSize,
+                (String) null, // contentType
+                (byte[]) null, // contentMd5
+                (String) null, // contentEncoding
+                (String) null, // contentDisposition
+                (String) null, // contentLanguage
+                (String) null, // cacheControl
+                (LeaseStatusType) null, // leaseStatus
+                (LeaseStateType) null, // leaseState
+                (LeaseDurationType) null, // leaseDuration
+                (String) null, // copyId
+                (CopyStatusType) null, // copyStatus
+                (String) null, // copySource
+                (String) null, // copyProgress
+                (OffsetDateTime) null, // copyCompletionTime
+                (String) null, // copyStatusDescription
+                (Boolean) null, // isServerEncrypted
+                (Boolean) null, // isIncrementalCopy
+                (AccessTier) null, // accessTier
+                (ArchiveStatus) null, // archiveStatus
+                (String) null, // encryptionKeySha256
+                (OffsetDateTime) null, // accessTierChangeTime
+                effectiveMetadata); // metadata
+    }
+
+    private static PathItem createPathItem(
+            final String name,
+            final boolean isDirectory,
+            final long contentLength,
+            @Nullable final OffsetDateTime lastModified) {
+        return new PathItem(
+                (String) null, // eTag
+                lastModified,
+                contentLength,
+                (String) null, // group
+                isDirectory,
+                name,
+                (String) null, // owner
+                (String) null); // permissions
+    }
+
+    /**
+     * An output stream that captures written bytes and blob metadata on close, storing them as a
+     * {@link PathEntry} in the enclosing {@link TestingDataLakeStorageOperations}.
+     *
+     * <p>This simulates the real Azure SDK behavior where metadata is attached to the blob at write
+     * time (via {@link DataLakeFileOutputStreamOptions#setMetadata}).
+     */
+    private final class MetadataCapturingOutputStream extends ByteArrayOutputStream {
+        private final String entryPath;
+        @Nullable private final Map<String, String> entryMetadata;
+
+        MetadataCapturingOutputStream(
+                final String entryPath, @Nullable final Map<String, String> entryMetadata) {
+            this.entryPath = entryPath;
+            this.entryMetadata = entryMetadata;
+        }
+
+        @Override
+        public void close() throws IOException {
+            super.close();
+            paths.put(
+                    entryPath,
+                    new PathEntry(false, toByteArray(), OffsetDateTime.now(), entryMetadata));
+        }
+    }
+
+    @Override
+    public FileClient getFileClient(final String path) {
+        return new FileClient() {
+            @Override
+            public PathProperties getProperties() throws DataLakeStorageException {
+                checkError(path);
+                final PathEntry entry = paths.get(path);
+                if (entry == null) {
+                    throw createStorageException(404, "Path not found: " + path);
+                }
+                final long fileSize = entry.content != null ? entry.content.length : 0L;
+                return createPathProperties(
+                        entry.isDirectory, fileSize, entry.lastModified, entry.metadata);
+            }
+
+            @Override
+            public void delete() throws DataLakeStorageException {
+                checkError(path);
+                checkDeleteError(path);
+                final PathEntry entry = paths.get(path);
+                if (entry == null) {
+                    throw createStorageException(404, "File not found: " + path);
+                }
+                if (entry.isDirectory) {
+                    throw createStorageException(409, "Cannot delete directory as file: " + path);
+                }
+                paths.remove(path);
+            }
+
+            @Override
+            public void rename(final String fileSystem, final String destinationPath)
+                    throws DataLakeStorageException {
+                checkError(path);
+                final PathEntry entry = paths.get(path);
+                if (entry == null) {
+                    throw createStorageException(404, "Source file not found: " + path);
+                }
+                if (entry.isDirectory) {
+                    throw createStorageException(409, "Cannot rename directory as file: " + path);
+                }
+                paths.remove(path);
+                paths.put(destinationPath, entry);
+            }
+
+            @Override
+            public OutputStream getOutputStream(final DataLakeFileOutputStreamOptions options)
+                    throws DataLakeStorageException {
+                checkCreateError(path);
+                return new MetadataCapturingOutputStream(path, options.getMetadata());
+            }
+
+            @Override
+            public InputStream openInputStream(final DataLakeFileInputStreamOptions options)
+                    throws DataLakeStorageException {
+                checkError(path);
+                final PathEntry entry = paths.get(path);
+                if (entry == null) {
+                    throw createStorageException(404, "File not found: " + path);
+                }
+                final byte[] content = entry.content != null ? entry.content : new byte[0];
+                return new ByteArrayInputStream(content);
+            }
+        };
+    }
+
+    @Override
+    public DirectoryClient getDirectoryClient(final String path) {
+        return new DirectoryClient() {
+            @Override
+            public void delete() throws DataLakeStorageException {
+                checkError(path);
+                checkDeleteError(path);
+                final PathEntry entry = paths.get(path);
+                if (entry == null) {
+                    throw createStorageException(404, "Directory not found: " + path);
+                }
+                if (!entry.isDirectory) {
+                    throw createStorageException(409, "Cannot delete file as directory: " + path);
+                }
+                // Check if directory is empty
+                final String prefix = path + "/";
+                for (final String p : paths.keySet()) {
+                    if (p.startsWith(prefix)) {
+                        throw createStorageException(409, "Directory is not empty: " + path);
+                    }
+                }
+                paths.remove(path);
+            }
+
+            @Override
+            public void deleteRecursively() throws DataLakeStorageException {
+                checkError(path);
+                checkDeleteError(path);
+                final PathEntry entry = paths.get(path);
+                if (entry == null) {
+                    throw createStorageException(404, "Directory not found: " + path);
+                }
+                if (!entry.isDirectory) {
+                    throw createStorageException(409, "Cannot delete file as directory: " + path);
+                }
+                // Delete the directory and all children
+                final String prefix = path + "/";
+                paths.keySet().removeIf(p -> p.equals(path) || p.startsWith(prefix));
+            }
+
+            @Override
+            public void createIfNotExists() throws DataLakeStorageException {
+                checkError(path);
+                paths.putIfAbsent(path, new PathEntry(true, null, OffsetDateTime.now(), null));
+            }
+
+            @Override
+            public void rename(final String fileSystem, final String destinationPath)
+                    throws DataLakeStorageException {
+                checkError(path);
+                final PathEntry entry = paths.get(path);
+                if (entry == null) {
+                    throw createStorageException(404, "Source directory not found: " + path);
+                }
+                if (!entry.isDirectory) {
+                    throw createStorageException(409, "Cannot rename file as directory: " + path);
+                }
+
+                // Rename the directory and all children
+                final String srcPrefix = path + "/";
+                final Map<String, PathEntry> toRename = new HashMap<>();
+                for (final Map.Entry<String, PathEntry> e : paths.entrySet()) {
+                    final String p = e.getKey();
+                    if (p.equals(path) || p.startsWith(srcPrefix)) {
+                        toRename.put(p, e.getValue());
+                    }
+                }
+
+                for (final Map.Entry<String, PathEntry> e : toRename.entrySet()) {
+                    final String oldPath = e.getKey();
+                    final String newPath;
+                    if (oldPath.equals(path)) {
+                        newPath = destinationPath;
+                    } else {
+                        newPath = destinationPath + oldPath.substring(path.length());
+                    }
+                    paths.remove(oldPath);
+                    paths.put(newPath, e.getValue());
+                }
+            }
+        };
+    }
+
+    @Override
+    public Iterable<PathItem> listPaths(
+            final ListPathsOptions options, @Nullable final Duration timeout)
+            throws DataLakeStorageException {
+        final String path = options.getPath() != null ? options.getPath() : "";
+        final boolean recursive = options.isRecursive();
+
+        checkError(path);
+        checkListError(path);
+        final List<PathItem> results = new ArrayList<>();
+
+        if (path.isEmpty()) {
+            // List root directory
+            for (final Map.Entry<String, PathEntry> entry : paths.entrySet()) {
+                final String entryPath = entry.getKey();
+                if (!recursive && entryPath.contains("/")) {
+                    // Skip nested items in non-recursive mode
+                    continue;
+                }
+                final PathEntry pathEntry = entry.getValue();
+                final long size = pathEntry.content != null ? pathEntry.content.length : 0L;
+                results.add(
+                        createPathItem(
+                                entryPath, pathEntry.isDirectory, size, pathEntry.lastModified));
+            }
+        } else {
+            // List specific directory
+            final String prefix = path + "/";
+            for (final Map.Entry<String, PathEntry> entry : paths.entrySet()) {
+                final String entryPath = entry.getKey();
+                if (!entryPath.startsWith(prefix)) {
+                    continue;
+                }
+                if (!recursive) {
+                    // Non-recursive: only immediate children
+                    final String relativePath = entryPath.substring(prefix.length());
+                    if (relativePath.contains("/")) {
+                        continue;
+                    }
+                }
+                final PathEntry pathEntry = entry.getValue();
+                final long size = pathEntry.content != null ? pathEntry.content.length : 0L;
+                results.add(
+                        createPathItem(
+                                entryPath, pathEntry.isDirectory, size, pathEntry.lastModified));
+            }
+        }
+
+        return results;
+    }
+
+    private void checkError(final String path) throws DataLakeStorageException {
+        final Integer statusCode = errorInjections.get(path);
+        if (statusCode != null) {
+            throw createStorageException(statusCode, "Injected error for path: " + path);
+        }
+    }
+
+    private void checkListError(final String path) throws DataLakeStorageException {
+        final Integer statusCode = listErrorInjections.get(path);
+        if (statusCode != null) {
+            throw createStorageException(statusCode, "Injected list error for path: " + path);
+        }
+    }
+
+    private void checkDeleteError(final String path) throws DataLakeStorageException {
+        final Integer statusCode = deleteErrorInjections.get(path);
+        if (statusCode != null) {
+            throw createStorageException(statusCode, "Injected delete error for path: " + path);
+        }
+    }
+
+    private void checkCreateError(final String path) throws DataLakeStorageException {
+        final Integer statusCode = createErrorInjections.get(path);
+        if (statusCode != null) {
+            throw createStorageException(statusCode, "Injected create error for path: " + path);
+        }
+    }
+
+    static DataLakeStorageException createStorageException(final int statusCode) {
+        return createStorageException(statusCode, "test error");
+    }
+
+    static DataLakeStorageException createStorageException(
+            final int statusCode, final String message) {
+        return new DataLakeStorageException(message, createMockResponse(statusCode), null);
+    }
+
+    private static HttpResponse createMockResponse(final int statusCode) {
+        return new HttpResponse(null) {
+            @Override
+            public int getStatusCode() {
+                return statusCode;
+            }
+
+            @Override
+            public String getHeaderValue(final String name) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public com.azure.core.http.HttpHeaders getHeaders() {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public Flux<ByteBuffer> getBody() {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public Mono<byte[]> getBodyAsByteArray() {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public Mono<String> getBodyAsString() {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public Mono<String> getBodyAsString(final Charset charset) {
+                throw new UnsupportedOperationException();
+            }
+        };
+    }
+}

--- a/flink-filesystems/flink-azure-fs-native/src/test/java/org/apache/flink/fs/azurefs/TestingDataLakeStorageOperationsTest.java
+++ b/flink-filesystems/flink-azure-fs-native/src/test/java/org/apache/flink/fs/azurefs/TestingDataLakeStorageOperationsTest.java
@@ -1,0 +1,462 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.fs.azurefs;
+
+import com.azure.storage.file.datalake.models.DataLakeStorageException;
+import com.azure.storage.file.datalake.models.ListPathsOptions;
+import com.azure.storage.file.datalake.models.PathItem;
+import com.azure.storage.file.datalake.models.PathProperties;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import javax.annotation.Nullable;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Tests for {@link TestingDataLakeStorageOperations}.
+ *
+ * <p>Validates that the test double correctly constructs SDK types ({@link PathProperties}, {@link
+ * PathItem}) whose constructors are fragile and could break on dependency upgrades.
+ */
+class TestingDataLakeStorageOperationsTest {
+
+    private static final OffsetDateTime TEST_TIME =
+            OffsetDateTime.of(2026, 1, 15, 10, 30, 0, 0, ZoneOffset.UTC);
+
+    // --- PathProperties construction (26-param SDK constructor) ---
+
+    static Stream<Arguments> pathPropertiesCases() {
+        return Stream.of(
+                // isDirectory, contentSize, lastModified, expectedSize
+                Arguments.of(false, 42, TEST_TIME, 42L),
+                Arguments.of(false, 10, TEST_TIME, 10L),
+                Arguments.of(true, 0, TEST_TIME, 0L),
+                Arguments.of(false, 5, null, 5L));
+    }
+
+    @ParameterizedTest
+    @MethodSource("pathPropertiesCases")
+    void shouldConstructPathPropertiesFromSdkConstructor(
+            final boolean isDirectory,
+            final int contentSize,
+            @Nullable final OffsetDateTime lastModified,
+            final long expectedSize) {
+        final TestingDataLakeStorageOperations ops = new TestingDataLakeStorageOperations();
+        if (isDirectory) {
+            ops.addDirectory("path", lastModified);
+        } else {
+            ops.addFile("path", new byte[contentSize], lastModified);
+        }
+
+        final PathProperties props = ops.getFileClient("path").getProperties();
+
+        assertThat(props.isDirectory()).isEqualTo(isDirectory);
+        assertThat(props.getFileSize()).isEqualTo(expectedSize);
+        assertThat(props.getLastModified()).isEqualTo(lastModified);
+    }
+
+    // --- PathItem construction ---
+
+    static Stream<Arguments> pathItemCases() {
+        return Stream.of(
+                // isDirectory, contentSize, expectedSize
+                Arguments.of(false, 100, 100L), Arguments.of(true, 0, 0L));
+    }
+
+    @ParameterizedTest
+    @MethodSource("pathItemCases")
+    void shouldConstructPathItemFromSdkConstructor(
+            final boolean isDirectory, final int contentSize, final long expectedSize) {
+        final TestingDataLakeStorageOperations ops = new TestingDataLakeStorageOperations();
+        final String parent = "parent";
+        final String child = parent + "/entry";
+        if (isDirectory) {
+            ops.addDirectory(child, TEST_TIME);
+        } else {
+            ops.addFile(child, new byte[contentSize], TEST_TIME);
+        }
+
+        final ListPathsOptions options = new ListPathsOptions().setPath(parent).setRecursive(false);
+        final List<PathItem> items = toList(ops.listPaths(options, null));
+
+        assertThat(items).hasSize(1);
+        final PathItem item = items.get(0);
+        assertThat(item.getName()).isEqualTo(child);
+        assertThat(item.isDirectory()).isEqualTo(isDirectory);
+        assertThat(item.getContentLength()).isEqualTo(expectedSize);
+        assertThat(item.getLastModified()).isEqualTo(TEST_TIME);
+    }
+
+    // --- Error injection ---
+
+    static Stream<Arguments> errorInjectionCases() {
+        return Stream.of(
+                // injector, trigger, expectedStatusCode
+                Arguments.of(
+                        (ErrorInjector) TestingDataLakeStorageOperations::injectError,
+                        (ErrorTrigger) (ops, path) -> ops.getFileClient(path).getProperties(),
+                        503),
+                Arguments.of(
+                        (ErrorInjector) TestingDataLakeStorageOperations::injectDeleteError,
+                        (ErrorTrigger) (ops, path) -> ops.getFileClient(path).delete(),
+                        403),
+                Arguments.of(
+                        (ErrorInjector) TestingDataLakeStorageOperations::injectDeleteError,
+                        (ErrorTrigger) (ops, path) -> ops.getDirectoryClient(path).delete(),
+                        403),
+                Arguments.of(
+                        (ErrorInjector) TestingDataLakeStorageOperations::injectDeleteError,
+                        (ErrorTrigger)
+                                (ops, path) -> ops.getDirectoryClient(path).deleteRecursively(),
+                        403),
+                Arguments.of(
+                        (ErrorInjector) TestingDataLakeStorageOperations::injectListError,
+                        (ErrorTrigger)
+                                (ops, path) ->
+                                        ops.listPaths(
+                                                new ListPathsOptions()
+                                                        .setPath(path)
+                                                        .setRecursive(false),
+                                                null),
+                        500));
+    }
+
+    @ParameterizedTest
+    @MethodSource("errorInjectionCases")
+    void shouldThrowInjectedError(
+            final ErrorInjector injector,
+            final ErrorTrigger trigger,
+            final int expectedStatusCode) {
+        final TestingDataLakeStorageOperations ops = new TestingDataLakeStorageOperations();
+        ops.addFile("target", new byte[10], TEST_TIME);
+        injector.inject(ops, "target", expectedStatusCode);
+
+        assertThatThrownBy(() -> trigger.execute(ops, "target"))
+                .isInstanceOf(DataLakeStorageException.class)
+                .satisfies(
+                        e ->
+                                assertThat(((DataLakeStorageException) e).getStatusCode())
+                                        .isEqualTo(expectedStatusCode));
+    }
+
+    @FunctionalInterface
+    private interface ErrorInjector {
+        void inject(TestingDataLakeStorageOperations ops, String path, int statusCode);
+    }
+
+    @FunctionalInterface
+    private interface ErrorTrigger {
+        void execute(TestingDataLakeStorageOperations ops, String path)
+                throws DataLakeStorageException;
+    }
+
+    // --- File operations ---
+
+    static Stream<Arguments> fileClient404Cases() {
+        return Stream.of(
+                Arguments.of((ErrorTrigger) (ops, path) -> ops.getFileClient(path).getProperties()),
+                Arguments.of((ErrorTrigger) (ops, path) -> ops.getFileClient(path).delete()),
+                Arguments.of(
+                        (ErrorTrigger) (ops, path) -> ops.getFileClient(path).rename("fs", "dst")));
+    }
+
+    @ParameterizedTest
+    @MethodSource("fileClient404Cases")
+    void shouldThrow404WhenFileNotFound(final ErrorTrigger trigger) {
+        final TestingDataLakeStorageOperations ops = new TestingDataLakeStorageOperations();
+
+        assertThatThrownBy(() -> trigger.execute(ops, "missing"))
+                .isInstanceOf(DataLakeStorageException.class)
+                .satisfies(
+                        e ->
+                                assertThat(((DataLakeStorageException) e).getStatusCode())
+                                        .isEqualTo(404));
+    }
+
+    static Stream<Arguments> fileClientTypeMismatchCases() {
+        return Stream.of(
+                Arguments.of((ErrorTrigger) (ops, path) -> ops.getFileClient(path).delete()),
+                Arguments.of(
+                        (ErrorTrigger) (ops, path) -> ops.getFileClient(path).rename("fs", "dst")));
+    }
+
+    @ParameterizedTest
+    @MethodSource("fileClientTypeMismatchCases")
+    void shouldThrow409WhenFileClientOperatesOnDirectory(final ErrorTrigger trigger) {
+        final TestingDataLakeStorageOperations ops = new TestingDataLakeStorageOperations();
+        ops.addDirectory("target", TEST_TIME);
+
+        assertThatThrownBy(() -> trigger.execute(ops, "target"))
+                .isInstanceOf(DataLakeStorageException.class)
+                .satisfies(
+                        e ->
+                                assertThat(((DataLakeStorageException) e).getStatusCode())
+                                        .isEqualTo(409));
+    }
+
+    static Stream<Arguments> deleteCases() {
+        return Stream.of(
+                // isDirectory, deleter
+                Arguments.of(false, (Deleter) (ops, path) -> ops.getFileClient(path).delete()),
+                Arguments.of(true, (Deleter) (ops, path) -> ops.getDirectoryClient(path).delete()));
+    }
+
+    @ParameterizedTest
+    @MethodSource("deleteCases")
+    void shouldDeleteEntry(final boolean isDirectory, final Deleter deleter) {
+        final TestingDataLakeStorageOperations ops = new TestingDataLakeStorageOperations();
+        if (isDirectory) {
+            ops.addDirectory("target", TEST_TIME);
+        } else {
+            ops.addFile("target", new byte[10], TEST_TIME);
+        }
+
+        deleter.delete(ops, "target");
+
+        assertThat(ops.exists("target")).isFalse();
+    }
+
+    @FunctionalInterface
+    private interface Deleter {
+        void delete(TestingDataLakeStorageOperations ops, String path);
+    }
+
+    @Test
+    void shouldRenameFile() {
+        final TestingDataLakeStorageOperations ops = new TestingDataLakeStorageOperations();
+        ops.addFile("old.txt", new byte[10], TEST_TIME);
+
+        ops.getFileClient("old.txt").rename("container", "new.txt");
+
+        assertThat(ops.exists("old.txt")).isFalse();
+        assertThat(ops.exists("new.txt")).isTrue();
+    }
+
+    // --- Directory operations ---
+
+    static Stream<Arguments> directoryClient404Cases() {
+        return Stream.of(
+                Arguments.of((ErrorTrigger) (ops, path) -> ops.getDirectoryClient(path).delete()),
+                Arguments.of(
+                        (ErrorTrigger)
+                                (ops, path) -> ops.getDirectoryClient(path).deleteRecursively()),
+                Arguments.of(
+                        (ErrorTrigger)
+                                (ops, path) -> ops.getDirectoryClient(path).rename("fs", "dst")));
+    }
+
+    @ParameterizedTest
+    @MethodSource("directoryClient404Cases")
+    void shouldThrow404WhenDirectoryNotFound(final ErrorTrigger trigger) {
+        final TestingDataLakeStorageOperations ops = new TestingDataLakeStorageOperations();
+
+        assertThatThrownBy(() -> trigger.execute(ops, "missing"))
+                .isInstanceOf(DataLakeStorageException.class)
+                .satisfies(
+                        e ->
+                                assertThat(((DataLakeStorageException) e).getStatusCode())
+                                        .isEqualTo(404));
+    }
+
+    static Stream<Arguments> directoryClientTypeMismatchCases() {
+        return Stream.of(
+                Arguments.of((ErrorTrigger) (ops, path) -> ops.getDirectoryClient(path).delete()),
+                Arguments.of(
+                        (ErrorTrigger)
+                                (ops, path) -> ops.getDirectoryClient(path).deleteRecursively()),
+                Arguments.of(
+                        (ErrorTrigger)
+                                (ops, path) -> ops.getDirectoryClient(path).rename("fs", "dst")));
+    }
+
+    @ParameterizedTest
+    @MethodSource("directoryClientTypeMismatchCases")
+    void shouldThrow409WhenDirectoryClientOperatesOnFile(final ErrorTrigger trigger) {
+        final TestingDataLakeStorageOperations ops = new TestingDataLakeStorageOperations();
+        ops.addFile("target", new byte[10], TEST_TIME);
+
+        assertThatThrownBy(() -> trigger.execute(ops, "target"))
+                .isInstanceOf(DataLakeStorageException.class)
+                .satisfies(
+                        e ->
+                                assertThat(((DataLakeStorageException) e).getStatusCode())
+                                        .isEqualTo(409));
+    }
+
+    @Test
+    void shouldThrow409WhenDeletingNonEmptyDirectory() {
+        final TestingDataLakeStorageOperations ops = new TestingDataLakeStorageOperations();
+        ops.addDirectory("dir", TEST_TIME);
+        ops.addFile("dir/child.txt", new byte[5], TEST_TIME);
+
+        assertThatThrownBy(() -> ops.getDirectoryClient("dir").delete())
+                .isInstanceOf(DataLakeStorageException.class)
+                .satisfies(
+                        e ->
+                                assertThat(((DataLakeStorageException) e).getStatusCode())
+                                        .isEqualTo(409));
+    }
+
+    @Test
+    void shouldDeleteRecursively() {
+        final TestingDataLakeStorageOperations ops = new TestingDataLakeStorageOperations();
+        ops.addDirectory("dir", TEST_TIME);
+        ops.addFile("dir/a.txt", new byte[5], TEST_TIME);
+        ops.addDirectory("dir/sub", TEST_TIME);
+        ops.addFile("dir/sub/b.txt", new byte[5], TEST_TIME);
+
+        ops.getDirectoryClient("dir").deleteRecursively();
+
+        assertThat(ops.exists("dir")).isFalse();
+        assertThat(ops.exists("dir/a.txt")).isFalse();
+        assertThat(ops.exists("dir/sub")).isFalse();
+        assertThat(ops.exists("dir/sub/b.txt")).isFalse();
+    }
+
+    @Test
+    void shouldCreateDirectoryIfNotExists() {
+        final TestingDataLakeStorageOperations ops = new TestingDataLakeStorageOperations();
+
+        ops.getDirectoryClient("newdir").createIfNotExists();
+
+        assertThat(ops.exists("newdir")).isTrue();
+    }
+
+    @Test
+    void shouldNotOverwriteExistingDirectoryOnCreateIfNotExists() {
+        final TestingDataLakeStorageOperations ops = new TestingDataLakeStorageOperations();
+        ops.addDirectory("existing", TEST_TIME);
+
+        ops.getDirectoryClient("existing").createIfNotExists();
+
+        assertThat(ops.exists("existing")).isTrue();
+    }
+
+    @Test
+    void shouldRenameDirectoryWithChildren() {
+        final TestingDataLakeStorageOperations ops = new TestingDataLakeStorageOperations();
+        ops.addDirectory("src", TEST_TIME);
+        ops.addFile("src/file.txt", new byte[10], TEST_TIME);
+
+        ops.getDirectoryClient("src").rename("container", "dst");
+
+        assertThat(ops.exists("src")).isFalse();
+        assertThat(ops.exists("src/file.txt")).isFalse();
+        assertThat(ops.exists("dst")).isTrue();
+        assertThat(ops.exists("dst/file.txt")).isTrue();
+    }
+
+    // --- listPaths ---
+
+    static Stream<Arguments> listPathsRecursiveCases() {
+        return Stream.of(
+                // recursive, expectedNames
+                Arguments.of(false, List.of("dir/a.txt", "dir/sub")),
+                Arguments.of(true, List.of("dir/a.txt", "dir/sub", "dir/sub/deep.txt")));
+    }
+
+    @ParameterizedTest
+    @MethodSource("listPathsRecursiveCases")
+    void shouldListPathsRespectingRecursiveFlag(
+            final boolean recursive, final List<String> expectedNames) {
+        final TestingDataLakeStorageOperations ops = new TestingDataLakeStorageOperations();
+        ops.addFile("dir/a.txt", new byte[1], TEST_TIME);
+        ops.addDirectory("dir/sub", TEST_TIME);
+        ops.addFile("dir/sub/deep.txt", new byte[1], TEST_TIME);
+
+        final ListPathsOptions options =
+                new ListPathsOptions().setPath("dir").setRecursive(recursive);
+        final List<PathItem> items = toList(ops.listPaths(options, null));
+
+        assertThat(items)
+                .extracting(PathItem::getName)
+                .containsExactlyInAnyOrderElementsOf(expectedNames);
+    }
+
+    static Stream<Arguments> listRootCases() {
+        return Stream.of(
+                // recursive, expectedNames
+                Arguments.of(false, List.of("top.txt", "dir")),
+                Arguments.of(true, List.of("top.txt", "dir", "dir/nested.txt")));
+    }
+
+    @ParameterizedTest
+    @MethodSource("listRootCases")
+    void shouldListRootPathsRespectingRecursiveFlag(
+            final boolean recursive, final List<String> expectedNames) {
+        final TestingDataLakeStorageOperations ops = new TestingDataLakeStorageOperations();
+        ops.addFile("top.txt", new byte[1], TEST_TIME);
+        ops.addDirectory("dir", TEST_TIME);
+        ops.addFile("dir/nested.txt", new byte[1], TEST_TIME);
+
+        final ListPathsOptions options = new ListPathsOptions().setRecursive(recursive);
+        final List<PathItem> items = toList(ops.listPaths(options, null));
+
+        assertThat(items)
+                .extracting(PathItem::getName)
+                .containsExactlyInAnyOrderElementsOf(expectedNames);
+    }
+
+    @Test
+    void shouldReturnEmptyListForEmptyDirectory() {
+        final TestingDataLakeStorageOperations ops = new TestingDataLakeStorageOperations();
+        ops.addDirectory("empty", TEST_TIME);
+
+        final ListPathsOptions options =
+                new ListPathsOptions().setPath("empty").setRecursive(false);
+        final List<PathItem> items = toList(ops.listPaths(options, null));
+
+        assertThat(items).isEmpty();
+    }
+
+    // --- createStorageException ---
+
+    @Test
+    void shouldCreateStorageExceptionWithStatusCode() {
+        final DataLakeStorageException ex =
+                TestingDataLakeStorageOperations.createStorageException(429);
+
+        assertThat(ex.getStatusCode()).isEqualTo(429);
+    }
+
+    @Test
+    void shouldCreateStorageExceptionWithMessage() {
+        final DataLakeStorageException ex =
+                TestingDataLakeStorageOperations.createStorageException(503, "Service Unavailable");
+
+        assertThat(ex.getStatusCode()).isEqualTo(503);
+        assertThat(ex.getMessage()).contains("Service Unavailable");
+    }
+
+    private static <T> List<T> toList(final Iterable<T> iterable) {
+        final List<T> list = new ArrayList<>();
+        iterable.forEach(list::add);
+        return list;
+    }
+}

--- a/flink-filesystems/flink-fs-cse-aes-gcm/pom.xml
+++ b/flink-filesystems/flink-fs-cse-aes-gcm/pom.xml
@@ -1,0 +1,150 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.flink</groupId>
+        <artifactId>flink-filesystems</artifactId>
+        <version>2.4-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>flink-fs-cse-aes-gcm</artifactId>
+    <name>Flink : FileSystems : CSE AES-GCM</name>
+
+    <packaging>jar</packaging>
+
+    <properties>
+        <bc-fips.version>2.1.2</bc-fips.version>
+    </properties>
+
+    <dependencies>
+        <!-- Flink core (provided — each FS plugin bundles its own) -->
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-core</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-fs-cse-common</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- bc-fips must NOT be shaded — JCA provider registration and FIPS self-integrity
+             checksums break under class relocation. Shipped as a separate jar via
+             flink-dist opt.xml. -->
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bc-fips</artifactId>
+            <version>${bc-fips.version}</version>
+        </dependency>
+
+        <!-- Test dependencies -->
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-fs-cse-common</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <!-- Copy bc-fips jar to target/ unshaded — FIPS self-integrity checksums
+                 break under class relocation. Consumed by flink-dist opt.xml. -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>copy-bc-fips</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>copy</goal>
+                        </goals>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>org.bouncycastle</groupId>
+                                    <artifactId>bc-fips</artifactId>
+                                    <version>${bc-fips.version}</version>
+                                    <outputDirectory>${project.build.directory}</outputDirectory>
+                                </artifactItem>
+                            </artifactItems>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>coverage</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.jacoco</groupId>
+                        <artifactId>jacoco-maven-plugin</artifactId>
+                        <version>0.8.12</version>
+                        <executions>
+                            <execution>
+                                <id>prepare-agent</id>
+                                <goals>
+                                    <goal>prepare-agent</goal>
+                                </goals>
+                            </execution>
+                            <execution>
+                                <id>report</id>
+                                <phase>test</phase>
+                                <goals>
+                                    <goal>report</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+            <properties>
+                <flink.surefire.baseArgLine>${argLine} -XX:+UseG1GC -Xms256m -XX:+IgnoreUnrecognizedVMOptions</flink.surefire.baseArgLine>
+            </properties>
+        </profile>
+    </profiles>
+
+</project>

--- a/flink-filesystems/flink-fs-cse-aes-gcm/src/main/java/org/apache/flink/fs/cse/aes/gcm/AesGcmCipherStreams.java
+++ b/flink-filesystems/flink-fs-cse-aes-gcm/src/main/java/org/apache/flink/fs/cse/aes/gcm/AesGcmCipherStreams.java
@@ -1,0 +1,161 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.fs.cse.aes.gcm;
+
+import org.apache.flink.util.Preconditions;
+
+import org.bouncycastle.jcajce.io.CipherOutputStream;
+
+import javax.annotation.concurrent.Immutable;
+import javax.crypto.Cipher;
+import javax.crypto.spec.GCMParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.security.GeneralSecurityException;
+import java.security.Provider;
+
+import static org.apache.flink.fs.cse.aes.gcm.AesGcmEncryptionMetadata.GCM_TAG_LENGTH;
+
+/**
+ * Static utilities for AES-256-GCM stream encryption and decryption via the BCFIPS JCA provider.
+ */
+@Immutable
+final class AesGcmCipherStreams {
+
+    /** GCM IV length in bytes (NIST SP 800-38D recommended). */
+    static final int GCM_IV_LENGTH = 12;
+
+    /** Total overhead: IV prefix plus GCM authentication tag. */
+    static final int GCM_OVERHEAD_BYTES = GCM_IV_LENGTH + GCM_TAG_LENGTH;
+
+    /** Key length in bytes for AES-256. */
+    static final int AES_256_KEY_LENGTH = 32;
+
+    /**
+     * JCA cipher algorithm identifier, also used as the wire-format algorithm value in metadata.
+     */
+    static final String ALGORITHM = "AES/GCM/NoPadding";
+
+    /** GCM tag length in bits, as required by {@link GCMParameterSpec}. */
+    private static final int GCM_TAG_LENGTH_BITS = GCM_TAG_LENGTH * 8;
+
+    private AesGcmCipherStreams() {}
+
+    /**
+     * Wraps {@code rawOut} in an AES-256-GCM encrypting stream.
+     *
+     * <p>Wire format: {@code [12-byte IV][ciphertext][16-byte GCM tag]}. The IV prefix is written
+     * immediately, and the GCM tag is appended automatically when the returned stream is closed.
+     *
+     * <p>Uses BouncyCastle FIPS via the supplied JCA {@link Provider}. The returned stream is a BC
+     * {@link CipherOutputStream} — not the JDK's {@code javax.crypto.CipherOutputStream} — because
+     * BC's implementation calls {@code cipher.doFinal()} on close, which is required to finalize
+     * the GCM authentication tag. The JDK's version swallows exceptions from {@code doFinal()},
+     * which would silently produce truncated ciphertext.
+     *
+     * @param rawOut the underlying output stream; must not be null
+     * @param key 32-byte AES-256 key material; must not be null
+     * @param iv 12-byte GCM initialization vector; must not be null
+     * @param provider the JCA {@link Provider} to use for cipher instantiation; must not be null
+     * @return an encrypting {@link OutputStream} wrapping {@code rawOut}
+     * @throws IOException if writing the IV prefix or cipher initialization fails
+     * @throws IllegalArgumentException if {@code key} or {@code iv} have wrong length
+     */
+    static OutputStream wrapEncrypting(
+            final OutputStream rawOut, final byte[] key, final byte[] iv, final Provider provider)
+            throws IOException {
+        Preconditions.checkNotNull(rawOut, "rawOut must not be null");
+        final Cipher cipher = initCipher(Cipher.ENCRYPT_MODE, key, iv, provider);
+        rawOut.write(iv);
+        return new CipherOutputStream(rawOut, cipher);
+    }
+
+    /**
+     * Wraps {@code ciphertextIn} in an AES-256-GCM decrypting stream.
+     *
+     * <p>The caller must have already consumed the 12-byte IV prefix from the underlying stream and
+     * provide it via {@code iv}. The returned stream decrypts ciphertext in 8192-byte chunks and
+     * verifies the GCM authentication tag when EOF is reached or the stream is closed (stream is
+     * drained till EOF on close).
+     *
+     * @param ciphertextIn ciphertext stream positioned after the IV prefix; must not be null
+     * @param key 32-byte AES-256 key material; must not be null
+     * @param iv 12-byte GCM initialization vector; must not be null
+     * @param provider the JCA {@link Provider} to use for cipher instantiation; must not be null
+     * @return a decrypting {@link InputStream} wrapping {@code ciphertextIn}
+     * @throws IOException if cipher initialization fails
+     * @throws IllegalArgumentException if {@code key} or {@code iv} have wrong length
+     */
+    static InputStream wrapDecrypting(
+            final InputStream ciphertextIn,
+            final byte[] key,
+            final byte[] iv,
+            final Provider provider)
+            throws IOException {
+        Preconditions.checkNotNull(ciphertextIn, "ciphertextIn must not be null");
+        final Cipher cipher = initCipher(Cipher.DECRYPT_MODE, key, iv, provider);
+        return new AesGcmDecryptingInputStream(ciphertextIn, cipher);
+    }
+
+    /**
+     * Validates {@code key} and {@code iv}, then creates and initializes an AES-GCM {@link Cipher}.
+     *
+     * @param mode {@link Cipher#ENCRYPT_MODE} or {@link Cipher#DECRYPT_MODE}
+     * @param key 32-byte AES-256 key material; must not be null
+     * @param iv 12-byte GCM initialization vector; must not be null
+     * @param provider the JCA {@link Provider} to use for cipher instantiation; must not be null
+     * @return an initialized {@link Cipher}
+     * @throws IOException if cipher instantiation or initialization fails
+     */
+    private static Cipher initCipher(
+            final int mode, final byte[] key, final byte[] iv, final Provider provider)
+            throws IOException {
+        Preconditions.checkNotNull(provider, "provider must not be null");
+        Preconditions.checkNotNull(key, "key must not be null");
+        Preconditions.checkArgument(
+                key.length == AES_256_KEY_LENGTH,
+                "key must be exactly %s bytes, got %s",
+                AES_256_KEY_LENGTH,
+                key.length);
+        Preconditions.checkNotNull(iv, "iv must not be null");
+        Preconditions.checkArgument(
+                iv.length == GCM_IV_LENGTH,
+                "iv must be exactly %s bytes, got %s",
+                GCM_IV_LENGTH,
+                iv.length);
+
+        try {
+            final Cipher cipher = Cipher.getInstance(ALGORITHM, provider);
+            cipher.init(
+                    mode,
+                    new SecretKeySpec(key, "AES"),
+                    new GCMParameterSpec(GCM_TAG_LENGTH_BITS, iv));
+            return cipher;
+        } catch (final GeneralSecurityException e) {
+            throw new IOException(
+                    String.format(
+                            "Failed to initialize AES-GCM cipher (algorithm=%s, provider=%s).",
+                            ALGORITHM, provider.getName()),
+                    e);
+        }
+    }
+}

--- a/flink-filesystems/flink-fs-cse-aes-gcm/src/main/java/org/apache/flink/fs/cse/aes/gcm/AesGcmCseInputStreamExtension.java
+++ b/flink-filesystems/flink-fs-cse-aes-gcm/src/main/java/org/apache/flink/fs/cse/aes/gcm/AesGcmCseInputStreamExtension.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.fs.cse.aes.gcm;
+
+import org.apache.flink.core.fs.InputStreamExtension;
+import org.apache.flink.core.fs.InputStreamOpener;
+import org.apache.flink.core.fs.RawAndWrappedInputStreams;
+import org.apache.flink.core.fs.ReadContext;
+import org.apache.flink.util.Preconditions;
+import org.apache.flink.util.function.FunctionWithException;
+
+import javax.annotation.concurrent.NotThreadSafe;
+
+import java.io.BufferedInputStream;
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * {@link InputStreamExtension} that opens a raw stream at offset 0, wraps it with buffering, and
+ * applies CSE decryption. On seek, the decrypting stream is reopened from the start and skipped
+ * forward.
+ */
+@NotThreadSafe
+final class AesGcmCseInputStreamExtension implements InputStreamExtension {
+
+    private final InputStreamOpener opener;
+    private final int readBufferSize;
+    private final FunctionWithException<InputStream, InputStream, IOException> decryptorFactory;
+
+    AesGcmCseInputStreamExtension(
+            final InputStreamOpener opener,
+            final int readBufferSize,
+            final FunctionWithException<InputStream, InputStream, IOException> decryptorFactory) {
+        this.opener = Preconditions.checkNotNull(opener, "opener");
+        Preconditions.checkArgument(readBufferSize > 0, "readBufferSize must be positive");
+        this.readBufferSize = readBufferSize;
+        this.decryptorFactory = Preconditions.checkNotNull(decryptorFactory, "decryptorFactory");
+    }
+
+    @Override
+    public RawAndWrappedInputStreams openStream(final StreamContext ctx) throws IOException {
+        final InputStream raw = opener.open(ReadContext.of(0L));
+        final InputStream buffered = new BufferedInputStream(raw, readBufferSize);
+        final InputStream decrypting = applyOrCloseOnFailure(buffered, decryptorFactory);
+
+        if (ctx.getPos() > 0L) {
+            skipToPositionOrCloseOnFailure(decrypting, ctx.getPos());
+        }
+
+        return new RawAndWrappedInputStreams(raw, decrypting);
+    }
+
+    /**
+     * Applies {@code factory} to {@code resource}, closing {@code resource} and adding the close
+     * exception as suppressed if the factory throws.
+     */
+    private static InputStream applyOrCloseOnFailure(
+            final InputStream resource,
+            final FunctionWithException<InputStream, InputStream, IOException> factory)
+            throws IOException {
+        try {
+            return factory.apply(resource);
+        } catch (final IOException | RuntimeException e) {
+            closeAndAddSuppressedOnFailure(resource, e);
+            throw e;
+        }
+    }
+
+    /**
+     * Skips {@code n} bytes on {@code resource}, closing it and adding the close exception as
+     * suppressed if skip throws.
+     */
+    private static void skipToPositionOrCloseOnFailure(final InputStream resource, final long n)
+            throws IOException {
+        try {
+            resource.skipNBytes(n);
+        } catch (final IOException | RuntimeException e) {
+            closeAndAddSuppressedOnFailure(resource, e);
+            throw e;
+        }
+    }
+
+    private static void closeAndAddSuppressedOnFailure(
+            final Closeable resource, final Throwable primary) {
+        try {
+            resource.close();
+        } catch (final Exception suppressed) {
+            primary.addSuppressed(suppressed);
+        }
+    }
+}

--- a/flink-filesystems/flink-fs-cse-aes-gcm/src/main/java/org/apache/flink/fs/cse/aes/gcm/AesGcmCseStreamFactory.java
+++ b/flink-filesystems/flink-fs-cse-aes-gcm/src/main/java/org/apache/flink/fs/cse/aes/gcm/AesGcmCseStreamFactory.java
@@ -1,0 +1,192 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.fs.cse.aes.gcm;
+
+import org.apache.flink.annotation.Experimental;
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.core.fs.FSDataInputStream;
+import org.apache.flink.core.fs.InputStreamOpener;
+import org.apache.flink.core.fs.ObjectStorageInputStream;
+import org.apache.flink.core.fs.OutputStreamOpener;
+import org.apache.flink.core.fs.WriteContext;
+import org.apache.flink.fs.cse.CseStreamFactory;
+import org.apache.flink.fs.cse.EncryptedReadContext;
+import org.apache.flink.fs.cse.EncryptedWriteContext;
+import org.apache.flink.fs.cse.KeyMaterial;
+import org.apache.flink.fs.cse.KeyProvider;
+import org.apache.flink.util.Preconditions;
+
+import org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.ThreadSafe;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.security.Provider;
+import java.security.SecureRandom;
+import java.util.Map;
+
+/**
+ * AES-256-GCM {@link CseStreamFactory} backed by BouncyCastle FIPS.
+ *
+ * <p>This factory owns all GCM-specific concerns: IV generation via a shared {@link SecureRandom},
+ * BCFIPS provider instantiation, {@link AesGcmEncryptionMetadata} construction (write path) and
+ * parsing (read path), and {@link KeyProvider} calls. The BCFIPS provider is held as a field and
+ * passed explicitly to each cipher operation.
+ *
+ * <p>Wire format: {@code [12-byte IV][ciphertext][16-byte GCM tag]}. The IV is written as a prefix
+ * to the ciphertext stream, and the GCM tag is appended on close.
+ *
+ * <p>Instances are thread-safe and intended to be shared across the filesystem.
+ *
+ * @see CseStreamFactory
+ * @see AesGcmEncryptionMetadata
+ */
+@Internal
+@Experimental
+@ThreadSafe
+public final class AesGcmCseStreamFactory implements CseStreamFactory {
+
+    private static final Logger LOG = LoggerFactory.getLogger(AesGcmCseStreamFactory.class);
+
+    /** Shared, thread-safe SecureRandom for IV generation. */
+    private static final SecureRandom SECURE_RANDOM = new SecureRandom();
+
+    private final KeyProvider keyProvider;
+    @Nullable private final String writeKeyId;
+    private final Map<String, String> encryptionContext;
+    private final Provider bcFipsProvider;
+
+    /**
+     * Creates an AES-256-GCM CSE stream factory and instantiates the BCFIPS JCA provider.
+     *
+     * <p>The provider is held as a field and passed explicitly to each cipher operation.
+     *
+     * @param keyProvider provider for DEK retrieval; must be thread-safe
+     * @param writeKeyId the key identifier passed to the key provider on every write, or {@code
+     *     null} for read-only decryption mode
+     * @param encryptionContext encryption context for authorization and audit; (pass {@link
+     *     Map#of()} when no context is needed)
+     */
+    public AesGcmCseStreamFactory(
+            final KeyProvider keyProvider,
+            @Nullable final String writeKeyId,
+            final Map<String, String> encryptionContext) {
+        this.keyProvider = Preconditions.checkNotNull(keyProvider, "keyProvider");
+        this.writeKeyId = writeKeyId;
+        Preconditions.checkNotNull(encryptionContext, "encryptionContext");
+        this.encryptionContext = Map.copyOf(encryptionContext);
+        this.bcFipsProvider = new BouncyCastleFipsProvider();
+    }
+
+    @Override
+    public OutputStream openEncryptedWrite(
+            final OutputStreamOpener opener, final EncryptedWriteContext ctx) throws IOException {
+        Preconditions.checkState(
+                writeKeyId != null,
+                "Cannot write encrypted data without a key-id (read-only decryption mode)");
+        LOG.debug("Opening encrypted write for '{}'", ctx.getFilePath());
+        final KeyMaterial keyMat = keyProvider.getActiveKey(writeKeyId, encryptionContext);
+        final AesGcmEncryptionMetadata encMeta =
+                new AesGcmEncryptionMetadata(
+                        keyMat.getKeyId(),
+                        keyMat.getVersion(),
+                        AesGcmCipherStreams.GCM_IV_LENGTH,
+                        encryptionContext);
+        final OutputStream raw = opener.open(WriteContext.of(encMeta.toMetadata()));
+        try {
+            return AesGcmCipherStreams.wrapEncrypting(
+                    raw, keyMat.getMaterial(), generateIv(), bcFipsProvider);
+        } catch (final IOException | RuntimeException e) {
+            try {
+                raw.close();
+            } catch (final Exception suppressed) {
+                e.addSuppressed(suppressed);
+            }
+            throw e;
+        }
+    }
+
+    @Override
+    public boolean isEncrypted(final Map<String, String> blobMetadata) {
+        return blobMetadata.containsKey(AesGcmEncryptionMetadata.META_KEY_ID);
+    }
+
+    @Override
+    public FSDataInputStream openEncryptedRead(
+            final InputStreamOpener opener, final EncryptedReadContext ctx) throws IOException {
+        final AesGcmEncryptionMetadata encMeta =
+                AesGcmEncryptionMetadata.fromMetadata(ctx.getBlobMetadata());
+        final KeyMaterial keyMat = keyProvider.getKeyForMetadata(encMeta);
+        final long ciphertextLength = ctx.getCiphertextLength();
+        Preconditions.checkArgument(
+                ciphertextLength >= AesGcmCipherStreams.GCM_OVERHEAD_BYTES,
+                "Ciphertext length %s is less than GCM overhead (%s bytes)",
+                ciphertextLength,
+                AesGcmCipherStreams.GCM_OVERHEAD_BYTES);
+        final long plaintextLength = ciphertextLength - AesGcmCipherStreams.GCM_OVERHEAD_BYTES;
+        // skipOnSeekThreshold = plaintextLength: always read-and-discard on forward seek,
+        // never reopen. GCM requires decryption from byte 0 regardless, so reopening
+        // would just add extra HTTP request(s) for the same full re-read.
+        return new ObjectStorageInputStream(
+                plaintextLength,
+                plaintextLength,
+                new AesGcmCseInputStreamExtension(
+                        opener,
+                        ctx.getReadBufferSize(),
+                        buffered -> readIvAndWrapDecrypting(buffered, keyMat, bcFipsProvider)));
+    }
+
+    /**
+     * Reads the {@link AesGcmCipherStreams#GCM_IV_LENGTH}-byte IV prefix from {@code buffered} and
+     * returns an AES-GCM decrypting stream.
+     *
+     * @param buffered the buffered ciphertext stream positioned at the start of the IV prefix
+     * @param keyMaterial the {@link AesGcmCipherStreams#AES_256_KEY_LENGTH}-byte AES-256 data
+     *     encryption key
+     * @param provider the JCA {@link Provider} to use for cipher instantiation
+     * @return a decrypting {@link InputStream}
+     * @throws IOException if the IV prefix is truncated or cipher initialization fails
+     */
+    private static InputStream readIvAndWrapDecrypting(
+            final InputStream buffered, final KeyMaterial keyMaterial, final Provider provider)
+            throws IOException {
+        final byte[] iv = buffered.readNBytes(AesGcmCipherStreams.GCM_IV_LENGTH);
+        if (iv.length != AesGcmCipherStreams.GCM_IV_LENGTH) {
+            throw new IOException("Unexpected EOF reading GCM IV prefix");
+        }
+        return AesGcmCipherStreams.wrapDecrypting(
+                buffered, keyMaterial.getMaterial(), iv, provider);
+    }
+
+    @Override
+    public void close() throws IOException {
+        keyProvider.close();
+    }
+
+    private static byte[] generateIv() {
+        final byte[] iv = new byte[AesGcmCipherStreams.GCM_IV_LENGTH];
+        SECURE_RANDOM.nextBytes(iv);
+        return iv;
+    }
+}

--- a/flink-filesystems/flink-fs-cse-aes-gcm/src/main/java/org/apache/flink/fs/cse/aes/gcm/AesGcmDecryptingInputStream.java
+++ b/flink-filesystems/flink-fs-cse-aes-gcm/src/main/java/org/apache/flink/fs/cse/aes/gcm/AesGcmDecryptingInputStream.java
@@ -1,0 +1,241 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.fs.cse.aes.gcm;
+
+import org.apache.flink.util.IOUtils;
+
+import javax.annotation.concurrent.NotThreadSafe;
+import javax.crypto.AEADBadTagException;
+import javax.crypto.Cipher;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * Streaming AES-256-GCM decrypting {@link InputStream} that works around two bugs in BC FIPS 2.1.2
+ * native GCM on Linux x86_64.
+ *
+ * <h3>Why a custom stream instead of {@code CipherInputStream}?</h3>
+ *
+ * <p>GCM decryption of checkpoint/state files must be streaming — files can be hundreds of
+ * megabytes and must not be buffered entirely in memory. Three candidate approaches exist, and none
+ * of them work:
+ *
+ * <ol>
+ *   <li><b>JDK's {@code javax.crypto.CipherInputStream}</b>: For AEAD ciphers, {@code
+ *       Cipher.update()} returns no output until {@code doFinal()} — so CipherInputStream buffers
+ *       the <em>entire</em> plaintext in memory before returning a single byte. This is a
+ *       fundamental limitation of the JDK's CipherInputStream/Cipher interaction for authenticated
+ *       ciphers, not a bug.
+ *   <li><b>BouncyCastle's {@code CipherInputStream}</b>: Streams correctly (its internal {@code
+ *       nextChunk()} calls BC's low-level {@code processBytes()} which does return intermediate
+ *       output). However, its internal buffer size is an implementation detail. If BC ever changes
+ *       it to a non-64-byte-aligned size, the native GCM bug (bc-java#2294) would corrupt
+ *       decryption silently.
+ *   <li><b>BC FIPS low-level API ({@code InputAEADDecryptor.getDecryptingStream()})</b>: Returns an
+ *       opaque {@link InputStream} backed by BC's internal {@code CipherInputStream}. Same
+ *       alignment concern as option 2, plus we lose control over buffer allocation.
+ * </ol>
+ *
+ * <p>This class takes a fourth approach: it calls {@code cipher.update()} and {@code
+ * cipher.doFinal()} directly with explicitly controlled chunk sizes. This gives us:
+ *
+ * <ul>
+ *   <li><b>Streaming</b>: plaintext is produced incrementally as ciphertext chunks are processed —
+ *       the file is never fully buffered in memory.
+ *   <li><b>Aligned reads</b>: ciphertext is always read in exact {@value #CIPHERTEXT_CHUNK_SIZE}
+ *       -byte chunks (64-byte aligned), avoiding the native GCM stale {@code inlen} bug.
+ *   <li><b>Correct buffer sizing</b>: output buffers use {@code cipher.getOutputSize()} instead of
+ *       {@code cipher.getUpdateOutputSize()}, avoiding the native {@code OutputLengthException}
+ *       bug.
+ *   <li><b>GCM tag verification at EOF</b>: {@code cipher.doFinal()} is called when the ciphertext
+ *       stream reaches EOF, verifying the authentication tag. If verification fails, an {@link
+ *       IOException} wrapping {@link AEADBadTagException} is thrown.
+ * </ul>
+ *
+ * <h3>BC FIPS bugs worked around</h3>
+ *
+ * <ol>
+ *   <li><b>Stale {@code inlen} in {@code process_buffer_dec}</b> (bc-java#2294): The native GCM
+ *       implementation does not decrement {@code inlen} after the initial alignment copy, causing
+ *       over-read and GCM hash corruption on non-64-byte-aligned input. Workaround: always feed
+ *       8192-byte (64-byte-aligned) chunks to {@code cipher.update()}.
+ *   <li><b>{@code getUpdateOutputSize()} underestimation</b>: The native path returns a buffer size
+ *       that is too small, causing {@code OutputLengthException}. Workaround: use {@code
+ *       cipher.getOutputSize()} which over-allocates to account for buffered state and tag.
+ * </ol>
+ *
+ * <p>Both bugs affect only the native GCM path on Linux x86_64 (ARM NEON, Intel AVX, Intel
+ * AVX-512). macOS and non-x86_64 platforms use the Java GCM fallback ({@code GCMBlockCipher}) which
+ * is not affected. Both are fixed in bc-fips 2.1.3 (pending FIPS re-certification).
+ *
+ * <h3>Threading and lifecycle contract</h3>
+ *
+ * <p>This stream is designed as an inner layer of {@link
+ * org.apache.flink.core.fs.ObjectStorageInputStream}, which provides thread safety (via {@code
+ * ReentrantLock}), argument validation, closed-state checks, and {@code available()} computation.
+ * This class therefore omits all of those concerns — it trusts its single caller to enforce them.
+ * It must not be used as a standalone public {@link InputStream}.
+ *
+ * @see <a href="https://github.com/bcgit/bc-java/issues/2294">bc-java#2294</a>
+ * @see AesGcmCipherStreams#wrapDecrypting
+ */
+@NotThreadSafe
+final class AesGcmDecryptingInputStream extends InputStream {
+
+    /**
+     * Ciphertext chunk size in bytes. Must be a multiple of 64 to avoid the BC FIPS native GCM
+     * stale {@code inlen} bug. 8192 is chosen for consistency with typical I/O buffer sizes.
+     *
+     * <p>{@code readNBytes()} is used to guarantee exactly this many bytes are read from the
+     * underlying stream (blocking until full or EOF), unlike {@code read()} which may return fewer.
+     */
+    static final int CIPHERTEXT_CHUNK_SIZE = 8192;
+
+    private final InputStream ciphertextStream;
+    private final Cipher cipher;
+
+    private final byte[] ciphertextBuffer;
+    private byte[] plaintextBuffer;
+    private int plaintextBufferPos;
+    private int plaintextBufferLimit;
+
+    private final byte[] singleByte = new byte[1];
+    private boolean endOfCiphertext;
+
+    AesGcmDecryptingInputStream(final InputStream ciphertextStream, final Cipher cipher) {
+        this.ciphertextStream = ciphertextStream;
+        this.cipher = cipher;
+        this.ciphertextBuffer = new byte[CIPHERTEXT_CHUNK_SIZE];
+        this.plaintextBuffer = new byte[0];
+        this.plaintextBufferPos = 0;
+        this.plaintextBufferLimit = 0;
+        this.endOfCiphertext = false;
+    }
+
+    /** Delegates to {@link #read(byte[], int, int)} to reuse the decryption logic. */
+    @Override
+    public int read() throws IOException {
+        // 0xFF mask converts signed byte (-128..127) to unsigned int (0..255) per InputStream
+        // contract
+        return read(singleByte, 0, 1) == -1 ? -1 : (singleByte[0] & 0xFF);
+    }
+
+    /** Returns at most one plaintext buffer worth of data per call; callers must loop for more. */
+    @Override
+    public int read(final byte[] b, final int off, final int len) throws IOException {
+        if (plaintextBufferPos >= plaintextBufferLimit && !fillPlaintextBuffer()) {
+            return -1;
+        }
+
+        final int available = plaintextBufferLimit - plaintextBufferPos;
+        final int toCopy = Math.min(len, available);
+        System.arraycopy(plaintextBuffer, plaintextBufferPos, b, off, toCopy);
+        plaintextBufferPos += toCopy;
+        return toCopy;
+    }
+
+    /**
+     * Reads a ciphertext chunk, decrypts it, and fills the internal plaintext buffer.
+     *
+     * <p>Uses {@code readNBytes()} to guarantee exactly {@link #CIPHERTEXT_CHUNK_SIZE} bytes are
+     * read from the underlying stream. This ensures {@code cipher.update()} always receives
+     * 64-byte-aligned input, avoiding bc-java#2294. When fewer bytes are returned (EOF), {@code
+     * cipher.doFinal()} processes the remaining ciphertext and verifies the GCM authentication tag.
+     *
+     * @return {@code true} if plaintext was produced, {@code false} if EOF
+     */
+    private boolean fillPlaintextBuffer() throws IOException {
+        if (endOfCiphertext) {
+            return false;
+        }
+
+        while (true) {
+            final int bytesRead =
+                    ciphertextStream.readNBytes(ciphertextBuffer, 0, ciphertextBuffer.length);
+
+            if (bytesRead < ciphertextBuffer.length) {
+                endOfCiphertext = true;
+                return finalizeCipher(bytesRead);
+            }
+
+            try {
+                // getOutputSize(), not getUpdateOutputSize() — the latter triggers
+                // OutputLengthException in BC native GCM.
+                final int requiredOutputBufferSize = cipher.getOutputSize(bytesRead);
+                if (plaintextBuffer.length < requiredOutputBufferSize) {
+                    plaintextBuffer = new byte[requiredOutputBufferSize];
+                }
+                final int plaintextLen =
+                        cipher.update(ciphertextBuffer, 0, bytesRead, plaintextBuffer, 0);
+                plaintextBufferPos = 0;
+                plaintextBufferLimit = plaintextLen;
+                if (plaintextLen > 0) {
+                    return true;
+                }
+            } catch (final Exception e) {
+                throw new IOException("Cipher update failed", e);
+            }
+        }
+    }
+
+    /** Calls {@code cipher.doFinal()} on the remaining ciphertext and verifies the GCM tag. */
+    private boolean finalizeCipher(final int bytesRead) throws IOException {
+        try {
+            final byte[] finalPlaintext = cipher.doFinal(ciphertextBuffer, 0, bytesRead);
+            if (finalPlaintext != null && finalPlaintext.length > 0) {
+                plaintextBuffer = finalPlaintext;
+                plaintextBufferPos = 0;
+                plaintextBufferLimit = finalPlaintext.length;
+                return true;
+            }
+        } catch (final AEADBadTagException e) {
+            throw new IOException("GCM authentication tag verification failed", e);
+        } catch (final Exception e) {
+            throw new IOException("Cipher finalization failed", e);
+        }
+        return false;
+    }
+
+    /**
+     * Drains remaining ciphertext through the cipher to trigger GCM tag verification, then closes
+     * the underlying stream.
+     *
+     * <p>If the stream was not fully consumed, this method feeds the remaining ciphertext to {@code
+     * cipher.update()} / {@code cipher.doFinal()} (discarding the plaintext output) so that the GCM
+     * authentication tag is always verified. This guarantees integrity even if the caller abandons
+     * the stream mid-read.
+     *
+     * @throws IOException if GCM tag verification fails or an I/O error occurs
+     */
+    @Override
+    public void close() throws IOException {
+        try {
+            IOUtils.closeAll(this::drainRemainingCiphertext, ciphertextStream);
+        } catch (final Exception e) {
+            throw e instanceof IOException ? (IOException) e : new IOException(e);
+        }
+    }
+
+    private void drainRemainingCiphertext() throws IOException {
+        while (!endOfCiphertext) {
+            fillPlaintextBuffer();
+        }
+    }
+}

--- a/flink-filesystems/flink-fs-cse-aes-gcm/src/main/java/org/apache/flink/fs/cse/aes/gcm/AesGcmEncryptionMetadata.java
+++ b/flink-filesystems/flink-fs-cse-aes-gcm/src/main/java/org/apache/flink/fs/cse/aes/gcm/AesGcmEncryptionMetadata.java
@@ -1,0 +1,227 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.fs.cse.aes.gcm;
+
+import org.apache.flink.annotation.Experimental;
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.fs.cse.EncryptionMetadata;
+import org.apache.flink.util.Preconditions;
+
+import javax.annotation.concurrent.Immutable;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.regex.Pattern;
+
+import static org.apache.flink.fs.cse.aes.gcm.AesGcmCipherStreams.ALGORITHM;
+
+/** AES-256-GCM {@link EncryptionMetadata}: key ID, key version, IV length, encryption context. */
+@Internal
+@Experimental
+@Immutable
+public final class AesGcmEncryptionMetadata implements EncryptionMetadata {
+
+    /** GCM authentication tag length in bytes. */
+    public static final int GCM_TAG_LENGTH = 16;
+
+    static final String META_KEY_ID = "x_cse_key_id";
+    private static final String META_KEY_VERSION = "x_cse_key_version";
+    private static final String META_IV_LENGTH = "x_cse_iv_bytes_length";
+    private static final String META_ALGORITHM = "x_cse_algorithm";
+    private static final String META_TAG_LENGTH = "x_cse_gcm_tag_length";
+    private static final String META_CTX_PREFIX = "x_cse_ctx_";
+    private static final String META_CHUNK_SIZE = "x_cse_chunk_size";
+    private static final String WHOLE_FILE_CHUNK_SIZE = "-1";
+
+    /**
+     * Allowed charset for an encryption-context key, applied to the {@code x_cse_ctx_} suffix. This
+     * is the strictest common denominator across cloud object stores: Azure blob metadata keys must
+     * be C# identifiers, which is a subset of the HTTP-header tokens AWS S3 and GCS accept. A key
+     * valid here is therefore portable to all three.
+     */
+    private static final Pattern CONTEXT_KEY_PATTERN = Pattern.compile("[A-Za-z_][A-Za-z0-9_]*");
+
+    private final String keyId;
+    private final String keyVersion;
+    private final int ivByteLength;
+    private final Map<String, String> encryptionContext;
+
+    /**
+     * @param keyId the encryption key identifier
+     * @param keyVersion the key version used for this file
+     * @param ivByteLength the IV length in bytes; must be positive
+     * @param encryptionContext key-provider authorization context; may be empty
+     */
+    public AesGcmEncryptionMetadata(
+            final String keyId,
+            final String keyVersion,
+            final int ivByteLength,
+            final Map<String, String> encryptionContext) {
+        this.keyId = Preconditions.checkNotNull(keyId, "keyId must not be null");
+        this.keyVersion = Preconditions.checkNotNull(keyVersion, "keyVersion must not be null");
+        Preconditions.checkArgument(
+                ivByteLength > 0, "ivByteLength must be positive, got %s", ivByteLength);
+        Preconditions.checkNotNull(encryptionContext, "encryptionContext must not be null");
+        encryptionContext
+                .keySet()
+                .forEach(
+                        k ->
+                                Preconditions.checkArgument(
+                                        CONTEXT_KEY_PATTERN.matcher(k).matches(),
+                                        "Encryption context key '%s' is not a valid object metadata"
+                                                + " key (must match %s)",
+                                        k,
+                                        CONTEXT_KEY_PATTERN.pattern()));
+        this.ivByteLength = ivByteLength;
+        this.encryptionContext = Map.copyOf(encryptionContext);
+    }
+
+    @Override
+    public String keyId() {
+        return keyId;
+    }
+
+    @Override
+    public String getKeyVersion() {
+        return keyVersion;
+    }
+
+    /** Returns the IV length in bytes. */
+    public int getIvByteLength() {
+        return ivByteLength;
+    }
+
+    @Override
+    public Map<String, String> getEncryptionContext() {
+        return encryptionContext;
+    }
+
+    @Override
+    public Map<String, String> toMetadata() {
+        final Map<String, String> map = new HashMap<>();
+        map.put(META_KEY_ID, keyId);
+        map.put(META_KEY_VERSION, keyVersion);
+        map.put(META_IV_LENGTH, Integer.toString(ivByteLength));
+        map.put(META_ALGORITHM, ALGORITHM);
+        map.put(META_TAG_LENGTH, Integer.toString(GCM_TAG_LENGTH));
+        map.put(META_CHUNK_SIZE, WHOLE_FILE_CHUNK_SIZE);
+        encryptionContext.forEach((k, v) -> map.put(META_CTX_PREFIX + k, v));
+        return Collections.unmodifiableMap(map);
+    }
+
+    /**
+     * Parses an {@link AesGcmEncryptionMetadata} from a flat map (e.g. file metadata).
+     *
+     * @param map the flat metadata map from cloud object metadata
+     * @return parsed metadata
+     * @throws IllegalArgumentException if any required key is missing or malformed
+     */
+    public static AesGcmEncryptionMetadata fromMetadata(final Map<String, String> map) {
+        final String keyId = requireEntry(map, META_KEY_ID);
+        final String keyVersion = requireEntry(map, META_KEY_VERSION);
+        final String ivByteLengthStr = requireEntry(map, META_IV_LENGTH);
+        final String algorithm = requireEntry(map, META_ALGORITHM);
+        final String tagLengthStr = requireEntry(map, META_TAG_LENGTH);
+
+        Preconditions.checkArgument(
+                ALGORITHM.equals(algorithm),
+                "Unsupported algorithm '%s', expected '%s'",
+                algorithm,
+                ALGORITHM);
+
+        final int tagLength = ensureInt(tagLengthStr, META_TAG_LENGTH);
+        Preconditions.checkArgument(
+                tagLength == GCM_TAG_LENGTH,
+                "Unsupported GCM tag length %s, expected %s",
+                tagLength,
+                GCM_TAG_LENGTH);
+
+        final String chunkSize = requireEntry(map, META_CHUNK_SIZE);
+        Preconditions.checkArgument(
+                WHOLE_FILE_CHUNK_SIZE.equals(chunkSize),
+                "Chunked encryption is not supported, got %s=%s",
+                META_CHUNK_SIZE,
+                chunkSize);
+
+        final int ivByteLength = ensureInt(ivByteLengthStr, META_IV_LENGTH);
+        Preconditions.checkArgument(
+                ivByteLength > 0, "IV byte length must be positive, got %s", ivByteLength);
+
+        final Map<String, String> context = new HashMap<>();
+        for (final Map.Entry<String, String> entry : map.entrySet()) {
+            if (entry.getKey().startsWith(META_CTX_PREFIX)) {
+                context.put(entry.getKey().substring(META_CTX_PREFIX.length()), entry.getValue());
+            }
+        }
+
+        return new AesGcmEncryptionMetadata(keyId, keyVersion, ivByteLength, context);
+    }
+
+    private static String requireEntry(final Map<String, String> map, final String key) {
+        final String value = map.get(key);
+        if (value == null) {
+            throw new IllegalArgumentException("Missing required metadata entry '" + key + "'");
+        }
+        return value;
+    }
+
+    private static int ensureInt(final String value, final String key) {
+        try {
+            return Integer.parseInt(value);
+        } catch (final NumberFormatException e) {
+            throw new IllegalArgumentException("Malformed value for '" + key + "': " + value, e);
+        }
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof AesGcmEncryptionMetadata)) {
+            return false;
+        }
+        final AesGcmEncryptionMetadata that = (AesGcmEncryptionMetadata) o;
+        return ivByteLength == that.ivByteLength
+                && Objects.equals(keyId, that.keyId)
+                && Objects.equals(keyVersion, that.keyVersion)
+                && Objects.equals(encryptionContext, that.encryptionContext);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(keyId, keyVersion, ivByteLength, encryptionContext);
+    }
+
+    @Override
+    public String toString() {
+        return "AesGcmEncryptionMetadata{"
+                + "keyId="
+                + keyId
+                + ", keyVersion="
+                + keyVersion
+                + ", ivByteLength="
+                + ivByteLength
+                + ", encryptionContext="
+                + encryptionContext
+                + "}";
+    }
+}

--- a/flink-filesystems/flink-fs-cse-aes-gcm/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-fs-cse-aes-gcm/src/main/resources/META-INF/NOTICE
@@ -1,0 +1,10 @@
+flink-fs-cse-aes-gcm
+Copyright 2014-2026 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+This project bundles the following dependencies under the MIT License.
+See bundled license files for details.
+
+- org.bouncycastle:bc-fips:2.1.2

--- a/flink-filesystems/flink-fs-cse-aes-gcm/src/test/java/org/apache/flink/fs/cse/aes/gcm/AesGcmCipherStreamsTest.java
+++ b/flink-filesystems/flink-fs-cse-aes-gcm/src/test/java/org/apache/flink/fs/cse/aes/gcm/AesGcmCipherStreamsTest.java
@@ -1,0 +1,307 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.fs.cse.aes.gcm;
+
+import org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.security.Provider;
+import java.security.SecureRandom;
+import java.util.stream.Stream;
+
+import static org.apache.flink.fs.cse.aes.gcm.AesGcmCipherStreams.GCM_IV_LENGTH;
+import static org.apache.flink.fs.cse.aes.gcm.AesGcmCipherStreams.GCM_OVERHEAD_BYTES;
+import static org.apache.flink.fs.cse.aes.gcm.AesGcmDecryptingInputStream.CIPHERTEXT_CHUNK_SIZE;
+import static org.apache.flink.fs.cse.aes.gcm.AesGcmEncryptionMetadata.GCM_TAG_LENGTH;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Tests for {@link AesGcmCipherStreams}. */
+class AesGcmCipherStreamsTest {
+
+    private static final Provider TEST_PROVIDER = new BouncyCastleFipsProvider();
+
+    /** 32-byte AES-256 test key (not secret — test only). */
+    private static final byte[] TEST_KEY = new byte[32];
+
+    /** Alternate 32-byte key for wrong-key tests. */
+    private static final byte[] OTHER_KEY = new byte[32];
+
+    static {
+        TEST_KEY[0] = 1;
+        OTHER_KEY[0] = 2;
+    }
+
+    private static final byte[] TEST_IV = new byte[GCM_IV_LENGTH];
+
+    // -------------------------------------------------------------------------
+    // Round-trip: parameterized over plaintext sizes
+    // -------------------------------------------------------------------------
+
+    static Stream<Integer> plaintextSizes() {
+        return Stream.of(
+                0,
+                1,
+                GCM_TAG_LENGTH,
+                CIPHERTEXT_CHUNK_SIZE - 1,
+                CIPHERTEXT_CHUNK_SIZE,
+                CIPHERTEXT_CHUNK_SIZE + 1,
+                CIPHERTEXT_CHUNK_SIZE * 3,
+                100_000);
+    }
+
+    @ParameterizedTest
+    @MethodSource("plaintextSizes")
+    void shouldRoundTripPlaintext(final int size) throws IOException {
+        final byte[] plaintext = randomBytes(size);
+        final byte[] decrypted = decrypt(encrypt(plaintext, TEST_KEY, TEST_IV), TEST_KEY);
+        assertThat(decrypted).isEqualTo(plaintext);
+    }
+
+    // -------------------------------------------------------------------------
+    // Single-byte read at EOF
+    // -------------------------------------------------------------------------
+
+    @Test
+    void singleByteReadShouldReturnMinusOneAtEof() throws IOException {
+        final byte[] plaintext = randomBytes(16);
+        final byte[] ciphertext = encrypt(plaintext, TEST_KEY, TEST_IV);
+        final ByteArrayInputStream bais = new ByteArrayInputStream(ciphertext);
+        final byte[] iv = bais.readNBytes(GCM_IV_LENGTH);
+        try (InputStream stream =
+                AesGcmCipherStreams.wrapDecrypting(bais, TEST_KEY, iv, TEST_PROVIDER)) {
+            stream.readAllBytes();
+            assertThat(stream.read()).isEqualTo(-1);
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Ciphertext size
+    // -------------------------------------------------------------------------
+
+    @ParameterizedTest
+    @MethodSource("plaintextSizes")
+    void ciphertextSizeShouldEqualPlaintextPlusOverhead(final int size) throws IOException {
+        final byte[] plaintext = randomBytes(size);
+        final byte[] ciphertext = encrypt(plaintext, TEST_KEY, TEST_IV);
+        assertThat(ciphertext).hasSize(size + GCM_OVERHEAD_BYTES);
+    }
+
+    // -------------------------------------------------------------------------
+    // Authentication failures
+    // -------------------------------------------------------------------------
+
+    @Test
+    void shouldThrowOnWrongKey() throws IOException {
+        final byte[] ciphertext = encrypt(randomBytes(64), TEST_KEY, TEST_IV);
+        assertThatThrownBy(() -> decrypt(ciphertext, OTHER_KEY)).isInstanceOf(IOException.class);
+    }
+
+    static Stream<Arguments> tamperPositions() {
+        return Stream.of(
+                Arguments.of("IV", 0),
+                Arguments.of("body", GCM_IV_LENGTH + 1),
+                Arguments.of("GCM tag", -1));
+    }
+
+    @ParameterizedTest
+    @MethodSource("tamperPositions")
+    void shouldThrowOnTamperedCiphertext(final String region, final int tamperOffset)
+            throws IOException {
+        final byte[] ciphertext = encrypt(randomBytes(64), TEST_KEY, TEST_IV);
+        final int pos = tamperOffset >= 0 ? tamperOffset : ciphertext.length - 1;
+        ciphertext[pos] ^= 0xFF;
+        assertThatThrownBy(() -> decrypt(ciphertext, TEST_KEY)).isInstanceOf(IOException.class);
+    }
+
+    // -------------------------------------------------------------------------
+    // Incremental reads: caller buffer smaller than internal plaintext buffer
+    // -------------------------------------------------------------------------
+
+    @ParameterizedTest
+    @ValueSource(ints = {1, 7, CIPHERTEXT_CHUNK_SIZE - 1})
+    void shouldDecryptCorrectlyWithSmallReadBuffer(final int readSize) throws IOException {
+        final byte[] plaintext = randomBytes(CIPHERTEXT_CHUNK_SIZE + 100);
+        final byte[] ciphertext = encrypt(plaintext, TEST_KEY, TEST_IV);
+
+        final ByteArrayInputStream bais = new ByteArrayInputStream(ciphertext);
+        final byte[] iv = bais.readNBytes(GCM_IV_LENGTH);
+        final InputStream decryptingStream =
+                AesGcmCipherStreams.wrapDecrypting(bais, TEST_KEY, iv, TEST_PROVIDER);
+
+        final ByteArrayOutputStream result = new ByteArrayOutputStream();
+        final byte[] buf = new byte[readSize];
+        int n;
+        while ((n = decryptingStream.read(buf, 0, readSize)) != -1) {
+            result.write(buf, 0, n);
+        }
+        decryptingStream.close();
+
+        assertThat(result.toByteArray()).isEqualTo(plaintext);
+    }
+
+    // -------------------------------------------------------------------------
+    // Input validation
+    // -------------------------------------------------------------------------
+
+    static Stream<Arguments> invalidWrapArgs() {
+        return Stream.of(
+                Arguments.of(
+                        "null provider",
+                        new byte[0],
+                        TEST_KEY,
+                        TEST_IV,
+                        null,
+                        NullPointerException.class),
+                Arguments.of(
+                        "null stream",
+                        null,
+                        TEST_KEY,
+                        TEST_IV,
+                        TEST_PROVIDER,
+                        NullPointerException.class),
+                Arguments.of(
+                        "null key",
+                        new byte[0],
+                        null,
+                        TEST_IV,
+                        TEST_PROVIDER,
+                        NullPointerException.class),
+                Arguments.of(
+                        "short key",
+                        new byte[0],
+                        new byte[16],
+                        TEST_IV,
+                        TEST_PROVIDER,
+                        IllegalArgumentException.class),
+                Arguments.of(
+                        "null IV",
+                        new byte[0],
+                        TEST_KEY,
+                        null,
+                        TEST_PROVIDER,
+                        NullPointerException.class),
+                Arguments.of(
+                        "short IV",
+                        new byte[0],
+                        TEST_KEY,
+                        new byte[8],
+                        TEST_PROVIDER,
+                        IllegalArgumentException.class));
+    }
+
+    @ParameterizedTest
+    @MethodSource("invalidWrapArgs")
+    void wrapEncryptingShouldRejectInvalidArgs(
+            final String label,
+            final byte[] streamBytes,
+            final byte[] key,
+            final byte[] iv,
+            final Provider provider,
+            final Class<? extends Throwable> expected) {
+        final OutputStream stream = streamBytes != null ? new ByteArrayOutputStream() : null;
+        assertThatThrownBy(() -> AesGcmCipherStreams.wrapEncrypting(stream, key, iv, provider))
+                .as(label)
+                .isInstanceOf(expected);
+    }
+
+    @ParameterizedTest
+    @MethodSource("invalidWrapArgs")
+    void wrapDecryptingShouldRejectInvalidArgs(
+            final String label,
+            final byte[] streamBytes,
+            final byte[] key,
+            final byte[] iv,
+            final Provider provider,
+            final Class<? extends Throwable> expected) {
+        final InputStream stream =
+                streamBytes != null ? new ByteArrayInputStream(streamBytes) : null;
+        assertThatThrownBy(() -> AesGcmCipherStreams.wrapDecrypting(stream, key, iv, provider))
+                .as(label)
+                .isInstanceOf(expected);
+    }
+
+    // -------------------------------------------------------------------------
+    // Close drains and verifies GCM tag
+    // -------------------------------------------------------------------------
+
+    static Stream<Arguments> closeTamperPositions() {
+        return Stream.of(
+                Arguments.of("IV", 0),
+                Arguments.of("read body", GCM_IV_LENGTH + CIPHERTEXT_CHUNK_SIZE / 2),
+                Arguments.of("unread body", GCM_IV_LENGTH + CIPHERTEXT_CHUNK_SIZE * 2),
+                Arguments.of("GCM tag", -1));
+    }
+
+    @ParameterizedTest
+    @MethodSource("closeTamperPositions")
+    void closeShouldThrowOnTamperedCiphertextWithoutFullRead(
+            final String region, final int tamperOffset) throws IOException {
+        final byte[] ciphertext =
+                encrypt(randomBytes(CIPHERTEXT_CHUNK_SIZE * 3), TEST_KEY, TEST_IV);
+        final int pos = tamperOffset >= 0 ? tamperOffset : ciphertext.length - 1;
+        ciphertext[pos] ^= 0xFF;
+
+        final ByteArrayInputStream bais = new ByteArrayInputStream(ciphertext);
+        final byte[] iv = bais.readNBytes(GCM_IV_LENGTH);
+        final InputStream stream =
+                AesGcmCipherStreams.wrapDecrypting(bais, TEST_KEY, iv, TEST_PROVIDER);
+        stream.read();
+        assertThatThrownBy(stream::close).as(region).isInstanceOf(IOException.class);
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private static byte[] encrypt(final byte[] plaintext, final byte[] key, final byte[] iv)
+            throws IOException {
+        final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        final OutputStream encryptingStream =
+                AesGcmCipherStreams.wrapEncrypting(baos, key, iv, TEST_PROVIDER);
+        encryptingStream.write(plaintext);
+        encryptingStream.close();
+        return baos.toByteArray();
+    }
+
+    private static byte[] decrypt(final byte[] ciphertext, final byte[] key) throws IOException {
+        final ByteArrayInputStream bais = new ByteArrayInputStream(ciphertext);
+        final byte[] iv = bais.readNBytes(GCM_IV_LENGTH);
+        final InputStream decryptingStream =
+                AesGcmCipherStreams.wrapDecrypting(bais, key, iv, TEST_PROVIDER);
+        final byte[] result = decryptingStream.readAllBytes();
+        decryptingStream.close();
+        return result;
+    }
+
+    private static byte[] randomBytes(final int size) {
+        final byte[] bytes = new byte[size];
+        new SecureRandom().nextBytes(bytes);
+        return bytes;
+    }
+}

--- a/flink-filesystems/flink-fs-cse-aes-gcm/src/test/java/org/apache/flink/fs/cse/aes/gcm/AesGcmCseInputStreamExtensionTest.java
+++ b/flink-filesystems/flink-fs-cse-aes-gcm/src/test/java/org/apache/flink/fs/cse/aes/gcm/AesGcmCseInputStreamExtensionTest.java
@@ -1,0 +1,220 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.fs.cse.aes.gcm;
+
+import org.apache.flink.core.fs.InputStreamExtension;
+import org.apache.flink.core.fs.InputStreamOpener;
+import org.apache.flink.core.fs.RawAndWrappedInputStreams;
+import org.apache.flink.util.function.FunctionWithException;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.io.ByteArrayInputStream;
+import java.io.FilterInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Tests for {@link AesGcmCseInputStreamExtension}. */
+class AesGcmCseInputStreamExtensionTest {
+
+    private static final int BUFFER_SIZE = 8192;
+    private static final byte[] PLAINTEXT = {1, 2, 3, 4, 5};
+
+    /** {@link InputStream} that tracks {@link #close()} calls. */
+    static class CloseTrackingInputStream extends ByteArrayInputStream {
+        boolean closed;
+
+        CloseTrackingInputStream(final byte[] buf) {
+            super(buf);
+        }
+
+        @Override
+        public void close() throws IOException {
+            closed = true;
+            super.close();
+        }
+    }
+
+    /** {@link InputStream} wrapper that throws on {@link #skipNBytes(long)}. */
+    static class FailOnSkipInputStream extends FilterInputStream {
+        boolean closed;
+
+        FailOnSkipInputStream(final InputStream in) {
+            super(in);
+        }
+
+        @Override
+        public void skipNBytes(final long n) throws IOException {
+            throw new IOException("simulated skip failure");
+        }
+
+        @Override
+        public void close() throws IOException {
+            closed = true;
+            super.close();
+        }
+    }
+
+    private static InputStreamExtension.StreamContext contextAt(
+            final long pos, final long contentLength) {
+        return new InputStreamExtension.StreamContext() {
+            @Override
+            public long getPos() {
+                return pos;
+            }
+
+            @Override
+            public long getContentLength() {
+                return contentLength;
+            }
+        };
+    }
+
+    /** Identity decryptor factory: returns the input stream unchanged. */
+    private static FunctionWithException<InputStream, InputStream, IOException> identity() {
+        return in -> in;
+    }
+
+    // --- shouldReadFromPosition ---
+
+    static Stream<Arguments> readPositionCases() {
+        return Stream.of(
+                Arguments.of(0L, 1, "position zero"), Arguments.of(3L, 4, "skip to middle"));
+    }
+
+    @ParameterizedTest
+    @MethodSource("readPositionCases")
+    void shouldReadFromPosition(final long pos, final int expectedFirstByte, final String label)
+            throws IOException {
+        final AtomicLong capturedOpenerPos = new AtomicLong(-1);
+        final InputStreamOpener opener =
+                ctx -> {
+                    capturedOpenerPos.set(ctx.getPos());
+                    return new ByteArrayInputStream(PLAINTEXT);
+                };
+
+        final AesGcmCseInputStreamExtension extension =
+                new AesGcmCseInputStreamExtension(opener, BUFFER_SIZE, identity());
+        final RawAndWrappedInputStreams streams =
+                extension.openStream(contextAt(pos, PLAINTEXT.length));
+
+        // opener always receives offset 0 — CSE streams cannot do range reads
+        assertThat(capturedOpenerPos.get()).as(label + ": opener pos").isEqualTo(0L);
+
+        final int firstByte = streams.wrapped().read();
+        assertThat(firstByte).as(label + ": first byte").isEqualTo(expectedFirstByte);
+    }
+
+    // --- shouldCloseAndPropagateOnDecryptorFailure ---
+
+    @Test
+    void shouldCloseAndPropagateOnDecryptorFailure() {
+        final IOException closeFailure = new IOException("close failed");
+        final CloseTrackingInputStream raw =
+                new CloseTrackingInputStream(PLAINTEXT) {
+                    @Override
+                    public void close() throws IOException {
+                        closed = true;
+                        throw closeFailure;
+                    }
+                };
+        final IOException decryptorFailure = new IOException("decryptor failed");
+        final AesGcmCseInputStreamExtension extension =
+                new AesGcmCseInputStreamExtension(
+                        ctx -> raw,
+                        BUFFER_SIZE,
+                        in -> {
+                            throw decryptorFailure;
+                        });
+
+        assertThatThrownBy(() -> extension.openStream(contextAt(0L, PLAINTEXT.length)))
+                .isSameAs(decryptorFailure)
+                .satisfies(e -> assertThat(e.getSuppressed()).containsExactly(closeFailure));
+        assertThat(raw.closed).isTrue();
+    }
+
+    // --- shouldCloseAndPropagateOnSkipFailure ---
+
+    @Test
+    void shouldCloseAndPropagateOnSkipFailure() {
+        final IOException closeFailure = new IOException("close failed");
+        final FailOnSkipInputStream decrypted =
+                new FailOnSkipInputStream(new ByteArrayInputStream(PLAINTEXT)) {
+                    @Override
+                    public void close() throws IOException {
+                        closed = true;
+                        throw closeFailure;
+                    }
+                };
+        final AesGcmCseInputStreamExtension extension =
+                new AesGcmCseInputStreamExtension(
+                        ctx -> new ByteArrayInputStream(PLAINTEXT), BUFFER_SIZE, in -> decrypted);
+
+        assertThatThrownBy(() -> extension.openStream(contextAt(100L, 200L)))
+                .isInstanceOf(IOException.class)
+                .hasMessageContaining("simulated skip failure")
+                .satisfies(e -> assertThat(e.getSuppressed()).containsExactly(closeFailure));
+        assertThat(decrypted.closed).isTrue();
+    }
+
+    // --- shouldRejectInvalidConstructorArgs ---
+
+    static Stream<Arguments> invalidConstructorArgs() {
+        final InputStreamOpener validOpener = ctx -> new ByteArrayInputStream(new byte[0]);
+        return Stream.of(
+                Arguments.of(
+                        null, BUFFER_SIZE, identity(), NullPointerException.class, "null opener"),
+                Arguments.of(
+                        validOpener,
+                        0,
+                        identity(),
+                        IllegalArgumentException.class,
+                        "non-positive buffer size"),
+                Arguments.of(
+                        validOpener,
+                        BUFFER_SIZE,
+                        null,
+                        NullPointerException.class,
+                        "null decryptorFactory"));
+    }
+
+    @ParameterizedTest
+    @MethodSource("invalidConstructorArgs")
+    void shouldRejectInvalidConstructorArgs(
+            final InputStreamOpener opener,
+            final int bufferSize,
+            final FunctionWithException<InputStream, InputStream, IOException> decryptorFactory,
+            final Class<? extends Exception> expectedType,
+            final String label) {
+        assertThatThrownBy(
+                        () ->
+                                new AesGcmCseInputStreamExtension(
+                                        opener, bufferSize, decryptorFactory))
+                .as(label)
+                .isInstanceOf(expectedType);
+    }
+}

--- a/flink-filesystems/flink-fs-cse-aes-gcm/src/test/java/org/apache/flink/fs/cse/aes/gcm/AesGcmCseStreamFactoryTest.java
+++ b/flink-filesystems/flink-fs-cse-aes-gcm/src/test/java/org/apache/flink/fs/cse/aes/gcm/AesGcmCseStreamFactoryTest.java
@@ -1,0 +1,320 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.fs.cse.aes.gcm;
+
+import org.apache.flink.core.fs.FSDataInputStream;
+import org.apache.flink.fs.cse.EncryptedReadContext;
+import org.apache.flink.fs.cse.EncryptedWriteContext;
+import org.apache.flink.fs.cse.KeyProviderException;
+import org.apache.flink.fs.cse.TestingKeyProvider;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Tests for {@link AesGcmCseStreamFactory}. */
+class AesGcmCseStreamFactoryTest {
+
+    static final String TEST_FILE = "test-file";
+
+    private static final String KEY_ID = "test-key";
+    private static final Map<String, String> ENC_CTX = Map.of("org_id", "org-test");
+    private static final int TEST_READ_BUFFER_SIZE = 8192;
+
+    // -------------------------------------------------------------------------
+    // Test helpers
+    // -------------------------------------------------------------------------
+
+    private static final class WriteResult {
+        final byte[] ciphertext;
+        final Map<String, String> metadata;
+
+        WriteResult(final byte[] ciphertext, final Map<String, String> metadata) {
+            this.ciphertext = ciphertext;
+            this.metadata = metadata;
+        }
+    }
+
+    private static WriteResult writeEncrypted(
+            final AesGcmCseStreamFactory factory, final byte[] plaintext) throws IOException {
+        final ByteArrayOutputStream ciphertextOut = new ByteArrayOutputStream();
+        final AtomicReference<Map<String, String>> capturedMetadata = new AtomicReference<>();
+        final OutputStream encryptingStream =
+                factory.openEncryptedWrite(
+                        ctx -> {
+                            capturedMetadata.set(ctx.getMetadata());
+                            return ciphertextOut;
+                        },
+                        EncryptedWriteContext.of(TEST_FILE));
+        encryptingStream.write(plaintext);
+        encryptingStream.close();
+        return new WriteResult(ciphertextOut.toByteArray(), capturedMetadata.get());
+    }
+
+    private static FSDataInputStream openRead(
+            final AesGcmCseStreamFactory factory,
+            final byte[] ciphertext,
+            final Map<String, String> metadata)
+            throws IOException {
+        final EncryptedReadContext readCtx =
+                EncryptedReadContext.of(
+                        metadata, TEST_FILE, ciphertext.length, TEST_READ_BUFFER_SIZE);
+        return factory.openEncryptedRead(ctx -> new ByteArrayInputStream(ciphertext), readCtx);
+    }
+
+    private static byte[] randomBytes(final int size) {
+        final byte[] bytes = new byte[size];
+        ThreadLocalRandom.current().nextBytes(bytes);
+        return bytes;
+    }
+
+    private static AesGcmCseStreamFactory newFactory() {
+        return newFactory(new TestingKeyProvider());
+    }
+
+    private static AesGcmCseStreamFactory newFactory(final TestingKeyProvider keyProvider) {
+        return new AesGcmCseStreamFactory(keyProvider, KEY_ID, ENC_CTX);
+    }
+
+    private static byte[] readAllEncrypted(
+            final AesGcmCseStreamFactory factory, final WriteResult result) throws IOException {
+        try (final FSDataInputStream in = openRead(factory, result.ciphertext, result.metadata)) {
+            return in.readAllBytes();
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Round-trip with key rotation
+    // -------------------------------------------------------------------------
+
+    @Test
+    void testKeyRotationIsReflectedInMetadata() throws IOException {
+        final TestingKeyProvider keyProvider = new TestingKeyProvider();
+        final AesGcmCseStreamFactory factory = newFactory(keyProvider);
+
+        final byte[] plaintext1 = randomBytes(500);
+        final byte[] plaintext2 = randomBytes(500);
+
+        final WriteResult result1 = writeEncrypted(factory, plaintext1);
+        keyProvider.rotateKey();
+        final WriteResult result2 = writeEncrypted(factory, plaintext2);
+
+        assertThat(readAllEncrypted(factory, result1)).isEqualTo(plaintext1);
+        assertThat(readAllEncrypted(factory, result2)).isEqualTo(plaintext2);
+        assertThat(result1.metadata.get("x_cse_key_version"))
+                .isNotEqualTo(result2.metadata.get("x_cse_key_version"));
+    }
+
+    // -------------------------------------------------------------------------
+    // isEncrypted: parameterized
+    // -------------------------------------------------------------------------
+
+    static Stream<Arguments> isEncryptedCases() {
+        return Stream.of(
+                Arguments.of("encryptedMetadata", Map.of("x_cse_key_id", "some-key-id"), true),
+                Arguments.of("emptyMap", Map.of(), false),
+                Arguments.of("unrelatedKeys", Map.of("unrelated", "value"), false));
+    }
+
+    @ParameterizedTest
+    @MethodSource("isEncryptedCases")
+    void isEncryptedTests(
+            final String caseName, final Map<String, String> inputMap, final boolean expected) {
+        final AesGcmCseStreamFactory factory = newFactory();
+        assertThat(factory.isEncrypted(inputMap)).as(caseName).isEqualTo(expected);
+    }
+
+    // -------------------------------------------------------------------------
+    // encryptionContext: parameterized
+    // -------------------------------------------------------------------------
+
+    static Stream<Arguments> encryptionContextCases() {
+        return Stream.of(
+                Arguments.of("withContext", Map.of("org_id", "org-123", "lfcp_id", "lfcp-456")),
+                Arguments.of("emptyContext", Map.of()));
+    }
+
+    @ParameterizedTest
+    @MethodSource("encryptionContextCases")
+    void encryptionContextTests(final String caseName, final Map<String, String> encryptionContext)
+            throws IOException {
+        final AesGcmCseStreamFactory factory =
+                new AesGcmCseStreamFactory(new TestingKeyProvider(), KEY_ID, encryptionContext);
+        final byte[] plaintext = randomBytes(64);
+        final WriteResult result = writeEncrypted(factory, plaintext);
+
+        if (!encryptionContext.isEmpty()) {
+            for (final Map.Entry<String, String> entry : encryptionContext.entrySet()) {
+                assertThat(result.metadata)
+                        .as(caseName + ": ctx key x_cse_ctx_" + entry.getKey())
+                        .containsEntry("x_cse_ctx_" + entry.getKey(), entry.getValue());
+            }
+        } else {
+            assertThat(result.metadata.keySet())
+                    .as(caseName + ": no ctx keys")
+                    .noneMatch(k -> k.startsWith("x_cse_ctx_"));
+        }
+
+        assertThat(result.metadata)
+                .as(caseName + ": iv length key present")
+                .containsKey("x_cse_iv_bytes_length");
+        assertThat(result.metadata).as(caseName + ": no raw iv key").doesNotContainKey("x_cse_iv");
+
+        assertThat(readAllEncrypted(factory, result))
+                .as(caseName + ": round-trip")
+                .isEqualTo(plaintext);
+    }
+
+    @Test
+    void shouldThrowOnNullEncryptionContext() {
+        assertThatThrownBy(() -> new AesGcmCseStreamFactory(new TestingKeyProvider(), KEY_ID, null))
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    // -------------------------------------------------------------------------
+    // Seek: parameterized
+    // -------------------------------------------------------------------------
+
+    static Stream<Arguments> seekCases() {
+        return Stream.of(
+                Arguments.of("seekToStart", 0),
+                Arguments.of("seekToMiddle", 5000),
+                Arguments.of("seekToEnd", 10_000));
+    }
+
+    @ParameterizedTest
+    @MethodSource("seekCases")
+    void seekTests(final String caseName, final int seekPosition) throws IOException {
+        final AesGcmCseStreamFactory factory = newFactory();
+        final byte[] plaintext = randomBytes(10_000);
+        final WriteResult result = writeEncrypted(factory, plaintext);
+
+        try (final FSDataInputStream in = openRead(factory, result.ciphertext, result.metadata)) {
+            in.seek(seekPosition);
+            final byte[] read = in.readAllBytes();
+            assertThat(read)
+                    .as(caseName)
+                    .isEqualTo(Arrays.copyOfRange(plaintext, seekPosition, plaintext.length));
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Empty-file round-trip
+    // -------------------------------------------------------------------------
+
+    @Test
+    void shouldRoundTripEmptyFile() throws IOException {
+        final AesGcmCseStreamFactory factory = newFactory();
+        final WriteResult result = writeEncrypted(factory, new byte[0]);
+        assertThat(readAllEncrypted(factory, result)).isEmpty();
+    }
+
+    // -------------------------------------------------------------------------
+    // Write-path failure: raw stream closed on wrapEncrypting error
+    // -------------------------------------------------------------------------
+
+    @Test
+    void shouldCloseRawStreamOnWriteFailure() {
+        final AesGcmCseStreamFactory factory = newFactory();
+        final IOException cause = new IOException("write failure");
+        final OutputStream failingStream =
+                new OutputStream() {
+                    boolean closed;
+
+                    @Override
+                    public void write(final int b) throws IOException {
+                        throw cause;
+                    }
+
+                    @Override
+                    public void close() {
+                        closed = true;
+                    }
+                };
+
+        assertThatThrownBy(
+                        () ->
+                                factory.openEncryptedWrite(
+                                        ctx -> failingStream, EncryptedWriteContext.of(TEST_FILE)))
+                .isInstanceOf(IOException.class)
+                .isSameAs(cause);
+        assertThat(failingStream).extracting("closed").isEqualTo(true);
+    }
+
+    // -------------------------------------------------------------------------
+    // Error: missing metadata
+    // -------------------------------------------------------------------------
+
+    @Test
+    void shouldThrowOnMissingMetadataForRead() {
+        final AesGcmCseStreamFactory factory = newFactory();
+        assertThatThrownBy(() -> openRead(factory, new byte[64], Map.of()))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void shouldThrowOnCiphertextLengthBelowOverhead() throws IOException {
+        final AesGcmCseStreamFactory factory = newFactory();
+        final WriteResult result = writeEncrypted(factory, randomBytes(64));
+        final EncryptedReadContext readCtx =
+                EncryptedReadContext.of(
+                        result.metadata,
+                        TEST_FILE,
+                        AesGcmCipherStreams.GCM_OVERHEAD_BYTES - 1,
+                        TEST_READ_BUFFER_SIZE);
+        assertThatThrownBy(
+                        () ->
+                                factory.openEncryptedRead(
+                                        ctx -> new ByteArrayInputStream(result.ciphertext),
+                                        readCtx))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("less than GCM overhead");
+    }
+
+    // -------------------------------------------------------------------------
+    // Error propagation: KeyProviderException from key provider
+    // -------------------------------------------------------------------------
+
+    @Test
+    void shouldPropagateKeyProviderException() throws IOException {
+        final AesGcmCseStreamFactory factory = newFactory();
+        final WriteResult result = writeEncrypted(factory, randomBytes(64));
+
+        final Map<String, String> tamperedMetadata = new HashMap<>(result.metadata);
+        tamperedMetadata.put("x_cse_key_version", "unknown-version");
+
+        assertThatThrownBy(() -> openRead(factory, result.ciphertext, tamperedMetadata))
+                .isInstanceOf(KeyProviderException.class);
+    }
+}

--- a/flink-filesystems/flink-fs-cse-aes-gcm/src/test/java/org/apache/flink/fs/cse/aes/gcm/AesGcmEncryptionMetadataTest.java
+++ b/flink-filesystems/flink-fs-cse-aes-gcm/src/test/java/org/apache/flink/fs/cse/aes/gcm/AesGcmEncryptionMetadataTest.java
@@ -1,0 +1,278 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.fs.cse.aes.gcm;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Tests for {@link AesGcmEncryptionMetadata}. */
+class AesGcmEncryptionMetadataTest {
+
+    private static final String KEY_ID = "my-key-id";
+    private static final String KEY_VERSION = "v1";
+    private static final int IV_BYTE_LENGTH = 12;
+    private static final Map<String, String> EMPTY_CONTEXT = Collections.emptyMap();
+    private static final AesGcmEncryptionMetadata DEFAULT_META =
+            new AesGcmEncryptionMetadata(KEY_ID, KEY_VERSION, IV_BYTE_LENGTH, EMPTY_CONTEXT);
+
+    // -------------------------------------------------------------------------
+    // Round-trip
+    // -------------------------------------------------------------------------
+
+    @Test
+    void toMetadataShouldContainAllEntries() {
+        final Map<String, String> context = Map.of("org_id", "org-123");
+        final AesGcmEncryptionMetadata meta =
+                new AesGcmEncryptionMetadata(KEY_ID, KEY_VERSION, IV_BYTE_LENGTH, context);
+
+        assertThat(meta.toMetadata())
+                .containsEntry("x_cse_key_id", KEY_ID)
+                .containsEntry("x_cse_key_version", KEY_VERSION)
+                .containsEntry("x_cse_iv_bytes_length", Integer.toString(IV_BYTE_LENGTH))
+                .containsEntry("x_cse_algorithm", "AES/GCM/NoPadding")
+                .containsEntry(
+                        "x_cse_gcm_tag_length",
+                        Integer.toString(AesGcmEncryptionMetadata.GCM_TAG_LENGTH))
+                .containsEntry("x_cse_chunk_size", "-1")
+                .containsEntry("x_cse_ctx_org_id", "org-123");
+    }
+
+    @Test
+    void shouldRoundTripThroughMetadataMap() {
+        final Map<String, String> context = Map.of("department", "eng");
+        final AesGcmEncryptionMetadata original =
+                new AesGcmEncryptionMetadata(KEY_ID, KEY_VERSION, IV_BYTE_LENGTH, context);
+
+        final AesGcmEncryptionMetadata parsed =
+                AesGcmEncryptionMetadata.fromMetadata(original.toMetadata());
+
+        assertThat(parsed.keyId()).isEqualTo(KEY_ID);
+        assertThat(parsed.getKeyVersion()).isEqualTo(KEY_VERSION);
+        assertThat(parsed.getIvByteLength()).isEqualTo(IV_BYTE_LENGTH);
+        assertThat(parsed.getEncryptionContext()).isEqualTo(context);
+        assertThat(parsed).isEqualTo(original);
+    }
+
+    @ParameterizedTest
+    @MethodSource("illegalContextKeys")
+    void shouldRejectContextKeyThatIsNotAValidMetadataKey(final String illegalKey) {
+        // Object metadata keys must be C# identifiers (Azure's rule, the strictest across clouds);
+        // dashes, dots and leading digits are rejected at construction so the write never reaches
+        // the object store with an illegal key.
+        final Map<String, String> context = Map.of(illegalKey, "v");
+
+        assertThatThrownBy(
+                        () ->
+                                new AesGcmEncryptionMetadata(
+                                        KEY_ID, KEY_VERSION, IV_BYTE_LENGTH, context))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining(illegalKey);
+    }
+
+    private static Stream<Arguments> illegalContextKeys() {
+        return Stream.of(
+                Arguments.of("org-id"),
+                Arguments.of("lfcp-id"),
+                Arguments.of("dotted.key"),
+                Arguments.of("1leading-digit"),
+                Arguments.of(""));
+    }
+
+    // -------------------------------------------------------------------------
+    // fromMetadata error cases
+    // -------------------------------------------------------------------------
+
+    @ParameterizedTest
+    @MethodSource("missingKeyArgs")
+    void shouldThrowOnMissingMetadataKey(final Map<String, String> map, final String missingKey) {
+        assertThatThrownBy(() -> AesGcmEncryptionMetadata.fromMetadata(map))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining(missingKey);
+    }
+
+    private static Stream<Arguments> missingKeyArgs() {
+        return Stream.of(
+                        "x_cse_key_id",
+                        "x_cse_key_version",
+                        "x_cse_iv_bytes_length",
+                        "x_cse_algorithm",
+                        "x_cse_gcm_tag_length",
+                        "x_cse_chunk_size")
+                .map(
+                        key -> {
+                            final Map<String, String> map = validMap();
+                            map.remove(key);
+                            return Arguments.of(map, key);
+                        });
+    }
+
+    @ParameterizedTest
+    @MethodSource("invalidValueArgs")
+    void shouldThrowOnInvalidMetadataValue(
+            final String key, final String value, final String expectedErrorMessage) {
+        final Map<String, String> map = validMap();
+        map.put(key, value);
+
+        assertThatThrownBy(() -> AesGcmEncryptionMetadata.fromMetadata(map))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining(expectedErrorMessage);
+    }
+
+    private static Stream<Arguments> invalidValueArgs() {
+        return Stream.of(
+                Arguments.of(
+                        "x_cse_iv_bytes_length",
+                        "not-a-number",
+                        "Malformed value for 'x_cse_iv_bytes_length'"),
+                Arguments.of("x_cse_iv_bytes_length", "0", "IV byte length must be positive"),
+                Arguments.of(
+                        "x_cse_algorithm",
+                        "AES/CTR/NoPadding",
+                        "Unsupported algorithm 'AES/CTR/NoPadding'"),
+                Arguments.of(
+                        "x_cse_gcm_tag_length", "12", "Unsupported GCM tag length 12, expected 16"),
+                Arguments.of(
+                        "x_cse_gcm_tag_length",
+                        "not-a-number",
+                        "Malformed value for 'x_cse_gcm_tag_length'"),
+                Arguments.of("x_cse_chunk_size", "1048576", "Chunked encryption is not supported"));
+    }
+
+    // -------------------------------------------------------------------------
+    // Constructor validation
+    // -------------------------------------------------------------------------
+
+    @ParameterizedTest
+    @MethodSource("nullConstructorArgs")
+    void shouldThrowOnNullConstructorArg(
+            final String keyId,
+            final String keyVersion,
+            final Map<String, String> context,
+            final String expectedMessageFragment) {
+        assertThatThrownBy(
+                        () ->
+                                new AesGcmEncryptionMetadata(
+                                        keyId, keyVersion, IV_BYTE_LENGTH, context))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessageContaining(expectedMessageFragment);
+    }
+
+    private static Stream<Arguments> nullConstructorArgs() {
+        return Stream.of(
+                Arguments.of(null, KEY_VERSION, EMPTY_CONTEXT, "keyId"),
+                Arguments.of(KEY_ID, null, EMPTY_CONTEXT, "keyVersion"),
+                Arguments.of(KEY_ID, KEY_VERSION, null, "encryptionContext"));
+    }
+
+    @Test
+    void shouldThrowOnNonPositiveIvLength() {
+        assertThatThrownBy(
+                        () -> new AesGcmEncryptionMetadata(KEY_ID, KEY_VERSION, 0, EMPTY_CONTEXT))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("ivByteLength must be positive");
+    }
+
+    // -------------------------------------------------------------------------
+    // equals / hashCode
+    // -------------------------------------------------------------------------
+
+    @Test
+    void equalsShouldReturnTrueForSameReference() {
+        assertThat(DEFAULT_META).isEqualTo(DEFAULT_META);
+    }
+
+    @Test
+    void equalsShouldReturnFalseForDifferentType() {
+        assertThat(DEFAULT_META).isNotEqualTo("not a metadata object");
+    }
+
+    @Test
+    void shouldBeEqualWhenAllFieldsMatch() {
+        final Map<String, String> context = Map.of("org_id", "org-123");
+        final AesGcmEncryptionMetadata a =
+                new AesGcmEncryptionMetadata(KEY_ID, KEY_VERSION, IV_BYTE_LENGTH, context);
+        final AesGcmEncryptionMetadata b =
+                new AesGcmEncryptionMetadata(KEY_ID, KEY_VERSION, IV_BYTE_LENGTH, context);
+
+        assertThat(a).isEqualTo(b);
+        assertThat(a.hashCode()).isEqualTo(b.hashCode());
+    }
+
+    @ParameterizedTest
+    @MethodSource("unequalInstances")
+    void shouldNotBeEqualWhenFieldDiffers(final AesGcmEncryptionMetadata other) {
+        assertThat(DEFAULT_META).isNotEqualTo(other);
+    }
+
+    private static Stream<Arguments> unequalInstances() {
+        return Stream.of(
+                Arguments.of(
+                        new AesGcmEncryptionMetadata(
+                                "other-key", KEY_VERSION, IV_BYTE_LENGTH, EMPTY_CONTEXT)),
+                Arguments.of(
+                        new AesGcmEncryptionMetadata(KEY_ID, "v2", IV_BYTE_LENGTH, EMPTY_CONTEXT)),
+                Arguments.of(
+                        new AesGcmEncryptionMetadata(
+                                KEY_ID, KEY_VERSION, IV_BYTE_LENGTH, Map.of("k", "v"))));
+    }
+
+    // -------------------------------------------------------------------------
+    // toString
+    // -------------------------------------------------------------------------
+
+    @Test
+    void toStringShouldContainAllFields() {
+        final Map<String, String> context = Map.of("org_id", "org-123");
+        final AesGcmEncryptionMetadata meta =
+                new AesGcmEncryptionMetadata(KEY_ID, KEY_VERSION, IV_BYTE_LENGTH, context);
+        final String str = meta.toString();
+
+        assertThat(str)
+                .contains(KEY_ID)
+                .contains(KEY_VERSION)
+                .contains("ivByteLength=12")
+                .contains("org_id")
+                .contains("org-123");
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private static Map<String, String> validMap() {
+        final Map<String, String> map = new HashMap<>();
+        map.put("x_cse_key_id", KEY_ID);
+        map.put("x_cse_key_version", KEY_VERSION);
+        map.put("x_cse_iv_bytes_length", Integer.toString(IV_BYTE_LENGTH));
+        map.put("x_cse_algorithm", AesGcmCipherStreams.ALGORITHM);
+        map.put("x_cse_gcm_tag_length", Integer.toString(AesGcmEncryptionMetadata.GCM_TAG_LENGTH));
+        map.put("x_cse_chunk_size", "-1");
+        return map;
+    }
+}

--- a/flink-filesystems/flink-fs-cse-common/pom.xml
+++ b/flink-filesystems/flink-fs-cse-common/pom.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.flink</groupId>
+        <artifactId>flink-filesystems</artifactId>
+        <version>2.4-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>flink-fs-cse-common</artifactId>
+    <name>Flink : FileSystems : CSE Common</name>
+
+    <packaging>jar</packaging>
+
+    <dependencies>
+        <!-- Flink core (provided — each FS plugin bundles its own) -->
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-core</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- Test dependencies -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals><goal>test-jar</goal></goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/flink-filesystems/flink-fs-cse-common/src/main/java/org/apache/flink/fs/cse/CseOptions.java
+++ b/flink-filesystems/flink-fs-cse-common/src/main/java/org/apache/flink/fs/cse/CseOptions.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.fs.cse;
+
+import org.apache.flink.annotation.Experimental;
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.ConfigOptions;
+import org.apache.flink.configuration.ReadableConfig;
+
+import javax.annotation.concurrent.Immutable;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Cloud-agnostic client-side encryption (CSE) configuration options shared across all native
+ * filesystem plugins.
+ *
+ * <p>When {@link #KEY_PROVIDER_FACTORY_CLASS} is set, encrypted files are transparently decrypted
+ * on read; plaintext files are read as-is. Write encryption is additionally gated on {@link
+ * #WRITE_KEY_ID}.
+ */
+@Experimental
+@Immutable
+public final class CseOptions {
+
+    /**
+     * Prefix shared by all CSE configuration keys. Global (not per-scheme) — all filesystem plugins
+     * share the same key provider. Per-scheme overrides can be added later if needed.
+     */
+    public static final String KEY_PREFIX = "fs.cse.";
+
+    /**
+     * Config key prefix for free-form encryption context entries. Keys matching {@code
+     * fs.cse.encryption-context.<name>} are extracted into a {@code Map<String, String>} and passed
+     * to the {@link KeyProvider} and the CSE factory.
+     */
+    public static final String ENCRYPTION_CONTEXT_PREFIX = "fs.cse.encryption-context.";
+
+    /**
+     * Fully-qualified class name of the {@link KeyProviderFactory} implementation. When absent, CSE
+     * is fully disabled.
+     */
+    public static final ConfigOption<String> KEY_PROVIDER_FACTORY_CLASS =
+            ConfigOptions.key("fs.cse.key-provider.factory-class")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "Fully-qualified class name of the KeyProviderFactory implementation. "
+                                    + "Must implement org.apache.flink.fs.cse.KeyProviderFactory "
+                                    + "with a public no-arg constructor. "
+                                    + "When absent, CSE is fully disabled.");
+
+    /**
+     * Key identifier used to encrypt new files. Requires {@link #KEY_PROVIDER_FACTORY_CLASS} to be
+     * set. When absent, writes are plaintext but encrypted files can still be read.
+     */
+    public static final ConfigOption<String> WRITE_KEY_ID =
+            ConfigOptions.key("fs.cse.write-key-id")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "Key identifier for CSE write encryption. "
+                                    + "Requires fs.cse.key-provider.factory-class to be set. "
+                                    + "When absent, writes are plaintext.");
+
+    /**
+     * Extracts encryption context entries from the configuration by collecting all keys with the
+     * {@link #ENCRYPTION_CONTEXT_PREFIX} and stripping the prefix.
+     *
+     * @param config the filesystem configuration
+     * @return an unmodifiable map of encryption context entries (may be empty)
+     */
+    public static Map<String, String> extractEncryptionContext(final ReadableConfig config) {
+        final Map<String, String> context = new HashMap<>();
+        for (final Map.Entry<String, String> entry : config.toMap().entrySet()) {
+            if (entry.getKey().startsWith(ENCRYPTION_CONTEXT_PREFIX)) {
+                context.put(
+                        entry.getKey().substring(ENCRYPTION_CONTEXT_PREFIX.length()),
+                        entry.getValue());
+            }
+        }
+        return Collections.unmodifiableMap(context);
+    }
+
+    private CseOptions() {}
+}

--- a/flink-filesystems/flink-fs-cse-common/src/main/java/org/apache/flink/fs/cse/CseStreamFactory.java
+++ b/flink-filesystems/flink-fs-cse-common/src/main/java/org/apache/flink/fs/cse/CseStreamFactory.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.fs.cse;
+
+import org.apache.flink.annotation.Experimental;
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.core.fs.FSDataInputStream;
+import org.apache.flink.core.fs.InputStreamOpener;
+import org.apache.flink.core.fs.OutputStreamOpener;
+
+import javax.annotation.concurrent.ThreadSafe;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.Map;
+
+/**
+ * Algorithm-agnostic factory for client-side encrypted streams.
+ *
+ * <p>Write path: call {@link #openEncryptedWrite(OutputStreamOpener, EncryptedWriteContext)} to
+ * obtain an encrypting {@link OutputStream}. The factory generates key material, builds a {@link
+ * org.apache.flink.core.fs.WriteContext} containing the encryption metadata, invokes the opener
+ * with that context so the caller can attach metadata to the cloud object, and wraps the returned
+ * stream with encryption.
+ *
+ * <p>Read path: call {@link #isEncrypted(Map)} to detect whether a blob is encrypted, then call
+ * {@link #openEncryptedRead} to obtain a decrypting {@link FSDataInputStream}.
+ *
+ * <p>Implementations must be thread-safe — a single instance is shared across the filesystem.
+ * Closing the factory releases the underlying {@link KeyProvider}.
+ */
+@Internal
+@Experimental
+@ThreadSafe
+public interface CseStreamFactory extends Closeable {
+
+    /**
+     * Opens an encrypted output stream for writing.
+     *
+     * <p>The factory generates key material, invokes {@code opener} with a {@link
+     * org.apache.flink.core.fs.WriteContext} carrying the encryption metadata, and wraps the
+     * returned stream with encryption. The returned stream must be closed by the caller to finalize
+     * the ciphertext (e.g., to append the GCM authentication tag).
+     *
+     * @param opener opens the underlying cloud output stream; receives encryption metadata via
+     *     {@link org.apache.flink.core.fs.WriteContext#getMetadata()}
+     * @param ctx write context carrying the file path and other write-time metadata
+     * @return an encrypting {@link OutputStream} wrapping the stream returned by {@code opener}
+     * @throws IOException if key material cannot be obtained or the stream cannot be initialized
+     */
+    OutputStream openEncryptedWrite(OutputStreamOpener opener, EncryptedWriteContext ctx)
+            throws IOException;
+
+    /**
+     * Returns {@code true} if the blob described by {@code blobMetadata} was encrypted by a
+     * compatible factory.
+     *
+     * @param blobMetadata the cloud object's metadata map
+     * @return {@code true} if the blob is encrypted; {@code false} otherwise
+     */
+    boolean isEncrypted(Map<String, String> blobMetadata);
+
+    /**
+     * Opens an encrypted blob for reading and returns a seekable decrypting stream.
+     *
+     * <p>The caller must verify {@link #isEncrypted(Map)} returns {@code true} before calling this
+     * method.
+     *
+     * @param opener opens a raw ciphertext stream at a given byte offset
+     * @param ctx read context carrying blob metadata, file path, ciphertext length, and buffer size
+     * @return a seekable, decrypting {@link FSDataInputStream} over the plaintext
+     * @throws IOException if key material cannot be obtained or the stream cannot be initialized
+     */
+    FSDataInputStream openEncryptedRead(InputStreamOpener opener, EncryptedReadContext ctx)
+            throws IOException;
+}

--- a/flink-filesystems/flink-fs-cse-common/src/main/java/org/apache/flink/fs/cse/EncryptedReadContext.java
+++ b/flink-filesystems/flink-fs-cse-common/src/main/java/org/apache/flink/fs/cse/EncryptedReadContext.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.fs.cse;
+
+import org.apache.flink.annotation.Experimental;
+import org.apache.flink.annotation.Internal;
+
+import javax.annotation.concurrent.Immutable;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * Carries all context required to open an encrypted blob for reading.
+ *
+ * @see CseStreamFactory#openEncryptedRead(org.apache.flink.core.fs.InputStreamOpener,
+ *     EncryptedReadContext)
+ */
+@Internal
+@Experimental
+@Immutable
+public interface EncryptedReadContext {
+
+    /** Returns the blob's metadata map containing encryption headers. */
+    Map<String, String> getBlobMetadata();
+
+    /** Returns the cloud object path (used for logging and error messages). */
+    String getFilePath();
+
+    /** Returns the total ciphertext length in bytes. */
+    long getCiphertextLength();
+
+    /** Returns the read buffer size in bytes. */
+    int getReadBufferSize();
+
+    /**
+     * Creates an {@link EncryptedReadContext} with the given values.
+     *
+     * @param blobMetadata the blob's metadata map containing encryption headers
+     * @param filePath the cloud object path
+     * @param ciphertextLength the total ciphertext length in bytes; must be &ge; 0
+     * @param readBufferSize the read buffer size in bytes; must be &gt; 0
+     * @return a new immutable {@link EncryptedReadContext}
+     */
+    static EncryptedReadContext of(
+            final Map<String, String> blobMetadata,
+            final String filePath,
+            final long ciphertextLength,
+            final int readBufferSize) {
+        checkNotNull(blobMetadata, "blobMetadata");
+        checkNotNull(filePath, "filePath");
+        checkArgument(ciphertextLength >= 0, "ciphertextLength must be >= 0");
+        checkArgument(readBufferSize > 0, "readBufferSize must be > 0");
+        final Map<String, String> unmodifiable =
+                Collections.unmodifiableMap(new HashMap<>(blobMetadata));
+        return new EncryptedReadContext() {
+            @Override
+            public Map<String, String> getBlobMetadata() {
+                return unmodifiable;
+            }
+
+            @Override
+            public String getFilePath() {
+                return filePath;
+            }
+
+            @Override
+            public long getCiphertextLength() {
+                return ciphertextLength;
+            }
+
+            @Override
+            public int getReadBufferSize() {
+                return readBufferSize;
+            }
+        };
+    }
+}

--- a/flink-filesystems/flink-fs-cse-common/src/main/java/org/apache/flink/fs/cse/EncryptedWriteContext.java
+++ b/flink-filesystems/flink-fs-cse-common/src/main/java/org/apache/flink/fs/cse/EncryptedWriteContext.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.fs.cse;
+
+import org.apache.flink.annotation.Experimental;
+import org.apache.flink.annotation.Internal;
+
+import javax.annotation.concurrent.Immutable;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * Carries all context required to open an encrypted blob for writing.
+ *
+ * @see CseStreamFactory#openEncryptedWrite(org.apache.flink.core.fs.OutputStreamOpener,
+ *     EncryptedWriteContext)
+ */
+@Internal
+@Experimental
+@Immutable
+public interface EncryptedWriteContext {
+
+    /** Returns the cloud object path. */
+    String getFilePath();
+
+    /**
+     * Creates an {@link EncryptedWriteContext} for the given file path.
+     *
+     * @param filePath the cloud object path; must not be null
+     * @return a new immutable {@link EncryptedWriteContext}
+     */
+    static EncryptedWriteContext of(final String filePath) {
+        checkNotNull(filePath, "filePath");
+        return () -> filePath;
+    }
+}

--- a/flink-filesystems/flink-fs-cse-common/src/main/java/org/apache/flink/fs/cse/EncryptionMetadata.java
+++ b/flink-filesystems/flink-fs-cse-common/src/main/java/org/apache/flink/fs/cse/EncryptionMetadata.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.fs.cse;
+
+import org.apache.flink.annotation.Experimental;
+import org.apache.flink.annotation.Internal;
+
+import java.util.Map;
+
+/**
+ * Per-file encryption metadata stored in cloud object metadata.
+ *
+ * <p>Implementations define how the data encryption key is referenced (e.g., by key ID + version
+ * for key-vending providers, or as a wrapped DEK blob for envelope encryption providers) and which
+ * cipher algorithm is used.
+ *
+ * <p>Serialization to/from a flat {@code Map<String, String>} is the common wire format, supported
+ * by all major cloud storage APIs (Azure blob metadata, S3 user metadata, GCS custom metadata).
+ */
+@Internal
+@Experimental
+public interface EncryptionMetadata {
+
+    /** Returns the encryption key identifier. */
+    String keyId();
+
+    /**
+     * Returns the key version identifier used to retrieve the correct decryption key.
+     *
+     * <p>Implementations that do not use key versioning (e.g., envelope encryption where the DEK is
+     * wrapped in the metadata itself) may return an empty string.
+     */
+    String getKeyVersion();
+
+    /** Returns an unmodifiable view of the encryption context, empty if none was set. */
+    Map<String, String> getEncryptionContext();
+
+    /** Converts this metadata to a map suitable for cloud object metadata. */
+    Map<String, String> toMetadata();
+}

--- a/flink-filesystems/flink-fs-cse-common/src/main/java/org/apache/flink/fs/cse/KeyMaterial.java
+++ b/flink-filesystems/flink-fs-cse-common/src/main/java/org/apache/flink/fs/cse/KeyMaterial.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.fs.cse;
+
+import org.apache.flink.annotation.Experimental;
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.util.Preconditions;
+
+import javax.annotation.concurrent.Immutable;
+
+import java.util.Objects;
+
+/**
+ * Holds key material returned by a {@link KeyProvider}: the key identifier, version, and plaintext
+ * key bytes.
+ *
+ * <p>The key ID and version are stored in file metadata so the correct key can be retrieved on the
+ * read path. The key material is the raw symmetric key (e.g., 32 bytes for AES-256).
+ */
+@Internal
+@Experimental
+@Immutable
+public final class KeyMaterial {
+
+    private final String keyId;
+    private final String version;
+    private final byte[] material;
+
+    /**
+     * @param material the plaintext key bytes (e.g., 32 bytes for AES-256); defensively copied
+     */
+    public KeyMaterial(final String keyId, final String version, final byte[] material) {
+        this.keyId = Preconditions.checkNotNull(keyId, "keyId must not be null");
+        this.version = Preconditions.checkNotNull(version, "version must not be null");
+        Preconditions.checkNotNull(material, "material must not be null");
+        Preconditions.checkArgument(material.length > 0, "material must not be empty");
+        this.material = material.clone();
+    }
+
+    /** Returns the key identifier. */
+    public String getKeyId() {
+        return keyId;
+    }
+
+    /** Returns the key version identifier. */
+    public String getVersion() {
+        return version;
+    }
+
+    /** Returns a copy of the plaintext key bytes. */
+    public byte[] getMaterial() {
+        return material.clone();
+    }
+
+    /**
+     * Equality is based on key identity (keyId + version) only — material is excluded to avoid
+     * timing side-channels on secret bytes.
+     */
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof KeyMaterial)) {
+            return false;
+        }
+        final KeyMaterial that = (KeyMaterial) o;
+        return Objects.equals(keyId, that.keyId) && Objects.equals(version, that.version);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(keyId, version);
+    }
+
+    /** Returns a redacted string — key bytes are never included. */
+    @Override
+    public String toString() {
+        return "KeyMaterial{keyId=" + keyId + ", version=" + version + "}";
+    }
+}

--- a/flink-filesystems/flink-fs-cse-common/src/main/java/org/apache/flink/fs/cse/KeyProvider.java
+++ b/flink-filesystems/flink-fs-cse-common/src/main/java/org/apache/flink/fs/cse/KeyProvider.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.fs.cse;
+
+import org.apache.flink.annotation.Experimental;
+import org.apache.flink.annotation.Internal;
+
+import javax.annotation.concurrent.ThreadSafe;
+
+import java.io.Closeable;
+import java.util.Map;
+
+/**
+ * Provider of encryption keys used in client-side encryption of filesystem data.
+ *
+ * <p>This interface abstracts the key management backend. Implementations may delegate to a KMS
+ * (e.g., AWS KMS, Azure Key Vault, GCP Cloud KMS, or a custom key vending service). For testing, a
+ * deterministic key implementation is provided.
+ *
+ * <p>Implementations must be thread-safe, as the same provider instance is shared across the
+ * filesystem.
+ *
+ * @see KeyProviderFactory
+ */
+@Internal
+@Experimental
+@ThreadSafe
+public interface KeyProvider extends Closeable {
+
+    /**
+     * Returns the current active key for encrypting new files (write path).
+     *
+     * @param keyId the key identifier (e.g., master key reference or key ARN)
+     * @param encryptionContext context for KMS authorization; empty map if none
+     * @throws KeyProviderException if the key cannot be retrieved
+     */
+    KeyMaterial getActiveKey(String keyId, Map<String, String> encryptionContext)
+            throws KeyProviderException;
+
+    /**
+     * Returns the plaintext key referenced by per-file encryption metadata (read path).
+     *
+     * @throws KeyProviderException if the key cannot be retrieved
+     */
+    KeyMaterial getKeyForMetadata(EncryptionMetadata metadata) throws KeyProviderException;
+}

--- a/flink-filesystems/flink-fs-cse-common/src/main/java/org/apache/flink/fs/cse/KeyProviderException.java
+++ b/flink-filesystems/flink-fs-cse-common/src/main/java/org/apache/flink/fs/cse/KeyProviderException.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.fs.cse;
+
+import org.apache.flink.annotation.Experimental;
+import org.apache.flink.annotation.Internal;
+
+import java.io.IOException;
+
+/** Base exception for key provider errors. */
+@Internal
+@Experimental
+public class KeyProviderException extends IOException {
+
+    private static final long serialVersionUID = 1L;
+
+    public KeyProviderException(final String message) {
+        super(message);
+    }
+
+    public KeyProviderException(final String message, final Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/flink-filesystems/flink-fs-cse-common/src/main/java/org/apache/flink/fs/cse/KeyProviderFactory.java
+++ b/flink-filesystems/flink-fs-cse-common/src/main/java/org/apache/flink/fs/cse/KeyProviderFactory.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.fs.cse;
+
+import org.apache.flink.annotation.Experimental;
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.configuration.ReadableConfig;
+
+/**
+ * Factory for creating {@link KeyProvider} instances from Flink configuration.
+ *
+ * <p>Implementations must have a public no-arg constructor for reflective instantiation by
+ * filesystem factories. The configuration passed to {@link #createKeyProvider} is the full
+ * filesystem configuration. Implementations should read only CSE-scoped keys (prefixed with {@link
+ * CseOptions#KEY_PREFIX}).
+ */
+@Internal
+@Experimental
+public interface KeyProviderFactory {
+
+    /** Creates a key provider from the given CSE configuration. */
+    KeyProvider createKeyProvider(ReadableConfig configuration) throws KeyProviderException;
+}

--- a/flink-filesystems/flink-fs-cse-common/src/main/java/org/apache/flink/fs/cse/KeyProviders.java
+++ b/flink-filesystems/flink-fs-cse-common/src/main/java/org/apache/flink/fs/cse/KeyProviders.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.fs.cse;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.configuration.ReadableConfig;
+import org.apache.flink.util.FlinkException;
+import org.apache.flink.util.InstantiationUtil;
+
+import javax.annotation.concurrent.Immutable;
+
+import java.io.IOException;
+
+/**
+ * Utility for instantiating {@link KeyProvider} instances via {@link KeyProviderFactory}.
+ *
+ * <p>Filesystem plugins call {@link #instantiate(String, ReadableConfig)} with the factory class
+ * name from {@link CseOptions#KEY_PROVIDER_FACTORY_CLASS} and the filesystem configuration.
+ */
+@Internal
+@Immutable
+public final class KeyProviders {
+
+    /**
+     * Reflectively instantiates a {@link KeyProviderFactory} and uses it to create a {@link
+     * KeyProvider}.
+     *
+     * @param factoryClassName fully-qualified class name of the {@link KeyProviderFactory}
+     * @param config the filesystem configuration passed to {@link
+     *     KeyProviderFactory#createKeyProvider}
+     * @return a new {@link KeyProvider} instance
+     * @throws IOException if the factory cannot be found, instantiated, or fails to create the
+     *     provider
+     */
+    public static KeyProvider instantiate(
+            final String factoryClassName, final ReadableConfig config) throws IOException {
+        try {
+            final KeyProviderFactory factory =
+                    InstantiationUtil.instantiate(
+                            factoryClassName.strip(),
+                            KeyProviderFactory.class,
+                            Thread.currentThread().getContextClassLoader());
+            return factory.createKeyProvider(config);
+        } catch (FlinkException | RuntimeException e) {
+            throw new IOException(
+                    "Failed to instantiate KeyProviderFactory class '" + factoryClassName + "'", e);
+        }
+    }
+
+    private KeyProviders() {}
+}

--- a/flink-filesystems/flink-fs-cse-common/src/main/java/org/apache/flink/fs/cse/TestingKeyProvider.java
+++ b/flink-filesystems/flink-fs-cse-common/src/main/java/org/apache/flink/fs/cse/TestingKeyProvider.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.fs.cse;
+
+import org.apache.flink.annotation.Experimental;
+import org.apache.flink.annotation.Internal;
+
+import javax.annotation.concurrent.ThreadSafe;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * A deterministic {@link KeyProvider} for testing CSE encryption with key rotation.
+ *
+ * <p>Uses predefined ULID versions that rotate in round-robin fashion. Keys are derived
+ * deterministically from their version string (UTF-8 bytes, padded to 32 bytes), so the same
+ * version always produces the same 256-bit key. This allows reading encrypted files after
+ * application restart and testing multi-version file access.
+ *
+ * <p><b>WARNING: This provider is for TESTING ONLY.</b> Keys are derived from predictable version
+ * strings with no real key management.
+ *
+ * <p>This class is placed in main sources (not test sources) so it is available on the plugin
+ * classpath for reflective instantiation from Flink configuration in E2E and manual tests.
+ */
+@Experimental
+@Internal
+@ThreadSafe
+public final class TestingKeyProvider implements KeyProvider {
+
+    /** Predefined ULID versions for deterministic rotation (Crockford Base32). */
+    static final List<String> PREDEFINED_VERSIONS =
+            List.of(
+                    "01ARZ3NDEKTSV4RRFFQ69G5FA1",
+                    "01ARZ3NDEKTSV4RRFFQ69G5FA2",
+                    "01ARZ3NDEKTSV4RRFFQ69G5FA3");
+
+    /** AES-256 requires 32 bytes. */
+    private static final int KEY_LENGTH_BYTES = 32;
+
+    private final Map<String, byte[]> keyMaterials;
+    private final AtomicInteger currentVersionIndex;
+
+    /** Creates a testing key provider with all predefined versions pre-derived. */
+    public TestingKeyProvider() {
+        this.currentVersionIndex = new AtomicInteger(0);
+
+        final Map<String, byte[]> materials = new HashMap<>();
+        for (final String version : PREDEFINED_VERSIONS) {
+            materials.put(version, deriveKeyFromVersion(version));
+        }
+        this.keyMaterials = Collections.unmodifiableMap(materials);
+    }
+
+    @Override
+    public KeyMaterial getActiveKey(
+            final String keyId, final Map<String, String> encryptionContext) {
+        final String version = PREDEFINED_VERSIONS.get(currentVersionIndex.get());
+        return new KeyMaterial(keyId, version, keyMaterials.get(version));
+    }
+
+    @Override
+    public KeyMaterial getKeyForMetadata(final EncryptionMetadata metadata)
+            throws KeyProviderException {
+        final String storedKeyId = metadata.keyId();
+        final String keyVersion = metadata.getKeyVersion();
+        final byte[] material = keyMaterials.get(keyVersion);
+        if (material == null) {
+            throw new KeyProviderException(
+                    "Unknown key version '" + keyVersion + "' for key '" + storedKeyId + "'");
+        }
+        return new KeyMaterial(storedKeyId, keyVersion, material);
+    }
+
+    @Override
+    public void close() {
+        // No resources to release.
+    }
+
+    /**
+     * Rotates to the next predefined version in round-robin fashion.
+     *
+     * @return the version string of the new current version
+     */
+    public String rotateKey() {
+        final int nextIndex =
+                currentVersionIndex.updateAndGet(i -> (i + 1) % PREDEFINED_VERSIONS.size());
+        return PREDEFINED_VERSIONS.get(nextIndex);
+    }
+
+    /**
+     * Returns the current version index (0-based).
+     *
+     * @return index of the current version in {@link #PREDEFINED_VERSIONS}
+     */
+    public int getCurrentVersionIndex() {
+        return currentVersionIndex.get();
+    }
+
+    private static byte[] deriveKeyFromVersion(final String version) {
+        final byte[] utf8 = version.getBytes(StandardCharsets.UTF_8);
+        final byte[] key = Arrays.copyOf(utf8, KEY_LENGTH_BYTES);
+        for (int i = utf8.length; i < KEY_LENGTH_BYTES; i++) {
+            key[i] = (byte) i;
+        }
+        return key;
+    }
+}

--- a/flink-filesystems/flink-fs-cse-common/src/main/java/org/apache/flink/fs/cse/TestingKeyProviderFactory.java
+++ b/flink-filesystems/flink-fs-cse-common/src/main/java/org/apache/flink/fs/cse/TestingKeyProviderFactory.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.fs.cse;
+
+import org.apache.flink.annotation.Experimental;
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.configuration.ReadableConfig;
+
+import javax.annotation.concurrent.Immutable;
+
+/**
+ * A {@link KeyProviderFactory} that creates {@link TestingKeyProvider} instances.
+ *
+ * <p>Placed in main sources alongside {@link TestingKeyProvider} for plugin classpath availability
+ * in E2E and manual tests.
+ */
+@Internal
+@Experimental
+@Immutable
+public final class TestingKeyProviderFactory implements KeyProviderFactory {
+
+    @Override
+    public KeyProvider createKeyProvider(final ReadableConfig configuration) {
+        return new TestingKeyProvider();
+    }
+}

--- a/flink-filesystems/flink-fs-cse-common/src/test/java/org/apache/flink/fs/cse/CseOptionsTest.java
+++ b/flink-filesystems/flink-fs-cse-common/src/test/java/org/apache/flink/fs/cse/CseOptionsTest.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.fs.cse;
+
+import org.apache.flink.configuration.Configuration;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.Map;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link CseOptions}. */
+class CseOptionsTest {
+
+    @ParameterizedTest
+    @MethodSource("encryptionContextCases")
+    void shouldExtractEncryptionContext(
+            final Map<String, String> configEntries, final Map<String, String> expected) {
+        final Configuration config = new Configuration();
+        configEntries.forEach(config::setString);
+
+        assertThat(CseOptions.extractEncryptionContext(config))
+                .containsExactlyInAnyOrderEntriesOf(expected);
+    }
+
+    static Stream<Arguments> encryptionContextCases() {
+        return Stream.of(
+                // multiple context entries
+                Arguments.of(
+                        Map.of(
+                                "fs.cse.encryption-context.org_id", "org-123",
+                                "fs.cse.encryption-context.pool_id", "lfcp-456"),
+                        Map.of("org_id", "org-123", "pool_id", "lfcp-456")),
+                // no context entries — only unrelated keys
+                Arguments.of(Map.of("fs.cse.write-key-id", "some-key"), Map.of()),
+                // empty config
+                Arguments.of(Map.of(), Map.of()),
+                // mixed: context entries alongside unrelated keys
+                Arguments.of(
+                        Map.of(
+                                "fs.cse.encryption-context.org_id", "org-123",
+                                "fs.cse.write-key-id", "some-key",
+                                "fs.azure.account-key", "secret"),
+                        Map.of("org_id", "org-123")));
+    }
+}

--- a/flink-filesystems/flink-fs-cse-common/src/test/java/org/apache/flink/fs/cse/KeyMaterialTest.java
+++ b/flink-filesystems/flink-fs-cse-common/src/test/java/org/apache/flink/fs/cse/KeyMaterialTest.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.fs.cse;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Tests for {@link KeyMaterial}. */
+class KeyMaterialTest {
+
+    private static final byte[] VALID_KEY = {1, 2, 3};
+
+    @Test
+    void shouldStoreKeyIdAndVersion() {
+        final KeyMaterial km = new KeyMaterial("id-1", "v2", VALID_KEY);
+        assertThat(km.getKeyId()).isEqualTo("id-1");
+        assertThat(km.getVersion()).isEqualTo("v2");
+    }
+
+    @Test
+    void shouldDefensivelyCopyMaterialOnConstruction() {
+        final byte[] original = {10, 20, 30};
+        final KeyMaterial km = new KeyMaterial("id", "v1", original);
+        original[0] = 99;
+        assertThat(km.getMaterial()).containsExactly(10, 20, 30);
+    }
+
+    @Test
+    void shouldDefensivelyCopyMaterialOnGet() {
+        final KeyMaterial km = new KeyMaterial("id", "v1", new byte[] {10, 20, 30});
+        final byte[] first = km.getMaterial();
+        first[0] = 99;
+        assertThat(km.getMaterial()).containsExactly(10, 20, 30);
+    }
+
+    @ParameterizedTest
+    @MethodSource("nullArgs")
+    void shouldThrowOnNullArg(
+            final String keyId,
+            final String version,
+            final byte[] material,
+            final String expectedMessage) {
+        assertThatThrownBy(() -> new KeyMaterial(keyId, version, material))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessageContaining(expectedMessage);
+    }
+
+    private static Stream<Arguments> nullArgs() {
+        return Stream.of(
+                Arguments.of(null, "v1", VALID_KEY, "keyId"),
+                Arguments.of("id", null, VALID_KEY, "version"),
+                Arguments.of("id", "v1", null, "material"));
+    }
+
+    @Test
+    void shouldThrowOnEmptyMaterial() {
+        assertThatThrownBy(() -> new KeyMaterial("id", "v1", new byte[0]))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("empty");
+    }
+
+    @Test
+    void shouldBeEqualForSameFields() {
+        final KeyMaterial a = new KeyMaterial("id-1", "v1", VALID_KEY);
+        final KeyMaterial b = new KeyMaterial("id-1", "v1", VALID_KEY);
+        assertThat(a).isEqualTo(b);
+        assertThat(a.hashCode()).isEqualTo(b.hashCode());
+    }
+
+    @Test
+    void shouldNotBeEqualWhenFieldDiffers() {
+        final KeyMaterial base = new KeyMaterial("id-1", "v1", VALID_KEY);
+        assertThat(base).isNotEqualTo(new KeyMaterial("id-2", "v1", VALID_KEY));
+        assertThat(base).isNotEqualTo(new KeyMaterial("id-1", "v2", VALID_KEY));
+    }
+
+    @Test
+    void equalsShouldNotCompareMaterial() {
+        final KeyMaterial a = new KeyMaterial("id-1", "v1", new byte[] {1, 2, 3});
+        final KeyMaterial b = new KeyMaterial("id-1", "v1", new byte[] {9, 8, 7});
+        assertThat(a).isEqualTo(b);
+        assertThat(a.hashCode()).isEqualTo(b.hashCode());
+    }
+
+    @Test
+    void shouldRedactMaterialInToString() {
+        final KeyMaterial km = new KeyMaterial("id-1", "v2", new byte[] {1, 2, 3});
+        final String str = km.toString();
+        assertThat(str).contains("id-1").contains("v2").doesNotContain("1, 2, 3");
+    }
+}

--- a/flink-filesystems/flink-fs-cse-common/src/test/java/org/apache/flink/fs/cse/TestingKeyProviderTest.java
+++ b/flink-filesystems/flink-fs-cse-common/src/test/java/org/apache/flink/fs/cse/TestingKeyProviderTest.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.fs.cse;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Tests for {@link TestingKeyProvider}. */
+class TestingKeyProviderTest {
+
+    private static final String TEST_KEY_ID = "test-key-1";
+    private static final int NUM_VERSIONS = TestingKeyProvider.PREDEFINED_VERSIONS.size();
+
+    static IntStream versionIndices() {
+        return IntStream.range(0, NUM_VERSIONS);
+    }
+
+    @Test
+    void shouldReturnDifferentKeyAfterRotation() {
+        final TestingKeyProvider provider = new TestingKeyProvider();
+        final KeyMaterial before = provider.getActiveKey(TEST_KEY_ID, Collections.emptyMap());
+
+        provider.rotateKey();
+
+        final KeyMaterial after = provider.getActiveKey(TEST_KEY_ID, Collections.emptyMap());
+        assertThat(after.getVersion()).isNotEqualTo(before.getVersion());
+        assertThat(after.getMaterial()).isNotEqualTo(before.getMaterial());
+    }
+
+    @ParameterizedTest
+    @MethodSource("versionIndices")
+    void getKeyForMetadataShouldResolveByVersion(final int versionIndex) throws Exception {
+        final TestingKeyProvider provider = new TestingKeyProvider();
+        final String version = TestingKeyProvider.PREDEFINED_VERSIONS.get(versionIndex);
+
+        for (int i = 0; i < versionIndex; i++) {
+            provider.rotateKey();
+        }
+        final KeyMaterial fromActive = provider.getActiveKey(TEST_KEY_ID, Collections.emptyMap());
+        final KeyMaterial fromMetadata =
+                provider.getKeyForMetadata(new TestingEncryptionMetadata(TEST_KEY_ID, version));
+
+        assertThat(fromMetadata.getKeyId()).isEqualTo(TEST_KEY_ID);
+        assertThat(fromMetadata.getVersion()).isEqualTo(version);
+        assertThat(fromMetadata.getMaterial()).isNotEmpty();
+        assertThat(fromMetadata.getMaterial()).isEqualTo(fromActive.getMaterial());
+    }
+
+    @Test
+    void getKeyForMetadataShouldThrowForUnknownVersion() {
+        final TestingKeyProvider provider = new TestingKeyProvider();
+
+        assertThatThrownBy(
+                        () ->
+                                provider.getKeyForMetadata(
+                                        new TestingEncryptionMetadata(
+                                                TEST_KEY_ID, "unknown-version")))
+                .isInstanceOf(KeyProviderException.class)
+                .hasMessageContaining("unknown-version");
+    }
+
+    // ---------------------------------------------------------------------------
+    // Stub
+    // ---------------------------------------------------------------------------
+
+    private static final class TestingEncryptionMetadata implements EncryptionMetadata {
+
+        private final String keyId;
+        private final String keyVersion;
+
+        TestingEncryptionMetadata(final String keyId, final String keyVersion) {
+            this.keyId = keyId;
+            this.keyVersion = keyVersion;
+        }
+
+        @Override
+        public String keyId() {
+            return keyId;
+        }
+
+        @Override
+        public String getKeyVersion() {
+            return keyVersion;
+        }
+
+        @Override
+        public Map<String, String> getEncryptionContext() {
+            return Collections.emptyMap();
+        }
+
+        @Override
+        public Map<String, String> toMetadata() {
+            return Collections.emptyMap();
+        }
+    }
+}

--- a/flink-filesystems/pom.xml
+++ b/flink-filesystems/pom.xml
@@ -47,6 +47,8 @@ under the License.
 		<module>flink-oss-fs-hadoop</module>
 		<module>flink-azure-fs-hadoop</module>
 		<module>flink-gs-fs-hadoop</module>
+		<module>flink-fs-cse-common</module>
+		<module>flink-fs-cse-aes-gcm</module>
 	</modules>
 
 	<!-- Common dependency setup for all filesystems -->

--- a/flink-filesystems/pom.xml
+++ b/flink-filesystems/pom.xml
@@ -46,6 +46,7 @@ under the License.
 		<module>flink-s3-fs-native</module>
 		<module>flink-oss-fs-hadoop</module>
 		<module>flink-azure-fs-hadoop</module>
+		<module>flink-azure-fs-native</module>
 		<module>flink-gs-fs-hadoop</module>
 		<module>flink-fs-cse-common</module>
 		<module>flink-fs-cse-aes-gcm</module>


### PR DESCRIPTION
## [DO NOT MERGE]
This PR is for discussions/reference. Once FLIPs are voted, I will split this PR in smaller reviewable chunks.

## What is the purpose of the change

Reference implementation for three related FLIPs that introduce Hadoop-less, SDK-native filesystem support in Flink:

- [FLIP-597](https://cwiki.apache.org/confluence/display/FLINK/FLIP-597): Common object storage stream abstractions (`flink-core`)
- [FLIP-601](https://cwiki.apache.org/confluence/display/FLINK/FLIP-601): Client-side encryption extension (`flink-fs-cse-common`, `flink-fs-cse-aes-gcm`)
- [FLIP-598](https://cwiki.apache.org/confluence/display/FLINK/FLIP-598): Azure Gen2 DataLake SDK-native filesystem (`flink-azure-fs-native`)

Mailing list discussion: https://lists.apache.org/thread/npjcpx3o73pg7b4p1hg073sqnj49b66j

All new types are annotated `@Internal` and `@Experimental`.

## Brief change log

- Common read/write stream abstractions with seek optimization and composable extensions
- Pluggable client-side encryption (AES-256-GCM via BouncyCastle FIPS) that any SDK-native filesystem can opt into
- Azure ABFS filesystem using the Gen2 DataLake SDK directly, with full CSE support

## Verifying this change

Unit tests for all three modules (281 tests total).

## Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): yes (Azure SDK, BouncyCastle FIPS, OkHttp — all shaded or isolated)
- The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
- The serializers: no
- The runtime per-record code paths (performance sensitive): no
- Anything that affects deployment or recovery: no
- The S3 file system connector: no

## Documentation

- Does this pull request introduce a new feature? yes
- If yes, how is the feature documented? JavaDocs (user-facing docs will follow)

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code

Generated-by: Claude Code