### PR TITLE
[hotfix] [docs] Fix java.util.Collection reference in DataStream overview

### DIFF
--- a/docs/content.zh/docs/dev/datastream/overview.md
+++ b/docs/content.zh/docs/dev/datastream/overview.md
@@ -241,7 +241,7 @@ Source 是你的程序从中读取其输入的地方。你可以用 `StreamExecu
 
 基于集合：
 
-- `fromData(Collection)` - 从 Java Java.util.Collection 创建数据流。集合中的所有元素必须属于同一类型。
+- `fromData(Collection)` - 从 Java `java.util.Collection` 创建数据流。集合中的所有元素必须属于同一类型。
   
 - `fromData(T ...)` - 从给定的对象序列中创建数据流。所有的对象必须属于同一类型。
   

--- a/docs/content/docs/dev/datastream/overview.md
+++ b/docs/content/docs/dev/datastream/overview.md
@@ -291,7 +291,7 @@ Socket-based:
 
 Collection-based:
 
-- `fromData(Collection)` - Creates a data stream from the Java Java.util.Collection. All elements
+- `fromData(Collection)` - Creates a data stream from a Java `java.util.Collection`. All elements
   in the collection must be of the same type.
 
 - `fromData(T ...)` - Creates a data stream from the given sequence of objects. All objects must be


### PR DESCRIPTION
## What is the purpose of the change

Trivial docs typo fix (no JIRA, per the contribution guide's exception for documentation typos).

In the DataStream API overview, the `fromData(Collection)` entry read "Creates a data stream from the Java Java.util.Collection" (and the Chinese mirror "从 Java Java.util.Collection 创建数据流"). The word "Java" was duplicated and the JDK type was left unformatted. This renders it as the inline code type `java.util.Collection` in both the English and Chinese docs.

## Brief change log

  - `docs/content/docs/dev/datastream/overview.md`: `java.util.Collection` reference
  - `docs/content.zh/docs/dev/datastream/overview.md`: same fix in the Chinese docs

## Verifying this change

This change is a trivial documentation fix without test coverage.

## Does this pull request potentially affect one of the following parts:

No.

## Documentation

  - Documentation-only change.
