### PR TITLE
[FLINK-39997] Upgrade pemja to 0.6

### DIFF
--- a/flink-python/pom.xml
+++ b/flink-python/pom.xml
@@ -137,7 +137,7 @@ under the License.
 		<dependency>
 			<groupId>com.alibaba</groupId>
 			<artifactId>pemja</artifactId>
-			<version>0.5.7</version>
+			<version>0.6.1</version>
 			<optional>${flink.markBundledAsOptional}</optional>
 		</dependency>
 

--- a/flink-python/pyflink/fn_execution/datastream/embedded/state_impl.py
+++ b/flink-python/pyflink/fn_execution/datastream/embedded/state_impl.py
@@ -223,8 +223,8 @@ class MapStateImpl(KeyedStateImpl, InternalMapState):
         entries = self._state.entries()
         if entries:
             for entry in entries:
-                yield (self._k_converter.to_internal(entry.getKey()),
-                       self._v_converter.to_internal(entry.getValue()))
+                yield (self._k_converter.to_internal(entry[0]),
+                       self._v_converter.to_internal(entry[1]))
 
     def keys(self) -> Iterable[K]:
         keys = self._state.keys()
@@ -261,8 +261,8 @@ class ReadOnlyBroadcastStateImpl(StateImpl, InternalReadOnlyBroadcastState):
     def items(self) -> Iterable[Tuple[K, V]]:
         entries = self._state.entries()
         for entry in entries:
-            yield (self._k_converter.to_internal(entry.getKey()),
-                   self._v_converter.to_internal(entry.getValue()))
+            yield (self._k_converter.to_internal(entry[0]),
+                   self._v_converter.to_internal(entry[1]))
 
     def keys(self) -> Iterable[K]:
         for k in self._state.keys():

--- a/flink-python/pyproject.toml
+++ b/flink-python/pyproject.toml
@@ -45,7 +45,7 @@ dev = [
   "fastavro>=1.1.0,!=1.8.0",
   "grpcio>=1.29.0,<=1.71.0",
   "grpcio-tools>=1.29.0,<=1.71.0",
-  "pemja>=0.5.7,<0.5.8; platform_system != 'Windows'",
+  "pemja>=0.5.7,<0.7; platform_system != 'Windows'",
   "httplib2>=0.19.0",
   "protobuf~=4.25",
   "pytest~=8.0",

--- a/flink-python/setup.py
+++ b/flink-python/setup.py
@@ -326,7 +326,7 @@ try:
                         'numpy>=1.22.4',
                         'pandas>=1.3.0,<2.3',  # FLINK-38513: 2.3+ drops cp39 wheels
                         'pyarrow>=5.0.0,<21.0.0',
-                        'pemja>=0.5.7,<0.5.8;platform_system != "Windows"',
+                        'pemja>=0.5.7,<0.7;platform_system != "Windows"',
                         'httplib2>=0.19.0',
                         'ruamel.yaml>=0.18.4',
                         apache_flink_libraries_dependency]

--- a/flink-python/src/main/resources/META-INF/NOTICE
+++ b/flink-python/src/main/resources/META-INF/NOTICE
@@ -29,7 +29,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - org.apache.beam:beam-sdks-java-transform-service-launcher:2.54.0
 - org.apache.beam:beam-vendor-guava-32_1_2-jre:0.1
 - org.apache.beam:beam-vendor-grpc-1_60_1:0.1
-- com.alibaba:pemja:0.5.7
+- com.alibaba:pemja:0.6.1
 
 This project bundles the following dependencies under the BSD license.
 See bundled license files for details


### PR DESCRIPTION
## What is the purpose of the change

Bumping to 0.6.2 ensures PyFlink ships with and resolves to the latest stable 0.6.x release.

Also pemja provides wheels for python 3.13 (related to [FLINK-39031](https://issues.apache.org/jira/browse/FLINK-39031?jql=project%20%3D%20FLINK%20AND%20resolution%20%3D%20Unresolved%20AND%20text%20~%20%22pemja%22%20ORDER%20BY%20priority%20DESC%2C%20updated%20DESC)).

## Brief change log

- Bump pemja version:
  - from >=0.5.7,<0.5.8
  - to >=0.6.2,<0.7

## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **yes**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**
