### PR TITLE
 [FLINK-39999][table] Make Flink Sql calls unparsable as it is required by Calcite 1.42.0

### DIFF
--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/SqlPartitionSpecProperty.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/SqlPartitionSpecProperty.java
@@ -20,6 +20,7 @@ package org.apache.flink.sql.parser;
 import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.SqlSpecialOperator;
@@ -41,7 +42,17 @@ import static java.util.Objects.requireNonNull;
 public class SqlPartitionSpecProperty extends SqlCall {
 
     /** Use this operator only if you don't have a better one. */
-    protected static final SqlOperator OPERATOR = new SqlSpecialOperator("Pair", SqlKind.OTHER);
+    protected static final SqlOperator OPERATOR =
+            new SqlSpecialOperator("Pair", SqlKind.OTHER) {
+                @Override
+                public SqlCall createCall(
+                        SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... operands) {
+                    return new SqlPartitionSpecProperty(
+                            (SqlIdentifier) operands[0],
+                            operands.length > 1 ? operands[1] : null,
+                            pos);
+                }
+            };
 
     private final SqlIdentifier key;
     private final @Nullable SqlNode value;

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/SqlProperty.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/SqlProperty.java
@@ -20,6 +20,7 @@ package org.apache.flink.sql.parser;
 import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.SqlSpecialOperator;
@@ -38,7 +39,14 @@ import static java.util.Objects.requireNonNull;
 public class SqlProperty extends SqlCall {
 
     /** Use this operator only if you don't have a better one. */
-    protected static final SqlOperator OPERATOR = new SqlSpecialOperator("Property", SqlKind.OTHER);
+    protected static final SqlOperator OPERATOR =
+            new SqlSpecialOperator("Property", SqlKind.OTHER) {
+                @Override
+                public SqlCall createCall(
+                        SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... operands) {
+                    return new SqlProperty((SqlIdentifier) operands[0], operands[1], pos);
+                }
+            };
 
     private final SqlIdentifier key;
     private final SqlNode value;

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlAddJar.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlAddJar.java
@@ -19,8 +19,10 @@
 package org.apache.flink.sql.parser.ddl;
 
 import org.apache.calcite.sql.SqlAlter;
+import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlCharStringLiteral;
 import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.SqlSpecialOperator;
@@ -34,7 +36,14 @@ import java.util.List;
 /** Add Jar command to add jar into the classloader. */
 public class SqlAddJar extends SqlAlter {
 
-    public static final SqlOperator OPERATOR = new SqlSpecialOperator("ADD JAR", SqlKind.OTHER_DDL);
+    public static final SqlOperator OPERATOR =
+            new SqlSpecialOperator("ADD JAR", SqlKind.OTHER_DDL) {
+                @Override
+                public SqlCall createCall(
+                        SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... operands) {
+                    return new SqlAddJar(pos, (SqlCharStringLiteral) operands[0]);
+                }
+            };
 
     private final SqlCharStringLiteral jarPath;
 

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlAddPartitions.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlAddPartitions.java
@@ -21,9 +21,14 @@ package org.apache.flink.sql.parser.ddl;
 import org.apache.flink.sql.parser.SqlParseUtils;
 import org.apache.flink.sql.parser.ddl.table.SqlAlterTable;
 
+import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlNodeList;
+import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql.SqlSpecialOperator;
 import org.apache.calcite.sql.SqlWriter;
 import org.apache.calcite.sql.parser.SqlParserPos;
 
@@ -35,6 +40,28 @@ import java.util.List;
 
 /** ALTER TABLE DDL to add partitions to a table. */
 public class SqlAddPartitions extends SqlAlterTable {
+
+    private static final SqlSpecialOperator ADD_PARTITION_OPERATOR =
+            new SqlSpecialOperator("ALTER TABLE ADD PARTITION", SqlKind.ALTER_TABLE) {
+                @Override
+                public SqlCall createCall(
+                        SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... operands) {
+                    List<SqlNodeList> partSpecs = new ArrayList<>();
+                    for (SqlNode spec : (SqlNodeList) operands[2]) {
+                        partSpecs.add((SqlNodeList) spec);
+                    }
+                    List<SqlNodeList> partProps = new ArrayList<>();
+                    for (SqlNode prop : (SqlNodeList) operands[3]) {
+                        partProps.add((SqlNodeList) prop);
+                    }
+                    return new SqlAddPartitions(
+                            pos,
+                            (SqlIdentifier) operands[0],
+                            ((SqlLiteral) operands[1]).booleanValue(),
+                            partSpecs,
+                            partProps);
+                }
+            };
 
     private final boolean ifPartitionNotExists;
     private final List<SqlNodeList> partSpecs;
@@ -68,14 +95,19 @@ public class SqlAddPartitions extends SqlAlterTable {
         return partProps;
     }
 
+    @Override
+    public SqlOperator getOperator() {
+        return ADD_PARTITION_OPERATOR;
+    }
+
     @Nonnull
     @Override
     public List<SqlNode> getOperandList() {
-        List<SqlNode> operands = new ArrayList<>();
-        operands.add(tableIdentifier);
-        operands.addAll(partSpecs);
-        operands.addAll(partProps);
-        return operands;
+        return List.of(
+                tableIdentifier,
+                SqlLiteral.createBoolean(ifPartitionNotExists, SqlParserPos.ZERO),
+                new SqlNodeList(partSpecs, SqlParserPos.ZERO),
+                new SqlNodeList(partProps, SqlParserPos.ZERO));
     }
 
     @Override

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlAlterDatabase.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlAlterDatabase.java
@@ -21,8 +21,10 @@ package org.apache.flink.sql.parser.ddl;
 import org.apache.flink.sql.parser.SqlParseUtils;
 import org.apache.flink.sql.parser.SqlUnparseUtils;
 
+import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlNodeList;
 import org.apache.calcite.sql.SqlOperator;
@@ -40,7 +42,14 @@ import static java.util.Objects.requireNonNull;
 public class SqlAlterDatabase extends SqlAlterObject {
 
     public static final SqlSpecialOperator OPERATOR =
-            new SqlSpecialOperator("ALTER DATABASE", SqlKind.OTHER_DDL);
+            new SqlSpecialOperator("ALTER DATABASE", SqlKind.OTHER_DDL) {
+                @Override
+                public SqlCall createCall(
+                        SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... operands) {
+                    return new SqlAlterDatabase(
+                            pos, (SqlIdentifier) operands[0], (SqlNodeList) operands[1]);
+                }
+            };
 
     private final SqlNodeList propertyList;
 

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlAlterFunction.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlAlterFunction.java
@@ -20,9 +20,11 @@ package org.apache.flink.sql.parser.ddl;
 
 import org.apache.flink.sql.parser.SqlUnparseUtils;
 
+import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlCharStringLiteral;
 import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlSpecialOperator;
 import org.apache.calcite.sql.SqlWriter;
@@ -39,7 +41,24 @@ import static java.util.Objects.requireNonNull;
 public class SqlAlterFunction extends SqlAlterObject {
 
     public static final SqlSpecialOperator OPERATOR =
-            new SqlSpecialOperator("ALTER FUNCTION", SqlKind.OTHER_DDL);
+            new SqlSpecialOperator("ALTER FUNCTION", SqlKind.OTHER_DDL) {
+                @Override
+                public SqlCall createCall(
+                        SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... operands) {
+                    String language =
+                            operands[2] instanceof SqlCharStringLiteral
+                                    ? ((SqlCharStringLiteral) operands[2]).getValueAs(String.class)
+                                    : null;
+                    return new SqlAlterFunction(
+                            pos,
+                            (SqlIdentifier) operands[0],
+                            (SqlCharStringLiteral) operands[1],
+                            language,
+                            ((SqlLiteral) operands[3]).booleanValue(),
+                            ((SqlLiteral) operands[4]).booleanValue(),
+                            ((SqlLiteral) operands[5]).booleanValue());
+                }
+            };
 
     private final SqlCharStringLiteral functionClassName;
 
@@ -79,7 +98,15 @@ public class SqlAlterFunction extends SqlAlterObject {
     @Nonnull
     @Override
     public List<SqlNode> getOperandList() {
-        return ImmutableNullableList.of(name, functionClassName);
+        return ImmutableNullableList.of(
+                name,
+                functionClassName,
+                functionLanguage == null
+                        ? SqlLiteral.createNull(SqlParserPos.ZERO)
+                        : SqlLiteral.createCharString(functionLanguage, SqlParserPos.ZERO),
+                SqlLiteral.createBoolean(ifExists, SqlParserPos.ZERO),
+                SqlLiteral.createBoolean(isTemporary, SqlParserPos.ZERO),
+                SqlLiteral.createBoolean(isSystemFunction, SqlParserPos.ZERO));
     }
 
     public String getFunctionLanguage() {

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlCompilePlan.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlCompilePlan.java
@@ -25,6 +25,7 @@ import org.apache.flink.sql.parser.dml.SqlStatementSet;
 
 import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.SqlSpecialOperator;
@@ -33,7 +34,6 @@ import org.apache.calcite.sql.parser.SqlParserPos;
 
 import javax.annotation.Nonnull;
 
-import java.util.Collections;
 import java.util.List;
 
 /**
@@ -44,7 +44,17 @@ import java.util.List;
 public class SqlCompilePlan extends SqlCall {
 
     public static final SqlSpecialOperator OPERATOR =
-            new SqlSpecialOperator("COMPILE PLAN", SqlKind.OTHER);
+            new SqlSpecialOperator("COMPILE PLAN", SqlKind.OTHER) {
+                @Override
+                public SqlCall createCall(
+                        SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... operands) {
+                    return new SqlCompilePlan(
+                            pos,
+                            operands[1],
+                            ((SqlLiteral) operands[2]).booleanValue(),
+                            operands[0]);
+                }
+            };
 
     private final SqlNode planFile;
     private final boolean ifNotExists;
@@ -75,7 +85,7 @@ public class SqlCompilePlan extends SqlCall {
     @Nonnull
     @Override
     public List<SqlNode> getOperandList() {
-        return Collections.singletonList(operand);
+        return List.of(operand, planFile, SqlLiteral.createBoolean(ifNotExists, SqlParserPos.ZERO));
     }
 
     @Override

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlCreateDatabase.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlCreateDatabase.java
@@ -18,9 +18,11 @@
 
 package org.apache.flink.sql.parser.ddl;
 
+import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlCharStringLiteral;
 import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlNodeList;
 import org.apache.calcite.sql.SqlSpecialOperator;
@@ -35,7 +37,18 @@ import static java.util.Objects.requireNonNull;
 public class SqlCreateDatabase extends SqlCreateObject {
 
     public static final SqlSpecialOperator OPERATOR =
-            new SqlSpecialOperator("CREATE DATABASE", SqlKind.OTHER_DDL);
+            new SqlSpecialOperator("CREATE DATABASE", SqlKind.OTHER_DDL) {
+                @Override
+                public SqlCall createCall(
+                        SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... operands) {
+                    return new SqlCreateDatabase(
+                            pos,
+                            (SqlIdentifier) operands[0],
+                            (SqlNodeList) operands[1],
+                            (SqlCharStringLiteral) operands[2],
+                            ((SqlLiteral) operands[3]).booleanValue());
+                }
+            };
 
     public SqlCreateDatabase(
             SqlParserPos pos,
@@ -49,7 +62,11 @@ public class SqlCreateDatabase extends SqlCreateObject {
 
     @Override
     public List<SqlNode> getOperandList() {
-        return ImmutableNullableList.of(name, properties, comment);
+        return ImmutableNullableList.of(
+                name,
+                properties,
+                comment,
+                SqlLiteral.createBoolean(isIfNotExists(), SqlParserPos.ZERO));
     }
 
     @Override

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlCreateFunction.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlCreateFunction.java
@@ -20,9 +20,11 @@ package org.apache.flink.sql.parser.ddl;
 
 import org.apache.flink.sql.parser.SqlUnparseUtils;
 
+import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlCharStringLiteral;
 import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlNodeList;
 import org.apache.calcite.sql.SqlSpecialOperator;
@@ -40,7 +42,26 @@ import static java.util.Objects.requireNonNull;
 public class SqlCreateFunction extends SqlCreateObject {
 
     private static final SqlSpecialOperator OPERATOR =
-            new SqlSpecialOperator("CREATE FUNCTION", SqlKind.CREATE_FUNCTION);
+            new SqlSpecialOperator("CREATE FUNCTION", SqlKind.CREATE_FUNCTION) {
+                @Override
+                public SqlCall createCall(
+                        SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... operands) {
+                    String language =
+                            operands[4] instanceof SqlCharStringLiteral
+                                    ? ((SqlCharStringLiteral) operands[4]).getValueAs(String.class)
+                                    : null;
+                    return new SqlCreateFunction(
+                            pos,
+                            (SqlIdentifier) operands[0],
+                            (SqlCharStringLiteral) operands[1],
+                            language,
+                            ((SqlLiteral) operands[5]).booleanValue(),
+                            ((SqlLiteral) operands[6]).booleanValue(),
+                            ((SqlLiteral) operands[7]).booleanValue(),
+                            (SqlNodeList) operands[2],
+                            (SqlNodeList) operands[3]);
+                }
+            };
 
     private final SqlCharStringLiteral functionClassName;
     private final String functionLanguage;
@@ -76,7 +97,17 @@ public class SqlCreateFunction extends SqlCreateObject {
     @Nonnull
     @Override
     public List<SqlNode> getOperandList() {
-        return ImmutableNullableList.of(name, functionClassName, resourceInfos);
+        return ImmutableNullableList.of(
+                name,
+                functionClassName,
+                resourceInfos,
+                properties,
+                functionLanguage == null
+                        ? SqlLiteral.createNull(SqlParserPos.ZERO)
+                        : SqlLiteral.createCharString(functionLanguage, SqlParserPos.ZERO),
+                SqlLiteral.createBoolean(isIfNotExists(), SqlParserPos.ZERO),
+                SqlLiteral.createBoolean(isTemporary(), SqlParserPos.ZERO),
+                SqlLiteral.createBoolean(isSystemFunction, SqlParserPos.ZERO));
     }
 
     public boolean isSystemFunction() {

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlDistribution.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlDistribution.java
@@ -20,8 +20,11 @@ package org.apache.flink.sql.parser.ddl;
 
 import org.apache.flink.sql.parser.SqlUnparseUtils;
 
+import org.apache.calcite.sql.SqlCall;
+import org.apache.calcite.sql.SqlCharStringLiteral;
 import org.apache.calcite.sql.SqlDdl;
 import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlNodeList;
 import org.apache.calcite.sql.SqlNumericLiteral;
@@ -42,7 +45,21 @@ import java.util.Optional;
 public class SqlDistribution extends SqlDdl {
 
     private static final SqlSpecialOperator OPERATOR =
-            new SqlSpecialOperator("DISTRIBUTED BY", SqlKind.OTHER);
+            new SqlSpecialOperator("DISTRIBUTED BY", SqlKind.OTHER) {
+                @Override
+                public SqlCall createCall(
+                        SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... operands) {
+                    String distributionKind =
+                            operands[2] instanceof SqlCharStringLiteral
+                                    ? ((SqlCharStringLiteral) operands[2]).getValueAs(String.class)
+                                    : null;
+                    return new SqlDistribution(
+                            pos,
+                            distributionKind,
+                            (SqlNodeList) operands[1],
+                            (SqlNumericLiteral) operands[0]);
+                }
+            };
 
     private final String distributionKind;
     private final SqlNodeList bucketColumns;
@@ -61,7 +78,12 @@ public class SqlDistribution extends SqlDdl {
 
     @Override
     public List<SqlNode> getOperandList() {
-        return ImmutableNullableList.of(bucketCount, bucketColumns);
+        return ImmutableNullableList.of(
+                bucketCount,
+                bucketColumns,
+                distributionKind == null
+                        ? SqlLiteral.createNull(SqlParserPos.ZERO)
+                        : SqlLiteral.createCharString(distributionKind, SqlParserPos.ZERO));
     }
 
     @Override

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlDropDatabase.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlDropDatabase.java
@@ -18,17 +18,32 @@
 
 package org.apache.flink.sql.parser.ddl;
 
+import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlLiteral;
+import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.SqlSpecialOperator;
 import org.apache.calcite.sql.SqlWriter;
 import org.apache.calcite.sql.parser.SqlParserPos;
 
+import java.util.List;
+
 /** DROP DATABASE DDL sql call. */
 public class SqlDropDatabase extends SqlDropObject {
     private static final SqlOperator OPERATOR =
-            new SqlSpecialOperator("DROP DATABASE", SqlKind.OTHER_DDL);
+            new SqlSpecialOperator("DROP DATABASE", SqlKind.OTHER_DDL) {
+                @Override
+                public SqlCall createCall(
+                        SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... operands) {
+                    return new SqlDropDatabase(
+                            pos,
+                            (SqlIdentifier) operands[0],
+                            ((SqlLiteral) operands[1]).booleanValue(),
+                            ((SqlLiteral) operands[2]).booleanValue());
+                }
+            };
 
     private final boolean isCascade;
 
@@ -40,6 +55,14 @@ public class SqlDropDatabase extends SqlDropObject {
 
     public boolean isCascade() {
         return isCascade;
+    }
+
+    @Override
+    public List<SqlNode> getOperandList() {
+        return List.of(
+                name,
+                SqlLiteral.createBoolean(ifExists, SqlParserPos.ZERO),
+                SqlLiteral.createBoolean(isCascade, SqlParserPos.ZERO));
     }
 
     @Override

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlDropFunction.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlDropFunction.java
@@ -18,17 +18,33 @@
 
 package org.apache.flink.sql.parser.ddl;
 
+import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlLiteral;
+import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlSpecialOperator;
 import org.apache.calcite.sql.SqlWriter;
 import org.apache.calcite.sql.parser.SqlParserPos;
+
+import java.util.List;
 
 /** DROP FUNCTION DDL sql call. */
 public class SqlDropFunction extends SqlDropObject {
 
     private static final SqlSpecialOperator OPERATOR =
-            new SqlSpecialOperator("DROP FUNCTION", SqlKind.DROP_FUNCTION);
+            new SqlSpecialOperator("DROP FUNCTION", SqlKind.DROP_FUNCTION) {
+                @Override
+                public SqlCall createCall(
+                        SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... operands) {
+                    return new SqlDropFunction(
+                            pos,
+                            (SqlIdentifier) operands[0],
+                            ((SqlLiteral) operands[1]).booleanValue(),
+                            ((SqlLiteral) operands[2]).booleanValue(),
+                            ((SqlLiteral) operands[3]).booleanValue());
+                }
+            };
 
     private final boolean isTemporary;
 
@@ -59,6 +75,15 @@ public class SqlDropFunction extends SqlDropObject {
             writer.keyword("IF EXISTS");
         }
         name.unparse(writer, leftPrec, rightPrec);
+    }
+
+    @Override
+    public List<SqlNode> getOperandList() {
+        return List.of(
+                name,
+                SqlLiteral.createBoolean(ifExists, SqlParserPos.ZERO),
+                SqlLiteral.createBoolean(isTemporary, SqlParserPos.ZERO),
+                SqlLiteral.createBoolean(isSystemFunction, SqlParserPos.ZERO));
     }
 
     public boolean isTemporary() {

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlDropPartitions.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlDropPartitions.java
@@ -21,9 +21,14 @@ package org.apache.flink.sql.parser.ddl;
 import org.apache.flink.sql.parser.SqlParseUtils;
 import org.apache.flink.sql.parser.ddl.table.SqlAlterTable;
 
+import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlNodeList;
+import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql.SqlSpecialOperator;
 import org.apache.calcite.sql.SqlWriter;
 import org.apache.calcite.sql.parser.SqlParserPos;
 
@@ -35,6 +40,23 @@ import java.util.List;
 
 /** ALTER TABLE DDL to drop partitions of a table. */
 public class SqlDropPartitions extends SqlAlterTable {
+
+    private static final SqlSpecialOperator DROP_PARTITION_OPERATOR =
+            new SqlSpecialOperator("ALTER TABLE DROP PARTITION", SqlKind.ALTER_TABLE) {
+                @Override
+                public SqlCall createCall(
+                        SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... operands) {
+                    List<SqlNodeList> partSpecs = new ArrayList<>();
+                    for (SqlNode spec : (SqlNodeList) operands[2]) {
+                        partSpecs.add((SqlNodeList) spec);
+                    }
+                    return new SqlDropPartitions(
+                            pos,
+                            (SqlIdentifier) operands[0],
+                            ((SqlLiteral) operands[1]).booleanValue(),
+                            partSpecs);
+                }
+            };
 
     private final boolean ifExists;
     private final List<SqlNodeList> partSpecs;
@@ -81,13 +103,18 @@ public class SqlDropPartitions extends SqlAlterTable {
         writer.endList(frame);
     }
 
+    @Override
+    public SqlOperator getOperator() {
+        return DROP_PARTITION_OPERATOR;
+    }
+
     @Nonnull
     @Override
     public List<SqlNode> getOperandList() {
-        List<SqlNode> operands = new ArrayList<>();
-        operands.add(tableIdentifier);
-        operands.addAll(partSpecs);
-        return operands;
+        return List.of(
+                tableIdentifier,
+                SqlLiteral.createBoolean(ifExists, SqlParserPos.ZERO),
+                new SqlNodeList(partSpecs, SqlParserPos.ZERO));
     }
 
     /** Alter table add partition context. */

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlRemoveJar.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlRemoveJar.java
@@ -19,8 +19,10 @@
 package org.apache.flink.sql.parser.ddl;
 
 import org.apache.calcite.sql.SqlAlter;
+import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlCharStringLiteral;
 import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.SqlSpecialOperator;
@@ -35,7 +37,13 @@ import java.util.List;
 public class SqlRemoveJar extends SqlAlter {
 
     public static final SqlOperator OPERATOR =
-            new SqlSpecialOperator("REMOVE JAR", SqlKind.OTHER_DDL);
+            new SqlSpecialOperator("REMOVE JAR", SqlKind.OTHER_DDL) {
+                @Override
+                public SqlCall createCall(
+                        SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... operands) {
+                    return new SqlRemoveJar(pos, (SqlCharStringLiteral) operands[0]);
+                }
+            };
 
     private final SqlCharStringLiteral jarPath;
 

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlReplaceTableAs.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlReplaceTableAs.java
@@ -25,9 +25,11 @@ import org.apache.flink.sql.parser.ddl.constraint.SqlTableConstraint;
 import org.apache.flink.sql.parser.ddl.table.SqlCreateTable;
 import org.apache.flink.sql.parser.error.SqlValidateException;
 
+import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlCharStringLiteral;
 import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlNodeList;
 import org.apache.calcite.sql.SqlSpecialOperator;
@@ -38,6 +40,7 @@ import org.apache.calcite.util.ImmutableNullableList;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -73,10 +76,44 @@ import java.util.List;
 public class SqlReplaceTableAs extends SqlCreateTable implements ExtendedSqlNode {
 
     public static final SqlSpecialOperator REPLACE_OPERATOR =
-            new SqlSpecialOperator("REPLACE TABLE AS", SqlKind.OTHER_DDL);
+            new SqlSpecialOperator("REPLACE TABLE AS", SqlKind.OTHER_DDL) {
+                @Override
+                public SqlCall createCall(
+                        SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... operands) {
+                    return createReplaceCall(pos, operands, false);
+                }
+            };
 
     public static final SqlSpecialOperator CREATE_OR_REPLACE_OPERATOR =
-            new SqlSpecialOperator("CREATE OR REPLACE TABLE AS", SqlKind.OTHER_DDL);
+            new SqlSpecialOperator("CREATE OR REPLACE TABLE AS", SqlKind.OTHER_DDL) {
+                @Override
+                public SqlCall createCall(
+                        SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... operands) {
+                    return createReplaceCall(pos, operands, true);
+                }
+            };
+
+    private static SqlReplaceTableAs createReplaceCall(
+            SqlParserPos pos, SqlNode[] operands, boolean isCreateOrReplace) {
+        List<SqlTableConstraint> constraints = new ArrayList<>();
+        for (SqlNode c : (SqlNodeList) operands[2]) {
+            constraints.add((SqlTableConstraint) c);
+        }
+        return new SqlReplaceTableAs(
+                pos,
+                (SqlIdentifier) operands[0],
+                (SqlNodeList) operands[1],
+                constraints,
+                (SqlNodeList) operands[3],
+                (SqlDistribution) operands[8],
+                (SqlNodeList) operands[4],
+                (SqlWatermark) operands[5],
+                (SqlCharStringLiteral) operands[6],
+                operands[7],
+                false,
+                false,
+                isCreateOrReplace);
+    }
 
     private final boolean isCreateOrReplace;
 
@@ -124,9 +161,10 @@ public class SqlReplaceTableAs extends SqlCreateTable implements ExtendedSqlNode
                 new SqlNodeList(getTableConstraints(), SqlParserPos.ZERO),
                 properties,
                 partitionKeyList,
-                getWatermark().get(),
+                getWatermark().orElse(null),
                 comment,
-                asQuery);
+                asQuery,
+                getDistribution());
     }
 
     @Override

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlReset.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlReset.java
@@ -23,6 +23,7 @@ import org.apache.flink.sql.parser.SqlParseUtils;
 
 import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.SqlSpecialOperator;
@@ -40,7 +41,13 @@ import java.util.List;
 public class SqlReset extends SqlCall {
 
     public static final SqlSpecialOperator OPERATOR =
-            new SqlSpecialOperator("RESET", SqlKind.OTHER);
+            new SqlSpecialOperator("RESET", SqlKind.OTHER) {
+                @Override
+                public SqlCall createCall(
+                        SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... operands) {
+                    return new SqlReset(pos, operands.length > 0 ? operands[0] : null);
+                }
+            };
 
     @Nullable private final SqlNode key;
 

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlSet.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlSet.java
@@ -23,6 +23,7 @@ import org.apache.flink.sql.parser.SqlParseUtils;
 
 import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.SqlSpecialOperator;
@@ -40,7 +41,17 @@ import java.util.Objects;
 @Internal
 public class SqlSet extends SqlCall {
 
-    public static final SqlSpecialOperator OPERATOR = new SqlSpecialOperator("SET", SqlKind.OTHER);
+    public static final SqlSpecialOperator OPERATOR =
+            new SqlSpecialOperator("SET", SqlKind.OTHER) {
+                @Override
+                public SqlCall createCall(
+                        SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... operands) {
+                    if (operands.length == 0 || operands[0] == null) {
+                        return new SqlSet(pos);
+                    }
+                    return new SqlSet(pos, operands[0], operands[1]);
+                }
+            };
 
     @Nullable private final SqlNode key;
     @Nullable private final SqlNode value;

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlStopJob.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlStopJob.java
@@ -21,6 +21,7 @@ package org.apache.flink.sql.parser.ddl;
 import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlCharStringLiteral;
 import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.SqlSpecialOperator;
@@ -30,14 +31,23 @@ import org.apache.calcite.util.NlsString;
 
 import javax.annotation.Nonnull;
 
-import java.util.Collections;
 import java.util.List;
 
 /** The command to stop a flink job. */
 public class SqlStopJob extends SqlCall {
 
     public static final SqlOperator OPERATOR =
-            new SqlSpecialOperator("STOP JOB", SqlKind.OTHER_DDL);
+            new SqlSpecialOperator("STOP JOB", SqlKind.OTHER_DDL) {
+                @Override
+                public SqlCall createCall(
+                        SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... operands) {
+                    return new SqlStopJob(
+                            pos,
+                            (SqlCharStringLiteral) operands[0],
+                            ((SqlLiteral) operands[1]).booleanValue(),
+                            ((SqlLiteral) operands[2]).booleanValue());
+                }
+            };
 
     private final SqlCharStringLiteral jobId;
 
@@ -78,7 +88,10 @@ public class SqlStopJob extends SqlCall {
     @Nonnull
     @Override
     public List<SqlNode> getOperandList() {
-        return Collections.singletonList(jobId);
+        return List.of(
+                jobId,
+                SqlLiteral.createBoolean(isWithSavepoint, SqlParserPos.ZERO),
+                SqlLiteral.createBoolean(isWithDrain, SqlParserPos.ZERO));
     }
 
     public String getId() {

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlTableColumn.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlTableColumn.java
@@ -26,6 +26,7 @@ import org.apache.calcite.sql.SqlCharStringLiteral;
 import org.apache.calcite.sql.SqlDataTypeSpec;
 import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.SqlSpecialOperator;
@@ -88,6 +89,20 @@ public abstract class SqlTableColumn extends SqlCall {
     /** A regular, physical column. */
     public static class SqlRegularColumn extends SqlTableColumn {
 
+        private static final SqlSpecialOperator REGULAR_OPERATOR =
+                new SqlSpecialOperator("COLUMN_DECL", SqlKind.COLUMN_DECL) {
+                    @Override
+                    public SqlCall createCall(
+                            SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... operands) {
+                        return new SqlRegularColumn(
+                                pos,
+                                (SqlIdentifier) operands[0],
+                                (SqlCharStringLiteral) operands[3],
+                                (SqlDataTypeSpec) operands[1],
+                                (SqlTableConstraint) operands[2]);
+                    }
+                };
+
         private SqlDataTypeSpec type;
 
         private final @Nullable SqlTableConstraint constraint;
@@ -128,6 +143,11 @@ public abstract class SqlTableColumn extends SqlCall {
         }
 
         @Override
+        public @Nonnull SqlOperator getOperator() {
+            return REGULAR_OPERATOR;
+        }
+
+        @Override
         public @Nonnull List<SqlNode> getOperandList() {
             return ImmutableNullableList.of(name, type, constraint, comment);
         }
@@ -135,6 +155,21 @@ public abstract class SqlTableColumn extends SqlCall {
 
     /** A column derived from metadata. */
     public static class SqlMetadataColumn extends SqlTableColumn {
+
+        private static final SqlSpecialOperator METADATA_OPERATOR =
+                new SqlSpecialOperator("COLUMN_DECL", SqlKind.COLUMN_DECL) {
+                    @Override
+                    public SqlCall createCall(
+                            SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... operands) {
+                        return new SqlMetadataColumn(
+                                pos,
+                                (SqlIdentifier) operands[0],
+                                (SqlCharStringLiteral) operands[2],
+                                (SqlDataTypeSpec) operands[1],
+                                operands[3],
+                                ((SqlLiteral) operands[4]).booleanValue());
+                    }
+                };
 
         private final SqlDataTypeSpec type;
 
@@ -185,13 +220,36 @@ public abstract class SqlTableColumn extends SqlCall {
         }
 
         @Override
+        public @Nonnull SqlOperator getOperator() {
+            return METADATA_OPERATOR;
+        }
+
+        @Override
         public @Nonnull List<SqlNode> getOperandList() {
-            return ImmutableNullableList.of(name, type, comment);
+            return ImmutableNullableList.of(
+                    name,
+                    type,
+                    comment,
+                    metadataAlias,
+                    SqlLiteral.createBoolean(isVirtual, SqlParserPos.ZERO));
         }
     }
 
     /** A column derived from an expression. */
     public static class SqlComputedColumn extends SqlTableColumn {
+
+        private static final SqlSpecialOperator COMPUTED_OPERATOR =
+                new SqlSpecialOperator("COLUMN_DECL", SqlKind.COLUMN_DECL) {
+                    @Override
+                    public SqlCall createCall(
+                            SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... operands) {
+                        return new SqlComputedColumn(
+                                pos,
+                                (SqlIdentifier) operands[0],
+                                (SqlCharStringLiteral) operands[2],
+                                operands[1]);
+                    }
+                };
 
         private final SqlNode expr;
 
@@ -212,6 +270,11 @@ public abstract class SqlTableColumn extends SqlCall {
         protected void unparseColumn(SqlWriter writer, int leftPrec, int rightPrec) {
             writer.keyword("AS");
             expr.unparse(writer, leftPrec, rightPrec);
+        }
+
+        @Override
+        public @Nonnull SqlOperator getOperator() {
+            return COMPUTED_OPERATOR;
         }
 
         @Override

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlTableOption.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlTableOption.java
@@ -21,6 +21,7 @@ import org.apache.flink.sql.parser.SqlParseUtils;
 
 import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.SqlSpecialOperator;
@@ -36,7 +37,13 @@ import static java.util.Objects.requireNonNull;
 public class SqlTableOption extends SqlCall {
     /** Use this operator only if you don't have a better one. */
     protected static final SqlOperator OPERATOR =
-            new SqlSpecialOperator("TableOption", SqlKind.OTHER);
+            new SqlSpecialOperator("TableOption", SqlKind.OTHER) {
+                @Override
+                public SqlCall createCall(
+                        SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... operands) {
+                    return new SqlTableOption(operands[0], operands[1], pos);
+                }
+            };
 
     private final SqlNode key;
     private final SqlNode value;

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlUseDatabase.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlUseDatabase.java
@@ -21,6 +21,7 @@ package org.apache.flink.sql.parser.ddl;
 import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.SqlSpecialOperator;
@@ -34,7 +35,13 @@ import java.util.List;
 public class SqlUseDatabase extends SqlCall {
 
     public static final SqlSpecialOperator OPERATOR =
-            new SqlSpecialOperator("USE DATABASE", SqlKind.OTHER_DDL);
+            new SqlSpecialOperator("USE DATABASE", SqlKind.OTHER_DDL) {
+                @Override
+                public SqlCall createCall(
+                        SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... operands) {
+                    return new SqlUseDatabase(pos, (SqlIdentifier) operands[0]);
+                }
+            };
     private final SqlIdentifier databaseName;
 
     public SqlUseDatabase(SqlParserPos pos, SqlIdentifier databaseName) {

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlUseModules.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlUseModules.java
@@ -21,6 +21,7 @@ package org.apache.flink.sql.parser.ddl;
 import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.SqlSpecialOperator;
@@ -28,6 +29,7 @@ import org.apache.calcite.sql.SqlWriter;
 import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.util.ImmutableNullableList;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -36,7 +38,17 @@ import static java.util.Objects.requireNonNull;
 /** USE MODULES sql call. */
 public class SqlUseModules extends SqlCall {
     public static final SqlSpecialOperator OPERATOR =
-            new SqlSpecialOperator("USE MODULES", SqlKind.OTHER);
+            new SqlSpecialOperator("USE MODULES", SqlKind.OTHER) {
+                @Override
+                public SqlCall createCall(
+                        SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... operands) {
+                    List<SqlIdentifier> moduleNames = new ArrayList<>(operands.length);
+                    for (SqlNode operand : operands) {
+                        moduleNames.add((SqlIdentifier) operand);
+                    }
+                    return new SqlUseModules(pos, moduleNames);
+                }
+            };
 
     private final List<SqlIdentifier> moduleNames;
 

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlWatermark.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlWatermark.java
@@ -21,6 +21,7 @@ package org.apache.flink.sql.parser.ddl;
 import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.SqlSpecialOperator;
@@ -39,7 +40,13 @@ import static java.util.Objects.requireNonNull;
 public class SqlWatermark extends SqlCall {
 
     private static final SqlSpecialOperator OPERATOR =
-            new SqlSpecialOperator("WATERMARK", SqlKind.OTHER);
+            new SqlSpecialOperator("WATERMARK", SqlKind.OTHER) {
+                @Override
+                public SqlCall createCall(
+                        SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... operands) {
+                    return new SqlWatermark(pos, (SqlIdentifier) operands[0], operands[1]);
+                }
+            };
 
     private final SqlIdentifier eventTimeColumnName;
     private final SqlNode watermarkStrategy;

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/catalog/SqlAlterCatalog.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/catalog/SqlAlterCatalog.java
@@ -20,8 +20,10 @@ package org.apache.flink.sql.parser.ddl.catalog;
 
 import org.apache.flink.sql.parser.ddl.SqlAlterObject;
 
+import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlSpecialOperator;
 import org.apache.calcite.sql.SqlWriter;
@@ -34,7 +36,13 @@ import java.util.List;
 public class SqlAlterCatalog extends SqlAlterObject {
 
     private static final SqlSpecialOperator OPERATOR =
-            new SqlSpecialOperator("ALTER CATALOG", SqlKind.OTHER_DDL);
+            new SqlSpecialOperator("ALTER CATALOG", SqlKind.OTHER_DDL) {
+                @Override
+                public SqlCall createCall(
+                        SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... operands) {
+                    return new SqlAlterCatalog(pos, (SqlIdentifier) operands[0]);
+                }
+            };
 
     public SqlAlterCatalog(SqlParserPos position, SqlIdentifier catalogName) {
         super(OPERATOR, position, "CATALOG", catalogName);

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/catalog/SqlAlterCatalogComment.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/catalog/SqlAlterCatalogComment.java
@@ -21,9 +21,14 @@ package org.apache.flink.sql.parser.ddl.catalog;
 import org.apache.flink.sql.parser.SqlParseUtils;
 import org.apache.flink.sql.parser.SqlUnparseUtils;
 
+import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlCharStringLiteral;
 import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql.SqlSpecialOperator;
 import org.apache.calcite.sql.SqlWriter;
 import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.util.ImmutableNullableList;
@@ -35,12 +40,27 @@ import static java.util.Objects.requireNonNull;
 /** ALTER CATALOG catalog_name COMMENT 'comment'. */
 public class SqlAlterCatalogComment extends SqlAlterCatalog {
 
+    private static final SqlSpecialOperator COMMENT_OPERATOR =
+            new SqlSpecialOperator("ALTER CATALOG COMMENT", SqlKind.OTHER_DDL) {
+                @Override
+                public SqlCall createCall(
+                        SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... operands) {
+                    return new SqlAlterCatalogComment(
+                            pos, (SqlIdentifier) operands[0], (SqlCharStringLiteral) operands[1]);
+                }
+            };
+
     private final SqlCharStringLiteral comment;
 
     public SqlAlterCatalogComment(
             SqlParserPos position, SqlIdentifier catalogName, SqlCharStringLiteral comment) {
         super(position, catalogName);
         this.comment = requireNonNull(comment, "comment cannot be null");
+    }
+
+    @Override
+    public SqlOperator getOperator() {
+        return COMMENT_OPERATOR;
     }
 
     @Override

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/catalog/SqlAlterCatalogOptions.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/catalog/SqlAlterCatalogOptions.java
@@ -21,9 +21,14 @@ package org.apache.flink.sql.parser.ddl.catalog;
 import org.apache.flink.sql.parser.SqlParseUtils;
 import org.apache.flink.sql.parser.SqlUnparseUtils;
 
+import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlNodeList;
+import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql.SqlSpecialOperator;
 import org.apache.calcite.sql.SqlWriter;
 import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.util.ImmutableNullableList;
@@ -36,12 +41,27 @@ import static java.util.Objects.requireNonNull;
 /** ALTER CATALOG catalog_name SET (key1=val1, ...). */
 public class SqlAlterCatalogOptions extends SqlAlterCatalog {
 
+    private static final SqlSpecialOperator OPTIONS_OPERATOR =
+            new SqlSpecialOperator("ALTER CATALOG OPTIONS", SqlKind.OTHER_DDL) {
+                @Override
+                public SqlCall createCall(
+                        SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... operands) {
+                    return new SqlAlterCatalogOptions(
+                            pos, (SqlIdentifier) operands[0], (SqlNodeList) operands[1]);
+                }
+            };
+
     private final SqlNodeList propertyList;
 
     public SqlAlterCatalogOptions(
             SqlParserPos position, SqlIdentifier catalogName, SqlNodeList propertyList) {
         super(position, catalogName);
         this.propertyList = requireNonNull(propertyList, "propertyList cannot be null");
+    }
+
+    @Override
+    public SqlOperator getOperator() {
+        return OPTIONS_OPERATOR;
     }
 
     @Override

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/catalog/SqlAlterCatalogReset.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/catalog/SqlAlterCatalogReset.java
@@ -21,9 +21,14 @@ package org.apache.flink.sql.parser.ddl.catalog;
 import org.apache.flink.sql.parser.SqlParseUtils;
 import org.apache.flink.sql.parser.SqlUnparseUtils;
 
+import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlNodeList;
+import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql.SqlSpecialOperator;
 import org.apache.calcite.sql.SqlWriter;
 import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.util.ImmutableNullableList;
@@ -37,12 +42,27 @@ import static java.util.Objects.requireNonNull;
 /** ALTER CATALOG catalog_name RESET (key1, ...). */
 public class SqlAlterCatalogReset extends SqlAlterCatalog {
 
+    private static final SqlSpecialOperator RESET_OPERATOR =
+            new SqlSpecialOperator("ALTER CATALOG RESET", SqlKind.OTHER_DDL) {
+                @Override
+                public SqlCall createCall(
+                        SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... operands) {
+                    return new SqlAlterCatalogReset(
+                            pos, (SqlIdentifier) operands[0], (SqlNodeList) operands[1]);
+                }
+            };
+
     private final SqlNodeList propertyKeyList;
 
     public SqlAlterCatalogReset(
             SqlParserPos position, SqlIdentifier catalogName, SqlNodeList propertyKeyList) {
         super(position, catalogName);
         this.propertyKeyList = requireNonNull(propertyKeyList, "propertyKeyList cannot be null");
+    }
+
+    @Override
+    public SqlOperator getOperator() {
+        return RESET_OPERATOR;
     }
 
     @Override

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/catalog/SqlCreateCatalog.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/catalog/SqlCreateCatalog.java
@@ -20,9 +20,11 @@ package org.apache.flink.sql.parser.ddl.catalog;
 
 import org.apache.flink.sql.parser.ddl.SqlCreateObject;
 
+import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlCharStringLiteral;
 import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlNodeList;
 import org.apache.calcite.sql.SqlSpecialOperator;
@@ -39,7 +41,18 @@ import static java.util.Objects.requireNonNull;
 public class SqlCreateCatalog extends SqlCreateObject {
 
     private static final SqlSpecialOperator OPERATOR =
-            new SqlSpecialOperator("CREATE CATALOG", SqlKind.OTHER_DDL);
+            new SqlSpecialOperator("CREATE CATALOG", SqlKind.OTHER_DDL) {
+                @Override
+                public SqlCall createCall(
+                        SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... operands) {
+                    return new SqlCreateCatalog(
+                            pos,
+                            (SqlIdentifier) operands[0],
+                            (SqlNodeList) operands[1],
+                            (SqlCharStringLiteral) operands[2],
+                            ((SqlLiteral) operands[3]).booleanValue());
+                }
+            };
 
     public SqlCreateCatalog(
             SqlParserPos position,
@@ -58,7 +71,11 @@ public class SqlCreateCatalog extends SqlCreateObject {
 
     @Override
     public List<SqlNode> getOperandList() {
-        return ImmutableNullableList.of(name, properties, comment);
+        return ImmutableNullableList.of(
+                name,
+                properties,
+                comment,
+                SqlLiteral.createBoolean(isIfNotExists(), SqlParserPos.ZERO));
     }
 
     public String catalogName() {

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/catalog/SqlDropCatalog.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/catalog/SqlDropCatalog.java
@@ -20,18 +20,32 @@ package org.apache.flink.sql.parser.ddl.catalog;
 
 import org.apache.flink.sql.parser.ddl.SqlDropObject;
 
+import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlLiteral;
+import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.SqlSpecialOperator;
 import org.apache.calcite.sql.SqlWriter;
 import org.apache.calcite.sql.parser.SqlParserPos;
 
+import java.util.List;
+
 /** DROP CATALOG DDL sql call. */
 public class SqlDropCatalog extends SqlDropObject {
 
     private static final SqlOperator OPERATOR =
-            new SqlSpecialOperator("DROP CATALOG", SqlKind.OTHER_DDL);
+            new SqlSpecialOperator("DROP CATALOG", SqlKind.OTHER_DDL) {
+                @Override
+                public SqlCall createCall(
+                        SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... operands) {
+                    return new SqlDropCatalog(
+                            pos,
+                            (SqlIdentifier) operands[0],
+                            ((SqlLiteral) operands[1]).booleanValue());
+                }
+            };
 
     public SqlDropCatalog(SqlParserPos pos, SqlIdentifier catalogName, boolean ifExists) {
         super(OPERATOR, pos, catalogName, ifExists);
@@ -49,5 +63,10 @@ public class SqlDropCatalog extends SqlDropObject {
 
     public String catalogName() {
         return name.getSimple();
+    }
+
+    @Override
+    public List<SqlNode> getOperandList() {
+        return List.of(name, SqlLiteral.createBoolean(ifExists, SqlParserPos.ZERO));
     }
 }

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/catalog/SqlUseCatalog.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/catalog/SqlUseCatalog.java
@@ -21,6 +21,7 @@ package org.apache.flink.sql.parser.ddl.catalog;
 import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.SqlSpecialOperator;
@@ -34,7 +35,13 @@ import java.util.List;
 public class SqlUseCatalog extends SqlCall {
 
     public static final SqlSpecialOperator OPERATOR =
-            new SqlSpecialOperator("USE CATALOG", SqlKind.OTHER_DDL);
+            new SqlSpecialOperator("USE CATALOG", SqlKind.OTHER_DDL) {
+                @Override
+                public SqlCall createCall(
+                        SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... operands) {
+                    return new SqlUseCatalog(pos, (SqlIdentifier) operands[0]);
+                }
+            };
     private final SqlIdentifier catalogName;
 
     public SqlUseCatalog(SqlParserPos pos, SqlIdentifier catalogName) {

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/connection/SqlAlterConnectionRename.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/connection/SqlAlterConnectionRename.java
@@ -18,8 +18,13 @@
 
 package org.apache.flink.sql.parser.ddl.connection;
 
+import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql.SqlSpecialOperator;
 import org.apache.calcite.sql.SqlWriter;
 import org.apache.calcite.sql.parser.SqlParserPos;
 
@@ -32,6 +37,19 @@ import static java.util.Objects.requireNonNull;
  * newConnectionName.
  */
 public class SqlAlterConnectionRename extends SqlAlterConnection {
+
+    private static final SqlSpecialOperator RENAME_OPERATOR =
+            new SqlSpecialOperator("ALTER CONNECTION RENAME", SqlKind.OTHER_DDL) {
+                @Override
+                public SqlCall createCall(
+                        SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... operands) {
+                    return new SqlAlterConnectionRename(
+                            pos,
+                            (SqlIdentifier) operands[0],
+                            (SqlIdentifier) operands[1],
+                            ((SqlLiteral) operands[2]).booleanValue());
+                }
+            };
 
     private final SqlIdentifier newConnectionName;
 
@@ -50,8 +68,16 @@ public class SqlAlterConnectionRename extends SqlAlterConnection {
     }
 
     @Override
+    public SqlOperator getOperator() {
+        return RENAME_OPERATOR;
+    }
+
+    @Override
     public List<SqlNode> getOperandList() {
-        return List.of(name, newConnectionName);
+        return List.of(
+                name,
+                newConnectionName,
+                SqlLiteral.createBoolean(ifConnectionExists, SqlParserPos.ZERO));
     }
 
     @Override

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/connection/SqlAlterConnectionReset.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/connection/SqlAlterConnectionReset.java
@@ -21,9 +21,14 @@ package org.apache.flink.sql.parser.ddl.connection;
 import org.apache.flink.sql.parser.SqlParseUtils;
 import org.apache.flink.sql.parser.SqlUnparseUtils;
 
+import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlNodeList;
+import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql.SqlSpecialOperator;
 import org.apache.calcite.sql.SqlWriter;
 import org.apache.calcite.sql.parser.SqlParserPos;
 
@@ -37,6 +42,19 @@ import static java.util.Objects.requireNonNull;
  * 'key2']...).
  */
 public class SqlAlterConnectionReset extends SqlAlterConnection {
+    private static final SqlSpecialOperator RESET_OPERATOR =
+            new SqlSpecialOperator("ALTER CONNECTION RESET", SqlKind.OTHER_DDL) {
+                @Override
+                public SqlCall createCall(
+                        SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... operands) {
+                    return new SqlAlterConnectionReset(
+                            pos,
+                            (SqlIdentifier) operands[0],
+                            ((SqlLiteral) operands[2]).booleanValue(),
+                            (SqlNodeList) operands[1]);
+                }
+            };
+
     private final SqlNodeList optionKeyList;
 
     public SqlAlterConnectionReset(
@@ -49,8 +67,16 @@ public class SqlAlterConnectionReset extends SqlAlterConnection {
     }
 
     @Override
+    public SqlOperator getOperator() {
+        return RESET_OPERATOR;
+    }
+
+    @Override
     public List<SqlNode> getOperandList() {
-        return List.of(name, optionKeyList);
+        return List.of(
+                name,
+                optionKeyList,
+                SqlLiteral.createBoolean(ifConnectionExists, SqlParserPos.ZERO));
     }
 
     public Set<String> getResetKeys() {

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/connection/SqlAlterConnectionSet.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/connection/SqlAlterConnectionSet.java
@@ -21,9 +21,14 @@ package org.apache.flink.sql.parser.ddl.connection;
 import org.apache.flink.sql.parser.SqlParseUtils;
 import org.apache.flink.sql.parser.SqlUnparseUtils;
 
+import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlNodeList;
+import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql.SqlSpecialOperator;
 import org.apache.calcite.sql.SqlWriter;
 import org.apache.calcite.sql.parser.SqlParserPos;
 
@@ -37,6 +42,19 @@ import static java.util.Objects.requireNonNull;
  * name=value]*).
  */
 public class SqlAlterConnectionSet extends SqlAlterConnection {
+
+    private static final SqlSpecialOperator SET_OPERATOR =
+            new SqlSpecialOperator("ALTER CONNECTION SET", SqlKind.OTHER_DDL) {
+                @Override
+                public SqlCall createCall(
+                        SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... operands) {
+                    return new SqlAlterConnectionSet(
+                            pos,
+                            (SqlIdentifier) operands[0],
+                            ((SqlLiteral) operands[2]).booleanValue(),
+                            (SqlNodeList) operands[1]);
+                }
+            };
 
     private final SqlNodeList connectionOptionList;
 
@@ -55,8 +73,16 @@ public class SqlAlterConnectionSet extends SqlAlterConnection {
     }
 
     @Override
+    public SqlOperator getOperator() {
+        return SET_OPERATOR;
+    }
+
+    @Override
     public List<SqlNode> getOperandList() {
-        return List.of(name, connectionOptionList);
+        return List.of(
+                name,
+                connectionOptionList,
+                SqlLiteral.createBoolean(ifConnectionExists, SqlParserPos.ZERO));
     }
 
     @Override

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/connection/SqlCreateConnection.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/connection/SqlCreateConnection.java
@@ -23,9 +23,11 @@ import org.apache.flink.sql.parser.SqlUnparseUtils;
 import org.apache.flink.sql.parser.ddl.SqlCreateObject;
 import org.apache.flink.sql.parser.error.SqlValidateException;
 
+import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlCharStringLiteral;
 import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlNodeList;
 import org.apache.calcite.sql.SqlSpecialOperator;
@@ -45,7 +47,20 @@ import java.util.List;
 public class SqlCreateConnection extends SqlCreateObject implements ExtendedSqlNode {
 
     private static final SqlSpecialOperator OPERATOR =
-            new SqlSpecialOperator("CREATE CONNECTION", SqlKind.OTHER_DDL);
+            new SqlSpecialOperator("CREATE CONNECTION", SqlKind.OTHER_DDL) {
+                @Override
+                public SqlCall createCall(
+                        SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... operands) {
+                    return new SqlCreateConnection(
+                            pos,
+                            (SqlIdentifier) operands[0],
+                            (SqlCharStringLiteral) operands[1],
+                            (SqlNodeList) operands[2],
+                            ((SqlLiteral) operands[3]).booleanValue(),
+                            ((SqlLiteral) operands[4]).booleanValue(),
+                            ((SqlLiteral) operands[5]).booleanValue());
+                }
+            };
 
     private final boolean isSystem;
 
@@ -71,7 +86,13 @@ public class SqlCreateConnection extends SqlCreateObject implements ExtendedSqlN
 
     @Override
     public @Nonnull List<SqlNode> getOperandList() {
-        return ImmutableNullableList.of(name, comment, properties);
+        return ImmutableNullableList.of(
+                name,
+                comment,
+                properties,
+                SqlLiteral.createBoolean(isTemporary(), SqlParserPos.ZERO),
+                SqlLiteral.createBoolean(isSystem, SqlParserPos.ZERO),
+                SqlLiteral.createBoolean(isIfNotExists(), SqlParserPos.ZERO));
     }
 
     public boolean isSystem() {

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/connection/SqlDropConnection.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/connection/SqlDropConnection.java
@@ -20,12 +20,17 @@ package org.apache.flink.sql.parser.ddl.connection;
 
 import org.apache.flink.sql.parser.ddl.SqlDropObject;
 
+import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlLiteral;
+import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.SqlSpecialOperator;
 import org.apache.calcite.sql.SqlWriter;
 import org.apache.calcite.sql.parser.SqlParserPos;
+
+import java.util.List;
 
 /**
  * {@link org.apache.calcite.sql.SqlNode} to describe the DROP CONNECTION [IF EXISTS]
@@ -33,7 +38,18 @@ import org.apache.calcite.sql.parser.SqlParserPos;
  */
 public class SqlDropConnection extends SqlDropObject {
     private static final SqlOperator OPERATOR =
-            new SqlSpecialOperator("DROP CONNECTION", SqlKind.OTHER_DDL);
+            new SqlSpecialOperator("DROP CONNECTION", SqlKind.OTHER_DDL) {
+                @Override
+                public SqlCall createCall(
+                        SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... operands) {
+                    return new SqlDropConnection(
+                            pos,
+                            (SqlIdentifier) operands[0],
+                            ((SqlLiteral) operands[1]).booleanValue(),
+                            ((SqlLiteral) operands[2]).booleanValue(),
+                            ((SqlLiteral) operands[3]).booleanValue());
+                }
+            };
 
     private final boolean isTemporary;
     private final boolean isSystemConnection;
@@ -55,6 +71,15 @@ public class SqlDropConnection extends SqlDropObject {
 
     public boolean isSystemConnection() {
         return isSystemConnection;
+    }
+
+    @Override
+    public List<SqlNode> getOperandList() {
+        return List.of(
+                name,
+                SqlLiteral.createBoolean(ifExists, SqlParserPos.ZERO),
+                SqlLiteral.createBoolean(isTemporary, SqlParserPos.ZERO),
+                SqlLiteral.createBoolean(isSystemConnection, SqlParserPos.ZERO));
     }
 
     @Override

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/constraint/SqlTableConstraint.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/constraint/SqlTableConstraint.java
@@ -59,7 +59,19 @@ import java.util.Optional;
 public class SqlTableConstraint extends SqlCall {
     /** Use this operator only if you don't have a better one. */
     private static final SqlOperator OPERATOR =
-            new SqlSpecialOperator("SqlTableConstraint", SqlKind.OTHER);
+            new SqlSpecialOperator("SqlTableConstraint", SqlKind.OTHER) {
+                @Override
+                public SqlCall createCall(
+                        SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... operands) {
+                    return new SqlTableConstraint(
+                            (SqlIdentifier) operands[0],
+                            (SqlLiteral) operands[1],
+                            (SqlNodeList) operands[2],
+                            (SqlLiteral) operands[3],
+                            ((SqlLiteral) operands[4]).booleanValue(),
+                            pos);
+                }
+            };
 
     private final SqlIdentifier constraintName;
     private final SqlLiteral uniqueSpec;
@@ -143,7 +155,12 @@ public class SqlTableConstraint extends SqlCall {
 
     @Override
     public List<SqlNode> getOperandList() {
-        return ImmutableNullableList.of(constraintName, uniqueSpec, columns, enforcement);
+        return ImmutableNullableList.of(
+                constraintName,
+                uniqueSpec,
+                columns,
+                enforcement,
+                SqlLiteral.createBoolean(isTableConstraint, SqlParserPos.ZERO));
     }
 
     @Override

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/materializedtable/SqlAlterMaterializedTableAsQuery.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/materializedtable/SqlAlterMaterializedTableAsQuery.java
@@ -20,8 +20,13 @@ package org.apache.flink.sql.parser.ddl.materializedtable;
 
 import org.apache.flink.sql.parser.SqlUnparseUtils;
 
+import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql.SqlSpecialOperator;
 import org.apache.calcite.sql.SqlWriter;
 import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.util.ImmutableNullableList;
@@ -33,6 +38,16 @@ import java.util.List;
  * statement.
  */
 public class SqlAlterMaterializedTableAsQuery extends SqlAlterMaterializedTable {
+
+    private static final SqlSpecialOperator AS_QUERY_OPERATOR =
+            new SqlSpecialOperator("ALTER MATERIALIZED TABLE AS", SqlKind.ALTER_TABLE) {
+                @Override
+                public SqlCall createCall(
+                        SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... operands) {
+                    return new SqlAlterMaterializedTableAsQuery(
+                            pos, (SqlIdentifier) operands[0], operands[1], SqlParserPos.ZERO);
+                }
+            };
 
     private final SqlNode asQuery;
 
@@ -55,6 +70,11 @@ public class SqlAlterMaterializedTableAsQuery extends SqlAlterMaterializedTable 
     /** Returns the parser position of the {@code AS} keyword. */
     public SqlParserPos getAsQueryKeywordPos() {
         return asQueryKeywordPos;
+    }
+
+    @Override
+    public SqlOperator getOperator() {
+        return AS_QUERY_OPERATOR;
     }
 
     @Override

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/materializedtable/SqlAlterMaterializedTableDistribution.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/materializedtable/SqlAlterMaterializedTableDistribution.java
@@ -20,8 +20,13 @@ package org.apache.flink.sql.parser.ddl.materializedtable;
 
 import org.apache.flink.sql.parser.ddl.SqlDistribution;
 
+import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql.SqlSpecialOperator;
 import org.apache.calcite.sql.SqlWriter;
 import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.util.ImmutableNullableList;
@@ -63,9 +68,25 @@ public abstract class SqlAlterMaterializedTableDistribution extends SqlAlterMate
     public static class SqlAlterMaterializedTableAddDistribution
             extends SqlAlterMaterializedTableDistribution {
 
+        private static final SqlSpecialOperator ADD_DISTRIBUTION_OPERATOR =
+                new SqlSpecialOperator(
+                        "ALTER MATERIALIZED TABLE ADD DISTRIBUTION", SqlKind.ALTER_TABLE) {
+                    @Override
+                    public SqlCall createCall(
+                            SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... operands) {
+                        return new SqlAlterMaterializedTableAddDistribution(
+                                pos, (SqlIdentifier) operands[0], (SqlDistribution) operands[1]);
+                    }
+                };
+
         public SqlAlterMaterializedTableAddDistribution(
                 SqlParserPos pos, SqlIdentifier tableName, SqlDistribution distribution) {
             super(pos, tableName, distribution);
+        }
+
+        @Override
+        public SqlOperator getOperator() {
+            return ADD_DISTRIBUTION_OPERATOR;
         }
 
         @Override
@@ -77,9 +98,25 @@ public abstract class SqlAlterMaterializedTableDistribution extends SqlAlterMate
     public static class SqlAlterMaterializedTableModifyDistribution
             extends SqlAlterMaterializedTableDistribution {
 
+        private static final SqlSpecialOperator MODIFY_DISTRIBUTION_OPERATOR =
+                new SqlSpecialOperator(
+                        "ALTER MATERIALIZED TABLE MODIFY DISTRIBUTION", SqlKind.ALTER_TABLE) {
+                    @Override
+                    public SqlCall createCall(
+                            SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... operands) {
+                        return new SqlAlterMaterializedTableModifyDistribution(
+                                pos, (SqlIdentifier) operands[0], (SqlDistribution) operands[1]);
+                    }
+                };
+
         public SqlAlterMaterializedTableModifyDistribution(
                 SqlParserPos pos, SqlIdentifier tableName, SqlDistribution distribution) {
             super(pos, tableName, distribution);
+        }
+
+        @Override
+        public SqlOperator getOperator() {
+            return MODIFY_DISTRIBUTION_OPERATOR;
         }
 
         @Override

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/materializedtable/SqlAlterMaterializedTableDropDistribution.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/materializedtable/SqlAlterMaterializedTableDropDistribution.java
@@ -18,8 +18,13 @@
 
 package org.apache.flink.sql.parser.ddl.materializedtable;
 
+import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql.SqlSpecialOperator;
 import org.apache.calcite.sql.SqlWriter;
 import org.apache.calcite.sql.parser.SqlParserPos;
 
@@ -31,8 +36,24 @@ import java.util.List;
  */
 public class SqlAlterMaterializedTableDropDistribution extends SqlAlterMaterializedTable {
 
+    private static final SqlSpecialOperator DROP_DISTRIBUTION_OPERATOR =
+            new SqlSpecialOperator(
+                    "ALTER MATERIALIZED TABLE DROP DISTRIBUTION", SqlKind.ALTER_TABLE) {
+                @Override
+                public SqlCall createCall(
+                        SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... operands) {
+                    return new SqlAlterMaterializedTableDropDistribution(
+                            pos, (SqlIdentifier) operands[0]);
+                }
+            };
+
     public SqlAlterMaterializedTableDropDistribution(SqlParserPos pos, SqlIdentifier tableName) {
         super(pos, tableName);
+    }
+
+    @Override
+    public SqlOperator getOperator() {
+        return DROP_DISTRIBUTION_OPERATOR;
     }
 
     @Override

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/materializedtable/SqlAlterMaterializedTableFreshness.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/materializedtable/SqlAlterMaterializedTableFreshness.java
@@ -20,9 +20,14 @@ package org.apache.flink.sql.parser.ddl.materializedtable;
 
 import org.apache.flink.sql.parser.SqlUnparseUtils;
 
+import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlIntervalLiteral;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql.SqlSpecialOperator;
 import org.apache.calcite.sql.SqlWriter;
 import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.util.ImmutableNullableList;
@@ -35,6 +40,16 @@ import java.util.List;
  */
 public class SqlAlterMaterializedTableFreshness extends SqlAlterMaterializedTable {
 
+    private static final SqlSpecialOperator FRESHNESS_OPERATOR =
+            new SqlSpecialOperator("ALTER MATERIALIZED TABLE SET FRESHNESS", SqlKind.ALTER_TABLE) {
+                @Override
+                public SqlCall createCall(
+                        SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... operands) {
+                    return new SqlAlterMaterializedTableFreshness(
+                            pos, (SqlIdentifier) operands[0], (SqlIntervalLiteral) operands[1]);
+                }
+            };
+
     private final SqlIntervalLiteral freshness;
 
     public SqlAlterMaterializedTableFreshness(
@@ -46,6 +61,11 @@ public class SqlAlterMaterializedTableFreshness extends SqlAlterMaterializedTabl
     @Override
     public List<SqlNode> getOperandList() {
         return ImmutableNullableList.of(name, freshness);
+    }
+
+    @Override
+    public SqlOperator getOperator() {
+        return FRESHNESS_OPERATOR;
     }
 
     public SqlIntervalLiteral getFreshness() {

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/materializedtable/SqlAlterMaterializedTableOptions.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/materializedtable/SqlAlterMaterializedTableOptions.java
@@ -20,9 +20,14 @@ package org.apache.flink.sql.parser.ddl.materializedtable;
 
 import org.apache.flink.sql.parser.SqlUnparseUtils;
 
+import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlNodeList;
+import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql.SqlSpecialOperator;
 import org.apache.calcite.sql.SqlWriter;
 import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.util.ImmutableNullableList;
@@ -34,6 +39,16 @@ import java.util.List;
  * 'val') clause.
  */
 public class SqlAlterMaterializedTableOptions extends SqlAlterMaterializedTable {
+
+    private static final SqlSpecialOperator OPTIONS_OPERATOR =
+            new SqlSpecialOperator("ALTER MATERIALIZED TABLE SET", SqlKind.ALTER_TABLE) {
+                @Override
+                public SqlCall createCall(
+                        SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... operands) {
+                    return new SqlAlterMaterializedTableOptions(
+                            pos, (SqlIdentifier) operands[0], (SqlNodeList) operands[1]);
+                }
+            };
 
     private final SqlNodeList propertyList;
 
@@ -50,6 +65,11 @@ public class SqlAlterMaterializedTableOptions extends SqlAlterMaterializedTable 
     @Override
     public List<SqlNode> getOperandList() {
         return ImmutableNullableList.of(name, propertyList);
+    }
+
+    @Override
+    public SqlOperator getOperator() {
+        return OPTIONS_OPERATOR;
     }
 
     @Override

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/materializedtable/SqlAlterMaterializedTableRefresh.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/materializedtable/SqlAlterMaterializedTableRefresh.java
@@ -18,9 +18,14 @@
 
 package org.apache.flink.sql.parser.ddl.materializedtable;
 
+import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlNodeList;
+import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql.SqlSpecialOperator;
 import org.apache.calcite.sql.SqlWriter;
 import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.util.ImmutableNullableList;
@@ -33,6 +38,16 @@ import java.util.List;
  */
 public class SqlAlterMaterializedTableRefresh extends SqlAlterMaterializedTable {
 
+    private static final SqlSpecialOperator REFRESH_OPERATOR =
+            new SqlSpecialOperator("ALTER MATERIALIZED TABLE REFRESH", SqlKind.ALTER_TABLE) {
+                @Override
+                public SqlCall createCall(
+                        SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... operands) {
+                    return new SqlAlterMaterializedTableRefresh(
+                            pos, (SqlIdentifier) operands[0], (SqlNodeList) operands[1]);
+                }
+            };
+
     private final SqlNodeList partitionSpec;
 
     public SqlAlterMaterializedTableRefresh(
@@ -44,6 +59,11 @@ public class SqlAlterMaterializedTableRefresh extends SqlAlterMaterializedTable 
     @Override
     public List<SqlNode> getOperandList() {
         return ImmutableNullableList.of(name, partitionSpec);
+    }
+
+    @Override
+    public SqlOperator getOperator() {
+        return REFRESH_OPERATOR;
     }
 
     @Override

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/materializedtable/SqlAlterMaterializedTableRefreshMode.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/materializedtable/SqlAlterMaterializedTableRefreshMode.java
@@ -18,9 +18,13 @@
 
 package org.apache.flink.sql.parser.ddl.materializedtable;
 
+import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql.SqlSpecialOperator;
 import org.apache.calcite.sql.SqlWriter;
 import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.util.ImmutableNullableList;
@@ -35,6 +39,17 @@ import static java.util.Objects.requireNonNull;
  */
 public class SqlAlterMaterializedTableRefreshMode extends SqlAlterMaterializedTable {
 
+    private static final SqlSpecialOperator REFRESH_MODE_OPERATOR =
+            new SqlSpecialOperator(
+                    "ALTER MATERIALIZED TABLE SET REFRESH_MODE", SqlKind.ALTER_TABLE) {
+                @Override
+                public SqlCall createCall(
+                        SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... operands) {
+                    return new SqlAlterMaterializedTableRefreshMode(
+                            pos, (SqlIdentifier) operands[0], (SqlLiteral) operands[1]);
+                }
+            };
+
     private final SqlLiteral sqlRefreshMode;
 
     public SqlAlterMaterializedTableRefreshMode(
@@ -44,8 +59,13 @@ public class SqlAlterMaterializedTableRefreshMode extends SqlAlterMaterializedTa
     }
 
     @Override
+    public SqlOperator getOperator() {
+        return REFRESH_MODE_OPERATOR;
+    }
+
+    @Override
     public List<SqlNode> getOperandList() {
-        return ImmutableNullableList.of(name);
+        return ImmutableNullableList.of(name, sqlRefreshMode);
     }
 
     @Override

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/materializedtable/SqlAlterMaterializedTableReset.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/materializedtable/SqlAlterMaterializedTableReset.java
@@ -20,9 +20,14 @@ package org.apache.flink.sql.parser.ddl.materializedtable;
 
 import org.apache.flink.sql.parser.SqlUnparseUtils;
 
+import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlNodeList;
+import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql.SqlSpecialOperator;
 import org.apache.calcite.sql.SqlWriter;
 import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.util.ImmutableNullableList;
@@ -34,6 +39,16 @@ import java.util.List;
  * clause.
  */
 public class SqlAlterMaterializedTableReset extends SqlAlterMaterializedTable {
+
+    private static final SqlSpecialOperator RESET_OPERATOR =
+            new SqlSpecialOperator("ALTER MATERIALIZED TABLE RESET", SqlKind.ALTER_TABLE) {
+                @Override
+                public SqlCall createCall(
+                        SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... operands) {
+                    return new SqlAlterMaterializedTableReset(
+                            pos, (SqlIdentifier) operands[0], (SqlNodeList) operands[1]);
+                }
+            };
 
     private final SqlNodeList propertyKeyList;
 
@@ -50,6 +65,11 @@ public class SqlAlterMaterializedTableReset extends SqlAlterMaterializedTable {
     @Override
     public List<SqlNode> getOperandList() {
         return ImmutableNullableList.of(name, propertyKeyList);
+    }
+
+    @Override
+    public SqlOperator getOperator() {
+        return RESET_OPERATOR;
     }
 
     @Override

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/materializedtable/SqlAlterMaterializedTableResume.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/materializedtable/SqlAlterMaterializedTableResume.java
@@ -21,9 +21,14 @@ package org.apache.flink.sql.parser.ddl.materializedtable;
 import org.apache.flink.sql.parser.SqlParseUtils;
 import org.apache.flink.sql.parser.SqlUnparseUtils;
 
+import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlNodeList;
+import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql.SqlSpecialOperator;
 import org.apache.calcite.sql.SqlWriter;
 import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.util.ImmutableNullableList;
@@ -37,6 +42,16 @@ import static java.util.Objects.requireNonNull;
  * SqlNode to describe ALTER MATERIALIZED TABLE [catalog_name.][db_name.]table_name RESUME clause.
  */
 public class SqlAlterMaterializedTableResume extends SqlAlterMaterializedTable {
+
+    private static final SqlSpecialOperator RESUME_OPERATOR =
+            new SqlSpecialOperator("ALTER MATERIALIZED TABLE RESUME", SqlKind.ALTER_TABLE) {
+                @Override
+                public SqlCall createCall(
+                        SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... operands) {
+                    return new SqlAlterMaterializedTableResume(
+                            pos, (SqlIdentifier) operands[0], (SqlNodeList) operands[1]);
+                }
+            };
 
     private final SqlNodeList propertyList;
 
@@ -54,6 +69,11 @@ public class SqlAlterMaterializedTableResume extends SqlAlterMaterializedTable {
     @Override
     public List<SqlNode> getOperandList() {
         return ImmutableNullableList.of(name, propertyList);
+    }
+
+    @Override
+    public SqlOperator getOperator() {
+        return RESUME_OPERATOR;
     }
 
     @Override

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/materializedtable/SqlAlterMaterializedTableSchema.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/materializedtable/SqlAlterMaterializedTableSchema.java
@@ -26,9 +26,14 @@ import org.apache.flink.sql.parser.ddl.constraint.SqlTableConstraint;
 import org.apache.flink.sql.parser.ddl.position.SqlTableColumnPosition;
 import org.apache.flink.sql.parser.error.SqlValidateException;
 
+import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlNodeList;
+import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql.SqlSpecialOperator;
 import org.apache.calcite.sql.SqlWriter;
 import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.util.ImmutableNullableList;
@@ -36,6 +41,7 @@ import org.apache.calcite.util.ImmutableNullableList;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -140,6 +146,29 @@ public abstract class SqlAlterMaterializedTableSchema extends SqlAlterMaterializ
             super(pos, materializedTableName, columnList, constraints, sqlWatermark);
         }
 
+        private static final SqlSpecialOperator ADD_SCHEMA_OPERATOR =
+                new SqlSpecialOperator("ALTER MATERIALIZED TABLE ADD", SqlKind.ALTER_TABLE) {
+                    @Override
+                    public SqlCall createCall(
+                            SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... operands) {
+                        List<SqlTableConstraint> constraints = new ArrayList<>();
+                        for (SqlNode c : (SqlNodeList) operands[2]) {
+                            constraints.add((SqlTableConstraint) c);
+                        }
+                        return new SqlAlterMaterializedTableAddSchema(
+                                pos,
+                                (SqlIdentifier) operands[0],
+                                (SqlNodeList) operands[1],
+                                constraints,
+                                (SqlWatermark) operands[3]);
+                    }
+                };
+
+        @Override
+        public SqlOperator getOperator() {
+            return ADD_SCHEMA_OPERATOR;
+        }
+
         @Override
         protected String getAlterOperation() {
             return "ADD";
@@ -174,6 +203,29 @@ public abstract class SqlAlterMaterializedTableSchema extends SqlAlterMaterializ
                 List<SqlTableConstraint> constraints,
                 @Nullable SqlWatermark sqlWatermark) {
             super(pos, materializedTableName, columnList, constraints, sqlWatermark);
+        }
+
+        private static final SqlSpecialOperator MODIFY_SCHEMA_OPERATOR =
+                new SqlSpecialOperator("ALTER MATERIALIZED TABLE MODIFY", SqlKind.ALTER_TABLE) {
+                    @Override
+                    public SqlCall createCall(
+                            SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... operands) {
+                        List<SqlTableConstraint> constraints = new ArrayList<>();
+                        for (SqlNode c : (SqlNodeList) operands[2]) {
+                            constraints.add((SqlTableConstraint) c);
+                        }
+                        return new SqlAlterMaterializedTableModifySchema(
+                                pos,
+                                (SqlIdentifier) operands[0],
+                                (SqlNodeList) operands[1],
+                                constraints,
+                                (SqlWatermark) operands[3]);
+                    }
+                };
+
+        @Override
+        public SqlOperator getOperator() {
+            return MODIFY_SCHEMA_OPERATOR;
         }
 
         @Override
@@ -215,6 +267,22 @@ public abstract class SqlAlterMaterializedTableSchema extends SqlAlterMaterializ
             super(pos, materializedTableName);
         }
 
+        private static final SqlSpecialOperator DROP_WATERMARK_OPERATOR =
+                new SqlSpecialOperator(
+                        "ALTER MATERIALIZED TABLE DROP WATERMARK", SqlKind.ALTER_TABLE) {
+                    @Override
+                    public SqlCall createCall(
+                            SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... operands) {
+                        return new SqlAlterMaterializedTableDropWatermark(
+                                pos, (SqlIdentifier) operands[0]);
+                    }
+                };
+
+        @Override
+        public SqlOperator getOperator() {
+            return DROP_WATERMARK_OPERATOR;
+        }
+
         @Override
         public List<SqlNode> getOperandList() {
             return List.of(name);
@@ -236,6 +304,27 @@ public abstract class SqlAlterMaterializedTableSchema extends SqlAlterMaterializ
             super(pos, materializedTableName);
         }
 
+        private static final SqlSpecialOperator DROP_PRIMARY_KEY_OPERATOR =
+                new SqlSpecialOperator(
+                        "ALTER MATERIALIZED TABLE DROP PRIMARY KEY", SqlKind.ALTER_TABLE) {
+                    @Override
+                    public SqlCall createCall(
+                            SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... operands) {
+                        return new SqlAlterMaterializedTableDropPrimaryKey(
+                                pos, (SqlIdentifier) operands[0]);
+                    }
+                };
+
+        @Override
+        public SqlOperator getOperator() {
+            return DROP_PRIMARY_KEY_OPERATOR;
+        }
+
+        @Override
+        public List<SqlNode> getOperandList() {
+            return List.of(name);
+        }
+
         @Override
         public void unparseDropOperation(SqlWriter writer, int leftPrec, int rightPrec) {
             writer.keyword("PRIMARY KEY");
@@ -254,6 +343,27 @@ public abstract class SqlAlterMaterializedTableSchema extends SqlAlterMaterializ
                 SqlParserPos pos, SqlIdentifier tableName, SqlIdentifier constraintName) {
             super(pos, tableName);
             this.constraintName = constraintName;
+        }
+
+        private static final SqlSpecialOperator DROP_CONSTRAINT_OPERATOR =
+                new SqlSpecialOperator(
+                        "ALTER MATERIALIZED TABLE DROP CONSTRAINT", SqlKind.ALTER_TABLE) {
+                    @Override
+                    public SqlCall createCall(
+                            SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... operands) {
+                        return new SqlAlterMaterializedTableDropConstraint(
+                                pos, (SqlIdentifier) operands[0], (SqlIdentifier) operands[1]);
+                    }
+                };
+
+        @Override
+        public SqlOperator getOperator() {
+            return DROP_CONSTRAINT_OPERATOR;
+        }
+
+        @Override
+        public List<SqlNode> getOperandList() {
+            return List.of(name, constraintName);
         }
 
         public SqlIdentifier getConstraintName() {
@@ -293,6 +403,22 @@ public abstract class SqlAlterMaterializedTableSchema extends SqlAlterMaterializ
 
         public SqlNodeList getColumnList() {
             return columnList;
+        }
+
+        private static final SqlSpecialOperator DROP_COLUMN_OPERATOR =
+                new SqlSpecialOperator(
+                        "ALTER MATERIALIZED TABLE DROP COLUMN", SqlKind.ALTER_TABLE) {
+                    @Override
+                    public SqlCall createCall(
+                            SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... operands) {
+                        return new SqlAlterMaterializedTableDropColumn(
+                                pos, (SqlIdentifier) operands[0], (SqlNodeList) operands[1]);
+                    }
+                };
+
+        @Override
+        public SqlOperator getOperator() {
+            return DROP_COLUMN_OPERATOR;
         }
 
         @Override

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/materializedtable/SqlAlterMaterializedTableSuspend.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/materializedtable/SqlAlterMaterializedTableSuspend.java
@@ -18,8 +18,13 @@
 
 package org.apache.flink.sql.parser.ddl.materializedtable;
 
+import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql.SqlSpecialOperator;
 import org.apache.calcite.sql.SqlWriter;
 import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.util.ImmutableNullableList;
@@ -30,8 +35,23 @@ import java.util.List;
  * SqlNode to describe ALTER MATERIALIZED TABLE [catalog_name.][db_name.]table_name SUSPEND clause.
  */
 public class SqlAlterMaterializedTableSuspend extends SqlAlterMaterializedTable {
+
+    private static final SqlSpecialOperator SUSPEND_OPERATOR =
+            new SqlSpecialOperator("ALTER MATERIALIZED TABLE SUSPEND", SqlKind.ALTER_TABLE) {
+                @Override
+                public SqlCall createCall(
+                        SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... operands) {
+                    return new SqlAlterMaterializedTableSuspend(pos, (SqlIdentifier) operands[0]);
+                }
+            };
+
     public SqlAlterMaterializedTableSuspend(SqlParserPos pos, SqlIdentifier tableName) {
         super(pos, tableName);
+    }
+
+    @Override
+    public SqlOperator getOperator() {
+        return SUSPEND_OPERATOR;
     }
 
     @Override

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/materializedtable/SqlCreateMaterializedTable.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/materializedtable/SqlCreateMaterializedTable.java
@@ -29,19 +29,23 @@ import org.apache.flink.sql.parser.ddl.SqlWatermark;
 import org.apache.flink.sql.parser.ddl.constraint.SqlTableConstraint;
 import org.apache.flink.sql.parser.error.SqlValidateException;
 
+import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlCharStringLiteral;
 import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlIntervalLiteral;
 import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlNodeList;
 import org.apache.calcite.sql.SqlSpecialOperator;
+import org.apache.calcite.sql.SqlTimestampLiteral;
 import org.apache.calcite.sql.SqlWriter;
 import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.util.ImmutableNullableList;
 
 import javax.annotation.Nullable;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -51,7 +55,49 @@ import static java.util.Objects.requireNonNull;
 public class SqlCreateMaterializedTable extends SqlCreateObject implements ExtendedSqlNode {
 
     public static final SqlSpecialOperator CREATE_OPERATOR =
-            new SqlSpecialOperator("CREATE MATERIALIZED TABLE", SqlKind.CREATE_TABLE);
+            new SqlSpecialOperator("CREATE MATERIALIZED TABLE", SqlKind.CREATE_TABLE) {
+                @Override
+                public SqlCall createCall(
+                        SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... operands) {
+                    return buildCreateCall(CREATE_OPERATOR, pos, operands);
+                }
+            };
+
+    static SqlCreateMaterializedTable buildCreateCall(
+            SqlSpecialOperator operator, SqlParserPos pos, SqlNode[] operands) {
+        List<SqlTableConstraint> constraints = new ArrayList<>();
+        for (SqlNode c : (SqlNodeList) operands[2]) {
+            constraints.add((SqlTableConstraint) c);
+        }
+        SqlRefreshMode refreshMode =
+                operands[10] == null
+                        ? null
+                        : ((SqlLiteral) operands[10]).getValueAs(SqlRefreshMode.class);
+        SqlStartMode startMode =
+                operands[11] == null
+                        ? null
+                        : new SqlStartMode(
+                                ((SqlLiteral) operands[11])
+                                        .getValueAs(SqlStartMode.SqlStartModeKind.class),
+                                (SqlIntervalLiteral) operands[12],
+                                (SqlTimestampLiteral) operands[13]);
+        return new SqlCreateMaterializedTable(
+                operator,
+                pos,
+                (SqlIdentifier) operands[0],
+                (SqlNodeList) operands[1],
+                constraints,
+                (SqlWatermark) operands[3],
+                (SqlCharStringLiteral) operands[4],
+                (SqlDistribution) operands[9],
+                (SqlNodeList) operands[5],
+                (SqlNodeList) operands[6],
+                (SqlIntervalLiteral) operands[7],
+                refreshMode,
+                startMode,
+                operands[8],
+                SqlParserPos.ZERO);
+    }
 
     private final SqlNodeList columnList;
 
@@ -115,7 +161,16 @@ public class SqlCreateMaterializedTable extends SqlCreateObject implements Exten
                 partitionKeyList,
                 properties,
                 freshness,
-                asQuery);
+                asQuery,
+                distribution,
+                refreshMode == null
+                        ? null
+                        : SqlLiteral.createSymbol(refreshMode, SqlParserPos.ZERO),
+                startMode == null
+                        ? null
+                        : SqlLiteral.createSymbol(startMode.getKind(), SqlParserPos.ZERO),
+                startMode == null ? null : startMode.getIntervalLiteral(),
+                startMode == null ? null : startMode.getTimestampLiteral());
     }
 
     public SqlNodeList getColumnList() {

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/materializedtable/SqlCreateOrAlterMaterializedTable.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/materializedtable/SqlCreateOrAlterMaterializedTable.java
@@ -23,25 +23,67 @@ import org.apache.flink.sql.parser.ddl.SqlRefreshMode;
 import org.apache.flink.sql.parser.ddl.SqlWatermark;
 import org.apache.flink.sql.parser.ddl.constraint.SqlTableConstraint;
 
+import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlCharStringLiteral;
 import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlIntervalLiteral;
 import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlNodeList;
 import org.apache.calcite.sql.SqlSpecialOperator;
+import org.apache.calcite.sql.SqlTimestampLiteral;
 import org.apache.calcite.sql.SqlWriter;
 import org.apache.calcite.sql.parser.SqlParserPos;
 
 import javax.annotation.Nullable;
 
+import java.util.ArrayList;
 import java.util.List;
 
 /** CREATE [OR ALTER] MATERIALIZED TABLE DDL sql call. */
 public class SqlCreateOrAlterMaterializedTable extends SqlCreateMaterializedTable {
 
     public static final SqlSpecialOperator CREATE_OR_ALTER_OPERATOR =
-            new SqlSpecialOperator("CREATE OR ALTER MATERIALIZED TABLE", SqlKind.OTHER_DDL);
+            new SqlSpecialOperator("CREATE OR ALTER MATERIALIZED TABLE", SqlKind.OTHER_DDL) {
+                @Override
+                public SqlCall createCall(
+                        SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... operands) {
+                    List<SqlTableConstraint> constraints = new ArrayList<>();
+                    for (SqlNode c : (SqlNodeList) operands[2]) {
+                        constraints.add((SqlTableConstraint) c);
+                    }
+                    SqlRefreshMode refreshMode =
+                            operands[10] == null
+                                    ? null
+                                    : ((SqlLiteral) operands[10]).getValueAs(SqlRefreshMode.class);
+                    SqlStartMode startMode =
+                            operands[11] == null
+                                    ? null
+                                    : new SqlStartMode(
+                                            ((SqlLiteral) operands[11])
+                                                    .getValueAs(
+                                                            SqlStartMode.SqlStartModeKind.class),
+                                            (SqlIntervalLiteral) operands[12],
+                                            (SqlTimestampLiteral) operands[13]);
+                    return new SqlCreateOrAlterMaterializedTable(
+                            pos,
+                            (SqlIdentifier) operands[0],
+                            (SqlNodeList) operands[1],
+                            constraints,
+                            (SqlWatermark) operands[3],
+                            (SqlCharStringLiteral) operands[4],
+                            (SqlDistribution) operands[9],
+                            (SqlNodeList) operands[5],
+                            (SqlNodeList) operands[6],
+                            (SqlIntervalLiteral) operands[7],
+                            refreshMode,
+                            startMode,
+                            operands[8],
+                            true,
+                            SqlParserPos.ZERO);
+                }
+            };
 
     public SqlCreateOrAlterMaterializedTable(
             SqlParserPos pos,

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/materializedtable/SqlDropMaterializedTable.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/materializedtable/SqlDropMaterializedTable.java
@@ -20,8 +20,10 @@ package org.apache.flink.sql.parser.ddl.materializedtable;
 
 import org.apache.flink.sql.parser.ddl.SqlDropObject;
 
+import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.SqlSpecialOperator;
@@ -34,7 +36,16 @@ import java.util.List;
 public class SqlDropMaterializedTable extends SqlDropObject {
 
     private static final SqlOperator OPERATOR =
-            new SqlSpecialOperator("DROP MATERIALIZED TABLE", SqlKind.DROP_TABLE);
+            new SqlSpecialOperator("DROP MATERIALIZED TABLE", SqlKind.DROP_TABLE) {
+                @Override
+                public SqlCall createCall(
+                        SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... operands) {
+                    return new SqlDropMaterializedTable(
+                            pos,
+                            (SqlIdentifier) operands[0],
+                            ((SqlLiteral) operands[1]).booleanValue());
+                }
+            };
 
     public SqlDropMaterializedTable(
             SqlParserPos pos, SqlIdentifier tableIdentifier, boolean ifExists) {
@@ -43,7 +54,7 @@ public class SqlDropMaterializedTable extends SqlDropObject {
 
     @Override
     public List<SqlNode> getOperandList() {
-        return List.of(name);
+        return List.of(name, SqlLiteral.createBoolean(ifExists, SqlParserPos.ZERO));
     }
 
     @Override

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/materializedtable/SqlStartMode.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/materializedtable/SqlStartMode.java
@@ -82,6 +82,16 @@ public class SqlStartMode {
         }
     }
 
+    /** Reconstruction constructor used by deep-copy ({@code createCall}). */
+    public SqlStartMode(
+            SqlStartModeKind kind,
+            @Nullable SqlIntervalLiteral intervalLiteral,
+            @Nullable SqlTimestampLiteral timestampLiteral) {
+        this.kind = kind;
+        this.intervalLiteral = intervalLiteral;
+        this.timestampLiteral = timestampLiteral;
+    }
+
     public SqlStartMode(SqlLiteral kind, @Nullable SqlLiteral literal, SqlParserPos pos) {
         this.kind = SqlParseUtils.extractEnum(kind, SqlStartModeKind.class);
         if (literal == null) {

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/model/SqlAlterModelRename.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/model/SqlAlterModelRename.java
@@ -18,8 +18,13 @@
 
 package org.apache.flink.sql.parser.ddl.model;
 
+import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql.SqlSpecialOperator;
 import org.apache.calcite.sql.SqlWriter;
 import org.apache.calcite.sql.parser.SqlParserPos;
 
@@ -29,6 +34,19 @@ import static java.util.Objects.requireNonNull;
 
 /** ALTER MODEL [IF EXISTS] [[catalogName.] dataBasesName.]modelName RENAME TO newModelName. */
 public class SqlAlterModelRename extends SqlAlterModel {
+
+    private static final SqlSpecialOperator RENAME_OPERATOR =
+            new SqlSpecialOperator("ALTER MODEL RENAME", SqlKind.OTHER_DDL) {
+                @Override
+                public SqlCall createCall(
+                        SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... operands) {
+                    return new SqlAlterModelRename(
+                            pos,
+                            (SqlIdentifier) operands[0],
+                            (SqlIdentifier) operands[1],
+                            ((SqlLiteral) operands[2]).booleanValue());
+                }
+            };
 
     private final SqlIdentifier newModelName;
 
@@ -50,8 +68,14 @@ public class SqlAlterModelRename extends SqlAlterModel {
     }
 
     @Override
+    public SqlOperator getOperator() {
+        return RENAME_OPERATOR;
+    }
+
+    @Override
     public List<SqlNode> getOperandList() {
-        return List.of(name, newModelName);
+        return List.of(
+                name, newModelName, SqlLiteral.createBoolean(ifModelExists, SqlParserPos.ZERO));
     }
 
     @Override

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/model/SqlAlterModelReset.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/model/SqlAlterModelReset.java
@@ -21,9 +21,14 @@ package org.apache.flink.sql.parser.ddl.model;
 import org.apache.flink.sql.parser.SqlParseUtils;
 import org.apache.flink.sql.parser.SqlUnparseUtils;
 
+import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlNodeList;
+import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql.SqlSpecialOperator;
 import org.apache.calcite.sql.SqlWriter;
 import org.apache.calcite.sql.parser.SqlParserPos;
 
@@ -36,6 +41,19 @@ import static java.util.Objects.requireNonNull;
  * ALTER MODEL [IF EXISTS] [[catalogName.] dataBasesName.]modelName RESET ( 'key1' [, 'key2']...).
  */
 public class SqlAlterModelReset extends SqlAlterModel {
+    private static final SqlSpecialOperator RESET_OPERATOR =
+            new SqlSpecialOperator("ALTER MODEL RESET", SqlKind.OTHER_DDL) {
+                @Override
+                public SqlCall createCall(
+                        SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... operands) {
+                    return new SqlAlterModelReset(
+                            pos,
+                            (SqlIdentifier) operands[0],
+                            ((SqlLiteral) operands[2]).booleanValue(),
+                            (SqlNodeList) operands[1]);
+                }
+            };
+
     private final SqlNodeList optionKeyList;
 
     public SqlAlterModelReset(
@@ -48,8 +66,14 @@ public class SqlAlterModelReset extends SqlAlterModel {
     }
 
     @Override
+    public SqlOperator getOperator() {
+        return RESET_OPERATOR;
+    }
+
+    @Override
     public List<SqlNode> getOperandList() {
-        return List.of(name, optionKeyList);
+        return List.of(
+                name, optionKeyList, SqlLiteral.createBoolean(ifModelExists, SqlParserPos.ZERO));
     }
 
     public Set<String> getResetKeys() {

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/model/SqlAlterModelSet.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/model/SqlAlterModelSet.java
@@ -21,9 +21,14 @@ package org.apache.flink.sql.parser.ddl.model;
 import org.apache.flink.sql.parser.SqlParseUtils;
 import org.apache.flink.sql.parser.SqlUnparseUtils;
 
+import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlNodeList;
+import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql.SqlSpecialOperator;
 import org.apache.calcite.sql.SqlWriter;
 import org.apache.calcite.sql.parser.SqlParserPos;
 
@@ -37,6 +42,19 @@ import static java.util.Objects.requireNonNull;
  * name=value]*).
  */
 public class SqlAlterModelSet extends SqlAlterModel {
+
+    private static final SqlSpecialOperator SET_OPERATOR =
+            new SqlSpecialOperator("ALTER MODEL SET", SqlKind.OTHER_DDL) {
+                @Override
+                public SqlCall createCall(
+                        SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... operands) {
+                    return new SqlAlterModelSet(
+                            pos,
+                            (SqlIdentifier) operands[0],
+                            ((SqlLiteral) operands[2]).booleanValue(),
+                            (SqlNodeList) operands[1]);
+                }
+            };
 
     private final SqlNodeList modelOptionList;
 
@@ -55,8 +73,14 @@ public class SqlAlterModelSet extends SqlAlterModel {
     }
 
     @Override
+    public SqlOperator getOperator() {
+        return SET_OPERATOR;
+    }
+
+    @Override
     public List<SqlNode> getOperandList() {
-        return List.of(name, modelOptionList);
+        return List.of(
+                name, modelOptionList, SqlLiteral.createBoolean(ifModelExists, SqlParserPos.ZERO));
     }
 
     @Override

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/model/SqlCreateModel.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/model/SqlCreateModel.java
@@ -23,9 +23,11 @@ import org.apache.flink.sql.parser.SqlUnparseUtils;
 import org.apache.flink.sql.parser.ddl.SqlCreateObject;
 import org.apache.flink.sql.parser.error.SqlValidateException;
 
+import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlCharStringLiteral;
 import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlNodeList;
 import org.apache.calcite.sql.SqlSpecialOperator;
@@ -46,7 +48,21 @@ import static java.util.Objects.requireNonNull;
 public class SqlCreateModel extends SqlCreateObject implements ExtendedSqlNode {
 
     private static final SqlSpecialOperator OPERATOR =
-            new SqlSpecialOperator("CREATE MODEL", SqlKind.OTHER_DDL);
+            new SqlSpecialOperator("CREATE MODEL", SqlKind.OTHER_DDL) {
+                @Override
+                public SqlCall createCall(
+                        SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... operands) {
+                    return new SqlCreateModel(
+                            pos,
+                            (SqlIdentifier) operands[0],
+                            (SqlCharStringLiteral) operands[1],
+                            (SqlNodeList) operands[2],
+                            (SqlNodeList) operands[3],
+                            (SqlNodeList) operands[4],
+                            ((SqlLiteral) operands[5]).booleanValue(),
+                            ((SqlLiteral) operands[6]).booleanValue());
+                }
+            };
 
     private final SqlNodeList inputColumnList;
     private final SqlNodeList outputColumnList;
@@ -69,7 +85,13 @@ public class SqlCreateModel extends SqlCreateObject implements ExtendedSqlNode {
     @Override
     public @Nonnull List<SqlNode> getOperandList() {
         return ImmutableNullableList.of(
-                name, comment, inputColumnList, outputColumnList, properties);
+                name,
+                comment,
+                inputColumnList,
+                outputColumnList,
+                properties,
+                SqlLiteral.createBoolean(isTemporary(), SqlParserPos.ZERO),
+                SqlLiteral.createBoolean(isIfNotExists(), SqlParserPos.ZERO));
     }
 
     public SqlNodeList getInputColumnList() {

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/model/SqlCreateModelAs.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/model/SqlCreateModelAs.java
@@ -21,11 +21,14 @@ package org.apache.flink.sql.parser.ddl.model;
 import org.apache.flink.sql.parser.SqlUnparseUtils;
 import org.apache.flink.sql.parser.error.SqlValidateException;
 
+import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlCharStringLiteral;
 import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlNodeList;
+import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.SqlSpecialOperator;
 import org.apache.calcite.sql.SqlWriter;
 import org.apache.calcite.sql.parser.SqlParserPos;
@@ -51,7 +54,22 @@ import static java.util.Objects.requireNonNull;
 public class SqlCreateModelAs extends SqlCreateModel {
 
     private static final SqlSpecialOperator OPERATOR =
-            new SqlSpecialOperator("CREATE MODEL AS", SqlKind.OTHER_DDL);
+            new SqlSpecialOperator("CREATE MODEL AS", SqlKind.OTHER_DDL) {
+                @Override
+                public SqlCall createCall(
+                        SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... operands) {
+                    return new SqlCreateModelAs(
+                            pos,
+                            (SqlIdentifier) operands[0],
+                            (SqlCharStringLiteral) operands[1],
+                            (SqlNodeList) operands[2],
+                            (SqlNodeList) operands[3],
+                            (SqlNodeList) operands[4],
+                            operands[7],
+                            ((SqlLiteral) operands[5]).booleanValue(),
+                            ((SqlLiteral) operands[6]).booleanValue());
+                }
+            };
 
     private final SqlNode asQuery;
 
@@ -103,6 +121,11 @@ public class SqlCreateModelAs extends SqlCreateModel {
 
     public SqlNode getAsQuery() {
         return asQuery;
+    }
+
+    @Override
+    public SqlOperator getOperator() {
+        return OPERATOR;
     }
 
     @Override

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/model/SqlDropModel.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/model/SqlDropModel.java
@@ -20,13 +20,17 @@ package org.apache.flink.sql.parser.ddl.model;
 
 import org.apache.flink.sql.parser.ddl.SqlDropObject;
 
+import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.SqlSpecialOperator;
 import org.apache.calcite.sql.SqlWriter;
 import org.apache.calcite.sql.parser.SqlParserPos;
+
+import java.util.List;
 
 /**
  * {@link SqlNode} to describe the DROP MODEL [IF EXISTS] [[catalogName.] dataBasesName].modelName
@@ -34,7 +38,17 @@ import org.apache.calcite.sql.parser.SqlParserPos;
  */
 public class SqlDropModel extends SqlDropObject {
     private static final SqlOperator OPERATOR =
-            new SqlSpecialOperator("DROP MODEL", SqlKind.OTHER_DDL);
+            new SqlSpecialOperator("DROP MODEL", SqlKind.OTHER_DDL) {
+                @Override
+                public SqlCall createCall(
+                        SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... operands) {
+                    return new SqlDropModel(
+                            pos,
+                            (SqlIdentifier) operands[0],
+                            ((SqlLiteral) operands[1]).booleanValue(),
+                            ((SqlLiteral) operands[2]).booleanValue());
+                }
+            };
 
     private final boolean isTemporary;
 
@@ -46,6 +60,14 @@ public class SqlDropModel extends SqlDropObject {
 
     public boolean isTemporary() {
         return isTemporary;
+    }
+
+    @Override
+    public List<SqlNode> getOperandList() {
+        return List.of(
+                name,
+                SqlLiteral.createBoolean(ifExists, SqlParserPos.ZERO),
+                SqlLiteral.createBoolean(isTemporary, SqlParserPos.ZERO));
     }
 
     @Override

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/position/SqlTableColumnPosition.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/position/SqlTableColumnPosition.java
@@ -40,7 +40,17 @@ import java.util.List;
 public class SqlTableColumnPosition extends SqlCall {
 
     private static final SqlOperator OPERATOR =
-            new SqlSpecialOperator("SqlTableColumnPosition", SqlKind.OTHER);
+            new SqlSpecialOperator("SqlTableColumnPosition", SqlKind.OTHER) {
+                @Override
+                public SqlCall createCall(
+                        SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... operands) {
+                    return new SqlTableColumnPosition(
+                            pos,
+                            (SqlTableColumn) operands[0],
+                            (SqlLiteral) operands[1],
+                            (SqlIdentifier) operands[2]);
+                }
+            };
 
     private final SqlTableColumn column;
     @Nullable private final SqlLiteral positionSpec;

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/resource/SqlResource.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/resource/SqlResource.java
@@ -37,7 +37,14 @@ import java.util.List;
 public class SqlResource extends SqlCall {
 
     private static final SqlOperator OPERATOR =
-            new SqlSpecialOperator("SqlResource", SqlKind.OTHER);
+            new SqlSpecialOperator("SqlResource", SqlKind.OTHER) {
+                @Override
+                public SqlCall createCall(
+                        SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... operands) {
+                    return new SqlResource(
+                            pos, (SqlLiteral) operands[0], (SqlCharStringLiteral) operands[1]);
+                }
+            };
 
     private final SqlLiteral resourceType;
     private final SqlCharStringLiteral resourcePath;

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/table/SqlAlterTableAdd.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/table/SqlAlterTableAdd.java
@@ -21,12 +21,19 @@ package org.apache.flink.sql.parser.ddl.table;
 import org.apache.flink.sql.parser.ddl.SqlWatermark;
 import org.apache.flink.sql.parser.ddl.constraint.SqlTableConstraint;
 
+import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlLiteral;
+import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlNodeList;
+import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql.SqlSpecialOperator;
 import org.apache.calcite.sql.parser.SqlParserPos;
 
 import javax.annotation.Nullable;
 
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -50,6 +57,25 @@ import java.util.List;
  */
 public class SqlAlterTableAdd extends SqlAlterTableSchema {
 
+    private static final SqlSpecialOperator ADD_OPERATOR =
+            new SqlSpecialOperator("ALTER TABLE ADD", SqlKind.ALTER_TABLE) {
+                @Override
+                public SqlCall createCall(
+                        SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... operands) {
+                    List<SqlTableConstraint> constraints = new ArrayList<>();
+                    for (SqlNode c : (SqlNodeList) operands[2]) {
+                        constraints.add((SqlTableConstraint) c);
+                    }
+                    return new SqlAlterTableAdd(
+                            pos,
+                            (SqlIdentifier) operands[0],
+                            (SqlNodeList) operands[1],
+                            constraints,
+                            (SqlWatermark) operands[3],
+                            ((SqlLiteral) operands[4]).booleanValue());
+                }
+            };
+
     public SqlAlterTableAdd(
             SqlParserPos pos,
             SqlIdentifier tableName,
@@ -58,6 +84,11 @@ public class SqlAlterTableAdd extends SqlAlterTableSchema {
             @Nullable SqlWatermark sqlWatermark,
             boolean ifTableExists) {
         super(pos, tableName, addedColumns, constraint, sqlWatermark, ifTableExists);
+    }
+
+    @Override
+    public SqlOperator getOperator() {
+        return ADD_OPERATOR;
     }
 
     @Override

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/table/SqlAlterTableDistribution.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/table/SqlAlterTableDistribution.java
@@ -20,8 +20,13 @@ package org.apache.flink.sql.parser.ddl.table;
 
 import org.apache.flink.sql.parser.ddl.SqlDistribution;
 
+import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql.SqlSpecialOperator;
 import org.apache.calcite.sql.SqlWriter;
 import org.apache.calcite.sql.parser.SqlParserPos;
 
@@ -68,9 +73,24 @@ public abstract class SqlAlterTableDistribution extends SqlAlterTable {
 
     public static class SqlAlterTableAddDistribution extends SqlAlterTableDistribution {
 
+        private static final SqlSpecialOperator ADD_DISTRIBUTION_OPERATOR =
+                new SqlSpecialOperator("ALTER TABLE ADD DISTRIBUTION", SqlKind.ALTER_TABLE) {
+                    @Override
+                    public SqlCall createCall(
+                            SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... operands) {
+                        return new SqlAlterTableAddDistribution(
+                                pos, (SqlIdentifier) operands[0], (SqlDistribution) operands[1]);
+                    }
+                };
+
         public SqlAlterTableAddDistribution(
                 SqlParserPos pos, SqlIdentifier tableName, SqlDistribution distribution) {
             super(pos, tableName, distribution);
+        }
+
+        @Override
+        public SqlOperator getOperator() {
+            return ADD_DISTRIBUTION_OPERATOR;
         }
 
         @Override
@@ -81,9 +101,24 @@ public abstract class SqlAlterTableDistribution extends SqlAlterTable {
 
     public static class SqlAlterTableModifyDistribution extends SqlAlterTableDistribution {
 
+        private static final SqlSpecialOperator MODIFY_DISTRIBUTION_OPERATOR =
+                new SqlSpecialOperator("ALTER TABLE MODIFY DISTRIBUTION", SqlKind.ALTER_TABLE) {
+                    @Override
+                    public SqlCall createCall(
+                            SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... operands) {
+                        return new SqlAlterTableModifyDistribution(
+                                pos, (SqlIdentifier) operands[0], (SqlDistribution) operands[1]);
+                    }
+                };
+
         public SqlAlterTableModifyDistribution(
                 SqlParserPos pos, SqlIdentifier tableName, SqlDistribution distribution) {
             super(pos, tableName, distribution);
+        }
+
+        @Override
+        public SqlOperator getOperator() {
+            return MODIFY_DISTRIBUTION_OPERATOR;
         }
 
         @Override

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/table/SqlAlterTableDrop.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/table/SqlAlterTableDrop.java
@@ -22,9 +22,14 @@ import org.apache.flink.sql.parser.SqlUnparseUtils;
 import org.apache.flink.sql.parser.ddl.SqlWatermark;
 import org.apache.flink.sql.parser.ddl.constraint.SqlTableConstraint;
 
+import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlNodeList;
+import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql.SqlSpecialOperator;
 import org.apache.calcite.sql.SqlWriter;
 import org.apache.calcite.sql.parser.SqlParserPos;
 
@@ -91,9 +96,32 @@ public abstract class SqlAlterTableDrop extends SqlAlterTableSchema {
     /** ALTER TABLE [IF EXISTS ][catalog_name.][db_name.]table_name DROP PRIMARY KEY. */
     public static class SqlAlterTableDropPrimaryKey extends SqlAlterTableDrop {
 
+        private static final SqlSpecialOperator DROP_PRIMARY_KEY_OPERATOR =
+                new SqlSpecialOperator("ALTER TABLE DROP PRIMARY KEY", SqlKind.ALTER_TABLE) {
+                    @Override
+                    public SqlCall createCall(
+                            SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... operands) {
+                        return new SqlAlterTableDropPrimaryKey(
+                                pos,
+                                (SqlIdentifier) operands[0],
+                                ((SqlLiteral) operands[1]).booleanValue());
+                    }
+                };
+
         public SqlAlterTableDropPrimaryKey(
                 SqlParserPos pos, SqlIdentifier tableName, boolean ifTableExists) {
             super(pos, tableName, ifTableExists);
+        }
+
+        @Override
+        public SqlOperator getOperator() {
+            return DROP_PRIMARY_KEY_OPERATOR;
+        }
+
+        @Override
+        public List<SqlNode> getOperandList() {
+            return List.of(
+                    tableIdentifier, SqlLiteral.createBoolean(ifTableExists, SqlParserPos.ZERO));
         }
 
         @Override
@@ -108,6 +136,19 @@ public abstract class SqlAlterTableDrop extends SqlAlterTableSchema {
     public static class SqlAlterTableDropConstraint extends SqlAlterTableDrop {
         private final SqlIdentifier constraintName;
 
+        private static final SqlSpecialOperator DROP_CONSTRAINT_OPERATOR =
+                new SqlSpecialOperator("ALTER TABLE DROP CONSTRAINT", SqlKind.ALTER_TABLE) {
+                    @Override
+                    public SqlCall createCall(
+                            SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... operands) {
+                        return new SqlAlterTableDropConstraint(
+                                pos,
+                                (SqlIdentifier) operands[0],
+                                (SqlIdentifier) operands[1],
+                                ((SqlLiteral) operands[2]).booleanValue());
+                    }
+                };
+
         public SqlAlterTableDropConstraint(
                 SqlParserPos pos,
                 SqlIdentifier tableName,
@@ -115,6 +156,19 @@ public abstract class SqlAlterTableDrop extends SqlAlterTableSchema {
                 boolean ifTableExists) {
             super(pos, tableName, ifTableExists);
             this.constraintName = constraintName;
+        }
+
+        @Override
+        public SqlOperator getOperator() {
+            return DROP_CONSTRAINT_OPERATOR;
+        }
+
+        @Override
+        public List<SqlNode> getOperandList() {
+            return List.of(
+                    tableIdentifier,
+                    constraintName,
+                    SqlLiteral.createBoolean(ifTableExists, SqlParserPos.ZERO));
         }
 
         public SqlIdentifier getConstraintName() {
@@ -131,9 +185,32 @@ public abstract class SqlAlterTableDrop extends SqlAlterTableSchema {
     /** ALTER TABLE [IF EXISTS ][catalog_name.][db_name.]table_name DROP WATERMARK. */
     public static class SqlAlterTableDropWatermark extends SqlAlterTableDrop {
 
+        private static final SqlSpecialOperator DROP_WATERMARK_OPERATOR =
+                new SqlSpecialOperator("ALTER TABLE DROP WATERMARK", SqlKind.ALTER_TABLE) {
+                    @Override
+                    public SqlCall createCall(
+                            SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... operands) {
+                        return new SqlAlterTableDropWatermark(
+                                pos,
+                                (SqlIdentifier) operands[0],
+                                ((SqlLiteral) operands[1]).booleanValue());
+                    }
+                };
+
         public SqlAlterTableDropWatermark(
                 SqlParserPos pos, SqlIdentifier tableName, boolean ifTableExists) {
             super(pos, tableName, ifTableExists);
+        }
+
+        @Override
+        public SqlOperator getOperator() {
+            return DROP_WATERMARK_OPERATOR;
+        }
+
+        @Override
+        public List<SqlNode> getOperandList() {
+            return List.of(
+                    tableIdentifier, SqlLiteral.createBoolean(ifTableExists, SqlParserPos.ZERO));
         }
 
         @Override
@@ -157,6 +234,19 @@ public abstract class SqlAlterTableDrop extends SqlAlterTableSchema {
      */
     public static class SqlAlterTableDropColumn extends SqlAlterTableDrop {
 
+        private static final SqlSpecialOperator DROP_COLUMN_OPERATOR =
+                new SqlSpecialOperator("ALTER TABLE DROP COLUMN", SqlKind.ALTER_TABLE) {
+                    @Override
+                    public SqlCall createCall(
+                            SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... operands) {
+                        return new SqlAlterTableDropColumn(
+                                pos,
+                                (SqlIdentifier) operands[0],
+                                (SqlNodeList) operands[1],
+                                ((SqlLiteral) operands[2]).booleanValue());
+                    }
+                };
+
         private final SqlNodeList columnList;
 
         public SqlAlterTableDropColumn(
@@ -169,8 +259,16 @@ public abstract class SqlAlterTableDrop extends SqlAlterTableSchema {
         }
 
         @Override
+        public SqlOperator getOperator() {
+            return DROP_COLUMN_OPERATOR;
+        }
+
+        @Override
         public List<SqlNode> getOperandList() {
-            return List.of(tableIdentifier, columnList);
+            return List.of(
+                    tableIdentifier,
+                    columnList,
+                    SqlLiteral.createBoolean(ifTableExists, SqlParserPos.ZERO));
         }
 
         public SqlNodeList getColumnList() {

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/table/SqlAlterTableDropDistribution.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/table/SqlAlterTableDropDistribution.java
@@ -18,12 +18,16 @@
 
 package org.apache.flink.sql.parser.ddl.table;
 
+import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql.SqlSpecialOperator;
 import org.apache.calcite.sql.SqlWriter;
 import org.apache.calcite.sql.parser.SqlParserPos;
 
-import java.util.Collections;
 import java.util.List;
 
 /**
@@ -38,14 +42,31 @@ import java.util.List;
  */
 public class SqlAlterTableDropDistribution extends SqlAlterTable {
 
+    private static final SqlSpecialOperator DROP_DISTRIBUTION_OPERATOR =
+            new SqlSpecialOperator("ALTER TABLE DROP DISTRIBUTION", SqlKind.ALTER_TABLE) {
+                @Override
+                public SqlCall createCall(
+                        SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... operands) {
+                    return new SqlAlterTableDropDistribution(
+                            pos,
+                            (SqlIdentifier) operands[0],
+                            ((SqlLiteral) operands[1]).booleanValue());
+                }
+            };
+
     public SqlAlterTableDropDistribution(
             SqlParserPos pos, SqlIdentifier tableName, boolean ifTableExists) {
         super(pos, tableName, ifTableExists);
     }
 
     @Override
+    public SqlOperator getOperator() {
+        return DROP_DISTRIBUTION_OPERATOR;
+    }
+
+    @Override
     public List<SqlNode> getOperandList() {
-        return Collections.emptyList();
+        return List.of(tableIdentifier, SqlLiteral.createBoolean(ifTableExists, SqlParserPos.ZERO));
     }
 
     @Override

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/table/SqlAlterTableModify.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/table/SqlAlterTableModify.java
@@ -21,12 +21,19 @@ package org.apache.flink.sql.parser.ddl.table;
 import org.apache.flink.sql.parser.ddl.SqlWatermark;
 import org.apache.flink.sql.parser.ddl.constraint.SqlTableConstraint;
 
+import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlLiteral;
+import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlNodeList;
+import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql.SqlSpecialOperator;
 import org.apache.calcite.sql.parser.SqlParserPos;
 
 import javax.annotation.Nullable;
 
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -50,6 +57,25 @@ import java.util.List;
  */
 public class SqlAlterTableModify extends SqlAlterTableSchema {
 
+    private static final SqlSpecialOperator MODIFY_OPERATOR =
+            new SqlSpecialOperator("ALTER TABLE MODIFY", SqlKind.ALTER_TABLE) {
+                @Override
+                public SqlCall createCall(
+                        SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... operands) {
+                    List<SqlTableConstraint> constraints = new ArrayList<>();
+                    for (SqlNode c : (SqlNodeList) operands[2]) {
+                        constraints.add((SqlTableConstraint) c);
+                    }
+                    return new SqlAlterTableModify(
+                            pos,
+                            (SqlIdentifier) operands[0],
+                            (SqlNodeList) operands[1],
+                            constraints,
+                            (SqlWatermark) operands[3],
+                            ((SqlLiteral) operands[4]).booleanValue());
+                }
+            };
+
     public SqlAlterTableModify(
             SqlParserPos pos,
             SqlIdentifier tableName,
@@ -58,6 +84,11 @@ public class SqlAlterTableModify extends SqlAlterTableSchema {
             @Nullable SqlWatermark watermark,
             boolean ifTableExists) {
         super(pos, tableName, modifiedColumns, constraints, watermark, ifTableExists);
+    }
+
+    @Override
+    public SqlOperator getOperator() {
+        return MODIFY_OPERATOR;
     }
 
     @Override

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/table/SqlAlterTableOptions.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/table/SqlAlterTableOptions.java
@@ -21,9 +21,14 @@ package org.apache.flink.sql.parser.ddl.table;
 import org.apache.flink.sql.parser.SqlParseUtils;
 import org.apache.flink.sql.parser.SqlUnparseUtils;
 
+import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlNodeList;
+import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql.SqlSpecialOperator;
 import org.apache.calcite.sql.SqlWriter;
 import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.util.ImmutableNullableList;
@@ -38,6 +43,20 @@ import static java.util.Objects.requireNonNull;
  * name=value]*).
  */
 public class SqlAlterTableOptions extends SqlAlterTable {
+
+    private static final SqlSpecialOperator OPTIONS_OPERATOR =
+            new SqlSpecialOperator("ALTER TABLE OPTIONS", SqlKind.ALTER_TABLE) {
+                @Override
+                public SqlCall createCall(
+                        SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... operands) {
+                    return new SqlAlterTableOptions(
+                            pos,
+                            (SqlIdentifier) operands[0],
+                            (SqlNodeList) operands[2],
+                            (SqlNodeList) operands[1],
+                            ((SqlLiteral) operands[3]).booleanValue());
+                }
+            };
 
     private final SqlNodeList propertyList;
 
@@ -68,8 +87,17 @@ public class SqlAlterTableOptions extends SqlAlterTable {
     }
 
     @Override
+    public SqlOperator getOperator() {
+        return OPTIONS_OPERATOR;
+    }
+
+    @Override
     public List<SqlNode> getOperandList() {
-        return ImmutableNullableList.of(tableIdentifier, propertyList);
+        return ImmutableNullableList.of(
+                tableIdentifier,
+                propertyList,
+                partitionSpec,
+                SqlLiteral.createBoolean(ifTableExists, SqlParserPos.ZERO));
     }
 
     public Map<String, String> getProperties() {

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/table/SqlAlterTableRename.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/table/SqlAlterTableRename.java
@@ -18,8 +18,13 @@
 
 package org.apache.flink.sql.parser.ddl.table;
 
+import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql.SqlSpecialOperator;
 import org.apache.calcite.sql.SqlWriter;
 import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.util.ImmutableNullableList;
@@ -33,6 +38,19 @@ import static java.util.Objects.requireNonNull;
  * dataBasesName].newTableName.
  */
 public class SqlAlterTableRename extends SqlAlterTable {
+
+    private static final SqlSpecialOperator RENAME_OPERATOR =
+            new SqlSpecialOperator("ALTER TABLE RENAME", SqlKind.ALTER_TABLE) {
+                @Override
+                public SqlCall createCall(
+                        SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... operands) {
+                    return new SqlAlterTableRename(
+                            pos,
+                            (SqlIdentifier) operands[0],
+                            (SqlIdentifier) operands[1],
+                            ((SqlLiteral) operands[2]).booleanValue());
+                }
+            };
 
     private final SqlIdentifier newTableIdentifier;
 
@@ -51,8 +69,16 @@ public class SqlAlterTableRename extends SqlAlterTable {
     }
 
     @Override
+    public SqlOperator getOperator() {
+        return RENAME_OPERATOR;
+    }
+
+    @Override
     public List<SqlNode> getOperandList() {
-        return ImmutableNullableList.of(tableIdentifier, newTableIdentifier);
+        return ImmutableNullableList.of(
+                tableIdentifier,
+                newTableIdentifier,
+                SqlLiteral.createBoolean(ifTableExists, SqlParserPos.ZERO));
     }
 
     @Override

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/table/SqlAlterTableRenameColumn.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/table/SqlAlterTableRenameColumn.java
@@ -18,8 +18,13 @@
 
 package org.apache.flink.sql.parser.ddl.table;
 
+import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql.SqlSpecialOperator;
 import org.apache.calcite.sql.SqlWriter;
 import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.util.ImmutableNullableList;
@@ -31,6 +36,20 @@ import java.util.List;
  * newColumnName.
  */
 public class SqlAlterTableRenameColumn extends SqlAlterTable {
+
+    private static final SqlSpecialOperator RENAME_COLUMN_OPERATOR =
+            new SqlSpecialOperator("ALTER TABLE RENAME COLUMN", SqlKind.ALTER_TABLE) {
+                @Override
+                public SqlCall createCall(
+                        SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... operands) {
+                    return new SqlAlterTableRenameColumn(
+                            pos,
+                            (SqlIdentifier) operands[0],
+                            (SqlIdentifier) operands[1],
+                            (SqlIdentifier) operands[2],
+                            ((SqlLiteral) operands[3]).booleanValue());
+                }
+            };
 
     private final SqlIdentifier originColumnIdentifier;
     private final SqlIdentifier newColumnIdentifier;
@@ -47,9 +66,17 @@ public class SqlAlterTableRenameColumn extends SqlAlterTable {
     }
 
     @Override
+    public SqlOperator getOperator() {
+        return RENAME_COLUMN_OPERATOR;
+    }
+
+    @Override
     public List<SqlNode> getOperandList() {
         return ImmutableNullableList.of(
-                tableIdentifier, originColumnIdentifier, newColumnIdentifier);
+                tableIdentifier,
+                originColumnIdentifier,
+                newColumnIdentifier,
+                SqlLiteral.createBoolean(ifTableExists, SqlParserPos.ZERO));
     }
 
     public SqlIdentifier getOldColumnIdentifier() {

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/table/SqlAlterTableReset.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/table/SqlAlterTableReset.java
@@ -21,9 +21,14 @@ package org.apache.flink.sql.parser.ddl.table;
 import org.apache.flink.sql.parser.SqlParseUtils;
 import org.apache.flink.sql.parser.SqlUnparseUtils;
 
+import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlNodeList;
+import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql.SqlSpecialOperator;
 import org.apache.calcite.sql.SqlWriter;
 import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.util.ImmutableNullableList;
@@ -35,6 +40,19 @@ import static java.util.Objects.requireNonNull;
 
 /** ALTER TABLE [IF EXISTS] [[catalogName.] dataBasesName].tableName RESET ( 'key1' [, 'key2']*). */
 public class SqlAlterTableReset extends SqlAlterTable {
+    private static final SqlSpecialOperator RESET_OPERATOR =
+            new SqlSpecialOperator("ALTER TABLE RESET", SqlKind.ALTER_TABLE) {
+                @Override
+                public SqlCall createCall(
+                        SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... operands) {
+                    return new SqlAlterTableReset(
+                            pos,
+                            (SqlIdentifier) operands[0],
+                            (SqlNodeList) operands[1],
+                            ((SqlLiteral) operands[2]).booleanValue());
+                }
+            };
+
     private final SqlNodeList propertyKeyList;
 
     public SqlAlterTableReset(
@@ -48,8 +66,16 @@ public class SqlAlterTableReset extends SqlAlterTable {
     }
 
     @Override
+    public SqlOperator getOperator() {
+        return RESET_OPERATOR;
+    }
+
+    @Override
     public List<SqlNode> getOperandList() {
-        return ImmutableNullableList.of(tableIdentifier, propertyKeyList);
+        return ImmutableNullableList.of(
+                tableIdentifier,
+                propertyKeyList,
+                SqlLiteral.createBoolean(ifTableExists, SqlParserPos.ZERO));
     }
 
     public SqlNodeList getPropertyKeyList() {

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/table/SqlAlterTableSchema.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/table/SqlAlterTableSchema.java
@@ -27,6 +27,7 @@ import org.apache.flink.sql.parser.ddl.position.SqlTableColumnPosition;
 import org.apache.flink.sql.parser.error.SqlValidateException;
 
 import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlNodeList;
 import org.apache.calcite.sql.SqlWriter;
@@ -67,7 +68,8 @@ public abstract class SqlAlterTableSchema extends SqlAlterTable implements Exten
                 getTableName(),
                 columnList,
                 new SqlNodeList(constraints, SqlParserPos.ZERO),
-                watermark);
+                watermark,
+                SqlLiteral.createBoolean(ifTableExists, SqlParserPos.ZERO));
     }
 
     @Override

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/table/SqlAnalyzeTable.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/table/SqlAnalyzeTable.java
@@ -24,6 +24,7 @@ import org.apache.flink.sql.parser.SqlPartitionSpecProperty;
 import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlNodeList;
 import org.apache.calcite.sql.SqlOperator;
@@ -42,7 +43,18 @@ import static java.util.Objects.requireNonNull;
 /** ANALYZE TABLE to compute the statistics for a given table. */
 public class SqlAnalyzeTable extends SqlCall {
     public static final SqlSpecialOperator OPERATOR =
-            new SqlSpecialOperator("ANALYZE TABLE", SqlKind.OTHER_DDL);
+            new SqlSpecialOperator("ANALYZE TABLE", SqlKind.OTHER_DDL) {
+                @Override
+                public SqlCall createCall(
+                        SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... operands) {
+                    return new SqlAnalyzeTable(
+                            pos,
+                            (SqlIdentifier) operands[0],
+                            (SqlNodeList) operands[1],
+                            (SqlNodeList) operands[2],
+                            ((SqlLiteral) operands[3]).booleanValue());
+                }
+            };
 
     private final SqlIdentifier tableName;
     private final SqlNodeList partitions;
@@ -97,7 +109,11 @@ public class SqlAnalyzeTable extends SqlCall {
     @Nonnull
     @Override
     public List<SqlNode> getOperandList() {
-        return ImmutableNullableList.of(tableName, partitions, columns);
+        return ImmutableNullableList.of(
+                tableName,
+                partitions,
+                columns,
+                SqlLiteral.createBoolean(allColumns, SqlParserPos.ZERO));
     }
 
     public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/table/SqlCreateTable.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/table/SqlCreateTable.java
@@ -30,9 +30,11 @@ import org.apache.flink.sql.parser.ddl.SqlWatermark;
 import org.apache.flink.sql.parser.ddl.constraint.SqlTableConstraint;
 import org.apache.flink.sql.parser.error.SqlValidateException;
 
+import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlCharStringLiteral;
 import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlNodeList;
 import org.apache.calcite.sql.SqlSpecialOperator;
@@ -45,6 +47,7 @@ import org.apache.calcite.util.ImmutableNullableList;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -54,7 +57,29 @@ import static java.util.Objects.requireNonNull;
 public class SqlCreateTable extends SqlCreateObject implements ExtendedSqlNode {
 
     private static final SqlSpecialOperator OPERATOR =
-            new SqlSpecialOperator("CREATE TABLE", SqlKind.CREATE_TABLE);
+            new SqlSpecialOperator("CREATE TABLE", SqlKind.CREATE_TABLE) {
+                @Override
+                public SqlCall createCall(
+                        SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... operands) {
+                    List<SqlTableConstraint> constraints = new ArrayList<>();
+                    for (SqlNode c : (SqlNodeList) operands[2]) {
+                        constraints.add((SqlTableConstraint) c);
+                    }
+                    return new SqlCreateTable(
+                            pos,
+                            (SqlIdentifier) operands[0],
+                            (SqlNodeList) operands[1],
+                            constraints,
+                            (SqlNodeList) operands[3],
+                            (SqlDistribution) operands[8],
+                            (SqlNodeList) operands[4],
+                            (SqlWatermark) operands[5],
+                            (SqlCharStringLiteral) operands[6],
+                            (SqlIdentifier) operands[7],
+                            ((SqlLiteral) operands[9]).booleanValue(),
+                            ((SqlLiteral) operands[10]).booleanValue());
+                }
+            };
 
     private final SqlNodeList columnList;
 
@@ -135,7 +160,10 @@ public class SqlCreateTable extends SqlCreateObject implements ExtendedSqlNode {
                 partitionKeyList,
                 watermark,
                 comment,
-                connection);
+                connection,
+                distribution,
+                SqlLiteral.createBoolean(isTemporary(), SqlParserPos.ZERO),
+                SqlLiteral.createBoolean(isIfNotExists(), SqlParserPos.ZERO));
     }
 
     public SqlNodeList getColumnList() {

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/table/SqlCreateTableAs.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/table/SqlCreateTableAs.java
@@ -24,11 +24,14 @@ import org.apache.flink.sql.parser.ddl.SqlWatermark;
 import org.apache.flink.sql.parser.ddl.constraint.SqlTableConstraint;
 import org.apache.flink.sql.parser.error.SqlValidateException;
 
+import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlCharStringLiteral;
 import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlNodeList;
+import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.SqlSpecialOperator;
 import org.apache.calcite.sql.SqlWriter;
 import org.apache.calcite.sql.parser.SqlParserPos;
@@ -37,6 +40,7 @@ import org.apache.calcite.util.ImmutableNullableList;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import static java.util.Objects.requireNonNull;
@@ -71,7 +75,29 @@ import static java.util.Objects.requireNonNull;
 public class SqlCreateTableAs extends SqlCreateTable {
 
     private static final SqlSpecialOperator OPERATOR =
-            new SqlSpecialOperator("CREATE TABLE AS", SqlKind.CREATE_TABLE);
+            new SqlSpecialOperator("CREATE TABLE AS", SqlKind.CREATE_TABLE) {
+                @Override
+                public SqlCall createCall(
+                        SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... operands) {
+                    List<SqlTableConstraint> constraints = new ArrayList<>();
+                    for (SqlNode c : (SqlNodeList) operands[2]) {
+                        constraints.add((SqlTableConstraint) c);
+                    }
+                    return new SqlCreateTableAs(
+                            pos,
+                            (SqlIdentifier) operands[0],
+                            (SqlNodeList) operands[1],
+                            constraints,
+                            (SqlNodeList) operands[3],
+                            (SqlDistribution) operands[8],
+                            (SqlNodeList) operands[4],
+                            (SqlWatermark) operands[5],
+                            (SqlCharStringLiteral) operands[6],
+                            operands[11],
+                            ((SqlLiteral) operands[9]).booleanValue(),
+                            ((SqlLiteral) operands[10]).booleanValue());
+                }
+            };
 
     private final SqlNode asQuery;
 
@@ -130,6 +156,11 @@ public class SqlCreateTableAs extends SqlCreateTable {
 
     public SqlNode getAsQuery() {
         return asQuery;
+    }
+
+    @Override
+    public SqlOperator getOperator() {
+        return OPERATOR;
     }
 
     public boolean isSchemaWithColumnsIdentifiersOnly() {

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/table/SqlCreateTableLike.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/table/SqlCreateTableLike.java
@@ -23,11 +23,14 @@ import org.apache.flink.sql.parser.ddl.SqlWatermark;
 import org.apache.flink.sql.parser.ddl.constraint.SqlTableConstraint;
 import org.apache.flink.sql.parser.error.SqlValidateException;
 
+import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlCharStringLiteral;
 import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlNodeList;
+import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.SqlSpecialOperator;
 import org.apache.calcite.sql.SqlWriter;
 import org.apache.calcite.sql.parser.SqlParserPos;
@@ -36,6 +39,7 @@ import org.apache.calcite.util.ImmutableNullableList;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import static java.util.Objects.requireNonNull;
@@ -72,7 +76,30 @@ import static java.util.Objects.requireNonNull;
 public class SqlCreateTableLike extends SqlCreateTable {
 
     private static final SqlSpecialOperator OPERATOR =
-            new SqlSpecialOperator("CREATE TABLE LIKE", SqlKind.CREATE_TABLE);
+            new SqlSpecialOperator("CREATE TABLE LIKE", SqlKind.CREATE_TABLE) {
+                @Override
+                public SqlCall createCall(
+                        SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... operands) {
+                    List<SqlTableConstraint> constraints = new ArrayList<>();
+                    for (SqlNode c : (SqlNodeList) operands[2]) {
+                        constraints.add((SqlTableConstraint) c);
+                    }
+                    return new SqlCreateTableLike(
+                            pos,
+                            (SqlIdentifier) operands[0],
+                            (SqlNodeList) operands[1],
+                            constraints,
+                            (SqlNodeList) operands[3],
+                            (SqlDistribution) operands[8],
+                            (SqlNodeList) operands[4],
+                            (SqlWatermark) operands[5],
+                            (SqlCharStringLiteral) operands[6],
+                            (SqlIdentifier) operands[7],
+                            (SqlTableLike) operands[11],
+                            ((SqlLiteral) operands[9]).booleanValue(),
+                            ((SqlLiteral) operands[10]).booleanValue());
+                }
+            };
 
     private final SqlTableLike tableLike;
 
@@ -125,6 +152,11 @@ public class SqlCreateTableLike extends SqlCreateTable {
 
     public SqlTableLike getTableLike() {
         return tableLike;
+    }
+
+    @Override
+    public SqlOperator getOperator() {
+        return OPERATOR;
     }
 
     @Override

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/table/SqlDropTable.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/table/SqlDropTable.java
@@ -20,17 +20,32 @@ package org.apache.flink.sql.parser.ddl.table;
 
 import org.apache.flink.sql.parser.ddl.SqlDropObject;
 
+import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlLiteral;
+import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.SqlSpecialOperator;
 import org.apache.calcite.sql.SqlWriter;
 import org.apache.calcite.sql.parser.SqlParserPos;
 
+import java.util.List;
+
 /** DROP TABLE DDL sql call. */
 public class SqlDropTable extends SqlDropObject {
     private static final SqlOperator OPERATOR =
-            new SqlSpecialOperator("DROP TABLE", SqlKind.DROP_TABLE);
+            new SqlSpecialOperator("DROP TABLE", SqlKind.DROP_TABLE) {
+                @Override
+                public SqlCall createCall(
+                        SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... operands) {
+                    return new SqlDropTable(
+                            pos,
+                            (SqlIdentifier) operands[0],
+                            ((SqlLiteral) operands[1]).booleanValue(),
+                            ((SqlLiteral) operands[2]).booleanValue());
+                }
+            };
 
     private final boolean isTemporary;
 
@@ -42,6 +57,14 @@ public class SqlDropTable extends SqlDropObject {
 
     public boolean isTemporary() {
         return this.isTemporary;
+    }
+
+    @Override
+    public List<SqlNode> getOperandList() {
+        return List.of(
+                name,
+                SqlLiteral.createBoolean(ifExists, SqlParserPos.ZERO),
+                SqlLiteral.createBoolean(isTemporary, SqlParserPos.ZERO));
     }
 
     @Override

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/table/SqlTableLike.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/table/SqlTableLike.java
@@ -22,9 +22,12 @@ import org.apache.flink.sql.parser.ExtendedSqlNode;
 import org.apache.flink.sql.parser.error.SqlValidateException;
 
 import org.apache.calcite.sql.SqlCall;
+import org.apache.calcite.sql.SqlCharStringLiteral;
 import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.SqlNodeList;
 import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.SqlSpecialOperator;
 import org.apache.calcite.sql.SqlWriter;
@@ -32,6 +35,7 @@ import org.apache.calcite.sql.parser.SqlParserPos;
 
 import javax.annotation.Nonnull;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -160,7 +164,24 @@ public class SqlTableLike extends SqlCall implements ExtendedSqlNode {
     private final List<SqlTableLikeOption> options;
 
     private static final SqlSpecialOperator OPERATOR =
-            new SqlSpecialOperator("LIKE TABLE", SqlKind.OTHER);
+            new SqlSpecialOperator("LIKE TABLE", SqlKind.OTHER) {
+                @Override
+                public SqlCall createCall(
+                        SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... operands) {
+                    List<SqlTableLikeOption> options = new ArrayList<>();
+                    for (SqlNode optionNode : (SqlNodeList) operands[1]) {
+                        String[] parts =
+                                ((SqlCharStringLiteral) optionNode)
+                                        .getValueAs(String.class)
+                                        .split(" ");
+                        options.add(
+                                new SqlTableLikeOption(
+                                        MergingStrategy.valueOf(parts[0]),
+                                        FeatureOption.valueOf(parts[1])));
+                    }
+                    return new SqlTableLike(pos, (SqlIdentifier) operands[0], options);
+                }
+            };
 
     public SqlTableLike(
             SqlParserPos pos, SqlIdentifier sourceTable, List<SqlTableLikeOption> options) {
@@ -178,7 +199,16 @@ public class SqlTableLike extends SqlCall implements ExtendedSqlNode {
     @Nonnull
     @Override
     public List<SqlNode> getOperandList() {
-        return singletonList(sourceTable);
+        SqlNodeList optionNodes = new SqlNodeList(SqlParserPos.ZERO);
+        for (SqlTableLikeOption option : options) {
+            optionNodes.add(
+                    SqlLiteral.createCharString(
+                            option.getMergingStrategy().name()
+                                    + " "
+                                    + option.getFeatureOption().name(),
+                            SqlParserPos.ZERO));
+        }
+        return List.of(sourceTable, optionNodes);
     }
 
     public SqlIdentifier getSourceTable() {

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/view/SqlAlterViewAs.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/view/SqlAlterViewAs.java
@@ -20,8 +20,13 @@ package org.apache.flink.sql.parser.ddl.view;
 
 import org.apache.flink.sql.parser.SqlUnparseUtils;
 
+import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql.SqlSpecialOperator;
 import org.apache.calcite.sql.SqlWriter;
 import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.util.ImmutableNullableList;
@@ -32,6 +37,16 @@ import java.util.List;
 
 /** ALTER DDL to change a view's query. */
 public class SqlAlterViewAs extends SqlAlterView {
+
+    private static final SqlSpecialOperator AS_OPERATOR =
+            new SqlSpecialOperator("ALTER VIEW AS", SqlKind.ALTER_VIEW) {
+                @Override
+                public SqlCall createCall(
+                        SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... operands) {
+                    return new SqlAlterViewAs(
+                            pos, (SqlIdentifier) operands[0], operands[1], SqlParserPos.ZERO);
+                }
+            };
 
     private final SqlNode newQuery;
 
@@ -45,6 +60,12 @@ public class SqlAlterViewAs extends SqlAlterView {
         super(pos, viewIdentifier);
         this.newQuery = newQuery;
         this.asQueryKeywordPos = asQueryKeywordPos;
+    }
+
+    @Nonnull
+    @Override
+    public SqlOperator getOperator() {
+        return AS_OPERATOR;
     }
 
     @Nonnull

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/view/SqlAlterViewProperties.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/view/SqlAlterViewProperties.java
@@ -21,9 +21,14 @@ package org.apache.flink.sql.parser.ddl.view;
 import org.apache.flink.sql.parser.SqlParseUtils;
 import org.apache.flink.sql.parser.SqlUnparseUtils;
 
+import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlNodeList;
+import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql.SqlSpecialOperator;
 import org.apache.calcite.sql.SqlWriter;
 import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.util.ImmutableNullableList;
@@ -36,12 +41,27 @@ import static java.util.Objects.requireNonNull;
 /** ALTER DDL to change properties of a view. */
 public class SqlAlterViewProperties extends SqlAlterView {
 
+    private static final SqlSpecialOperator PROPERTIES_OPERATOR =
+            new SqlSpecialOperator("ALTER VIEW SET", SqlKind.ALTER_VIEW) {
+                @Override
+                public SqlCall createCall(
+                        SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... operands) {
+                    return new SqlAlterViewProperties(
+                            pos, (SqlIdentifier) operands[0], (SqlNodeList) operands[1]);
+                }
+            };
+
     private final SqlNodeList propertyList;
 
     public SqlAlterViewProperties(
             SqlParserPos pos, SqlIdentifier viewName, SqlNodeList propertyList) {
         super(pos, viewName);
         this.propertyList = requireNonNull(propertyList, "propertyList should not be null");
+    }
+
+    @Override
+    public SqlOperator getOperator() {
+        return PROPERTIES_OPERATOR;
     }
 
     @Override

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/view/SqlAlterViewRename.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/view/SqlAlterViewRename.java
@@ -18,8 +18,13 @@
 
 package org.apache.flink.sql.parser.ddl.view;
 
+import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql.SqlSpecialOperator;
 import org.apache.calcite.sql.SqlWriter;
 import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.util.ImmutableNullableList;
@@ -31,12 +36,28 @@ import java.util.List;
 /** ALTER DDL to rename a view. */
 public class SqlAlterViewRename extends SqlAlterView {
 
+    private static final SqlSpecialOperator RENAME_OPERATOR =
+            new SqlSpecialOperator("ALTER VIEW RENAME", SqlKind.ALTER_VIEW) {
+                @Override
+                public SqlCall createCall(
+                        SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... operands) {
+                    return new SqlAlterViewRename(
+                            pos, (SqlIdentifier) operands[0], (SqlIdentifier) operands[1]);
+                }
+            };
+
     private final SqlIdentifier newViewIdentifier;
 
     public SqlAlterViewRename(
             SqlParserPos pos, SqlIdentifier viewIdentifier, SqlIdentifier newViewIdentifier) {
         super(pos, viewIdentifier);
         this.newViewIdentifier = newViewIdentifier;
+    }
+
+    @Nonnull
+    @Override
+    public SqlOperator getOperator() {
+        return RENAME_OPERATOR;
     }
 
     @Nonnull

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/view/SqlCreateView.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/view/SqlCreateView.java
@@ -21,6 +21,7 @@ package org.apache.flink.sql.parser.ddl.view;
 import org.apache.flink.sql.parser.SqlUnparseUtils;
 import org.apache.flink.sql.parser.ddl.SqlCreateObject;
 
+import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlCharStringLiteral;
 import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlKind;
@@ -39,7 +40,23 @@ import static java.util.Objects.requireNonNull;
 /** CREATE VIEW DDL sql call. */
 public class SqlCreateView extends SqlCreateObject {
     private static final SqlSpecialOperator OPERATOR =
-            new SqlSpecialOperator("CREATE_VIEW", SqlKind.CREATE_VIEW);
+            new SqlSpecialOperator("CREATE_VIEW", SqlKind.CREATE_VIEW) {
+                @Override
+                public SqlCall createCall(
+                        SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... operands) {
+                    return new SqlCreateView(
+                            pos,
+                            (SqlIdentifier) operands[0],
+                            (SqlNodeList) operands[1],
+                            operands[2],
+                            ((SqlLiteral) operands[3]).booleanValue(),
+                            ((SqlLiteral) operands[4]).booleanValue(),
+                            ((SqlLiteral) operands[5]).booleanValue(),
+                            (SqlCharStringLiteral) operands[6],
+                            (SqlNodeList) operands[7],
+                            SqlParserPos.ZERO);
+                }
+            };
 
     private final SqlNodeList fieldList;
     private final SqlNode query;
@@ -69,6 +86,10 @@ public class SqlCreateView extends SqlCreateObject {
         ops.add(fieldList);
         ops.add(query);
         ops.add(SqlLiteral.createBoolean(getReplace(), SqlParserPos.ZERO));
+        ops.add(SqlLiteral.createBoolean(isTemporary(), SqlParserPos.ZERO));
+        ops.add(SqlLiteral.createBoolean(isIfNotExists(), SqlParserPos.ZERO));
+        ops.add(comment);
+        ops.add(properties);
         return ops;
     }
 

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/view/SqlDropView.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/view/SqlDropView.java
@@ -20,17 +20,32 @@ package org.apache.flink.sql.parser.ddl.view;
 
 import org.apache.flink.sql.parser.ddl.SqlDropObject;
 
+import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlLiteral;
+import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.SqlSpecialOperator;
 import org.apache.calcite.sql.SqlWriter;
 import org.apache.calcite.sql.parser.SqlParserPos;
 
+import java.util.List;
+
 /** DROP VIEW DDL sql call. */
 public class SqlDropView extends SqlDropObject {
     private static final SqlOperator OPERATOR =
-            new SqlSpecialOperator("DROP VIEW", SqlKind.DROP_VIEW);
+            new SqlSpecialOperator("DROP VIEW", SqlKind.DROP_VIEW) {
+                @Override
+                public SqlCall createCall(
+                        SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... operands) {
+                    return new SqlDropView(
+                            pos,
+                            (SqlIdentifier) operands[0],
+                            ((SqlLiteral) operands[1]).booleanValue(),
+                            ((SqlLiteral) operands[2]).booleanValue());
+                }
+            };
 
     private final boolean isTemporary;
 
@@ -54,5 +69,13 @@ public class SqlDropView extends SqlDropObject {
 
     public boolean isTemporary() {
         return isTemporary;
+    }
+
+    @Override
+    public List<SqlNode> getOperandList() {
+        return List.of(
+                name,
+                SqlLiteral.createBoolean(ifExists, SqlParserPos.ZERO),
+                SqlLiteral.createBoolean(isTemporary, SqlParserPos.ZERO));
     }
 }

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/dml/RichSqlInsert.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/dml/RichSqlInsert.java
@@ -21,23 +21,46 @@ package org.apache.flink.sql.parser.dml;
 import org.apache.flink.sql.parser.SqlParseUtils;
 import org.apache.flink.sql.parser.SqlProperty;
 
+import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlInsert;
 import org.apache.calcite.sql.SqlInsertKeyword;
+import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlNodeList;
+import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql.SqlSpecialOperator;
 import org.apache.calcite.sql.SqlTableRef;
 import org.apache.calcite.sql.SqlWriter;
 import org.apache.calcite.sql.parser.SqlParserPos;
 
 import javax.annotation.Nullable;
 
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Optional;
 
 /** A {@link SqlInsert} that have some extension functions like partition, overwrite. * */
 public class RichSqlInsert extends SqlInsert {
+
+    public static final SqlSpecialOperator OPERATOR =
+            new SqlSpecialOperator("INSERT", SqlKind.INSERT) {
+                @Override
+                public SqlCall createCall(
+                        SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... operands) {
+                    return new RichSqlInsert(
+                            pos,
+                            (SqlNodeList) operands[0],
+                            (SqlNodeList) operands[4],
+                            operands[1],
+                            operands[2],
+                            (SqlNodeList) operands[3],
+                            (SqlNodeList) operands[5],
+                            (SqlLiteral) operands[6]);
+                }
+            };
+
     private final SqlNodeList staticPartitions;
 
     private final SqlNodeList extendedKeywords;
@@ -91,6 +114,22 @@ public class RichSqlInsert extends SqlInsert {
             this.targetTableID = targetTable;
             this.tableHints = SqlNodeList.EMPTY;
         }
+    }
+
+    @Override
+    public SqlOperator getOperator() {
+        return OPERATOR;
+    }
+
+    @Override
+    public List<SqlNode> getOperandList() {
+        // SqlInsert exposes [keywords, targetTable, source, columnList]; append the
+        // Flink-specific operands so that a deep copy can faithfully rebuild this node.
+        List<SqlNode> operands = new ArrayList<>(super.getOperandList());
+        operands.add(extendedKeywords);
+        operands.add(staticPartitions);
+        operands.add(conflictAction);
+        return operands;
     }
 
     /**

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/dml/SqlBeginStatementSet.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/dml/SqlBeginStatementSet.java
@@ -20,6 +20,7 @@ package org.apache.flink.sql.parser.dml;
 
 import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.SqlSpecialOperator;
@@ -33,7 +34,13 @@ import java.util.List;
 public class SqlBeginStatementSet extends SqlCall {
 
     public static final SqlSpecialOperator OPERATOR =
-            new SqlSpecialOperator("BEGIN STATEMENT SET", SqlKind.OTHER);
+            new SqlSpecialOperator("BEGIN STATEMENT SET", SqlKind.OTHER) {
+                @Override
+                public SqlCall createCall(
+                        SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... operands) {
+                    return new SqlBeginStatementSet(pos);
+                }
+            };
 
     public SqlBeginStatementSet(SqlParserPos pos) {
         super(pos);

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/dml/SqlCompileAndExecutePlan.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/dml/SqlCompileAndExecutePlan.java
@@ -23,6 +23,7 @@ import org.apache.flink.sql.parser.SqlParseUtils;
 
 import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.SqlSpecialOperator;
@@ -31,7 +32,6 @@ import org.apache.calcite.sql.parser.SqlParserPos;
 
 import javax.annotation.Nonnull;
 
-import java.util.Collections;
 import java.util.List;
 
 /**
@@ -42,7 +42,13 @@ import java.util.List;
 public class SqlCompileAndExecutePlan extends SqlCall {
 
     public static final SqlSpecialOperator OPERATOR =
-            new SqlSpecialOperator("COMPILE AND EXECUTE PLAN", SqlKind.OTHER);
+            new SqlSpecialOperator("COMPILE AND EXECUTE PLAN", SqlKind.OTHER) {
+                @Override
+                public SqlCall createCall(
+                        SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... operands) {
+                    return new SqlCompileAndExecutePlan(pos, operands[1], operands[0]);
+                }
+            };
 
     private final SqlNode planFile;
     private SqlNode operand;
@@ -67,7 +73,7 @@ public class SqlCompileAndExecutePlan extends SqlCall {
     @Nonnull
     @Override
     public List<SqlNode> getOperandList() {
-        return Collections.singletonList(operand);
+        return List.of(operand, planFile);
     }
 
     @Override

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/dml/SqlEndStatementSet.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/dml/SqlEndStatementSet.java
@@ -20,6 +20,7 @@ package org.apache.flink.sql.parser.dml;
 
 import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.SqlSpecialOperator;
@@ -32,7 +33,14 @@ import java.util.List;
 /** END. */
 public class SqlEndStatementSet extends SqlCall {
 
-    public static final SqlSpecialOperator OPERATOR = new SqlSpecialOperator("END", SqlKind.OTHER);
+    public static final SqlSpecialOperator OPERATOR =
+            new SqlSpecialOperator("END", SqlKind.OTHER) {
+                @Override
+                public SqlCall createCall(
+                        SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... operands) {
+                    return new SqlEndStatementSet(pos);
+                }
+            };
 
     public SqlEndStatementSet(SqlParserPos pos) {
         super(pos);

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/dml/SqlExecute.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/dml/SqlExecute.java
@@ -20,6 +20,7 @@ package org.apache.flink.sql.parser.dml;
 
 import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.SqlSelect;
@@ -51,7 +52,13 @@ import java.util.List;
 public class SqlExecute extends SqlCall {
 
     public static final SqlSpecialOperator OPERATOR =
-            new SqlSpecialOperator("Execute", SqlKind.OTHER);
+            new SqlSpecialOperator("Execute", SqlKind.OTHER) {
+                @Override
+                public SqlCall createCall(
+                        SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... operands) {
+                    return new SqlExecute(operands[0], pos);
+                }
+            };
 
     private SqlNode statement;
 

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/dml/SqlExecutePlan.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/dml/SqlExecutePlan.java
@@ -23,6 +23,7 @@ import org.apache.flink.sql.parser.SqlParseUtils;
 
 import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.SqlSpecialOperator;
@@ -39,7 +40,13 @@ import java.util.List;
 public class SqlExecutePlan extends SqlCall {
 
     public static final SqlSpecialOperator OPERATOR =
-            new SqlSpecialOperator("EXECUTE PLAN", SqlKind.OTHER);
+            new SqlSpecialOperator("EXECUTE PLAN", SqlKind.OTHER) {
+                @Override
+                public SqlCall createCall(
+                        SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... operands) {
+                    return new SqlExecutePlan(pos, operands[0]);
+                }
+            };
 
     private final SqlNode planFile;
 
@@ -61,7 +68,7 @@ public class SqlExecutePlan extends SqlCall {
     @Nonnull
     @Override
     public List<SqlNode> getOperandList() {
-        return Collections.emptyList();
+        return Collections.singletonList(planFile);
     }
 
     @Override

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/dml/SqlStatementSet.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/dml/SqlStatementSet.java
@@ -20,6 +20,7 @@ package org.apache.flink.sql.parser.dml;
 
 import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.SqlSpecialOperator;
@@ -41,7 +42,17 @@ import java.util.List;
 public class SqlStatementSet extends SqlCall {
 
     public static final SqlSpecialOperator OPERATOR =
-            new SqlSpecialOperator("Statement Set", SqlKind.OTHER);
+            new SqlSpecialOperator("Statement Set", SqlKind.OTHER) {
+                @Override
+                public SqlCall createCall(
+                        SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... operands) {
+                    List<RichSqlInsert> inserts = new ArrayList<>(operands.length);
+                    for (SqlNode operand : operands) {
+                        inserts.add((RichSqlInsert) operand);
+                    }
+                    return new SqlStatementSet(inserts, pos);
+                }
+            };
 
     private final ArrayList<RichSqlInsert> inserts = new ArrayList<>();
 

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/dml/SqlTruncateTable.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/dml/SqlTruncateTable.java
@@ -21,6 +21,7 @@ package org.apache.flink.sql.parser.dml;
 import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.SqlSpecialOperator;
@@ -42,7 +43,13 @@ public class SqlTruncateTable extends SqlCall {
     private final SqlIdentifier tableNameIdentifier;
 
     public static final SqlSpecialOperator OPERATOR =
-            new SqlSpecialOperator("TRUNCATE TABLE", SqlKind.OTHER);
+            new SqlSpecialOperator("TRUNCATE TABLE", SqlKind.OTHER) {
+                @Override
+                public SqlCall createCall(
+                        SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... operands) {
+                    return new SqlTruncateTable(pos, (SqlIdentifier) operands[0]);
+                }
+            };
 
     public SqlTruncateTable(SqlParserPos pos, SqlIdentifier tableNameIdentifier) {
         super(pos);

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/dql/SqlDescribeCatalog.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/dql/SqlDescribeCatalog.java
@@ -21,20 +21,29 @@ package org.apache.flink.sql.parser.dql;
 import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.SqlSpecialOperator;
 import org.apache.calcite.sql.SqlWriter;
 import org.apache.calcite.sql.parser.SqlParserPos;
 
-import java.util.Collections;
 import java.util.List;
 
 /** DESCRIBE CATALOG sql call. */
 public class SqlDescribeCatalog extends SqlCall {
 
     public static final SqlSpecialOperator OPERATOR =
-            new SqlSpecialOperator("DESCRIBE CATALOG", SqlKind.OTHER_DDL);
+            new SqlSpecialOperator("DESCRIBE CATALOG", SqlKind.OTHER_DDL) {
+                @Override
+                public SqlCall createCall(
+                        SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... operands) {
+                    return new SqlDescribeCatalog(
+                            pos,
+                            (SqlIdentifier) operands[0],
+                            ((SqlLiteral) operands[1]).booleanValue());
+                }
+            };
     private final SqlIdentifier catalogName;
     private final boolean isExtended;
 
@@ -51,7 +60,7 @@ public class SqlDescribeCatalog extends SqlCall {
 
     @Override
     public List<SqlNode> getOperandList() {
-        return Collections.singletonList(catalogName);
+        return List.of(catalogName, SqlLiteral.createBoolean(isExtended, SqlParserPos.ZERO));
     }
 
     public String getCatalogName() {

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/dql/SqlDescribeDatabase.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/dql/SqlDescribeDatabase.java
@@ -21,20 +21,29 @@ package org.apache.flink.sql.parser.dql;
 import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.SqlSpecialOperator;
 import org.apache.calcite.sql.SqlWriter;
 import org.apache.calcite.sql.parser.SqlParserPos;
 
-import java.util.Collections;
 import java.util.List;
 
 /** DESCRIBE DATABASE [ EXTENDED] [ databaseName.] dataBasesName sql call. */
 public class SqlDescribeDatabase extends SqlCall {
 
     public static final SqlSpecialOperator OPERATOR =
-            new SqlSpecialOperator("DESCRIBE DATABASE", SqlKind.OTHER);
+            new SqlSpecialOperator("DESCRIBE DATABASE", SqlKind.OTHER) {
+                @Override
+                public SqlCall createCall(
+                        SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... operands) {
+                    return new SqlDescribeDatabase(
+                            pos,
+                            (SqlIdentifier) operands[0],
+                            ((SqlLiteral) operands[1]).booleanValue());
+                }
+            };
     private final SqlIdentifier databaseName;
     private boolean isExtended = false;
 
@@ -51,7 +60,7 @@ public class SqlDescribeDatabase extends SqlCall {
 
     @Override
     public List<SqlNode> getOperandList() {
-        return Collections.singletonList(databaseName);
+        return List.of(databaseName, SqlLiteral.createBoolean(isExtended, SqlParserPos.ZERO));
     }
 
     public String getDatabaseName() {

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/dql/SqlDescribeJob.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/dql/SqlDescribeJob.java
@@ -21,6 +21,7 @@ package org.apache.flink.sql.parser.dql;
 import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlCharStringLiteral;
 import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.SqlSpecialOperator;
@@ -35,7 +36,13 @@ import java.util.List;
 public class SqlDescribeJob extends SqlCall {
 
     public static final SqlOperator OPERATOR =
-            new SqlSpecialOperator("DESCRIBE JOB", SqlKind.OTHER);
+            new SqlSpecialOperator("DESCRIBE JOB", SqlKind.OTHER) {
+                @Override
+                public SqlCall createCall(
+                        SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... operands) {
+                    return new SqlDescribeJob(pos, (SqlCharStringLiteral) operands[0]);
+                }
+            };
 
     private final SqlCharStringLiteral jobId;
 

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/dql/SqlLoadModule.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/dql/SqlLoadModule.java
@@ -24,6 +24,7 @@ import org.apache.flink.sql.parser.SqlUnparseUtils;
 import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlNodeList;
 import org.apache.calcite.sql.SqlOperator;
@@ -40,7 +41,14 @@ import static java.util.Objects.requireNonNull;
 /** LOAD MODULE sql call. */
 public class SqlLoadModule extends SqlCall {
     public static final SqlSpecialOperator OPERATOR =
-            new SqlSpecialOperator("LOAD MODULE", SqlKind.OTHER);
+            new SqlSpecialOperator("LOAD MODULE", SqlKind.OTHER) {
+                @Override
+                public SqlCall createCall(
+                        SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... operands) {
+                    return new SqlLoadModule(
+                            pos, (SqlIdentifier) operands[0], (SqlNodeList) operands[1]);
+                }
+            };
 
     private final SqlIdentifier moduleName;
     private final SqlNodeList propertyList;

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/dql/SqlRichDescribeConnection.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/dql/SqlRichDescribeConnection.java
@@ -21,13 +21,13 @@ package org.apache.flink.sql.parser.dql;
 import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.SqlSpecialOperator;
 import org.apache.calcite.sql.SqlWriter;
 import org.apache.calcite.sql.parser.SqlParserPos;
 
-import java.util.Collections;
 import java.util.List;
 
 /**
@@ -39,7 +39,16 @@ import java.util.List;
 public class SqlRichDescribeConnection extends SqlCall {
 
     public static final SqlSpecialOperator OPERATOR =
-            new SqlSpecialOperator("DESCRIBE CONNECTION", SqlKind.OTHER);
+            new SqlSpecialOperator("DESCRIBE CONNECTION", SqlKind.OTHER) {
+                @Override
+                public SqlCall createCall(
+                        SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... operands) {
+                    return new SqlRichDescribeConnection(
+                            pos,
+                            (SqlIdentifier) operands[0],
+                            ((SqlLiteral) operands[1]).booleanValue());
+                }
+            };
     protected final SqlIdentifier connectionNameIdentifier;
     private final boolean isExtended;
 
@@ -57,7 +66,8 @@ public class SqlRichDescribeConnection extends SqlCall {
 
     @Override
     public List<SqlNode> getOperandList() {
-        return Collections.singletonList(connectionNameIdentifier);
+        return List.of(
+                connectionNameIdentifier, SqlLiteral.createBoolean(isExtended, SqlParserPos.ZERO));
     }
 
     public boolean isExtended() {

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/dql/SqlRichDescribeFunction.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/dql/SqlRichDescribeFunction.java
@@ -21,13 +21,13 @@ package org.apache.flink.sql.parser.dql;
 import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.SqlSpecialOperator;
 import org.apache.calcite.sql.SqlWriter;
 import org.apache.calcite.sql.parser.SqlParserPos;
 
-import java.util.Collections;
 import java.util.List;
 
 /**
@@ -39,7 +39,16 @@ import java.util.List;
 public class SqlRichDescribeFunction extends SqlCall {
 
     public static final SqlSpecialOperator OPERATOR =
-            new SqlSpecialOperator("DESCRIBE FUNCTION", SqlKind.OTHER);
+            new SqlSpecialOperator("DESCRIBE FUNCTION", SqlKind.OTHER) {
+                @Override
+                public SqlCall createCall(
+                        SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... operands) {
+                    return new SqlRichDescribeFunction(
+                            pos,
+                            (SqlIdentifier) operands[0],
+                            ((SqlLiteral) operands[1]).booleanValue());
+                }
+            };
     protected final SqlIdentifier functionNameIdentifier;
     private final boolean isExtended;
 
@@ -57,7 +66,8 @@ public class SqlRichDescribeFunction extends SqlCall {
 
     @Override
     public List<SqlNode> getOperandList() {
-        return Collections.singletonList(functionNameIdentifier);
+        return List.of(
+                functionNameIdentifier, SqlLiteral.createBoolean(isExtended, SqlParserPos.ZERO));
     }
 
     public boolean isExtended() {

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/dql/SqlRichDescribeModel.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/dql/SqlRichDescribeModel.java
@@ -21,13 +21,13 @@ package org.apache.flink.sql.parser.dql;
 import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.SqlSpecialOperator;
 import org.apache.calcite.sql.SqlWriter;
 import org.apache.calcite.sql.parser.SqlParserPos;
 
-import java.util.Collections;
 import java.util.List;
 
 /**
@@ -39,7 +39,16 @@ import java.util.List;
 public class SqlRichDescribeModel extends SqlCall {
 
     public static final SqlSpecialOperator OPERATOR =
-            new SqlSpecialOperator("DESCRIBE MODEL", SqlKind.OTHER);
+            new SqlSpecialOperator("DESCRIBE MODEL", SqlKind.OTHER) {
+                @Override
+                public SqlCall createCall(
+                        SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... operands) {
+                    return new SqlRichDescribeModel(
+                            pos,
+                            (SqlIdentifier) operands[0],
+                            ((SqlLiteral) operands[1]).booleanValue());
+                }
+            };
     protected final SqlIdentifier modelNameIdentifier;
     private final boolean isExtended;
 
@@ -57,7 +66,8 @@ public class SqlRichDescribeModel extends SqlCall {
 
     @Override
     public List<SqlNode> getOperandList() {
-        return Collections.singletonList(modelNameIdentifier);
+        return List.of(
+                modelNameIdentifier, SqlLiteral.createBoolean(isExtended, SqlParserPos.ZERO));
     }
 
     public boolean isExtended() {

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/dql/SqlRichDescribeTable.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/dql/SqlRichDescribeTable.java
@@ -21,13 +21,13 @@ package org.apache.flink.sql.parser.dql;
 import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.SqlSpecialOperator;
 import org.apache.calcite.sql.SqlWriter;
 import org.apache.calcite.sql.parser.SqlParserPos;
 
-import java.util.Collections;
 import java.util.List;
 
 /**
@@ -37,7 +37,16 @@ import java.util.List;
 public class SqlRichDescribeTable extends SqlCall {
 
     public static final SqlSpecialOperator OPERATOR =
-            new SqlSpecialOperator("DESCRIBE TABLE", SqlKind.DESCRIBE_TABLE);
+            new SqlSpecialOperator("DESCRIBE TABLE", SqlKind.DESCRIBE_TABLE) {
+                @Override
+                public SqlCall createCall(
+                        SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... operands) {
+                    return new SqlRichDescribeTable(
+                            pos,
+                            (SqlIdentifier) operands[0],
+                            ((SqlLiteral) operands[1]).booleanValue());
+                }
+            };
     protected final SqlIdentifier tableNameIdentifier;
     private final boolean isExtended;
 
@@ -55,7 +64,8 @@ public class SqlRichDescribeTable extends SqlCall {
 
     @Override
     public List<SqlNode> getOperandList() {
-        return Collections.singletonList(tableNameIdentifier);
+        return List.of(
+                tableNameIdentifier, SqlLiteral.createBoolean(isExtended, SqlParserPos.ZERO));
     }
 
     public boolean isExtended() {

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/dql/SqlRichExplain.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/dql/SqlRichExplain.java
@@ -19,15 +19,18 @@
 package org.apache.flink.sql.parser.dql;
 
 import org.apache.calcite.sql.SqlCall;
+import org.apache.calcite.sql.SqlCharStringLiteral;
 import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.SqlNodeList;
 import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.SqlSpecialOperator;
 import org.apache.calcite.sql.SqlWriter;
 import org.apache.calcite.sql.parser.SqlParserPos;
 
-import java.util.Collections;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -39,7 +42,18 @@ import java.util.Set;
 public class SqlRichExplain extends SqlCall {
 
     public static final SqlSpecialOperator OPERATOR =
-            new SqlSpecialOperator("EXPLAIN", SqlKind.EXPLAIN);
+            new SqlSpecialOperator("EXPLAIN", SqlKind.EXPLAIN) {
+                @Override
+                public SqlCall createCall(
+                        SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... operands) {
+                    Set<String> explainDetails = new LinkedHashSet<>();
+                    for (SqlNode detail : (SqlNodeList) operands[1]) {
+                        explainDetails.add(
+                                ((SqlCharStringLiteral) detail).getValueAs(String.class));
+                    }
+                    return new SqlRichExplain(pos, operands[0], explainDetails);
+                }
+            };
 
     private SqlNode statement;
     private final Set<String> explainDetails;
@@ -65,7 +79,11 @@ public class SqlRichExplain extends SqlCall {
 
     @Override
     public List<SqlNode> getOperandList() {
-        return Collections.singletonList(statement);
+        SqlNodeList details = new SqlNodeList(SqlParserPos.ZERO);
+        for (String detail : explainDetails) {
+            details.add(SqlLiteral.createCharString(detail, SqlParserPos.ZERO));
+        }
+        return List.of(statement, details);
     }
 
     public Set<String> getExplainDetails() {

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/dql/SqlShowCall.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/dql/SqlShowCall.java
@@ -21,10 +21,12 @@ package org.apache.flink.sql.parser.dql;
 import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlCharStringLiteral;
 import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.SqlWriter;
 import org.apache.calcite.sql.parser.SqlParserPos;
+import org.apache.calcite.util.ImmutableNullableList;
 
 import java.util.Collections;
 import java.util.List;
@@ -59,9 +61,33 @@ public abstract class SqlShowCall extends SqlCall {
 
     @Override
     public List<SqlNode> getOperandList() {
-        return Objects.isNull(sqlIdentifier)
-                ? Collections.emptyList()
-                : Collections.singletonList(sqlIdentifier);
+        // Fixed layout so that deep-copy via operator.createCall can faithfully reconstruct the
+        // subclass: [identifier, preposition, likeType, likeLiteral, notLike].
+        return ImmutableNullableList.of(
+                sqlIdentifier,
+                stringToOperand(preposition),
+                stringToOperand(likeType),
+                likeLiteral,
+                SqlLiteral.createBoolean(notLike, SqlParserPos.ZERO));
+    }
+
+    /** Encodes a nullable {@code String} field as an operand for {@link #getOperandList()}. */
+    protected static SqlNode stringToOperand(String value) {
+        return value == null
+                ? SqlLiteral.createNull(SqlParserPos.ZERO)
+                : SqlLiteral.createCharString(value, SqlParserPos.ZERO);
+    }
+
+    /** Decodes a {@code String} field previously encoded by {@link #stringToOperand(String)}. */
+    protected static String operandToString(SqlNode operand) {
+        return operand instanceof SqlCharStringLiteral
+                ? ((SqlCharStringLiteral) operand).getValueAs(String.class)
+                : null;
+    }
+
+    /** Decodes a {@code boolean} field encoded as a {@link SqlLiteral}. */
+    protected static boolean operandToBoolean(SqlNode operand) {
+        return ((SqlLiteral) operand).booleanValue();
     }
 
     @Override

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/dql/SqlShowCatalogs.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/dql/SqlShowCatalogs.java
@@ -18,8 +18,11 @@
 
 package org.apache.flink.sql.parser.dql;
 
+import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlCharStringLiteral;
 import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlLiteral;
+import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.SqlSpecialOperator;
 import org.apache.calcite.sql.parser.SqlParserPos;
@@ -34,7 +37,17 @@ import org.apache.calcite.sql.parser.SqlParserPos;
 public class SqlShowCatalogs extends SqlShowCall {
 
     public static final SqlSpecialOperator OPERATOR =
-            new SqlSpecialOperator("SHOW CATALOGS", SqlKind.OTHER);
+            new SqlSpecialOperator("SHOW CATALOGS", SqlKind.OTHER) {
+                @Override
+                public SqlCall createCall(
+                        SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... operands) {
+                    return new SqlShowCatalogs(
+                            pos,
+                            operandToString(operands[2]),
+                            (SqlCharStringLiteral) operands[3],
+                            operandToBoolean(operands[4]));
+                }
+            };
 
     public SqlShowCatalogs(
             SqlParserPos pos, String likeType, SqlCharStringLiteral likeLiteral, boolean notLike) {

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/dql/SqlShowColumns.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/dql/SqlShowColumns.java
@@ -18,9 +18,12 @@
 
 package org.apache.flink.sql.parser.dql;
 
+import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlCharStringLiteral;
 import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlLiteral;
+import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.SqlSpecialOperator;
 import org.apache.calcite.sql.parser.SqlParserPos;
@@ -31,7 +34,18 @@ import static java.util.Objects.requireNonNull;
 public class SqlShowColumns extends SqlShowCall {
 
     public static final SqlSpecialOperator OPERATOR =
-            new SqlSpecialOperator("SHOW COLUMNS", SqlKind.OTHER);
+            new SqlSpecialOperator("SHOW COLUMNS", SqlKind.OTHER) {
+                @Override
+                public SqlCall createCall(
+                        SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... operands) {
+                    return new SqlShowColumns(
+                            pos,
+                            operandToString(operands[1]),
+                            (SqlIdentifier) operands[0],
+                            operandToBoolean(operands[4]),
+                            (SqlCharStringLiteral) operands[3]);
+                }
+            };
 
     public SqlShowColumns(
             SqlParserPos pos,

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/dql/SqlShowConnections.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/dql/SqlShowConnections.java
@@ -18,9 +18,11 @@
 
 package org.apache.flink.sql.parser.dql;
 
+import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlCharStringLiteral;
 import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.SqlSpecialOperator;
@@ -30,7 +32,18 @@ import org.apache.calcite.sql.parser.SqlParserPos;
 public class SqlShowConnections extends SqlShowCall {
 
     public static final SqlSpecialOperator OPERATOR =
-            new SqlSpecialOperator("SHOW CONNECTIONS", SqlKind.OTHER);
+            new SqlSpecialOperator("SHOW CONNECTIONS", SqlKind.OTHER) {
+                @Override
+                public SqlCall createCall(
+                        SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... operands) {
+                    return new SqlShowConnections(
+                            pos,
+                            operandToString(operands[1]),
+                            (SqlIdentifier) operands[0],
+                            operandToBoolean(operands[4]),
+                            (SqlCharStringLiteral) operands[3]);
+                }
+            };
 
     public SqlShowConnections(
             SqlParserPos pos,

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/dql/SqlShowCreateCatalog.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/dql/SqlShowCreateCatalog.java
@@ -18,8 +18,10 @@
 
 package org.apache.flink.sql.parser.dql;
 
+import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.SqlSpecialOperator;
@@ -33,7 +35,13 @@ import java.util.List;
 public class SqlShowCreateCatalog extends SqlShowCreate {
 
     public static final SqlSpecialOperator OPERATOR =
-            new SqlSpecialOperator("SHOW CREATE CATALOG", SqlKind.OTHER_DDL);
+            new SqlSpecialOperator("SHOW CREATE CATALOG", SqlKind.OTHER_DDL) {
+                @Override
+                public SqlCall createCall(
+                        SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... operands) {
+                    return new SqlShowCreateCatalog(pos, (SqlIdentifier) operands[0]);
+                }
+            };
 
     public SqlShowCreateCatalog(SqlParserPos pos, SqlIdentifier catalogName) {
         super(pos, catalogName);

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/dql/SqlShowCreateConnection.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/dql/SqlShowCreateConnection.java
@@ -18,8 +18,10 @@
 
 package org.apache.flink.sql.parser.dql;
 
+import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.SqlSpecialOperator;
@@ -33,7 +35,13 @@ import java.util.List;
 public class SqlShowCreateConnection extends SqlShowCreate {
 
     public static final SqlSpecialOperator OPERATOR =
-            new SqlSpecialOperator("SHOW CREATE CONNECTION", SqlKind.OTHER_DDL);
+            new SqlSpecialOperator("SHOW CREATE CONNECTION", SqlKind.OTHER_DDL) {
+                @Override
+                public SqlCall createCall(
+                        SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... operands) {
+                    return new SqlShowCreateConnection(pos, (SqlIdentifier) operands[0]);
+                }
+            };
 
     public SqlShowCreateConnection(SqlParserPos pos, SqlIdentifier connectionName) {
         super(pos, connectionName);

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/dql/SqlShowCreateMaterializedTable.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/dql/SqlShowCreateMaterializedTable.java
@@ -18,8 +18,10 @@
 
 package org.apache.flink.sql.parser.dql;
 
+import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.SqlSpecialOperator;
@@ -32,10 +34,24 @@ import java.util.List;
 /** SHOW CREATE [OR ALTER ]MATERIALIZED TABLE sql call. */
 public class SqlShowCreateMaterializedTable extends SqlShowCreate {
     private static final SqlSpecialOperator SHOW_CREATE_OPERATOR =
-            new SqlSpecialOperator("SHOW CREATE MATERIALIZED TABLE", SqlKind.OTHER_DDL);
+            new SqlSpecialOperator("SHOW CREATE MATERIALIZED TABLE", SqlKind.OTHER_DDL) {
+                @Override
+                public SqlCall createCall(
+                        SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... operands) {
+                    return new SqlShowCreateMaterializedTable(
+                            pos, (SqlIdentifier) operands[0], false);
+                }
+            };
 
     private static final SqlSpecialOperator SHOW_CREATE_OR_ALTER_OPERATOR =
-            new SqlSpecialOperator("SHOW CREATE OR ALTER MATERIALIZED TABLE", SqlKind.OTHER_DDL);
+            new SqlSpecialOperator("SHOW CREATE OR ALTER MATERIALIZED TABLE", SqlKind.OTHER_DDL) {
+                @Override
+                public SqlCall createCall(
+                        SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... operands) {
+                    return new SqlShowCreateMaterializedTable(
+                            pos, (SqlIdentifier) operands[0], true);
+                }
+            };
 
     private final boolean createOrAlter;
 

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/dql/SqlShowCreateModel.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/dql/SqlShowCreateModel.java
@@ -18,8 +18,10 @@
 
 package org.apache.flink.sql.parser.dql;
 
+import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.SqlSpecialOperator;
@@ -33,7 +35,13 @@ import java.util.List;
 public class SqlShowCreateModel extends SqlShowCreate {
 
     public static final SqlSpecialOperator OPERATOR =
-            new SqlSpecialOperator("SHOW CREATE MODEL", SqlKind.OTHER_DDL);
+            new SqlSpecialOperator("SHOW CREATE MODEL", SqlKind.OTHER_DDL) {
+                @Override
+                public SqlCall createCall(
+                        SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... operands) {
+                    return new SqlShowCreateModel(pos, (SqlIdentifier) operands[0]);
+                }
+            };
 
     public SqlShowCreateModel(SqlParserPos pos, SqlIdentifier modelName) {
         super(pos, modelName);

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/dql/SqlShowCreateTable.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/dql/SqlShowCreateTable.java
@@ -18,8 +18,10 @@
 
 package org.apache.flink.sql.parser.dql;
 
+import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.SqlSpecialOperator;
@@ -33,7 +35,13 @@ import java.util.List;
 public class SqlShowCreateTable extends SqlShowCreate {
 
     public static final SqlSpecialOperator OPERATOR =
-            new SqlSpecialOperator("SHOW CREATE TABLE", SqlKind.OTHER_DDL);
+            new SqlSpecialOperator("SHOW CREATE TABLE", SqlKind.OTHER_DDL) {
+                @Override
+                public SqlCall createCall(
+                        SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... operands) {
+                    return new SqlShowCreateTable(pos, (SqlIdentifier) operands[0]);
+                }
+            };
 
     public SqlShowCreateTable(SqlParserPos pos, SqlIdentifier tableName) {
         super(pos, tableName);

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/dql/SqlShowCreateView.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/dql/SqlShowCreateView.java
@@ -18,8 +18,10 @@
 
 package org.apache.flink.sql.parser.dql;
 
+import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.SqlSpecialOperator;
@@ -33,7 +35,13 @@ import java.util.List;
 public class SqlShowCreateView extends SqlShowCreate {
 
     public static final SqlSpecialOperator OPERATOR =
-            new SqlSpecialOperator("SHOW CREATE VIEW", SqlKind.OTHER_DDL);
+            new SqlSpecialOperator("SHOW CREATE VIEW", SqlKind.OTHER_DDL) {
+                @Override
+                public SqlCall createCall(
+                        SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... operands) {
+                    return new SqlShowCreateView(pos, (SqlIdentifier) operands[0]);
+                }
+            };
 
     public SqlShowCreateView(SqlParserPos pos, SqlIdentifier viewName) {
         super(pos, viewName);

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/dql/SqlShowCurrentCatalog.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/dql/SqlShowCurrentCatalog.java
@@ -20,6 +20,7 @@ package org.apache.flink.sql.parser.dql;
 
 import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.SqlSpecialOperator;
@@ -33,7 +34,13 @@ import java.util.List;
 public class SqlShowCurrentCatalog extends SqlCall {
 
     public static final SqlSpecialOperator OPERATOR =
-            new SqlSpecialOperator("SHOW CURRENT CATALOG", SqlKind.OTHER);
+            new SqlSpecialOperator("SHOW CURRENT CATALOG", SqlKind.OTHER) {
+                @Override
+                public SqlCall createCall(
+                        SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... operands) {
+                    return new SqlShowCurrentCatalog(pos);
+                }
+            };
 
     public SqlShowCurrentCatalog(SqlParserPos pos) {
         super(pos);

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/dql/SqlShowCurrentDatabase.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/dql/SqlShowCurrentDatabase.java
@@ -20,6 +20,7 @@ package org.apache.flink.sql.parser.dql;
 
 import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.SqlSpecialOperator;
@@ -33,7 +34,13 @@ import java.util.List;
 public class SqlShowCurrentDatabase extends SqlCall {
 
     public static final SqlSpecialOperator OPERATOR =
-            new SqlSpecialOperator("SHOW CURRENT DATABASE", SqlKind.OTHER);
+            new SqlSpecialOperator("SHOW CURRENT DATABASE", SqlKind.OTHER) {
+                @Override
+                public SqlCall createCall(
+                        SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... operands) {
+                    return new SqlShowCurrentDatabase(pos);
+                }
+            };
 
     public SqlShowCurrentDatabase(SqlParserPos pos) {
         super(pos);

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/dql/SqlShowDatabases.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/dql/SqlShowDatabases.java
@@ -20,9 +20,12 @@ package org.apache.flink.sql.parser.dql;
 
 import org.apache.flink.sql.parser.impl.ParseException;
 
+import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlCharStringLiteral;
 import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlLiteral;
+import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.SqlSpecialOperator;
 import org.apache.calcite.sql.parser.SqlParserPos;
@@ -38,7 +41,23 @@ import org.apache.calcite.sql.parser.SqlParserPos;
 public class SqlShowDatabases extends SqlShowCall {
 
     public static final SqlSpecialOperator OPERATOR =
-            new SqlSpecialOperator("SHOW DATABASES", SqlKind.OTHER);
+            new SqlSpecialOperator("SHOW DATABASES", SqlKind.OTHER) {
+                @Override
+                public SqlCall createCall(
+                        SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... operands) {
+                    try {
+                        return new SqlShowDatabases(
+                                pos,
+                                operandToString(operands[1]),
+                                (SqlIdentifier) operands[0],
+                                operandToString(operands[2]),
+                                (SqlCharStringLiteral) operands[3],
+                                operandToBoolean(operands[4]));
+                    } catch (ParseException e) {
+                        throw new RuntimeException(e);
+                    }
+                }
+            };
 
     public SqlShowDatabases(
             SqlParserPos pos,

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/dql/SqlShowFunctions.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/dql/SqlShowFunctions.java
@@ -18,12 +18,18 @@
 
 package org.apache.flink.sql.parser.dql;
 
+import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlCharStringLiteral;
 import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlLiteral;
+import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.SqlSpecialOperator;
 import org.apache.calcite.sql.parser.SqlParserPos;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Show Functions sql call. The full syntax for show functions is as followings:
@@ -36,7 +42,20 @@ import org.apache.calcite.sql.parser.SqlParserPos;
 public class SqlShowFunctions extends SqlShowCall {
 
     public static final SqlSpecialOperator OPERATOR =
-            new SqlSpecialOperator("SHOW FUNCTIONS", SqlKind.OTHER);
+            new SqlSpecialOperator("SHOW FUNCTIONS", SqlKind.OTHER) {
+                @Override
+                public SqlCall createCall(
+                        SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... operands) {
+                    return new SqlShowFunctions(
+                            pos,
+                            operandToBoolean(operands[5]),
+                            operandToString(operands[1]),
+                            (SqlIdentifier) operands[0],
+                            operandToString(operands[2]),
+                            (SqlCharStringLiteral) operands[3],
+                            operandToBoolean(operands[4]));
+                }
+            };
 
     private final boolean requireUser;
 
@@ -59,6 +78,13 @@ public class SqlShowFunctions extends SqlShowCall {
 
     public boolean requireUser() {
         return requireUser;
+    }
+
+    @Override
+    public List<SqlNode> getOperandList() {
+        List<SqlNode> operands = new ArrayList<>(super.getOperandList());
+        operands.add(SqlLiteral.createBoolean(requireUser, SqlParserPos.ZERO));
+        return operands;
     }
 
     @Override

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/dql/SqlShowJars.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/dql/SqlShowJars.java
@@ -20,6 +20,7 @@ package org.apache.flink.sql.parser.dql;
 
 import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.SqlSpecialOperator;
@@ -33,7 +34,13 @@ import java.util.List;
 public class SqlShowJars extends SqlCall {
 
     public static final SqlSpecialOperator OPERATOR =
-            new SqlSpecialOperator("SHOW JARS", SqlKind.OTHER);
+            new SqlSpecialOperator("SHOW JARS", SqlKind.OTHER) {
+                @Override
+                public SqlCall createCall(
+                        SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... operands) {
+                    return new SqlShowJars(pos);
+                }
+            };
 
     public SqlShowJars(SqlParserPos pos) {
         super(pos);

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/dql/SqlShowJobs.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/dql/SqlShowJobs.java
@@ -20,6 +20,7 @@ package org.apache.flink.sql.parser.dql;
 
 import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.SqlSpecialOperator;
@@ -33,7 +34,13 @@ import java.util.List;
 public class SqlShowJobs extends SqlCall {
 
     public static final SqlSpecialOperator OPERATOR =
-            new SqlSpecialOperator("SHOW JOBS", SqlKind.OTHER);
+            new SqlSpecialOperator("SHOW JOBS", SqlKind.OTHER) {
+                @Override
+                public SqlCall createCall(
+                        SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... operands) {
+                    return new SqlShowJobs(pos);
+                }
+            };
 
     public SqlShowJobs(SqlParserPos pos) {
         super(pos);

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/dql/SqlShowModels.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/dql/SqlShowModels.java
@@ -18,9 +18,11 @@
 
 package org.apache.flink.sql.parser.dql;
 
+import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlCharStringLiteral;
 import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.SqlSpecialOperator;
@@ -30,7 +32,18 @@ import org.apache.calcite.sql.parser.SqlParserPos;
 public class SqlShowModels extends SqlShowCall {
 
     public static final SqlSpecialOperator OPERATOR =
-            new SqlSpecialOperator("SHOW MODELS", SqlKind.OTHER);
+            new SqlSpecialOperator("SHOW MODELS", SqlKind.OTHER) {
+                @Override
+                public SqlCall createCall(
+                        SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... operands) {
+                    return new SqlShowModels(
+                            pos,
+                            operandToString(operands[1]),
+                            (SqlIdentifier) operands[0],
+                            operandToBoolean(operands[4]),
+                            (SqlCharStringLiteral) operands[3]);
+                }
+            };
 
     public SqlShowModels(
             SqlParserPos pos,

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/dql/SqlShowModules.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/dql/SqlShowModules.java
@@ -20,6 +20,7 @@ package org.apache.flink.sql.parser.dql;
 
 import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.SqlSpecialOperator;
@@ -31,7 +32,13 @@ import java.util.List;
 /** SHOW [FULL] MODULES sql call. */
 public class SqlShowModules extends SqlCall {
     public static final SqlOperator OPERATOR =
-            new SqlSpecialOperator("SHOW MODULES", SqlKind.OTHER);
+            new SqlSpecialOperator("SHOW MODULES", SqlKind.OTHER) {
+                @Override
+                public SqlCall createCall(
+                        SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... operands) {
+                    return new SqlShowModules(pos, ((SqlLiteral) operands[0]).booleanValue());
+                }
+            };
     private final boolean requireFull;
 
     public SqlShowModules(SqlParserPos pos, boolean requireFull) {
@@ -46,7 +53,7 @@ public class SqlShowModules extends SqlCall {
 
     @Override
     public List<SqlNode> getOperandList() {
-        return List.of();
+        return List.of(SqlLiteral.createBoolean(requireFull, SqlParserPos.ZERO));
     }
 
     @Override

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/dql/SqlShowPartitions.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/dql/SqlShowPartitions.java
@@ -23,6 +23,7 @@ import org.apache.flink.sql.parser.SqlParseUtils;
 import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlNodeList;
 import org.apache.calcite.sql.SqlOperator;
@@ -42,7 +43,14 @@ import static java.util.Objects.requireNonNull;
 public class SqlShowPartitions extends SqlCall {
 
     public static final SqlSpecialOperator OPERATOR =
-            new SqlSpecialOperator("SHOW PARTITIONS", SqlKind.OTHER);
+            new SqlSpecialOperator("SHOW PARTITIONS", SqlKind.OTHER) {
+                @Override
+                public SqlCall createCall(
+                        SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... operands) {
+                    return new SqlShowPartitions(
+                            pos, (SqlIdentifier) operands[0], (SqlNodeList) operands[1]);
+                }
+            };
 
     private final SqlIdentifier tableIdentifier;
     @Nullable private final SqlNodeList partitionSpec;

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/dql/SqlShowProcedures.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/dql/SqlShowProcedures.java
@@ -18,9 +18,12 @@
 
 package org.apache.flink.sql.parser.dql;
 
+import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlCharStringLiteral;
 import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlLiteral;
+import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.SqlSpecialOperator;
 import org.apache.calcite.sql.parser.SqlParserPos;
@@ -38,7 +41,19 @@ import javax.annotation.Nullable;
 public class SqlShowProcedures extends SqlShowCall {
 
     public static final SqlSpecialOperator OPERATOR =
-            new SqlSpecialOperator("SHOW PROCEDURES", SqlKind.OTHER);
+            new SqlSpecialOperator("SHOW PROCEDURES", SqlKind.OTHER) {
+                @Override
+                public SqlCall createCall(
+                        SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... operands) {
+                    return new SqlShowProcedures(
+                            pos,
+                            operandToString(operands[1]),
+                            (SqlIdentifier) operands[0],
+                            operandToBoolean(operands[4]),
+                            operandToString(operands[2]),
+                            (SqlCharStringLiteral) operands[3]);
+                }
+            };
 
     public SqlShowProcedures(
             SqlParserPos pos,

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/dql/SqlShowTables.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/dql/SqlShowTables.java
@@ -18,9 +18,12 @@
 
 package org.apache.flink.sql.parser.dql;
 
+import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlCharStringLiteral;
 import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlLiteral;
+import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.SqlSpecialOperator;
 import org.apache.calcite.sql.parser.SqlParserPos;
@@ -69,14 +72,53 @@ public class SqlShowTables extends SqlShowCall {
         return kind;
     }
 
+    private static SqlCall createCallForKind(
+            SqlOperator operator, SqlParserPos pos, SqlNode... operands) {
+        SqlTableKind tableKind = SqlTableKind.TABLE;
+        for (SqlTableKind candidate : SqlTableKind.values()) {
+            if (candidate.getOperator() == operator) {
+                tableKind = candidate;
+                break;
+            }
+        }
+        return new SqlShowTables(
+                pos,
+                tableKind,
+                operandToString(operands[1]),
+                (SqlIdentifier) operands[0],
+                operandToBoolean(operands[4]),
+                (SqlCharStringLiteral) operands[3]);
+    }
+
     /**
      * The kind of table. Keep in sync with {@link
      * org.apache.flink.table.catalog.CatalogBaseTable.TableKind}.
      */
     public enum SqlTableKind {
-        MATERIALIZED_TABLE(new SqlSpecialOperator("SHOW MATERIALIZED TABLES", SqlKind.OTHER)),
-        TABLE(new SqlSpecialOperator("SHOW TABLES", SqlKind.OTHER)),
-        VIEW(new SqlSpecialOperator("SHOW VIEWS", SqlKind.OTHER));
+        MATERIALIZED_TABLE(
+                new SqlSpecialOperator("SHOW MATERIALIZED TABLES", SqlKind.OTHER) {
+                    @Override
+                    public SqlCall createCall(
+                            SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... operands) {
+                        return createCallForKind(this, pos, operands);
+                    }
+                }),
+        TABLE(
+                new SqlSpecialOperator("SHOW TABLES", SqlKind.OTHER) {
+                    @Override
+                    public SqlCall createCall(
+                            SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... operands) {
+                        return createCallForKind(this, pos, operands);
+                    }
+                }),
+        VIEW(
+                new SqlSpecialOperator("SHOW VIEWS", SqlKind.OTHER) {
+                    @Override
+                    public SqlCall createCall(
+                            SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... operands) {
+                        return createCallForKind(this, pos, operands);
+                    }
+                });
 
         private final SqlSpecialOperator operator;
 

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/dql/SqlShowTables.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/dql/SqlShowTables.java
@@ -95,30 +95,9 @@ public class SqlShowTables extends SqlShowCall {
      * org.apache.flink.table.catalog.CatalogBaseTable.TableKind}.
      */
     public enum SqlTableKind {
-        MATERIALIZED_TABLE(
-                new SqlSpecialOperator("SHOW MATERIALIZED TABLES", SqlKind.OTHER) {
-                    @Override
-                    public SqlCall createCall(
-                            SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... operands) {
-                        return createCallForKind(this, pos, operands);
-                    }
-                }),
-        TABLE(
-                new SqlSpecialOperator("SHOW TABLES", SqlKind.OTHER) {
-                    @Override
-                    public SqlCall createCall(
-                            SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... operands) {
-                        return createCallForKind(this, pos, operands);
-                    }
-                }),
-        VIEW(
-                new SqlSpecialOperator("SHOW VIEWS", SqlKind.OTHER) {
-                    @Override
-                    public SqlCall createCall(
-                            SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... operands) {
-                        return createCallForKind(this, pos, operands);
-                    }
-                });
+        MATERIALIZED_TABLE(getSpecialOperator("SHOW MATERIALIZED TABLES")),
+        TABLE(getSpecialOperator("SHOW TABLES")),
+        VIEW(getSpecialOperator("SHOW VIEWS"));
 
         private final SqlSpecialOperator operator;
 
@@ -128,6 +107,16 @@ public class SqlShowTables extends SqlShowCall {
 
         public SqlSpecialOperator getOperator() {
             return operator;
+        }
+
+        private static SqlSpecialOperator getSpecialOperator(final String name) {
+            return new SqlSpecialOperator(name, SqlKind.OTHER) {
+                @Override
+                public SqlCall createCall(
+                        SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... operands) {
+                    return createCallForKind(this, pos, operands);
+                }
+            };
         }
     }
 }

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/dql/SqlUnloadModule.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/dql/SqlUnloadModule.java
@@ -21,6 +21,7 @@ package org.apache.flink.sql.parser.dql;
 import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.SqlSpecialOperator;
@@ -34,7 +35,13 @@ import java.util.List;
 public class SqlUnloadModule extends SqlCall {
 
     public static final SqlSpecialOperator OPERATOR =
-            new SqlSpecialOperator("UNLOAD MODULE", SqlKind.OTHER);
+            new SqlSpecialOperator("UNLOAD MODULE", SqlKind.OTHER) {
+                @Override
+                public SqlCall createCall(
+                        SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... operands) {
+                    return new SqlUnloadModule(pos, (SqlIdentifier) operands[0]);
+                }
+            };
 
     private final SqlIdentifier moduleName;
 

--- a/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/DeepCopyUnparsingTesterImpl.java
+++ b/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/DeepCopyUnparsingTesterImpl.java
@@ -1,0 +1,155 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.sql.parser;
+
+import org.apache.calcite.sql.SqlCall;
+import org.apache.calcite.sql.SqlDialect;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.SqlNodeList;
+import org.apache.calcite.sql.SqlWriterConfig;
+import org.apache.calcite.sql.dialect.AnsiSqlDialect;
+import org.apache.calcite.sql.parser.SqlParser;
+import org.apache.calcite.sql.parser.SqlParserTest;
+import org.apache.calcite.sql.parser.StringAndPos;
+import org.apache.calcite.sql.test.SqlTestFactory;
+import org.apache.calcite.sql.util.SqlShuttle;
+import org.apache.calcite.util.Util;
+
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.function.UnaryOperator;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unparsing tester that, on top of the regular parse/unparse round-trips performed by {@link
+ * SqlParserTest.UnparsingTesterImpl}, also makes a deep copy of every parsed {@link SqlNode} and
+ * asserts that the copy unparses to the same SQL as the original.
+ *
+ * <p>The class should be dropped after upgrading to Calcite 1.42.0 since similar logic is there.
+ * More details are at CALCITE-7301.
+ */
+class DeepCopyUnparsingTesterImpl extends SqlParserTest.UnparsingTesterImpl {
+
+    private static final String FLINK_PARSER_PACKAGE = "org.apache.flink.sql.parser";
+
+    /** Whether {@code node} or any node in its subtree is a Flink parser node. */
+    private static boolean containsFlinkNode(SqlNode node) {
+        if (isFlinkNode(node)) {
+            return true;
+        }
+        final boolean[] found = {false};
+        node.accept(
+                new SqlShuttle() {
+                    @Override
+                    public SqlNode visit(final SqlCall call) {
+                        if (isFlinkNode(call)) {
+                            found[0] = true;
+                        }
+                        // Default traversal copies nothing (alwaysCopy=false), so it never
+                        // invokes createCall and is safe even for unfixed core operators.
+                        return super.visit(call);
+                    }
+                });
+        return found[0];
+    }
+
+    private static boolean isFlinkNode(SqlNode node) {
+        return node.getClass().getName().startsWith(FLINK_PARSER_PACKAGE);
+    }
+
+    private static SqlNode deepCopy(SqlNode sqlNode) {
+        return sqlNode.accept(
+                new SqlShuttle() {
+                    @Override
+                    public SqlNode visit(final SqlCall call) {
+                        // Handler always creates a new copy of 'call'.
+                        CallCopyingArgHandler argHandler = new CallCopyingArgHandler(call, true);
+                        call.getOperator().acceptCall(this, call, false, argHandler);
+                        return argHandler.result();
+                    }
+                });
+    }
+
+    private static UnaryOperator<SqlWriterConfig> simple() {
+        return c ->
+                c.withSelectListItemsOnSeparateLines(false)
+                        .withUpdateSetListNewline(false)
+                        .withIndentation(0)
+                        .withFromFolding(SqlWriterConfig.LineFolding.TALL);
+    }
+
+    private static SqlWriterConfig simpleWithParens(SqlWriterConfig c) {
+        return simple().apply(c).withAlwaysUseParentheses(true);
+    }
+
+    private static String toSqlString(
+            SqlNodeList sqlNodeList, UnaryOperator<SqlWriterConfig> transform) {
+        return sqlNodeList.stream()
+                .map(node -> node.toSqlString(transform).getSql())
+                .collect(Collectors.joining(";"));
+    }
+
+    @Override
+    public void checkList(
+            SqlTestFactory factory,
+            StringAndPos sap,
+            SqlDialect dialect,
+            UnaryOperator<String> converter,
+            List<String> expected) {
+        super.checkList(factory, sap, dialect, converter, expected);
+
+        final SqlNodeList sqlNodeList = parseStmtsAndHandleEx(factory, sap.sql);
+        if (!containsFlinkNode(sqlNodeList)) {
+            return;
+        }
+        final String sql1 = toSqlString(sqlNodeList, simple());
+
+        // Make a deep copy of the SqlNodeList, unparse it.
+        final SqlNodeList sqlNodeList3 = (SqlNodeList) deepCopy(sqlNodeList);
+        final String sql4 = toSqlString(sqlNodeList3, simple());
+        // Should be the same as we started with.
+        assertThat(sql4).isEqualTo(sql1);
+    }
+
+    @Override
+    public void check(
+            SqlTestFactory factory,
+            StringAndPos sap,
+            SqlDialect dialect,
+            UnaryOperator<String> converter,
+            String expected,
+            Consumer<SqlParser> parserChecker) {
+        super.check(factory, sap, dialect, converter, expected, parserChecker);
+
+        final SqlNode sqlNode = parseStmtAndHandleEx(factory, sap.sql, parserChecker);
+        if (!containsFlinkNode(sqlNode)) {
+            return;
+        }
+        final SqlDialect dialect2 = Util.first(dialect, AnsiSqlDialect.DEFAULT);
+        final UnaryOperator<SqlWriterConfig> writerTransform =
+                c -> simpleWithParens(c).withDialect(dialect2);
+
+        // Make a deep copy of the original SqlNode, unparse it.
+        final SqlNode sqlNode5 = deepCopy(sqlNode);
+        final String actual5 = sqlNode5.toSqlString(writerTransform).getSql();
+        assertThat(converter.apply(actual5)).isEqualTo(expected);
+    }
+}

--- a/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/DeepCopyUnparsingTesterImpl.java
+++ b/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/DeepCopyUnparsingTesterImpl.java
@@ -120,13 +120,13 @@ class DeepCopyUnparsingTesterImpl extends SqlParserTest.UnparsingTesterImpl {
         if (!containsFlinkNode(sqlNodeList)) {
             return;
         }
-        final String sql1 = toSqlString(sqlNodeList, simple());
+        final String sql = toSqlString(sqlNodeList, simple());
 
         // Make a deep copy of the SqlNodeList, unparse it.
-        final SqlNodeList sqlNodeList3 = (SqlNodeList) deepCopy(sqlNodeList);
-        final String sql4 = toSqlString(sqlNodeList3, simple());
+        final SqlNodeList deepCopiedSqlNodeList = (SqlNodeList) deepCopy(sqlNodeList);
+        final String sqlFromDeepCopy = toSqlString(deepCopiedSqlNodeList, simple());
         // Should be the same as we started with.
-        assertThat(sql4).isEqualTo(sql1);
+        assertThat(sqlFromDeepCopy).isEqualTo(sql);
     }
 
     @Override

--- a/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkSqlParserImplTest.java
+++ b/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkSqlParserImplTest.java
@@ -38,6 +38,7 @@ import org.junit.jupiter.params.provider.CsvSource;
 import java.util.List;
 import java.util.Locale;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
 
@@ -2450,6 +2451,18 @@ class FlinkSqlParserImplTest extends SqlParserTest {
                         + "SELECT `COL3`, `COL4`\n"
                         + "FROM `TBL`";
         sql(sql).ok(expected);
+    }
+
+    @Test
+    void testCreateViewWithFieldNamesWithToString() throws SqlParseException {
+        final String sql = "create view v(col1, col2) as select col3, col4 from tbl";
+        final String expected =
+                "CREATE VIEW `V` (`COL1`, `COL2`)\n"
+                        + "AS\n"
+                        + "SELECT `COL3`, `COL4`\n"
+                        + "FROM `TBL`";
+        final SqlNode node = sql(sql).parser().parseQuery();
+        assertThat(node).hasToString(expected);
     }
 
     @Test

--- a/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkSqlParserImplTest.java
+++ b/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkSqlParserImplTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.sql.parser;
 
+import org.apache.flink.sql.parser.ddl.view.SqlCreateView;
 import org.apache.flink.sql.parser.error.SqlValidateException;
 import org.apache.flink.sql.parser.impl.FlinkSqlParserImpl;
 
@@ -2462,7 +2463,7 @@ class FlinkSqlParserImplTest extends SqlParserTest {
                         + "SELECT `COL3`, `COL4`\n"
                         + "FROM `TBL`";
         final SqlNode node = sql(sql).parser().parseQuery();
-        assertThat(node).hasToString(expected);
+        assertThat(node).isInstanceOf(SqlCreateView.class).hasToString(expected);
     }
 
     @Test

--- a/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkSqlUnParserTest.java
+++ b/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkSqlUnParserTest.java
@@ -39,7 +39,9 @@ class FlinkSqlUnParserTest extends FlinkSqlParserImplTest {
 
     public SqlParserFixture fixture() {
         return super.fixture()
-                .withTester(new UnparsingTesterImpl())
+                // Replace back with UnparsingTesterImpl after upgrading Calcite to 1.42.0
+                // since after that the logic is embedded into Calcite
+                .withTester(new DeepCopyUnparsingTesterImpl())
                 .withConfig(c -> c.withParserFactory(FlinkSqlParserImpl.FACTORY));
     }
 }

--- a/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkSqlUnParserTest.java
+++ b/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkSqlUnParserTest.java
@@ -39,8 +39,6 @@ class FlinkSqlUnParserTest extends FlinkSqlParserImplTest {
 
     public SqlParserFixture fixture() {
         return super.fixture()
-                // Replace back with UnparsingTesterImpl after upgrading Calcite to 1.42.0
-                // since after that the logic is embedded into Calcite
                 .withTester(new DeepCopyUnparsingTesterImpl())
                 .withConfig(c -> c.withParserFactory(FlinkSqlParserImpl.FACTORY));
     }

--- a/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/MaterializedTableStatementUnParserTest.java
+++ b/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/MaterializedTableStatementUnParserTest.java
@@ -21,7 +21,6 @@ package org.apache.flink.sql.parser;
 import org.apache.flink.sql.parser.impl.FlinkSqlParserImpl;
 
 import org.apache.calcite.sql.parser.SqlParserFixture;
-import org.apache.calcite.sql.parser.SqlParserTest;
 import org.junit.jupiter.api.parallel.Execution;
 
 import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
@@ -40,7 +39,9 @@ class MaterializedTableStatementUnParserTest extends MaterializedTableStatementP
 
     public SqlParserFixture fixture() {
         return super.fixture()
-                .withTester(new SqlParserTest.UnparsingTesterImpl())
+                // Replace back with UnparsingTesterImpl after upgrading Calcite to 1.42.0
+                // since after that the logic is embedded into Calcite
+                .withTester(new DeepCopyUnparsingTesterImpl())
                 .withConfig(c -> c.withParserFactory(FlinkSqlParserImpl.FACTORY));
     }
 }

--- a/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/MaterializedTableStatementUnParserTest.java
+++ b/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/MaterializedTableStatementUnParserTest.java
@@ -39,8 +39,6 @@ class MaterializedTableStatementUnParserTest extends MaterializedTableStatementP
 
     public SqlParserFixture fixture() {
         return super.fixture()
-                // Replace back with UnparsingTesterImpl after upgrading Calcite to 1.42.0
-                // since after that the logic is embedded into Calcite
                 .withTester(new DeepCopyUnparsingTesterImpl())
                 .withConfig(c -> c.withParserFactory(FlinkSqlParserImpl.FACTORY));
     }


### PR DESCRIPTION

## What is the purpose of the change

The main reason is CALCITE-7301(https://issues.apache.org/jira/browse/CALCITE-7301) issue which introduced tests for every sql operator to check whether it is unparsable

The PR introduces  similar fix and a similar test (in a separate commit to easily revert it once after upgrade Calcite's test could be reused)
## Brief change log

parse sql operators
## Verifying this change

test introduced

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: ( no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes )
  - If yes, how is the feature documented? (not applicable)

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change the checkbox below to `[X]` followed by the name of the tool, and uncomment the
"Generated-by" line. See the ASF Generative Tooling Guidance for details:
https://www.apache.org/legal/generative-tooling.html

You are responsible for the quality and correctness of every change in this PR
regardless of the tooling used. Low-effort AI-generated PRs will be closed. See
AGENTS.md for the full guidance.
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name and Version]
-->
