### PR TITLE
[FLINK-39969][runtime] use the same SSL protcol and algorithms in flink

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/net/SSLUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/net/SSLUtils.java
@@ -35,6 +35,9 @@ import org.apache.flink.shaded.netty4.io.netty.handler.ssl.SslContextBuilder;
 import org.apache.flink.shaded.netty4.io.netty.handler.ssl.SslProvider;
 import org.apache.flink.shaded.netty4.io.netty.handler.ssl.util.FingerprintTrustManagerFactory;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import javax.annotation.Nullable;
 import javax.net.ServerSocketFactory;
 import javax.net.SocketFactory;
@@ -42,6 +45,8 @@ import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLServerSocket;
 import javax.net.ssl.SSLServerSocketFactory;
+import javax.net.ssl.SSLSocket;
+import javax.net.ssl.SSLSocketFactory;
 import javax.net.ssl.TrustManagerFactory;
 
 import java.io.File;
@@ -49,6 +54,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.InetAddress;
 import java.net.ServerSocket;
+import java.net.Socket;
 import java.nio.file.Files;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
@@ -67,6 +73,8 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 /** Common utilities to manage SSL transport settings. */
 public class SSLUtils {
 
+    private static final Logger LOG = LoggerFactory.getLogger(SSLUtils.class);
+
     /**
      * Creates a factory for SSL Server Sockets from the given configuration. SSL Server Sockets are
      * always part of internal communication.
@@ -81,6 +89,9 @@ public class SSLUtils {
         String[] protocols = getEnabledProtocols(config);
         String[] cipherSuites = getEnabledCipherSuites(config);
 
+        debugSslProtocolAndCiphers(
+                "internal-server-socket", protocols, Arrays.asList(cipherSuites));
+
         SSLServerSocketFactory factory = sslContext.getServerSocketFactory();
         return new ConfiguringSSLServerSocketFactory(factory, protocols, cipherSuites);
     }
@@ -88,6 +99,9 @@ public class SSLUtils {
     /**
      * Creates a factory for SSL Client Sockets from the given configuration. SSL Client Sockets are
      * always part of internal communication.
+     *
+     * <p>The returned factory explicitly applies the configured protocols and cipher suites to
+     * every socket it creates, mirroring the server-side {@code ConfiguringSSLServerSocketFactory}.
      */
     public static SocketFactory createSSLClientSocketFactory(Configuration config)
             throws Exception {
@@ -96,7 +110,14 @@ public class SSLUtils {
             throw new IllegalConfigurationException("SSL is not enabled");
         }
 
-        return sslContext.getSocketFactory();
+        String[] protocols = getEnabledProtocols(config);
+        String[] cipherSuites = getEnabledCipherSuites(config);
+
+        debugSslProtocolAndCiphers(
+                "internal-client-socket", protocols, Arrays.asList(cipherSuites));
+
+        return new ConfiguringSSLClientSocketFactory(
+                sslContext.getSocketFactory(), protocols, cipherSuites);
     }
 
     /** Creates a SSLEngineFactory to be used by internal communication server endpoints. */
@@ -370,6 +391,8 @@ public class SSLUtils {
         Optional<TrustManagerFactory> tmf = getTrustManagerFactory(config, true);
         tmf.map(sslContextBuilder::trustManager);
 
+        debugSslProtocolAndCiphers("internal-netty-socket", sslProtocols, ciphers);
+
         return sslContextBuilder
                 .sslProvider(provider)
                 .protocols(sslProtocols)
@@ -425,6 +448,7 @@ public class SSLUtils {
         if (clientMode) {
             sslContextBuilder = SslContextBuilder.forClient();
             if (clientAuth != ClientAuth.NONE) {
+                // mutual TLS is enabled at client side
                 KeyManagerFactory kmf = getKeyManagerFactory(config, false, provider);
                 sslContextBuilder.keyManager(kmf);
             }
@@ -435,20 +459,34 @@ public class SSLUtils {
             sslContextBuilder = SslContextBuilder.forServer(kmf);
         }
 
+        // Always apply operator-configured protocols and ciphers to both server and client
+        // contexts:
+        sslContextBuilder.protocols(sslProtocols).ciphers(ciphers);
+        debugSslProtocolAndCiphers("external-rest-socket", sslProtocols, ciphers);
+
         if (clientMode || clientAuth != ClientAuth.NONE) {
+            // mutual TLS is enabled at client side
             Optional<TrustManagerFactory> tmf = getTrustManagerFactory(config, false);
-            tmf.map(
-                    // Use specific ciphers and protocols if SSL is configured with self-signed
-                    // certificates (user-supplied truststore)
-                    tm ->
-                            sslContextBuilder
-                                    .trustManager(tm)
-                                    .protocols(sslProtocols)
-                                    .ciphers(ciphers)
-                                    .clientAuth(clientAuth));
+            tmf.map(tm -> sslContextBuilder.trustManager(tm).clientAuth(clientAuth));
         }
 
         return sslContextBuilder.sslProvider(provider).build();
+    }
+
+    private static void debugSslProtocolAndCiphers(
+            String sslContextName, String[] sslProtocols, List<String> ciphers) {
+        if (LOG.isDebugEnabled()) {
+            LOG.debug(
+                    "'{}' ssl context uses {}: {}",
+                    sslContextName,
+                    SecurityOptions.SSL_PROTOCOL.key(),
+                    Arrays.asList(sslProtocols));
+            LOG.debug(
+                    "'{}' ssl context uses {}: {}",
+                    sslContextName,
+                    SecurityOptions.SSL_ALGORITHMS.key(),
+                    ciphers);
+        }
     }
 
     // ------------------------------------------------------------------------
@@ -522,6 +560,62 @@ public class SSLUtils {
             socket.setEnabledProtocols(protocols);
             socket.setEnabledCipherSuites(cipherSuites);
             socket.setNeedClientAuth(true);
+        }
+    }
+
+    /**
+     * A {@link javax.net.SocketFactory} that applies operator-configured TLS protocols and cipher
+     * suites to every client socket it creates. This mirrors {@link
+     * ConfiguringSSLServerSocketFactory} for the client (BlobClient) side.
+     */
+    private static class ConfiguringSSLClientSocketFactory extends SocketFactory {
+
+        private final SSLSocketFactory sslSocketFactory;
+        private final String[] protocols;
+        private final String[] cipherSuites;
+
+        ConfiguringSSLClientSocketFactory(
+                SSLSocketFactory sslSocketFactory, String[] protocols, String[] cipherSuites) {
+            this.sslSocketFactory = sslSocketFactory;
+            this.protocols = protocols;
+            this.cipherSuites = cipherSuites;
+        }
+
+        @Override
+        public Socket createSocket() throws IOException {
+            return configureSocket((SSLSocket) sslSocketFactory.createSocket());
+        }
+
+        @Override
+        public Socket createSocket(String host, int port) throws IOException {
+            return configureSocket((SSLSocket) sslSocketFactory.createSocket(host, port));
+        }
+
+        @Override
+        public Socket createSocket(String host, int port, InetAddress localHost, int localPort)
+                throws IOException {
+            return configureSocket(
+                    (SSLSocket) sslSocketFactory.createSocket(host, port, localHost, localPort));
+        }
+
+        @Override
+        public Socket createSocket(InetAddress host, int port) throws IOException {
+            return configureSocket((SSLSocket) sslSocketFactory.createSocket(host, port));
+        }
+
+        @Override
+        public Socket createSocket(
+                InetAddress address, int port, InetAddress localAddress, int localPort)
+                throws IOException {
+            return configureSocket(
+                    (SSLSocket)
+                            sslSocketFactory.createSocket(address, port, localAddress, localPort));
+        }
+
+        private SSLSocket configureSocket(javax.net.ssl.SSLSocket socket) {
+            socket.setEnabledProtocols(protocols);
+            socket.setEnabledCipherSuites(cipherSuites);
+            return socket;
         }
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/net/SSLUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/net/SSLUtilsTest.java
@@ -34,10 +34,12 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import javax.net.ssl.SSLServerSocket;
+import javax.net.ssl.SSLSocket;
 
 import java.io.File;
 import java.io.InputStream;
 import java.net.ServerSocket;
+import java.net.Socket;
 import java.nio.file.Files;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
@@ -175,6 +177,31 @@ public class SSLUtilsTest {
         assertThat(cipherSuites).containsExactlyInAnyOrder(testSSLAlgorithms.split(","));
     }
 
+    /**
+     * Tests that the configured cipher suites are applied to the REST <b>server</b> context even
+     * when mutual authentication is disabled ({@link ClientAuth#NONE}). Previously the server
+     * context only received the configured ciphers in the mutual-auth code path and otherwise fell
+     * back to Netty's TLS defaults.
+     */
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void testRESTServerSSLConfigCipherAlgorithmsWithoutMutualAuth(String sslProvider)
+            throws Exception {
+        String testSSLAlgorithms = "test_algorithm1,test_algorithm2";
+        String testTlsVersion = "TLSv1.2,TLSv1.3";
+        Configuration config = createRestSslConfigWithKeyStore(sslProvider);
+        config.set(SecurityOptions.SSL_REST_ENABLED, true);
+        config.setString(SecurityOptions.SSL_ALGORITHMS.key(), testSSLAlgorithms);
+        config.setString(SecurityOptions.SSL_PROTOCOL.key(), testTlsVersion);
+
+        JdkSslContext nettySSLContext =
+                (JdkSslContext)
+                        SSLUtils.createRestNettySSLContext(config, false, ClientAuth.NONE, JDK);
+        List<String> cipherSuites = checkNotNull(nettySSLContext).cipherSuites();
+        assertThat(cipherSuites).hasSize(2);
+        assertThat(cipherSuites).containsExactlyInAnyOrder(testSSLAlgorithms.split(","));
+    }
+
     // ------------------------ server --------------------------
 
     /** Tests that REST Server SSL Engine is created given a valid SSL configuration. */
@@ -229,6 +256,51 @@ public class SSLUtilsTest {
 
         assertThatThrownBy(() -> SSLUtils.createRestServerSSLEngineFactory(serverConfig))
                 .isInstanceOf(KeyStoreException.class);
+    }
+
+    /**
+     * Tests that the {@link SSLHandlerFactory} produced for the REST server applies the configured
+     * protocols and cipher suites to its {@code SSLEngine} even without mutual authentication. This
+     * guards the fix where the REST server context previously fell back to Netty's TLS defaults
+     * (leading to "no cipher suites in common" against clients restricted to the configured list).
+     */
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void testRESTServerSSLEngineUsesConfiguredProtocolsAndCipherSuites(String sslProvider)
+            throws Exception {
+        Configuration serverConfig = createRestSslConfigWithKeyStore(sslProvider);
+        final String[] sslAlgorithms;
+        final String[] expectedSslProtocols;
+        if (sslProvider.equalsIgnoreCase("OPENSSL")) {
+            // openSSL does not support the same set of cipher algorithms!
+            sslAlgorithms =
+                    new String[] {
+                        "TLS_RSA_WITH_AES_128_GCM_SHA256", "TLS_RSA_WITH_AES_256_GCM_SHA384"
+                    };
+            expectedSslProtocols = new String[] {"SSLv2Hello", "TLSv1"};
+        } else {
+            sslAlgorithms =
+                    new String[] {
+                        "TLS_DHE_RSA_WITH_AES_128_CBC_SHA", "TLS_DHE_RSA_WITH_AES_128_CBC_SHA256"
+                    };
+            expectedSslProtocols = new String[] {"TLSv1"};
+        }
+
+        // set custom protocol and cipher suites; REST authentication stays disabled so the engine
+        // is built with ClientAuth.NONE.
+        serverConfig.set(SecurityOptions.SSL_PROTOCOL, "TLSv1");
+        serverConfig.set(SecurityOptions.SSL_ALGORITHMS, String.join(",", sslAlgorithms));
+
+        final SSLHandlerFactory restServerSSLHandlerFactory =
+                SSLUtils.createRestServerSSLEngineFactory(serverConfig);
+        final SslHandler sslHandler =
+                restServerSSLHandlerFactory.createNettySSLHandler(UnpooledByteBufAllocator.DEFAULT);
+
+        assertThat(sslHandler.engine().getEnabledProtocols()).hasSameSizeAs(expectedSslProtocols);
+        assertThat(sslHandler.engine().getEnabledProtocols()).contains(expectedSslProtocols);
+
+        assertThat(sslHandler.engine().getEnabledCipherSuites()).hasSameSizeAs(sslAlgorithms);
+        assertThat(sslHandler.engine().getEnabledCipherSuites()).contains(sslAlgorithms);
     }
 
     // ----------------------- mutual auth contexts --------------------------
@@ -373,6 +445,40 @@ public class SSLUtilsTest {
                 SSLUtils.createSSLServerSocketFactory(serverConfig).createServerSocket(0)) {
             assertThat(socket).isInstanceOf(SSLServerSocket.class);
             final SSLServerSocket sslSocket = (SSLServerSocket) socket;
+
+            String[] protocols = sslSocket.getEnabledProtocols();
+            String[] algorithms = sslSocket.getEnabledCipherSuites();
+
+            assertThat(protocols).hasSize(1);
+            assertThat(protocols[0]).isEqualTo("TLSv1.1");
+            assertThat(algorithms).hasSize(2);
+            assertThat(algorithms)
+                    .contains(
+                            "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+                            "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384");
+        }
+    }
+
+    /**
+     * Tests that {@link SSLUtils#createSSLClientSocketFactory} applies the configured ssl version
+     * and cipher suites to the client sockets it creates. Without the {@code
+     * ConfiguringSSLClientSocketFactory} wrapper these sockets would use the JVM defaults (all
+     * protocols and ciphers) instead of the operator-configured ones.
+     */
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void testSetSSLVersionAndCipherSuitesForSSLClientSocket(String sslProvider) throws Exception {
+        Configuration clientConfig = createInternalSslConfigWithKeyAndTrustStores(sslProvider);
+
+        // set custom protocol and cipher suites
+        clientConfig.set(SecurityOptions.SSL_PROTOCOL, "TLSv1.1");
+        clientConfig.set(
+                SecurityOptions.SSL_ALGORITHMS,
+                "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384");
+
+        try (Socket socket = SSLUtils.createSSLClientSocketFactory(clientConfig).createSocket()) {
+            assertThat(socket).isInstanceOf(SSLSocket.class);
+            final SSLSocket sslSocket = (SSLSocket) socket;
 
             String[] protocols = sslSocket.getEnabledProtocols();
             String[] algorithms = sslSocket.getEnabledCipherSuites();


### PR DESCRIPTION


## What is the purpose of the change

*Use the same SSL protcol and algorithms configuration properties in all the flink services and all clients with additional debug logs to make ssl setup visible if needed.*

In our flink environment we have to support custom `security.ssl.protocol `and `security.ssl.algorithms` configuration, so we had to test through from `Tlsv1.2` to `Tlsv1.2,Tlsv1.3` till pure `Tlsv1.3` tls protocol setups using default and non-default ciphers sets.

In the cases where there was a common set between the configured and the default java ssl.protocol-ssl.algorithms setup, then everything worked fine, there was a tls version and cipher to use between the client and service side.
However when the cases where there was not any common set we faced
- BlobClient cannot connect to its service: 
  - `org.apache.flink.runtime.blob.Connection - Error wBlobServerhile executing BLOB connection from /0:0:0:0:0:0:0:1:41630.` 
- MiniDispatcherRestEndpoint fails with: `javax.net.ssl.SSLHandshakeException: no cipher suites in common`


## Brief change log

`org.apache.flink.runtime.net.SSLUtils` needs the following adjustments: 

- [SSLUtils#createSSLClientSocketFactory does not sets the enabled protocols and cipherSuites](https://github.com/apache/flink/blob/9bc156b7faf811ca6940a05e02df900ab9bf6627/flink-runtime/src/main/java/org/apache/flink/runtime/net/SSLUtils.java#L92-L99)
  - while its service side [SSLUtils#createSSLServerSocketFactory does](https://github.com/apache/flink/blob/9bc156b7faf811ca6940a05e02df900ab9bf6627/flink-runtime/src/main/java/org/apache/flink/runtime/net/SSLUtils.java#L81-L82)
  - resulting BlobServerConnection-s were dropping its clients 
    - since server expects the configured non-default cipher, client was using the default java ciphers

- SSLUtils#createRestNettySSLContext [does sets the enabled sslProtocols and ciphers ONLY for the clients](https://github.com/apache/flink/blob/9bc156b7faf811ca6940a05e02df900ab9bf6627/flink-runtime/src/main/java/org/apache/flink/runtime/net/SSLUtils.java#L438-L449) and skips it for the services
  - Resulting Flink dashboards - MiniDispatcherRestEndpoint - uses incompatible ciphers
    - one uses the java default tls config - service,
    - one uses the non-defaults the configured one - client


## Verifying this change

org.apache.flink.runtime.net.SSLUtilsTest had been extended with the following test cases - using TDD where the new tests were failing without the code fixes:
- testRESTServerSSLConfigCipherAlgorithmsWithoutMutualAuth
- testRESTServerSSLEngineUsesConfiguredProtocolsAndCipherSuites
- testSetSSLVersionAndCipherSuitesForSSLClientSocket

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency):  no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers:  no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no

----

Was generative AI tooling used to co-author this PR?
 yes - (Cursor Agent, Opus 4.8) - used for initall code only, refacts and testing are done manually!
Generated-partially-by: Cursor Agent, Opus 4.8

