### PR TITLE
[FLINK-40002][table] Fix PushFilterInCalcIntoTableSourceScanRule for metadata filter push-down

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/source/abilities/SupportsReadingMetadata.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/source/abilities/SupportsReadingMetadata.java
@@ -174,14 +174,29 @@ public interface SupportsReadingMetadata {
 
     /**
      * Provides a list of metadata filters in conjunctive form. A source can pick filters and return
-     * the accepted and remaining filters. Same contract as {@link
-     * SupportsFilterPushDown#applyFilters(List)}, but for metadata columns.
+     * the accepted and remaining filters.
+     *
+     * <p><b>Identity contract:</b> The source MUST return the exact same {@link ResolvedExpression}
+     * instances it received — no copies, no wrappers, no rebuilds. The planner uses instance
+     * identity (not {@code equals}) to correlate returned expressions back to their original
+     * positions. Typical implementations partition the input list:
+     *
+     * <pre>{@code
+     * return MetadataFilterResult.of(
+     *     metadataFilters.subList(0, accepted),
+     *     metadataFilters.subList(accepted, metadataFilters.size()));
+     * }</pre>
      *
      * <p>The provided filters reference metadata key names (from {@link #listReadableMetadata()}),
      * not SQL column aliases. For example, a column declared as {@code msg_offset BIGINT METADATA
      * FROM 'offset'} will have its predicate expressed as {@code offset >= 1000}, not {@code
      * msg_offset >= 1000}. The planner handles the alias-to-key translation before calling this
      * method.
+     *
+     * <p>Acceptance must be decided per predicate, independent of which other predicates are in the
+     * list. On compiled-plan restore only the previously-accepted subset is re-presented, so a
+     * source that accepts one predicate only when another is also present would fail to re-accept
+     * it.
      */
     default MetadataFilterResult applyMetadataFilters(List<ResolvedExpression> metadataFilters) {
         return MetadataFilterResult.of(Collections.emptyList(), metadataFilters);

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/logical/PushFilterInCalcIntoTableSourceScanRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/logical/PushFilterInCalcIntoTableSourceScanRule.java
@@ -18,10 +18,8 @@
 
 package org.apache.flink.table.planner.plan.rules.logical;
 
-import org.apache.flink.table.connector.source.abilities.SupportsFilterPushDown;
 import org.apache.flink.table.planner.plan.nodes.logical.FlinkLogicalCalc;
 import org.apache.flink.table.planner.plan.nodes.logical.FlinkLogicalTableSourceScan;
-import org.apache.flink.table.planner.plan.schema.FlinkPreparingTableBase;
 import org.apache.flink.table.planner.plan.schema.TableSourceTable;
 import org.apache.flink.table.planner.plan.utils.FlinkRexUtil;
 
@@ -31,6 +29,10 @@ import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.rex.RexProgram;
 import org.apache.calcite.rex.RexProgramBuilder;
 import org.apache.calcite.tools.RelBuilder;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 import scala.Tuple2;
 
@@ -63,8 +65,7 @@ public class PushFilterInCalcIntoTableSourceScanRule extends PushFilterIntoSourc
 
         FlinkLogicalTableSourceScan scan = call.rel(1);
         TableSourceTable tableSourceTable = scan.getTable().unwrap(TableSourceTable.class);
-        // we can not push filter twice
-        return canPushdownFilter(tableSourceTable);
+        return canPushdownFilter(tableSourceTable) || canPushdownMetadataFilter(tableSourceTable);
     }
 
     @Override
@@ -79,7 +80,7 @@ public class PushFilterInCalcIntoTableSourceScanRule extends PushFilterIntoSourc
             RelOptRuleCall call,
             Calc calc,
             FlinkLogicalTableSourceScan scan,
-            FlinkPreparingTableBase relOptTable) {
+            TableSourceTable tableSourceTable) {
 
         RexProgram originProgram = calc.getProgram();
 
@@ -94,33 +95,29 @@ public class PushFilterInCalcIntoTableSourceScanRule extends PushFilterIntoSourc
         RexNode[] convertiblePredicates = extractedPredicates._1;
         RexNode[] unconvertedPredicates = extractedPredicates._2;
         if (convertiblePredicates.length == 0) {
-            // no condition can be translated to expression
             return;
         }
 
-        Tuple2<SupportsFilterPushDown.Result, TableSourceTable> pushdownResultWithScan =
-                resolveFiltersAndCreateTableSourceTable(
-                        convertiblePredicates,
-                        relOptTable.unwrap(TableSourceTable.class),
-                        scan,
-                        relBuilder);
+        FilterClassificationResult result =
+                classifyAndPushFilters(convertiblePredicates, tableSourceTable, scan, relBuilder);
+        if (result == null) {
+            return;
+        }
 
-        SupportsFilterPushDown.Result result = pushdownResultWithScan._1;
-        TableSourceTable tableSourceTable = pushdownResultWithScan._2;
+        List<RexNode> allRemainingRexNodes = new ArrayList<>(result.remainingPredicates);
+        allRemainingRexNodes.addAll(Arrays.asList(unconvertedPredicates));
 
         FlinkLogicalTableSourceScan newScan =
                 FlinkLogicalTableSourceScan.create(
-                        scan.getCluster(), scan.getHints(), tableSourceTable);
+                        scan.getCluster(), scan.getHints(), result.updatedTable);
 
         // build new calc program
         RexProgramBuilder programBuilder =
                 RexProgramBuilder.forProgram(originProgram, call.builder().getRexBuilder(), true);
         programBuilder.clearCondition();
 
-        if (!result.getRemainingFilters().isEmpty() || unconvertedPredicates.length != 0) {
-            RexNode remainingCondition =
-                    createRemainingCondition(
-                            relBuilder, result.getRemainingFilters(), unconvertedPredicates);
+        if (!allRemainingRexNodes.isEmpty()) {
+            RexNode remainingCondition = relBuilder.and(allRemainingRexNodes);
             RexNode simplifiedRemainingCondition =
                     FlinkRexUtil.simplify(
                             relBuilder.getRexBuilder(),

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/logical/PushFilterIntoSourceScanRuleBase.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/logical/PushFilterIntoSourceScanRuleBase.java
@@ -49,6 +49,7 @@ import org.apache.calcite.tools.RelBuilder;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -113,6 +114,82 @@ public abstract class PushFilterIntoSourceScanRuleBase extends RelOptRule {
         return new Tuple2<>(result, newTableSourceTable);
     }
 
+    /**
+     * Classifies convertible predicates into physical and metadata, pushes each through the
+     * appropriate path, and returns the updated table plus any remaining predicates.
+     */
+    protected FilterClassificationResult classifyAndPushFilters(
+            RexNode[] convertiblePredicates,
+            TableSourceTable tableSourceTable,
+            TableScan scan,
+            RelBuilder relBuilder) {
+
+        boolean supportsPhysicalFilter = canPushdownFilter(tableSourceTable);
+        boolean supportsMetadataFilter = canPushdownMetadataFilter(tableSourceTable);
+        Set<Integer> metadataColumnIndices = metadataColumnIndices(tableSourceTable, scan);
+
+        List<RexNode> allRemainingRexNodes = new ArrayList<>();
+        TableSourceTable currentTable = tableSourceTable;
+
+        List<RexNode> physicalPredicates = new ArrayList<>();
+        List<RexNode> metadataPredicates = new ArrayList<>();
+        for (RexNode predicate : convertiblePredicates) {
+            if (referencesOnlyMetadataColumns(predicate, metadataColumnIndices)) {
+                if (supportsMetadataFilter) {
+                    metadataPredicates.add(predicate);
+                } else {
+                    allRemainingRexNodes.add(predicate);
+                }
+            } else if (referencesAnyMetadataColumns(predicate, metadataColumnIndices)) {
+                allRemainingRexNodes.add(predicate);
+            } else {
+                physicalPredicates.add(predicate);
+            }
+        }
+
+        if ((physicalPredicates.isEmpty() || !supportsPhysicalFilter)
+                && metadataPredicates.isEmpty()) {
+            return null;
+        }
+
+        if (!physicalPredicates.isEmpty() && supportsPhysicalFilter) {
+            Tuple2<SupportsFilterPushDown.Result, TableSourceTable> physicalResult =
+                    resolveFiltersAndCreateTableSourceTable(
+                            physicalPredicates.toArray(new RexNode[0]),
+                            currentTable,
+                            scan,
+                            relBuilder);
+            currentTable = physicalResult._2;
+            List<RexNode> physicalRemaining =
+                    convertExpressionToRexNode(physicalResult._1.getRemainingFilters(), relBuilder);
+            allRemainingRexNodes.addAll(physicalRemaining);
+        } else {
+            allRemainingRexNodes.addAll(physicalPredicates);
+        }
+
+        if (!metadataPredicates.isEmpty()) {
+            MetadataPushDownOutcome metadataResult =
+                    resolveMetadataFiltersAndCreateTableSourceTable(
+                            metadataPredicates.toArray(new RexNode[0]), currentTable, scan);
+            currentTable = metadataResult.newTableSourceTable;
+            allRemainingRexNodes.addAll(metadataResult.remainingInputRexNodes);
+        }
+
+        return new FilterClassificationResult(currentTable, allRemainingRexNodes);
+    }
+
+    /** Result of classifying and pushing filters through physical and metadata paths. */
+    protected static final class FilterClassificationResult {
+        final TableSourceTable updatedTable;
+        final List<RexNode> remainingPredicates;
+
+        FilterClassificationResult(
+                TableSourceTable updatedTable, List<RexNode> remainingPredicates) {
+            this.updatedTable = updatedTable;
+            this.remainingPredicates = remainingPredicates;
+        }
+    }
+
     /** Whether filter push-down is possible and not already assigned. */
     protected boolean canPushdownFilter(TableSourceTable tableSourceTable) {
         return tableSourceTable != null
@@ -143,13 +220,27 @@ public abstract class PushFilterIntoSourceScanRuleBase extends RelOptRule {
      * <p>A predicate like {@code OR(physical_pred, metadata_pred)} returns false because it
      * references both physical and metadata columns. Mixed predicates remain as runtime filters.
      */
-    protected boolean referencesOnlyMetadataColumns(RexNode predicate, int physicalColumnCount) {
+    protected boolean referencesOnlyMetadataColumns(
+            RexNode predicate, Set<Integer> metadataColumnIndices) {
+        boolean[] saw = classifyColumnReferences(predicate, metadataColumnIndices);
+        return saw[1] && !saw[0];
+    }
+
+    /** True if predicate references at least one metadata column (may also reference physical). */
+    protected boolean referencesAnyMetadataColumns(
+            RexNode predicate, Set<Integer> metadataColumnIndices) {
+        boolean[] saw = classifyColumnReferences(predicate, metadataColumnIndices);
+        return saw[1];
+    }
+
+    private boolean[] classifyColumnReferences(
+            RexNode predicate, Set<Integer> metadataColumnIndices) {
         boolean[] saw = new boolean[2]; // [0] = sawPhysical, [1] = sawMetadata
         predicate.accept(
                 new RexVisitorImpl<Void>(true) {
                     @Override
                     public Void visitInputRef(RexInputRef inputRef) {
-                        if (inputRef.getIndex() >= physicalColumnCount) {
+                        if (metadataColumnIndices.contains(inputRef.getIndex())) {
                             saw[1] = true;
                         } else {
                             saw[0] = true;
@@ -157,13 +248,24 @@ public abstract class PushFilterIntoSourceScanRuleBase extends RelOptRule {
                         return null;
                     }
                 });
-        return saw[1] && !saw[0];
+        return saw;
     }
 
-    /** Number of physical columns in the scan's schema. */
-    protected int getPhysicalColumnCount(TableSourceTable tableSourceTable) {
-        ResolvedSchema schema = tableSourceTable.contextResolvedTable().getResolvedSchema();
-        return (int) schema.getColumns().stream().filter(Column::isPhysical).count();
+    /**
+     * Indices of metadata columns within the scan's current (possibly projection-narrowed) row
+     * type. Predicate {@link RexInputRef}s are positioned against this same row type, so the
+     * physical/metadata distinction must be derived from it rather than from the full table schema.
+     */
+    private Set<Integer> metadataColumnIndices(TableSourceTable tableSourceTable, TableScan scan) {
+        Map<String, String> columnToMetadataKey = buildColumnToMetadataKeyMap(tableSourceTable);
+        List<String> fieldNames = scan.getRowType().getFieldNames();
+        Set<Integer> indices = new HashSet<>();
+        for (int i = 0; i < fieldNames.size(); i++) {
+            if (columnToMetadataKey.containsKey(fieldNames.get(i))) {
+                indices.add(i);
+            }
+        }
+        return indices;
     }
 
     /** Maps SQL column names to metadata keys for metadata columns. */

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/logical/PushFilterIntoTableSourceScanRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/logical/PushFilterIntoTableSourceScanRule.java
@@ -95,63 +95,17 @@ public class PushFilterIntoTableSourceScanRule extends PushFilterIntoSourceScanR
             return;
         }
 
-        boolean supportsPhysicalFilter = canPushdownFilter(tableSourceTable);
-        boolean supportsMetadataFilter = canPushdownMetadataFilter(tableSourceTable);
-        int physicalColumnCount = getPhysicalColumnCount(tableSourceTable);
-
-        List<RexNode> allRemainingRexNodes = new ArrayList<>();
-        TableSourceTable currentTable = tableSourceTable;
-
-        // Unpushable metadata predicates stay as a runtime Calc, not the physical path —
-        // physical routing produces a FilterPushDownSpec that crashes compiled-plan restore
-        // once ProjectPushDownSpec narrows the scan row type.
-        List<RexNode> physicalPredicates = new ArrayList<>();
-        List<RexNode> metadataPredicates = new ArrayList<>();
-        for (RexNode predicate : convertiblePredicates) {
-            if (referencesOnlyMetadataColumns(predicate, physicalColumnCount)) {
-                if (supportsMetadataFilter) {
-                    metadataPredicates.add(predicate);
-                } else {
-                    allRemainingRexNodes.add(predicate);
-                }
-            } else {
-                physicalPredicates.add(predicate);
-            }
-        }
-
-        // Avoid re-firing on shapes we can't transform — saves wasted Hep iterations.
-        boolean nothingToPushPhysically = physicalPredicates.isEmpty() || !supportsPhysicalFilter;
-        if (nothingToPushPhysically && metadataPredicates.isEmpty()) {
+        FilterClassificationResult result =
+                classifyAndPushFilters(convertiblePredicates, tableSourceTable, scan, relBuilder);
+        if (result == null) {
             return;
         }
 
-        if (!physicalPredicates.isEmpty() && supportsPhysicalFilter) {
-            Tuple2<SupportsFilterPushDown.Result, TableSourceTable> physicalResult =
-                    resolveFiltersAndCreateTableSourceTable(
-                            physicalPredicates.toArray(new RexNode[0]),
-                            currentTable,
-                            scan,
-                            relBuilder);
-            currentTable = physicalResult._2;
-            List<RexNode> physicalRemaining =
-                    convertExpressionToRexNode(physicalResult._1.getRemainingFilters(), relBuilder);
-            allRemainingRexNodes.addAll(physicalRemaining);
-        } else {
-            allRemainingRexNodes.addAll(physicalPredicates);
-        }
-
-        if (!metadataPredicates.isEmpty()) {
-            MetadataPushDownOutcome metadataResult =
-                    resolveMetadataFiltersAndCreateTableSourceTable(
-                            metadataPredicates.toArray(new RexNode[0]), currentTable, scan);
-            currentTable = metadataResult.newTableSourceTable;
-            allRemainingRexNodes.addAll(metadataResult.remainingInputRexNodes);
-        }
-
+        List<RexNode> allRemainingRexNodes = new ArrayList<>(result.remainingPredicates);
         allRemainingRexNodes.addAll(Arrays.asList(unconvertedPredicates));
 
         LogicalTableScan newScan =
-                LogicalTableScan.create(scan.getCluster(), currentTable, scan.getHints());
+                LogicalTableScan.create(scan.getCluster(), result.updatedTable, scan.getHints());
 
         if (allRemainingRexNodes.isEmpty()) {
             call.transformTo(newScan);

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/rules/logical/MetadataFilterResultShapesITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/rules/logical/MetadataFilterResultShapesITCase.java
@@ -29,6 +29,7 @@ import org.apache.flink.table.api.TableEnvironment;
 import org.apache.flink.table.api.TableResult;
 import org.apache.flink.table.connector.source.DynamicTableSource;
 import org.apache.flink.table.connector.source.SourceProvider;
+import org.apache.flink.table.connector.source.abilities.SupportsFilterPushDown;
 import org.apache.flink.table.connector.source.abilities.SupportsReadingMetadata;
 import org.apache.flink.table.connector.source.abilities.SupportsReadingMetadata.MetadataFilterResult;
 import org.apache.flink.table.data.RowData;
@@ -44,6 +45,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedHashMap;
@@ -190,6 +192,77 @@ class MetadataFilterResultShapesITCase {
         assertThat(explain).contains("where=[AND(>(m0, 0), >(m1, 0))]");
     }
 
+    /**
+     * A mixed OR predicate like {@code id > 0 OR m0 > 0} references both physical and metadata
+     * columns in a single predicate that AND-decomposition cannot split. Such predicates must NOT
+     * leak into the physical {@code filter=[...]} path because {@code FilterPushDownSpec} stores
+     * RexInputRef indices without a row type — metadata column indices break during compiled-plan
+     * restore when {@code ProjectPushDownSpec} narrows the scan type.
+     *
+     * <p>The mixed predicate must stay as a runtime Calc ({@code where=[...]}).
+     */
+    @Test
+    void testMixedOrPredicateStaysAsRuntimeFilter() throws Exception {
+        Schema schema =
+                Schema.newBuilder()
+                        .column("id", INT())
+                        .columnByMetadata("m0", INT())
+                        .columnByMetadata("m1", INT())
+                        .build();
+
+        MixedFilterTrackingSource source = new MixedFilterTrackingSource();
+        TableDescriptor descriptor =
+                TableFactoryHarness.newBuilder().schema(schema).source(source).build();
+        tableEnv.createTable("T_MIXED_OR", descriptor);
+
+        // id < 3: rows 1,2.  m0 > 0: rows 1,2,5.  Union: rows 1,2,5.
+        String sql = "SELECT id FROM T_MIXED_OR WHERE id < 3 OR m0 > 0 ORDER BY id";
+
+        String explain = tableEnv.explainSql(sql);
+        assertThat(explain)
+                .as("Mixed OR must not leak into physical filter path")
+                .doesNotContain("filter=[OR(");
+        assertThat(explain)
+                .as("Mixed OR must not leak into metadata filter path")
+                .doesNotContain("metadataFilter=[OR(");
+
+        // Row data: (1,5,5), (2,5,-1), (3,-1,5), (4,-1,-1), (5,7,9), (6,0,0)
+        assertThat(collectIds(sql)).containsExactly(1, 2, 5);
+    }
+
+    /**
+     * When AND connects a pure physical predicate and a mixed OR, the physical predicate should be
+     * pushed while the mixed OR stays as a runtime Calc.
+     */
+    @Test
+    void testMixedOrWithSeparatePhysicalPredicate() throws Exception {
+        Schema schema =
+                Schema.newBuilder()
+                        .column("id", INT())
+                        .columnByMetadata("m0", INT())
+                        .columnByMetadata("m1", INT())
+                        .build();
+
+        MixedFilterTrackingSource source = new MixedFilterTrackingSource();
+        TableDescriptor descriptor =
+                TableFactoryHarness.newBuilder().schema(schema).source(source).build();
+        tableEnv.createTable("T_MIXED_OR2", descriptor);
+
+        // id > 2 (physical, pushable) AND (id < 5 OR m0 > 0) (mixed, must stay as runtime)
+        String sql = "SELECT id FROM T_MIXED_OR2 WHERE id > 2 AND (id < 5 OR m0 > 0) ORDER BY id";
+
+        String explain = tableEnv.explainSql(sql);
+        // The mixed OR must NOT appear in filter= or metadataFilter=
+        assertThat(explain)
+                .as("Mixed OR must not leak into physical filter path")
+                .doesNotContain("filter=[OR(");
+
+        // Row data: (1,5,5), (2,5,-1), (3,-1,5), (4,-1,-1), (5,7,9), (6,0,0)
+        // id>2: rows 3,4,5,6.  AND (id<5 OR m0>0): row3(yes,no→yes), row4(yes,no→yes),
+        // row5(no,yes→yes), row6(no,no→no).  Result: 3,4,5
+        assertThat(collectIds(sql)).containsExactly(3, 4, 5);
+    }
+
     // -----------------------------------------------------------------------------------------
     // Helpers
     // -----------------------------------------------------------------------------------------
@@ -299,6 +372,66 @@ class MetadataFilterResultShapesITCase {
             DataGeneratorSource<RowData> source =
                     new DataGeneratorSource<>(
                             generator, emittedRows.size(), TypeInformation.of(RowData.class));
+            return SourceProvider.of(source);
+        }
+    }
+
+    /**
+     * Source that supports both physical and metadata filter push-down. Accepts all filters it
+     * receives, emits all rows (runtime Calc is the load-bearing filter for remaining predicates).
+     */
+    static class MixedFilterTrackingSource extends TableFactoryHarness.ScanSourceBase
+            implements SupportsReadingMetadata, SupportsFilterPushDown {
+
+        private DataType producedDataType;
+        private List<ResolvedExpression> acceptedPhysicalFilters = new ArrayList<>();
+
+        MixedFilterTrackingSource() {
+            super(true);
+        }
+
+        @Override
+        public Map<String, DataType> listReadableMetadata() {
+            Map<String, DataType> metadata = new LinkedHashMap<>();
+            metadata.put("m0", INT());
+            metadata.put("m1", INT());
+            return metadata;
+        }
+
+        @Override
+        public void applyReadableMetadata(List<String> metadataKeys, DataType producedDataType) {
+            this.producedDataType = producedDataType;
+        }
+
+        @Override
+        public boolean supportsMetadataFilterPushDown() {
+            return true;
+        }
+
+        @Override
+        public MetadataFilterResult applyMetadataFilters(List<ResolvedExpression> metadataFilters) {
+            return MetadataFilterResult.of(metadataFilters, Collections.emptyList());
+        }
+
+        @Override
+        public Result applyFilters(List<ResolvedExpression> filters) {
+            acceptedPhysicalFilters.addAll(filters);
+            return Result.of(Collections.emptyList(), filters);
+        }
+
+        @Override
+        public ScanRuntimeProvider getScanRuntimeProvider(ScanContext runtimeProviderContext) {
+            DataType emitted =
+                    producedDataType != null
+                            ? producedDataType
+                            : getFactoryContext().getPhysicalRowDataType();
+            DynamicTableSource.DataStructureConverter converter =
+                    runtimeProviderContext.createDataStructureConverter(emitted);
+            GeneratorFunction<Long, RowData> generator =
+                    index -> (RowData) converter.toInternal(ROWS.get(index.intValue()));
+            DataGeneratorSource<RowData> source =
+                    new DataGeneratorSource<>(
+                            generator, ROWS.size(), TypeInformation.of(RowData.class));
             return SourceProvider.of(source);
         }
     }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/rules/logical/MetadataFilterResultShapesITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/rules/logical/MetadataFilterResultShapesITCase.java
@@ -45,7 +45,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedHashMap;
@@ -384,7 +383,6 @@ class MetadataFilterResultShapesITCase {
             implements SupportsReadingMetadata, SupportsFilterPushDown {
 
         private DataType producedDataType;
-        private List<ResolvedExpression> acceptedPhysicalFilters = new ArrayList<>();
 
         MixedFilterTrackingSource() {
             super(true);
@@ -415,7 +413,6 @@ class MetadataFilterResultShapesITCase {
 
         @Override
         public Result applyFilters(List<ResolvedExpression> filters) {
-            acceptedPhysicalFilters.addAll(filters);
             return Result.of(Collections.emptyList(), filters);
         }
 

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/rules/logical/PushFilterInCalcIntoTableSourceRuleTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/rules/logical/PushFilterInCalcIntoTableSourceRuleTest.java
@@ -113,6 +113,24 @@ class PushFilterInCalcIntoTableSourceRuleTest extends PushFilterIntoTableSourceS
     }
 
     @Test
+    void testMixedPhysicalAndMetadataFilterPushDown() {
+        String ddl =
+                "CREATE TABLE MixedPhysMetaTable (\n"
+                        + "  id BIGINT,\n"
+                        + "  m0 INT METADATA\n"
+                        + ") WITH (\n"
+                        + " 'connector' = 'values',\n"
+                        + " 'filterable-fields' = 'id',\n"
+                        + " 'enable-metadata-filter-push-down' = 'true',\n"
+                        + " 'readable-metadata' = 'm0:INT',\n"
+                        + " 'bounded' = 'true',\n"
+                        + " 'disable-lookup' = 'true'\n"
+                        + ")";
+        util.tableEnv().executeSql(ddl);
+        util.verifyRelPlan("SELECT id FROM MixedPhysMetaTable WHERE id > 5 AND m0 > 10");
+    }
+
+    @Test
     void testMetadataFilterPushdown() {
         String ddl =
                 "CREATE TABLE MetaTable (\n"

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/rules/logical/PushFilterInCalcIntoTableSourceRuleTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/rules/logical/PushFilterInCalcIntoTableSourceRuleTest.java
@@ -113,6 +113,23 @@ class PushFilterInCalcIntoTableSourceRuleTest extends PushFilterIntoTableSourceS
     }
 
     @Test
+    void testMetadataFilterPushdown() {
+        String ddl =
+                "CREATE TABLE MetaTable (\n"
+                        + "  id BIGINT,\n"
+                        + "  m0 INT METADATA\n"
+                        + ") WITH (\n"
+                        + " 'connector' = 'values',\n"
+                        + " 'enable-metadata-filter-push-down' = 'true',\n"
+                        + " 'readable-metadata' = 'm0:INT',\n"
+                        + " 'bounded' = 'true',\n"
+                        + " 'disable-lookup' = 'true'\n"
+                        + ")";
+        util.tableEnv().executeSql(ddl);
+        util.verifyRelPlan("SELECT id FROM MetaTable WHERE m0 > 10");
+    }
+
+    @Test
     void testFailureToPushFilterIntoSourceWithoutWatermarkPushdown() {
         util.verifyRelPlan("SELECT * FROM WithWatermark WHERE LOWER(name) = 'foo'");
     }

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/PushFilterInCalcIntoTableSourceRuleTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/PushFilterInCalcIntoTableSourceRuleTest.xml
@@ -252,6 +252,25 @@ FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MTable, f
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testMixedPhysicalAndMetadataFilterPushDown">
+    <Resource name="sql">
+      <![CDATA[SELECT id FROM MixedPhysMetaTable WHERE id > 5 AND m0 > 10]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(id=[$0])
++- LogicalFilter(condition=[AND(>($0, 5), >($1, 10))])
+   +- LogicalProject(id=[$0], m0=[$1])
+      +- LogicalTableScan(table=[[default_catalog, default_database, MixedPhysMetaTable, metadata=[m0]]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+FlinkLogicalCalc(select=[id])
++- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MixedPhysMetaTable, metadata=[m0], filter=[>(id, 5)], metadataFilter=[>(m0, 10)]]], fields=[id, m0])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testMetadataFilterPushdown">
     <Resource name="sql">
       <![CDATA[SELECT id FROM MetaTable WHERE m0 > 10]]>

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/PushFilterInCalcIntoTableSourceRuleTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/PushFilterInCalcIntoTableSourceRuleTest.xml
@@ -252,6 +252,25 @@ FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MTable, f
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testMetadataFilterPushdown">
+    <Resource name="sql">
+      <![CDATA[SELECT id FROM MetaTable WHERE m0 > 10]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(id=[$0])
++- LogicalFilter(condition=[>($1, 10)])
+   +- LogicalProject(id=[$0], m0=[$1])
+      +- LogicalTableScan(table=[[default_catalog, default_database, MetaTable, metadata=[m0]]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+FlinkLogicalCalc(select=[id])
++- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MetaTable, metadata=[m0], metadataFilter=[>(m0, 10)]]], fields=[id, m0])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testPartialPushDown">
     <Resource name="sql">
       <![CDATA[SELECT * FROM MyTable WHERE amount > 2 AND price > 10]]>


### PR DESCRIPTION
## What is the purpose of the change
- Mixed physical+metadata predicates now stay as runtime Calc filters
  instead of being routed through FilterPushDownSpec, which crashed on
  compiled-plan restore when ProjectPushDownSpec narrowed the row type.
- Fix PushFilterInCalcIntoTableSourceScanRule to separate metadata-only
  predicates from physical predicates, matching PushFilterIntoTableSourceScanRule.
- Extract the duplicated classify-push logic into a shared
  classifyAndPushFilters() method in PushFilterIntoSourceScanRuleBase.
- Document the identity contract on applyMetadataFilters Javadoc.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes (`SupportsReadingMetadata` — Javadoc only, no interface change)
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (Claude Sonnet 4.6)

<!--
Generated-by: Claude Sonnet 4.6
-->
