### PR TITLE
[FLINK-33725][core] Return false from MathUtils.isPowerOf2 for non-positive values

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/util/MathUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/util/MathUtils.java
@@ -98,7 +98,7 @@ public final class MathUtils {
      * @return True, if the value is a power of two, false otherwise.
      */
     public static boolean isPowerOf2(long value) {
-        return (value & (value - 1)) == 0;
+        return value > 0 && (value & (value - 1)) == 0;
     }
 
     /**

--- a/flink-core/src/test/java/org/apache/flink/util/MathUtilTest.java
+++ b/flink-core/src/test/java/org/apache/flink/util/MathUtilTest.java
@@ -123,6 +123,9 @@ class MathUtilTest {
         assertThat(MathUtils.isPowerOf2(567923)).isFalse();
         assertThat(MathUtils.isPowerOf2(Integer.MAX_VALUE)).isFalse();
         assertThat(MathUtils.isPowerOf2(Long.MAX_VALUE)).isFalse();
+        assertThat(MathUtils.isPowerOf2(0)).isFalse();
+        assertThat(MathUtils.isPowerOf2(-1)).isFalse();
+        assertThat(MathUtils.isPowerOf2(Long.MIN_VALUE)).isFalse();
     }
 
     @Test


### PR DESCRIPTION
## What is the purpose of the change

`MathUtils.isPowerOf2(long)` returns `true` for `0` and for `Long.MIN_VALUE`,
neither of which is a power of two. `0 & (0 - 1) == 0` and
`Long.MIN_VALUE & (Long.MIN_VALUE - 1) == 0`, so the existing bit trick alone
misclassifies non-positive inputs. This fixes
[FLINK-33725](https://issues.apache.org/jira/browse/FLINK-33725).

## Brief change log

  - Guard `isPowerOf2` with `value > 0` so non-positive values return `false`.
  - Extend `MathUtilTest#testPowerOfTwo` with the `0`, `-1` and `Long.MIN_VALUE` cases.

## Verifying this change

Added assertions to `MathUtilTest#testPowerOfTwo` for `0`, `-1` and `Long.MIN_VALUE`. Running just that test on the current `master` (before the one-line change) fails, and passes after it:

Before the fix (on `master`):

```
$ mvn test -Dtest=MathUtilTest#testPowerOfTwo -pl flink-core
[INFO] Running org.apache.flink.util.MathUtilTest
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0 <<< FAILURE! -- in org.apache.flink.util.MathUtilTest
[ERROR] org.apache.flink.util.MathUtilTest.testPowerOfTwo <<< FAILURE!
Expecting value to be false but was true
	at org.apache.flink.util.MathUtilTest.testPowerOfTwo(MathUtilTest.java:126)
[INFO] BUILD FAILURE
```

After the fix:

```
$ mvn test -Dtest=MathUtilTest#testPowerOfTwo -pl flink-core
[INFO] Running org.apache.flink.util.MathUtilTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0 -- in org.apache.flink.util.MathUtilTest
[INFO] BUILD SUCCESS
```

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Change to the configuration of TaskManager, etc.: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (Claude Code, Claude Opus 4.8)

Generated-by: Claude Code (Claude Opus 4.8)
