### PR TITLE
[FLINK-38961][metrics] Display process metrics (CPU, Memory, I/O) on TaskManager Web UI

### DIFF
--- a/docs/content.zh/docs/ops/metrics.md
+++ b/docs/content.zh/docs/ops/metrics.md
@@ -2316,6 +2316,44 @@ logged by `SystemResourcesMetricsInitializer` during the startup.
   </tbody>
 </table>
 
+#### Process resources
+
+These metrics describe the Flink JVM process itself, as opposed to the `System.*` metrics
+which describe the whole machine.
+
+<table class="table table-bordered">
+  <thead>
+    <tr>
+      <th class="text-left" style="width: 20%">Scope</th>
+      <th class="text-left" style="width: 25%">Infix</th>
+      <th class="text-left" style="width: 23%">Metrics</th>
+      <th class="text-left" style="width: 32%">Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th rowspan="4"><strong>Job-/TaskManager</strong></th>
+      <td>Process.CPU</td>
+      <td>Usage</td>
+      <td>% of CPU used by the Flink process, relative to the total capacity of the machine.</td>
+    </tr>
+    <tr>
+      <td>Process.Memory</td>
+      <td>RSS</td>
+      <td>Resident set size of the Flink process in bytes.</td>
+    </tr>
+    <tr>
+      <td rowspan="2">Process.IO</td>
+      <td>Read</td>
+      <td>Total bytes read by the Flink process.</td>
+    </tr>
+    <tr>
+      <td>Write</td>
+      <td>Total bytes written by the Flink process.</td>
+    </tr>
+  </tbody>
+</table>
+
 ### 预测执行
 
 以下指标可以用来衡量预测执行的有效性。

--- a/docs/content/docs/ops/metrics.md
+++ b/docs/content/docs/ops/metrics.md
@@ -2315,6 +2315,44 @@ logged by `SystemResourcesMetricsInitializer` during the startup.
   </tbody>
 </table>
 
+#### Process resources
+
+These metrics describe the Flink JVM process itself, as opposed to the `System.*` metrics
+which describe the whole machine.
+
+<table class="table table-bordered">
+  <thead>
+    <tr>
+      <th class="text-left" style="width: 20%">Scope</th>
+      <th class="text-left" style="width: 25%">Infix</th>
+      <th class="text-left" style="width: 23%">Metrics</th>
+      <th class="text-left" style="width: 32%">Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th rowspan="4"><strong>Job-/TaskManager</strong></th>
+      <td>Process.CPU</td>
+      <td>Usage</td>
+      <td>% of CPU used by the Flink process, relative to the total capacity of the machine.</td>
+    </tr>
+    <tr>
+      <td>Process.Memory</td>
+      <td>RSS</td>
+      <td>Resident set size of the Flink process in bytes.</td>
+    </tr>
+    <tr>
+      <td rowspan="2">Process.IO</td>
+      <td>Read</td>
+      <td>Total bytes read by the Flink process.</td>
+    </tr>
+    <tr>
+      <td>Write</td>
+      <td>Total bytes written by the Flink process.</td>
+    </tr>
+  </tbody>
+</table>
+
 ### Speculative Execution
 
 Metrics below can be used to measure the effectiveness of speculative execution.

--- a/flink-runtime-web/web-dashboard/src/app/pages/task-manager/metrics/task-manager-metrics.component.html
+++ b/flink-runtime-web/web-dashboard/src/app/pages/task-manager/metrics/task-manager-metrics.component.html
@@ -164,6 +164,56 @@
     </tbody>
   </nz-table>
 </nz-card>
+<nz-card nzTitle="Process Usage" nzSize="small" class="flink-memory-model">
+  <nz-table
+    nzBordered
+    [nzTemplateMode]="true"
+    [nzFrontPagination]="false"
+    [nzShowPagination]="false"
+    [nzSize]="'small'"
+    class="no-border"
+    [nzWidthConfig]="['220px', null]"
+  >
+    <thead>
+      <tr>
+        <th>
+          Type
+          <i
+            class="header-icon"
+            nz-icon
+            nz-tooltip
+            nzTooltipTitle="Process resource usage is reported only when system resource metrics are enabled via metrics.system-resource: true. Otherwise these values stay empty."
+            nzType="info-circle"
+          ></i>
+        </th>
+        <th>Value</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><strong>CPU Usage</strong></td>
+        <td>
+          {{
+            metrics['Process.CPU.Usage'] !== undefined
+              ? (metrics['Process.CPU.Usage'] | number: '1.0-6') + ' %'
+              : '-'
+          }}
+        </td>
+      </tr>
+      <tr>
+        <td><strong>Memory (RSS)</strong></td>
+        <td>{{ metrics['Process.Memory.RSS'] | humanizeBytes }}</td>
+      </tr>
+      <tr>
+        <td><strong>I/O (Read / Write)</strong></td>
+        <td>
+          {{ metrics['Process.IO.Read'] | humanizeBytes }} /
+          {{ metrics['Process.IO.Write'] | humanizeBytes }}
+        </td>
+      </tr>
+    </tbody>
+  </nz-table>
+</nz-card>
 <nz-card nzTitle="Advanced" nzSize="small" class="flink-memory-model">
   <div nz-row [nzGutter]="16">
     <div nz-col [nzSpan]="12">

--- a/flink-runtime-web/web-dashboard/src/app/pages/task-manager/metrics/task-manager-metrics.component.ts
+++ b/flink-runtime-web/web-dashboard/src/app/pages/task-manager/metrics/task-manager-metrics.component.ts
@@ -96,7 +96,11 @@ export class TaskManagerMetricsComponent implements OnInit, OnDestroy {
         'Status.Flink.Memory.Managed.Used',
         'Status.Flink.Memory.Managed.Total',
         'Status.JVM.Memory.Metaspace.Used',
-        'Status.JVM.Memory.Metaspace.Max'
+        'Status.JVM.Memory.Metaspace.Max',
+        'Process.CPU.Usage',
+        'Process.Memory.RSS',
+        'Process.IO.Read',
+        'Process.IO.Write'
       ])
       .pipe(
         catchError(() => of({} as MetricMap)),

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/util/SystemResourcesCounter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/util/SystemResourcesCounter.java
@@ -24,6 +24,8 @@ import oshi.hardware.CentralProcessor;
 import oshi.hardware.CentralProcessor.TickType;
 import oshi.hardware.HardwareAbstractionLayer;
 import oshi.hardware.NetworkIF;
+import oshi.software.os.OSProcess;
+import oshi.software.os.OperatingSystem;
 
 import javax.annotation.concurrent.ThreadSafe;
 
@@ -49,6 +51,9 @@ public class SystemResourcesCounter extends Thread {
     private final long probeIntervalMs;
     private final SystemInfo systemInfo = new SystemInfo();
     private final HardwareAbstractionLayer hardwareAbstractionLayer = systemInfo.getHardware();
+    private final OperatingSystem operatingSystem = systemInfo.getOperatingSystem();
+    private final int processId;
+    private final int logicalProcessorCount;
 
     private volatile boolean running = true;
 
@@ -78,15 +83,23 @@ public class SystemResourcesCounter extends Thread {
     private AtomicLongArray receiveRatePerInterface;
     private AtomicLongArray sendRatePerInterface;
 
+    private OSProcess previousProcessSnapshot;
+
+    private volatile double processCpuUsage;
+    private volatile long processMemoryRSS;
+    private volatile long processBytesRead;
+    private volatile long processBytesWritten;
+
     public SystemResourcesCounter(Duration probeInterval) {
         probeIntervalMs = probeInterval.toMillis();
         checkState(this.probeIntervalMs > 0);
 
         setName(SystemResourcesCounter.class.getSimpleName() + " probing thread");
 
-        cpuUsagePerProcessor =
-                new AtomicReferenceArray<>(
-                        hardwareAbstractionLayer.getProcessor().getLogicalProcessorCount());
+        processId = operatingSystem.getProcessId();
+        logicalProcessorCount = hardwareAbstractionLayer.getProcessor().getLogicalProcessorCount();
+
+        cpuUsagePerProcessor = new AtomicReferenceArray<>(logicalProcessorCount);
 
         List<NetworkIF> networkIFs = hardwareAbstractionLayer.getNetworkIFs();
         bytesReceivedPerInterface = new long[networkIFs.size()];
@@ -106,6 +119,7 @@ public class SystemResourcesCounter extends Thread {
             while (running) {
                 calculateCPUUsage(hardwareAbstractionLayer.getProcessor());
                 calculateNetworkUsage(hardwareAbstractionLayer.getNetworkIFs());
+                calculateProcessUsage();
                 Thread.sleep(probeIntervalMs);
             }
         } catch (InterruptedException e) {
@@ -187,6 +201,22 @@ public class SystemResourcesCounter extends Thread {
 
     public long getSendRatePerInterface(int interfaceNo) {
         return sendRatePerInterface.get(interfaceNo);
+    }
+
+    public double getProcessCpuUsage() {
+        return processCpuUsage;
+    }
+
+    public long getProcessMemoryRSS() {
+        return processMemoryRSS;
+    }
+
+    public long getProcessBytesRead() {
+        return processBytesRead;
+    }
+
+    public long getProcessBytesWritten() {
+        return processBytesWritten;
     }
 
     private long[] getSystemCpuLoadTicksDiff(CentralProcessor processor) {
@@ -279,5 +309,25 @@ public class SystemResourcesCounter extends Thread {
             bytesReceivedPerInterface[i] = networkIF.getBytesRecv();
             bytesSentPerInterface[i] = networkIF.getBytesSent();
         }
+    }
+
+    private void calculateProcessUsage() {
+        OSProcess process = operatingSystem.getProcess(processId);
+        if (process == null) {
+            return;
+        }
+        // CPU load is only available relative to a prior snapshot; report 0 until we have one.
+        if (previousProcessSnapshot != null) {
+            // getProcessCpuLoadBetweenTicks() returns the number of cores used; normalize it to a
+            // percentage of the whole machine to match the semantics of System.CPU.Usage.
+            processCpuUsage =
+                    100d
+                            * process.getProcessCpuLoadBetweenTicks(previousProcessSnapshot)
+                            / logicalProcessorCount;
+        }
+        processMemoryRSS = process.getResidentSetSize();
+        processBytesRead = process.getBytesRead();
+        processBytesWritten = process.getBytesWritten();
+        previousProcessSnapshot = process;
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/util/SystemResourcesMetricsInitializer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/util/SystemResourcesMetricsInitializer.java
@@ -50,6 +50,8 @@ public class SystemResourcesMetricsInitializer {
             instantiateSwapMetrics(system.addGroup("Swap"), hardwareAbstractionLayer.getMemory());
             instantiateCPUMetrics(system.addGroup("CPU"), systemResourcesCounter);
             instantiateNetworkMetrics(system.addGroup("Network"), systemResourcesCounter);
+
+            instantiateProcessMetrics(metricGroup.addGroup("Process"), systemResourcesCounter);
         } catch (NoClassDefFoundError ex) {
             LOG.warn(
                     "Failed to initialize system resource metrics because of missing class definitions."
@@ -90,6 +92,19 @@ public class SystemResourcesMetricsInitializer {
                     String.format("UsageCPU%d", processor),
                     () -> usageCounter.getCpuUsagePerProcessor(processor));
         }
+    }
+
+    private static void instantiateProcessMetrics(
+            MetricGroup metrics, SystemResourcesCounter usageCounter) {
+        metrics.addGroup("CPU")
+                .<Double, Gauge<Double>>gauge("Usage", usageCounter::getProcessCpuUsage);
+
+        metrics.addGroup("Memory")
+                .<Long, Gauge<Long>>gauge("RSS", usageCounter::getProcessMemoryRSS);
+
+        MetricGroup io = metrics.addGroup("IO");
+        io.<Long, Gauge<Long>>gauge("Read", usageCounter::getProcessBytesRead);
+        io.<Long, Gauge<Long>>gauge("Write", usageCounter::getProcessBytesWritten);
     }
 
     private static void instantiateNetworkMetrics(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/utils/SystemResourcesCounterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/utils/SystemResourcesCounterTest.java
@@ -66,5 +66,14 @@ class SystemResourcesCounterTest {
                 .withFailMessage("There should be at least one network interface")
                 .isGreaterThan(0);
         assertThat(totalCpuUsage + systemResources.getCpuIdle()).isCloseTo(100.0, within(EPSILON));
+
+        // The current process must occupy some resident memory; CPU and I/O can legitimately be
+        // zero on a quiet/unsupported platform, so we only assert they are non-negative.
+        assertThat(systemResources.getProcessMemoryRSS())
+                .withFailMessage("Process RSS should be positive")
+                .isGreaterThan(0);
+        assertThat(systemResources.getProcessCpuUsage()).isGreaterThanOrEqualTo(0.0);
+        assertThat(systemResources.getProcessBytesRead()).isGreaterThanOrEqualTo(0);
+        assertThat(systemResources.getProcessBytesWritten()).isGreaterThanOrEqualTo(0);
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

This pull request surfaces the TaskManager **process's own** resource usage (CPU, memory and disk I/O) as Flink metrics and displays them on the TaskManager Web UI.

When `metrics.system-resource` is enabled, `SystemResourcesCounter` now additionally collects the TaskManager process's CPU usage, resident set size and disk bytes read/written via OSHI, exposing them as the `Process.CPU.Usage`, `Process.Memory.RSS`, `Process.IO.Read` and `Process.IO.Write` gauges. A new "Process Usage" panel on the TaskManager metrics page renders these values.

## Brief change log

  - `SystemResourcesCounter` collects per-process CPU usage, RSS and disk read/written bytes via OSHI
  - `SystemResourcesMetricsInitializer` registers the new `Process.*` gauges
  - Added a "Process Usage" panel to the TaskManager metrics page in the Web UI, querying the new gauges over the REST API
  - Documented the new metrics in `docs/content/docs/ops/metrics.md` and the zh translation

## Verifying this change

This change added unit-test coverage in `SystemResourcesCounterTest` and can additionally be verified as follows:

  - Start a cluster with `metrics.system-resource: true`, open the TaskManager metrics page and confirm the new "Process Usage" panel shows CPU, memory (RSS) and combined I/O.

Note: per-process I/O is only populated on platforms where OSHI supports it (e.g. Linux via `/proc`); on macOS these counters report 0.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no** (OSHI is already a Flink dependency)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **yes**
  - If yes, how is the feature documented? **docs** (`metrics.md`, en + zh)

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (Claude Code)

Generated-by: Claude Code
