### PR TITLE
[FLINK-40009][FLINK-40010][runtime] Stabilize RescaleTimelineITCase

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/timeline/RescaleTimelineITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/timeline/RescaleTimelineITCase.java
@@ -351,6 +351,16 @@ class RescaleTimelineITCase {
 
     @TestTemplate
     void testRescaleTerminatedByNoResourcesOrNoParallelismsChange() throws Exception {
+        // This case only asserts on the recorded rescale history; skip the disabled-history
+        // parameter before the cluster rebuild below so it does not pay for an unused cluster.
+        assumeThat(enabledRescaleHistory(configuration)).isTrue();
+
+        // NO_RESOURCES_OR_PARALLELISMS_CHANGE is only stamped when the update RPC is processed
+        // during Cooldown and the manager re-enters Idling. Unlike the sibling
+        // testRescaleTerminatedByResourceRequirementsUpdated, this case must wait out the whole
+        // cooldown, so it cannot reuse 60s: 10s outlasts the RPC yet stays within the 60s budget.
+        rebuildClusterWithExecutingTimeouts(Duration.ofSeconds(10), Duration.ofMillis(50));
+
         final MiniCluster miniCluster = miniClusterResource.getMiniCluster();
         final JobGraph jobGraph = createBlockingJobGraph(PARALLELISM);
         miniCluster.submitJob(jobGraph).join();
@@ -358,7 +368,6 @@ class RescaleTimelineITCase {
 
         updateJobResourceRequirements(miniCluster, jobGraph, 1, PARALLELISM * 2);
 
-        assumeThat(enabledRescaleHistory(configuration)).isTrue();
         waitUntilConditionWithTimeout(
                 () -> {
                     List<Rescale> rescaleHistory = getRescaleHistory(miniCluster, jobGraph);
@@ -367,7 +376,7 @@ class RescaleTimelineITCase {
                             2,
                             TerminatedReason.NO_RESOURCES_OR_PARALLELISMS_CHANGE);
                 },
-                20000);
+                60000);
     }
 
     @TestTemplate
@@ -396,44 +405,12 @@ class RescaleTimelineITCase {
         // parameter before the cluster rebuild below so it does not pay for an unused cluster.
         assumeThat(enabledRescaleHistory(configuration)).isTrue();
 
-        // This test asserts that the second resource-requirements update terminates the in-progress
-        // rescale started by the first update with terminal reason RESOURCE_REQUIREMENTS_UPDATED.
-        // For that to happen the second update must be processed while the first rescale is still
-        // in-progress: AdaptiveScheduler#recordRescaleForNewResourceRequirements only sets the
-        // RESOURCE_REQUIREMENTS_UPDATED reason via RescaleTimeline#updateRescale, which is a no-op
-        // once the current rescale is already terminated (DefaultRescaleTimeline#isIdling).
-        //
-        // The upper bound exceeds the available slots, so the first rescale cannot change the
-        // parallelism. With the short cooldown/stabilization timeouts shared by the other cases the
-        // DefaultStateTransitionManager re-enters its Idling phase and the Idling constructor
-        // terminates that rescale with NO_RESOURCES_OR_PARALLELISMS_CHANGE (a legitimate terminal
-        // reason for an in-progress rescale that cannot change parallelism). That termination is
-        // driven by wall-clock timers that start the moment the first rescale is recorded, so no
-        // amount of waiting between the two updates can guarantee the second update wins the race;
-        // waiting only consumes the same budget. Widening cooldown and stabilization for this case
-        // is therefore the only deterministic test-side fix: it keeps the in-progress rescale alive
-        // far longer than the single synchronous RPC round trip between the two updates.
-        //
-        // Rebuild the shared fixture cluster in place rather than starting a second one on top of
-        // it, so only one cluster is ever running and the @AfterEach teardown still applies. 60s is
-        // an intentionally generous bound (the suite already uses second-scale guards for slow CI);
-        // the test completes as soon as the second update lands, so a large value has no cost.
-        miniClusterResource.after();
-        final Configuration testConfiguration = new Configuration(configuration);
-        testConfiguration.set(
-                JobManagerOptions.SCHEDULER_EXECUTING_COOLDOWN_AFTER_RESCALING,
-                Duration.ofSeconds(60));
-        testConfiguration.set(
-                JobManagerOptions.SCHEDULER_EXECUTING_RESOURCE_STABILIZATION_TIMEOUT,
-                Duration.ofSeconds(60));
-        miniClusterResource =
-                new MiniClusterResource(
-                        new MiniClusterResourceConfiguration.Builder()
-                                .setConfiguration(testConfiguration)
-                                .setNumberSlotsPerTaskManager(NUMBER_SLOTS_PER_TASK_MANAGER)
-                                .setNumberTaskManagers(NUMBER_TASK_MANAGERS)
-                                .build());
-        miniClusterResource.before();
+        // The second update only terminates the first rescale with RESOURCE_REQUIREMENTS_UPDATED
+        // while that rescale is still in-progress; once it is terminated, updateRescale is a no-op.
+        // With the short shared cooldown the manager re-enters Idling and terminates it on a
+        // wall-clock timer first, so waiting cannot win the race. Widening cooldown and
+        // stabilization to 60s keeps the rescale in-progress far longer than the RPC round trip.
+        rebuildClusterWithExecutingTimeouts(Duration.ofSeconds(60), Duration.ofSeconds(60));
 
         final MiniCluster miniCluster = miniClusterResource.getMiniCluster();
         final JobGraph jobGraph = createBlockingJobGraph(PARALLELISM);
@@ -738,6 +715,30 @@ class RescaleTimelineITCase {
                 () ->
                         miniClusterResource.getMiniCluster().getJobStatus(jobGraph.getJobID()).get()
                                 == JobStatus.RUNNING);
+    }
+
+    /**
+     * Rebuilds the shared fixture cluster in place with the given executing-phase cooldown and
+     * resource-stabilization timeouts. Rebuilding in place rather than starting a second cluster
+     * keeps a single cluster running so the {@link AfterEach} teardown still applies.
+     */
+    private void rebuildClusterWithExecutingTimeouts(
+            Duration cooldown, Duration resourceStabilizationTimeout) throws Exception {
+        miniClusterResource.after();
+        final Configuration testConfiguration = new Configuration(configuration);
+        testConfiguration.set(
+                JobManagerOptions.SCHEDULER_EXECUTING_COOLDOWN_AFTER_RESCALING, cooldown);
+        testConfiguration.set(
+                JobManagerOptions.SCHEDULER_EXECUTING_RESOURCE_STABILIZATION_TIMEOUT,
+                resourceStabilizationTimeout);
+        miniClusterResource =
+                new MiniClusterResource(
+                        new MiniClusterResourceConfiguration.Builder()
+                                .setConfiguration(testConfiguration)
+                                .setNumberSlotsPerTaskManager(NUMBER_SLOTS_PER_TASK_MANAGER)
+                                .setNumberTaskManagers(NUMBER_TASK_MANAGERS)
+                                .build());
+        miniClusterResource.before();
     }
 
     private void updateJobResourceRequirements(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/timeline/RescaleTimelineITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/timeline/RescaleTimelineITCase.java
@@ -57,9 +57,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
@@ -77,6 +75,8 @@ class RescaleTimelineITCase {
     private static final int NUMBER_TASK_MANAGERS = 2;
     private static final int PARALLELISM = NUMBER_SLOTS_PER_TASK_MANAGER * NUMBER_TASK_MANAGERS;
     private static final JobVertexID JOB_VERTEX_ID = new JobVertexID();
+    // Matches the default poll interval of the CommonTestUtils#waitUntilCondition it replaced.
+    private static final long RETRY_INTERVAL_MILLIS = 100L;
 
     @Parameter private Configuration configuration;
     private MiniClusterResource miniClusterResource;
@@ -700,15 +700,21 @@ class RescaleTimelineITCase {
     private void waitUntilConditionWithTimeout(
             SupplierWithException<Boolean, Exception> condition, long timeoutMillis)
             throws Exception {
-        CompletableFuture.runAsync(
-                        () -> {
-                            try {
-                                CommonTestUtils.waitUntilCondition(condition);
-                            } catch (Exception e) {
-                                throw new RuntimeException(e);
-                            }
-                        })
-                .get(timeoutMillis, TimeUnit.MILLISECONDS);
+        // Poll synchronously via waitUtil. The previous CompletableFuture#runAsync + get(timeout)
+        // wrapper hangs on JDK 11: on a ForkJoinPool worker (JUnit's executor) timedGet
+        // help-executes the unbounded poll loop inline on the waiting thread, so the timeout
+        // never fires.
+        org.apache.flink.core.testutils.CommonTestUtils.waitUtil(
+                () -> {
+                    try {
+                        return condition.get();
+                    } catch (Exception e) {
+                        throw new RuntimeException(e);
+                    }
+                },
+                Duration.ofMillis(timeoutMillis),
+                Duration.ofMillis(RETRY_INTERVAL_MILLIS),
+                "Condition was not met within " + timeoutMillis + " ms.");
     }
 
     private void waitForVertexParallelismReachedAndJobRunning(


### PR DESCRIPTION
## What is the purpose of the change

`RescaleTimelineITCase` is flaky on CI in two independent ways, fixed here as two commits:

- **FLINK-40009** — `waitUntilConditionWithTimeout` never enforces its timeout on JDK 11 when the test runs on a ForkJoinPool worker (the test can hang until the CI watchdog kills the fork; a thread dump in build 76242, the `test_cron_jdk11` leg, showed it parked after 978s on a 20s budget).
- **FLINK-40010** — `testRescaleTerminatedByNoResourcesOrNoParallelismsChange` can time out because the awaited terminal reason `NO_RESOURCES_OR_PARALLELISMS_CHANGE` is never recorded (builds 76242, 76350).

## Brief change log

- **FLINK-40009**: `waitUntilConditionWithTimeout` wrapped an unbounded `CommonTestUtils#waitUntilCondition` in `CompletableFuture#runAsync` and bounded it with `get(timeout)`. On JDK 11, when the test runs on a ForkJoinPool worker (JUnit 5's test executor), `CompletableFuture#timedGet` help-executes the async task inline via `ForkJoinPool#helpAsyncBlocker`, so the never-ending poll loop runs on the waiting thread and the timeout never fires. (JDK 17 and 21 changed `helpAsyncBlocker` and do not hang.) Replaced with a synchronous poll on the calling thread via `CommonTestUtils#waitUtil`.
- **FLINK-40010**: `NO_RESOURCES_OR_PARALLELISMS_CHANGE` is stamped only on the rescale tracked when the manager re-enters its Idling phase. With the short shared cooldown, the cooldown can elapse and Idling be reached before the requirements-update RPC is processed, so the `UPDATE_REQUIREMENT` rescale never receives the terminal reason. The fixture is rebuilt with a 10s cooldown (with the wait budget widened to 60s) so the update is processed in Cooldown and routed back through Idling. The shared cluster-rebuild logic is extracted into a helper reused by the sibling `testRescaleTerminatedByResourceRequirementsUpdated`.

## Verifying this change

This change is already covered by existing tests in `RescaleTimelineITCase`. Verified locally: the failing method passes repeatedly; the full `RescaleTimelineITCase` is green (30 run, 8 skipped, 0 failures). A standalone probe of the `CompletableFuture#runAsync` + `get(timeout)` pattern reproduced the hang on JDK 11 (~100% of iterations) and confirmed JDK 17/21 do not hang, matching the CI thread dump; the rewritten helper enforces the timeout.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (Claude Opus 4.8 (1M context))

Generated-by: Claude Opus 4.8 (1M context)
