### PR TITLE
[FLINK-21995][yarn-tests] Whitelist netty-wrapped Pekko connection-refused WARN

### DIFF
--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YarnTestBase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YarnTestBase.java
@@ -152,8 +152,9 @@ public abstract class YarnTestBase {
         Pattern.compile(
                 "Remote connection to \\[.*\\] failed with java.nio.channels.NotYetConnectedException"),
         Pattern.compile("java\\.io\\.IOException: Connection reset by peer"),
+        // gated re-association WARN; the cause may now be Netty-wrapped
         Pattern.compile(
-                "Association with remote system \\[pekko.tcp://flink@[^]]+\\] has failed, address is now gated for \\[50\\] ms. Reason: \\[Association failed with \\[pekko.tcp://flink@[^]]+\\]\\] Caused by: \\[java.net.ConnectException: Connection refused: [^]]+\\]"),
+                "Association with remote system \\[pekko.tcp://flink@[^]]+\\] has failed, address is now gated for \\[50\\] ms. Reason: \\[Association failed with \\[pekko.tcp://flink@[^]]+\\]\\] Caused by: \\[(java\\.net\\.ConnectException|org\\.apache\\.flink\\.shaded\\.netty4\\.io\\.netty\\.channel\\.AbstractChannel\\$AnnotatedConnectException): Connection refused[^]]*\\]"),
 
         // filter out expected ResourceManagerException caused by intended shutdown request
         Pattern.compile(YarnResourceManagerDriver.ERROR_MESSAGE_ON_SHUTDOWN_REQUEST),

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YarnTestBaseTest.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YarnTestBaseTest.java
@@ -33,7 +33,17 @@ class YarnTestBaseTest {
         ensureWhitelistEntryMatch(
                 "2020-09-19 22:06:19,458 WARN  org.apache.pekko.remote.ReliableDeliverySupervisor                       [] - Association with remote system [pekko.tcp://flink@e466f3e261f3:42352] has failed, address is now gated for [50] ms. Reason: [Association failed with [pekko.tcp://flink@e466f3e261f3:42352]] Caused by: [java.net.ConnectException: Connection refused: e466f3e261f3/192.168.224.2:42352]");
         ensureWhitelistEntryMatch(
+                "2026-06-18 05:08:21,447 WARN  org.apache.pekko.remote.ReliableDeliverySupervisor           [] - Association with remote system [pekko.tcp://flink@14b2224d67fd:38335] has failed, address is now gated for [50] ms. Reason: [Association failed with [pekko.tcp://flink@14b2224d67fd:38335]] Caused by: [org.apache.flink.shaded.netty4.io.netty.channel.AbstractChannel$AnnotatedConnectException: Connection refused: 14b2224d67fd/172.21.0.2:38335, caused by: java.net.ConnectException: Connection refused]");
+        ensureWhitelistEntryMatch(
                 "2020-10-15 10:31:09,661 WARN  org.apache.pekko.remote.transport.netty.NettyTransport                   [] - Remote connection to [61b81e62b514/192.168.128.2:39365] failed with java.io.IOException: Broken pipe");
+    }
+
+    @Test
+    void ensureGatedReassociationWithNonConnectionCauseIsNotWhitelisted() {
+        ensureWhitelistEntryDoesNotMatch(
+                "2026-06-18 05:08:21,447 WARN  org.apache.pekko.remote.ReliableDeliverySupervisor           [] - Association with remote system [pekko.tcp://flink@14b2224d67fd:38335] has failed, address is now gated for [50] ms. Reason: [Association failed with [pekko.tcp://flink@14b2224d67fd:38335]] Caused by: [java.lang.IllegalStateException: something unrelated]");
+        ensureWhitelistEntryDoesNotMatch(
+                "2026-06-18 05:08:21,447 WARN  org.apache.pekko.remote.ReliableDeliverySupervisor           [] - Association with remote system [pekko.tcp://flink@14b2224d67fd:38335] has failed, address is now gated for [50] ms. Reason: [Association failed with [pekko.tcp://flink@14b2224d67fd:38335]] Caused by: [java.lang.NullPointerException: Connection refused: 14b2224d67fd/172.21.0.2:38335]");
     }
 
     private void ensureWhitelistEntryMatch(String probe) {
@@ -43,5 +53,18 @@ class YarnTestBaseTest {
             }
         }
         fail("The following string didn't match any whitelisted patterns '" + probe + "'");
+    }
+
+    private void ensureWhitelistEntryDoesNotMatch(String probe) {
+        for (Pattern pattern : YarnTestBase.WHITELISTED_STRINGS) {
+            if (pattern.matcher(probe).find()) {
+                fail(
+                        "The following string unexpectedly matched whitelisted pattern '"
+                                + pattern
+                                + "': '"
+                                + probe
+                                + "'");
+            }
+        }
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

`YARNSessionFIFOSecuredITCase` (and the other YARN session ITCases) flakily fails in the `checkForProhibitedLogContents` hook, which scans the TaskManager/JobManager logs for prohibited substrings such as `Exception`. A benign transient WARN is emitted by Pekko during association teardown when a remote system is gated and the reconnect is refused. That line was already whitelisted, but the whitelist regex assumed the cause was a bare `java.net.ConnectException: Connection refused: <host>`. Current Pekko/Netty wraps the cause in `org.apache.flink.shaded.netty4.io.netty.channel.AbstractChannel$AnnotatedConnectException`, so the line no longer matches and the transient WARN trips the check.

This is the long-standing prohibited-log-contents flakiness tracked under FLINK-21995; it most recently surfaced as `testDetachedMode` (FLINK-26514). The example WARN line observed in CI:

```
WARN org.apache.pekko.remote.ReliableDeliverySupervisor - Association with remote system [pekko.tcp://flink@<host>:<port>] has failed, address is now gated for [50] ms. Reason: [Association failed with [pekko.tcp://flink@<host>:<port>]] Caused by: [org.apache.flink.shaded.netty4.io.netty.channel.AbstractChannel$AnnotatedConnectException: Connection refused: <host>/<ip>:<port>, caused by: java.net.ConnectException: Connection refused]
```

This change removes one source of false positives in the prohibited-log-contents check. It does not claim to address every flaky cause tracked under FLINK-21995.

## Brief change log

  - Extend the `Caused by:` portion of the existing gated-reassociation whitelist pattern in `YarnTestBase.WHITELISTED_STRINGS` to accept both the old direct `java.net.ConnectException` form and the new Netty-wrapped `AbstractChannel$AnnotatedConnectException` form. The cause class is pinned to those two known types (not any class mentioning "Connection refused"), so an unrelated exception cannot slip through; the rest of the pattern stays specific to the gated re-association WARN.
  - Add a positive probe for the wrapped form and a negative probe (a gated-reassociation WARN with a non-connection cause, still containing "Connection refused" text) to `YarnTestBaseTest`, guarding the discriminating property of the pattern.

## Verifying this change

This change added tests and can be verified as follows:

  - `YarnTestBaseTest` exercises `YarnTestBase.WHITELISTED_STRINGS` end-to-end. Positive probes cover the bare `java.net.ConnectException` form, the new Netty-wrapped `AnnotatedConnectException` form, and the existing `Broken pipe` line. A new negative probe asserts that a gated-reassociation WARN with an unrelated cause (e.g. `IllegalStateException`, and a `NullPointerException: Connection refused ...` decoy) is NOT whitelisted.
  - Red/green confirmed: against the previous regex the wrapped-form probe fails with the exact message seen in CI; against the relaxed-but-pinned regex it passes, and the negative probe fails if the pattern is loosened to match "Connection refused" alone.
  - `spotless:check` passes on `flink-yarn-tests`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no (test-only change in `flink-yarn-tests`)
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (Claude Code, Opus 4.8)

Generated-by: Claude Code (Opus 4.8)
