### PR TITLE
[FLINK-40013][table] Correctly clear state in ctx.clearState in ProcessTableFunctionTestHarness

### DIFF
--- a/flink-table/flink-table-test-utils/src/main/java/org/apache/flink/table/runtime/functions/TestHarnessStateManager.java
+++ b/flink-table/flink-table-test-utils/src/main/java/org/apache/flink/table/runtime/functions/TestHarnessStateManager.java
@@ -124,7 +124,10 @@ class TestHarnessStateManager {
         Map<String, Object> internalState = new HashMap<>();
         for (ProcessTableFunctionTestHarness.StateArgumentInfo stateArg : stateArguments) {
             Object external = externalState.get(stateArg.name);
-            Object internalData = convertToInternal(external, stateArg);
+            Object internalData =
+                    external == null
+                            ? createNewStateInternalData(stateArg)
+                            : convertToInternal(external, stateArg);
             internalState.put(stateArg.name, internalData);
         }
         stateByKey.put(key, internalState);

--- a/flink-table/flink-table-test-utils/src/test/java/org/apache/flink/table/runtime/functions/ProcessTableFunctionTestHarnessTest.java
+++ b/flink-table/flink-table-test-utils/src/test/java/org/apache/flink/table/runtime/functions/ProcessTableFunctionTestHarnessTest.java
@@ -1918,9 +1918,6 @@ class ProcessTableFunctionTestHarnessTest {
                         Row input) {
             String action = input.getFieldAs("action");
             if ("increment".equals(action)) {
-                if (state == null) {
-                    state = new CounterState();
-                }
                 state.count++;
                 collect(Row.of("count=" + state.count));
             } else if ("clear-state".equals(action)) {


### PR DESCRIPTION
## What is the purpose of the change

While validating the behaviour of the PTF test harness against the tests defined in `ProcessTableFunctionTestPrograms`, I found that the harness was incorrectly handling instances where, inside a PTF, the user calls `ctx.clearState()` to clear the state.

This caused the harness to write back a `null` value to the underlying state handler, which would then be passed into the PTF and cause a npe within the PTF which expects a non-null state. The tests didn't surface this because I had added a defensive null check for the state within the context state clearing PTF 🤦‍♀️ 

This PR instead maps to the behaviour of live by writing a freshly created instance of the state to backing state store when the state is cleared, rather than a null.

## Brief change log

- Fixed bug in ProcessTableFunctionTestHarness when clearing state using `ctx.clearState`


## Verifying this change

This change is already covered by existing tests, such as `testContextClearState` and `testContextClearAllState` in `ProcessTableFunctionTestHarnessTest`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
