### PR TITLE
feat: new baseline nightly build

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -72,6 +72,17 @@ jobs:
       s3_bucket: ${{ secrets.IT_CASE_S3_BUCKET }}
       s3_access_key: ${{ secrets.IT_CASE_S3_ACCESS_KEY }}
       s3_secret_key: ${{ secrets.IT_CASE_S3_SECRET_KEY }}
+  java17:
+    name: "Java 17 (default)"
+    uses: ./.github/workflows/template.flink-ci.yml
+    with:
+      workflow-caller-id: java17
+      environment: 'PROFILE="-Dflink.hadoop.version=2.10.2 -Djdk17 -Pjava17-target"'
+      jdk_version: 17
+    secrets:
+      s3_bucket: ${{ secrets.IT_CASE_S3_BUCKET }}
+      s3_access_key: ${{ secrets.IT_CASE_S3_ACCESS_KEY }}
+      s3_secret_key: ${{ secrets.IT_CASE_S3_SECRET_KEY }}
 
   build_python_wheels:
     name: "Build Python Wheels on ${{ matrix.os_name }}"


### PR DESCRIPTION
Azure's nightly stage in tools/azure-pipelines/build-apache-repo.yml has cron_azure as a default baseline build, but there is no equivalent build in the Github Actions scheduled nightly pipeline.

The goal of this commit is to update the GHA nightly release pipeline towards parity with the AZP implementation, treating it as a reference.