### PR TITLE
[FLINK-40012][table] Correctly inject Context into scalar-only PTFs in ProcessTableFunctionTestHarness

### DIFF
--- a/flink-table/flink-table-test-utils/src/main/java/org/apache/flink/table/runtime/functions/InvocationContext.java
+++ b/flink-table/flink-table-test-utils/src/main/java/org/apache/flink/table/runtime/functions/InvocationContext.java
@@ -51,6 +51,10 @@ class InvocationContext {
         return new InvocationContext(timer.partitionKey, null, null, timer);
     }
 
+    static InvocationContext forScalarOnlyEval() {
+        return new InvocationContext(Row.of(), null, null, null);
+    }
+
     boolean isTimerInvocation() {
         return firingTimer != null;
     }

--- a/flink-table/flink-table-test-utils/src/main/java/org/apache/flink/table/runtime/functions/ProcessTableFunctionTestHarness.java
+++ b/flink-table/flink-table-test-utils/src/main/java/org/apache/flink/table/runtime/functions/ProcessTableFunctionTestHarness.java
@@ -287,10 +287,13 @@ public class ProcessTableFunctionTestHarness<OUT> implements AutoCloseable {
         Object[] args = arguments.stream().map(arg -> ((ScalarArgumentInfo) arg).value).toArray();
 
         try {
-            eval.method.invoke(function, args);
+            currentInvocation = InvocationContext.forScalarOnlyEval();
+            eval.invoke(function, new TestContext(new HashMap<>()), args);
         } catch (InvocationTargetException e) {
             handleEvalInvocationException(
                     "Exception occurred during scalar-only PTF eval() invocation.\n", args, e);
+        } finally {
+            currentInvocation = null;
         }
     }
 

--- a/flink-table/flink-table-test-utils/src/test/java/org/apache/flink/table/runtime/functions/ProcessTableFunctionTestHarnessTest.java
+++ b/flink-table/flink-table-test-utils/src/test/java/org/apache/flink/table/runtime/functions/ProcessTableFunctionTestHarnessTest.java
@@ -328,6 +328,21 @@ class ProcessTableFunctionTestHarnessTest {
         }
     }
 
+    /**
+     * Scalar-only PTF whose eval() takes a {@link ProcessTableFunction.Context}. With no table
+     * arguments, we expect there to be no time/watermark, so both resolve to null.
+     */
+    @DataTypeHint("ROW<ts INT, watermark INT, value INT>")
+    public static class ScalarOnlyContextPTF extends ProcessTableFunction<Row> {
+        public void eval(
+                Context ctx,
+                @ArgumentHint(ArgumentTrait.SCALAR) Integer a,
+                @ArgumentHint(ArgumentTrait.SCALAR) Integer b) {
+            final TimeContext<Long> timeCtx = ctx.timeContext(Long.class);
+            collect(Row.of(timeCtx.time(), timeCtx.currentWatermark(), a + b));
+        }
+    }
+
     /** PTF with simple value state - counts rows per partition. */
     @DataTypeHint("ROW<count BIGINT>")
     public static class PTFWithValueState extends ProcessTableFunction<Row> {
@@ -562,6 +577,24 @@ class ProcessTableFunctionTestHarnessTest {
             List<Row> output = harness.getOutput();
             assertThat(output).hasSize(1);
             assertThat(output.get(0).getField("sum")).isEqualTo(30);
+        }
+    }
+
+    @Test
+    void testScalarOnlyPTFInjectsContext() throws Exception {
+        try (ProcessTableFunctionTestHarness<Row> harness =
+                ProcessTableFunctionTestHarness.ofClass(ScalarOnlyContextPTF.class)
+                        .withScalarArgument("a", 10)
+                        .withScalarArgument("b", 20)
+                        .build()) {
+
+            harness.process();
+
+            List<Row> output = harness.getOutput();
+            assertThat(output).hasSize(1);
+            assertThat(output.get(0).getField("ts")).isNull();
+            assertThat(output.get(0).getField("watermark")).isNull();
+            assertThat(output.get(0).getField("value")).isEqualTo(30);
         }
     }
 


### PR DESCRIPTION
## What is the purpose of the change

While validating the behaviour of the PTF test harness against the tests defined in `ProcessTableFunctionTestPrograms`, I found that the harness didn't handle PTFs that had scalar only arguments, as well as a context. This resulted in an error when calling `process`, as the arity of `eval` and the number of arguments passed in did not match.

This PR correctly invokes scalar only PTFs with a context, when required.

## Brief change log

- Fixed a bug in ProcessTableFunctionTestHarness when using it with a scalar-only PTF that also expects a Context.


## Verifying this change

This change added tests and can be verified as follows:

- Added a `testScalarOnlyPTFInjectsContext` that tests whether invoking a scalar only PTF with a Context works correctly, and that the time and watermark values are null (similar to the `PROCESS_SCALAR_ARGS_TIME` semantic test)

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (no)