### PR TITLE
[BP-1.20][FLINK-38406][runtime] Fix DefaultSchedulerCheckpointCoordinatorTest failures

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/DefaultSchedulerCheckpointCoordinatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/DefaultSchedulerCheckpointCoordinatorTest.java
@@ -20,11 +20,11 @@ package org.apache.flink.runtime.checkpoint;
 
 import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.api.common.time.Time;
-import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutorServiceAdapter;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.executiongraph.Execution;
 import org.apache.flink.runtime.executiongraph.ExecutionGraph;
 import org.apache.flink.runtime.executiongraph.ExecutionVertex;
+import org.apache.flink.runtime.executiongraph.TestingComponentMainThreadExecutor;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobGraphBuilder;
 import org.apache.flink.runtime.jobgraph.JobVertex;
@@ -56,6 +56,13 @@ class DefaultSchedulerCheckpointCoordinatorTest {
     private static final TestExecutorExtension<ScheduledExecutorService> EXECUTOR_EXTENSION =
             TestingUtils.defaultExecutorExtension();
 
+    @RegisterExtension
+    static final TestingComponentMainThreadExecutor.Extension MAIN_EXECUTOR_RESOURCE =
+            new TestingComponentMainThreadExecutor.Extension();
+
+    private final TestingComponentMainThreadExecutor mainThreadExecutor =
+            MAIN_EXECUTOR_RESOURCE.getComponentMainThreadTestExecutor();
+
     /** Tests that the checkpoint coordinator is shut down if the execution graph is failed. */
     @Test
     void testClosingSchedulerShutsDownCheckpointCoordinatorOnFailedExecutionGraph()
@@ -77,9 +84,14 @@ class DefaultSchedulerCheckpointCoordinatorTest {
         assertThat(checkpointCoordinator).isNotNull();
         assertThat(checkpointCoordinator.isShutdown()).isFalse();
 
-        graph.failJob(new Exception("Test Exception"), System.currentTimeMillis());
-
-        scheduler.closeAsync().get();
+        mainThreadExecutor
+                .execute(
+                        () -> {
+                            graph.failJob(
+                                    new Exception("Test Exception"), System.currentTimeMillis());
+                            return scheduler.closeAsync();
+                        })
+                .get();
 
         assertThat(checkpointCoordinator.isShutdown()).isTrue();
         assertThat(counterShutdownFuture).isCompletedWithValue(JobStatus.FAILED);
@@ -107,9 +119,13 @@ class DefaultSchedulerCheckpointCoordinatorTest {
         assertThat(checkpointCoordinator).isNotNull();
         assertThat(checkpointCoordinator.isShutdown()).isFalse();
 
-        graph.suspend(new Exception("Test Exception"));
-
-        scheduler.closeAsync().get();
+        mainThreadExecutor
+                .execute(
+                        () -> {
+                            graph.suspend(new Exception("Test Exception"));
+                            return scheduler.closeAsync();
+                        })
+                .get();
 
         assertThat(checkpointCoordinator.isShutdown()).isTrue();
         assertThat(counterShutdownFuture).isCompletedWithValue(JobStatus.SUSPENDED);
@@ -137,18 +153,22 @@ class DefaultSchedulerCheckpointCoordinatorTest {
         assertThat(checkpointCoordinator).isNotNull();
         assertThat(checkpointCoordinator.isShutdown()).isFalse();
 
-        scheduler.startScheduling();
-
-        for (ExecutionVertex executionVertex : graph.getAllExecutionVertices()) {
-            final Execution currentExecutionAttempt = executionVertex.getCurrentExecutionAttempt();
-            scheduler.updateTaskExecutionState(
-                    new TaskExecutionState(
-                            currentExecutionAttempt.getAttemptId(), ExecutionState.FINISHED));
-        }
+        mainThreadExecutor.execute(
+                () -> {
+                    scheduler.startScheduling();
+                    for (ExecutionVertex executionVertex : graph.getAllExecutionVertices()) {
+                        final Execution currentExecutionAttempt =
+                                executionVertex.getCurrentExecutionAttempt();
+                        scheduler.updateTaskExecutionState(
+                                new TaskExecutionState(
+                                        currentExecutionAttempt.getAttemptId(),
+                                        ExecutionState.FINISHED));
+                    }
+                });
 
         assertThat(graph.getTerminationFuture()).isCompletedWithValue(JobStatus.FINISHED);
 
-        scheduler.closeAsync().get();
+        mainThreadExecutor.execute(scheduler::closeAsync).get();
 
         assertThat(checkpointCoordinator.isShutdown()).isTrue();
         assertThat(counterShutdownFuture).isCompletedWithValue(JobStatus.FINISHED);
@@ -176,7 +196,7 @@ class DefaultSchedulerCheckpointCoordinatorTest {
         assertThat(checkpointCoordinator).isNotNull();
         assertThat(checkpointCoordinator.isShutdown()).isFalse();
 
-        scheduler.closeAsync().get();
+        mainThreadExecutor.execute(scheduler::closeAsync).get();
 
         assertThat(graph.getState()).isEqualTo(JobStatus.SUSPENDED);
         assertThat(checkpointCoordinator.isShutdown()).isTrue();
@@ -208,7 +228,7 @@ class DefaultSchedulerCheckpointCoordinatorTest {
 
         return new DefaultSchedulerBuilder(
                         jobGraph,
-                        ComponentMainThreadExecutorServiceAdapter.forMainThread(),
+                        mainThreadExecutor.getMainThreadExecutor(),
                         EXECUTOR_EXTENSION.getExecutor())
                 .setCheckpointRecoveryFactory(new TestingCheckpointRecoveryFactory(store, counter))
                 .setRpcTimeout(timeout)


### PR DESCRIPTION
## What is the purpose of the change

Backport of [FLINK-38406](https://issues.apache.org/jira/browse/FLINK-38406) to `release-1.20`.

`DefaultSchedulerCheckpointCoordinatorTest` is flaky because it invokes `ExecutionGraph` operations (`failJob`, `suspend`, `startScheduling`, `closeAsync`) directly instead of from the scheduler main thread. #27061 (commit `bfd13de1520`) fixed this by routing those calls through a `TestingComponentMainThreadExecutor`. The fix is present on `master` and `release-2.3` but was never backported to `release-1.20`, which still exercises the original pre-fix code path and is therefore subject to the same race.

Note: I have not observed this specific test failing on a recent `release-1.20` cron (the demonstrated CI failure is on `release-2.2`, [build 76470](https://dev.azure.com/apache-flink/apache-flink/_build/results?buildId=76470&view=results)). This backport keeps `release-1.20` consistent with the fixed branches rather than fixing an observed `release-1.20` failure.

## Brief change log

  - Cherry-pick `bfd13de1520` onto `release-1.20`.
  - Resolved an import conflict: kept the `org.apache.flink.api.common.time.Time` import (still used by `Time.days(...)` in `createSchedulerAndEnableCheckpointing` on 1.x; 2.x migrated to `java.time.Duration`) and dropped the now-unused `ComponentMainThreadExecutorServiceAdapter` import.

## Verifying this change

This change is covered by the modified test itself. Ran `DefaultSchedulerCheckpointCoordinatorTest` locally on `release-1.20`: 4 tests, 0 failures.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: no (test-only change)
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (Claude Opus 4.8)

Generated-by: Claude Opus 4.8 (1M context)
