### PR TITLE
[FLINK-40021][table] `AND` for pushdown filters should be in uppercase

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/abilities/source/FilterPushDownSpec.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/abilities/source/FilterPushDownSpec.java
@@ -191,7 +191,7 @@ public final class FilterPushDownSpec extends SourceAbilitySpecBase {
         return String.format(
                 "filter=[%s]",
                 expressionStrs.stream()
-                        .reduce((l, r) -> String.format("and(%s, %s)", l, r))
+                        .reduce((l, r) -> String.format("AND(%s, %s)", l, r))
                         .orElse(""));
     }
 

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/PushFilterInCalcIntoTableSourceRuleTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/PushFilterInCalcIntoTableSourceRuleTest.xml
@@ -212,7 +212,7 @@ LogicalProject(name=[$0], id=[$1], amount=[$2], price=[$3])
     </Resource>
     <Resource name="optimized rel plan">
       <![CDATA[
-FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, filter=[and(>(amount, 2), <(amount, 10))]]], fields=[name, id, amount, price])
+FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, filter=[AND(>(amount, 2), <(amount, 10))]]], fields=[name, id, amount, price])
 ]]>
     </Resource>
   </TestCase>
@@ -231,7 +231,7 @@ LogicalProject(name=[$0], id=[$1], amount=[$2], virtualField=[$3], price=[$4])
     <Resource name="optimized rel plan">
       <![CDATA[
 FlinkLogicalCalc(select=[name, id, amount, +(amount, 1) AS virtualField, price])
-+- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, VirtualTable, filter=[and(>(amount, 2), <(amount, 10))]]], fields=[name, id, amount, price])
++- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, VirtualTable, filter=[AND(>(amount, 2), <(amount, 10))]]], fields=[name, id, amount, price])
 ]]>
     </Resource>
   </TestCase>
@@ -248,7 +248,7 @@ LogicalProject(a=[$0], b=[$1])
     </Resource>
     <Resource name="optimized rel plan">
       <![CDATA[
-FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MTable, filter=[and(=(LOWER(a), _UTF-16LE'foo':VARCHAR(2147483647) CHARACTER SET "UTF-16LE"), =(UPPER(b), _UTF-16LE'bar':VARCHAR(2147483647) CHARACTER SET "UTF-16LE"))]]], fields=[a, b])
+FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MTable, filter=[AND(=(LOWER(a), _UTF-16LE'foo':VARCHAR(2147483647) CHARACTER SET "UTF-16LE"), =(UPPER(b), _UTF-16LE'bar':VARCHAR(2147483647) CHARACTER SET "UTF-16LE"))]]], fields=[a, b])
 ]]>
     </Resource>
   </TestCase>

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/PushFilterIntoTableSourceScanRuleTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/PushFilterIntoTableSourceScanRuleTest.xml
@@ -222,7 +222,7 @@ LogicalProject(name=[$0], id=[$1], amount=[$2], price=[$3])
     <Resource name="optimized rel plan">
       <![CDATA[
 LogicalProject(name=[$0], id=[$1], amount=[$2], price=[$3])
-+- LogicalTableScan(table=[[default_catalog, default_database, MyTable, filter=[and(>(amount, 2), <(amount, 10))]]])
++- LogicalTableScan(table=[[default_catalog, default_database, MyTable, filter=[AND(>(amount, 2), <(amount, 10))]]])
 ]]>
     </Resource>
   </TestCase>
@@ -242,7 +242,7 @@ LogicalProject(name=[$0], id=[$1], amount=[$2], virtualField=[$3], price=[$4])
       <![CDATA[
 LogicalProject(name=[$0], id=[$1], amount=[$2], virtualField=[$3], price=[$4])
 +- LogicalProject(name=[$0], id=[$1], amount=[$2], virtualField=[+($2, 1)], price=[$3])
-   +- LogicalTableScan(table=[[default_catalog, default_database, VirtualTable, filter=[and(>(amount, 2), <(amount, 10))]]])
+   +- LogicalTableScan(table=[[default_catalog, default_database, VirtualTable, filter=[AND(>(amount, 2), <(amount, 10))]]])
 ]]>
     </Resource>
   </TestCase>
@@ -260,7 +260,7 @@ LogicalProject(a=[$0], b=[$1])
     <Resource name="optimized rel plan">
       <![CDATA[
 LogicalProject(a=[$0], b=[$1])
-+- LogicalTableScan(table=[[default_catalog, default_database, MTable, filter=[and(=(LOWER(a), _UTF-16LE'foo':VARCHAR(2147483647) CHARACTER SET "UTF-16LE"), =(UPPER(b), _UTF-16LE'bar':VARCHAR(2147483647) CHARACTER SET "UTF-16LE"))]]])
++- LogicalTableScan(table=[[default_catalog, default_database, MTable, filter=[AND(=(LOWER(a), _UTF-16LE'foo':VARCHAR(2147483647) CHARACTER SET "UTF-16LE"), =(UPPER(b), _UTF-16LE'bar':VARCHAR(2147483647) CHARACTER SET "UTF-16LE"))]]])
 ]]>
     </Resource>
   </TestCase>

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/FilterableSourceTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/FilterableSourceTest.xml
@@ -87,7 +87,7 @@ LogicalProject(name=[$0], event_time=[$1])
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
-TableSourceScan(table=[[default_catalog, default_database, NoWatermark, filter=[and(=(LOWER(name), _UTF-16LE'foo':VARCHAR(2147483647) CHARACTER SET "UTF-16LE"), =(UPPER(name), _UTF-16LE'FOO':VARCHAR(2147483647) CHARACTER SET "UTF-16LE"))]]], fields=[name, event_time])
+TableSourceScan(table=[[default_catalog, default_database, NoWatermark, filter=[AND(=(LOWER(name), _UTF-16LE'foo':VARCHAR(2147483647) CHARACTER SET "UTF-16LE"), =(UPPER(name), _UTF-16LE'FOO':VARCHAR(2147483647) CHARACTER SET "UTF-16LE"))]]], fields=[name, event_time])
 ]]>
     </Resource>
   </TestCase>


### PR DESCRIPTION
## What is the purpose of the change

The PR makes `and` for pushed down filters to uppercase

## Brief change log
plans and `FilterPushDownSpec`

## Verifying this change

existing tests
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no )
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no )
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable)

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change the checkbox below to `[X]` followed by the name of the tool, and uncomment the
"Generated-by" line. See the ASF Generative Tooling Guidance for details:
https://www.apache.org/legal/generative-tooling.html

You are responsible for the quality and correctness of every change in this PR
regardless of the tooling used. Low-effort AI-generated PRs will be closed. See
AGENTS.md for the full guidance.
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name and Version]
-->
