### PR TITLE
[FLINK-40018][table] Fix OOB and throw a clear error when PTF changelogs mismatch

### DIFF
--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/optimize/program/FlinkChangelogModeInferenceProgram.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/optimize/program/FlinkChangelogModeInferenceProgram.scala
@@ -857,7 +857,7 @@ class FlinkChangelogModeInferenceProgram extends FlinkOptimizeProgram[StreamOpti
           // input traits, partition keys, and upsert keys
           val inputArgs = StreamPhysicalProcessTableFunction
             .getProvidedInputArgs(process.getCall)
-          val children = process.getInputs
+          val childOpts = process.getInputs
             .map(_.asInstanceOf[StreamPhysicalRel])
             .zipWithIndex
             .map {
@@ -888,15 +888,20 @@ class FlinkChangelogModeInferenceProgram extends FlinkOptimizeProgram[StreamOpti
                 }
             }
             .toList
-            .flatten
-          // Query PTF for upsert vs. retract
-          val providedUpdateTrait = queryPtfChangelogMode(
-            process,
-            children,
-            toChangelogMode(process, Some(requiredUpdateTrait), None),
-            UpdateKindTrait.fromChangelogMode,
-            UpdateKindTrait.NONE)
-          createNewNode(rel, Some(children), providedUpdateTrait)
+
+          if (childOpts.exists(_.isEmpty)) {
+            None
+          } else {
+            val children = childOpts.flatten
+            // Query PTF for upsert vs. retract
+            val providedUpdateTrait = queryPtfChangelogMode(
+              process,
+              children,
+              toChangelogMode(process, Some(requiredUpdateTrait), None),
+              UpdateKindTrait.fromChangelogMode,
+              UpdateKindTrait.NONE)
+            createNewNode(rel, Some(children), providedUpdateTrait)
+          }
 
         case multiJoin: StreamPhysicalMultiJoin =>
           val onlyAfterByParent = requiredUpdateTrait.updateKind == UpdateKind.ONLY_UPDATE_AFTER

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/stream/sql/ProcessTableFunctionTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/stream/sql/ProcessTableFunctionTest.java
@@ -43,6 +43,7 @@ import org.apache.flink.table.planner.plan.nodes.exec.stream.ProcessTableFunctio
 import org.apache.flink.table.planner.plan.nodes.exec.stream.ProcessTableFunctionTestUtils.ScalarArgsFunction;
 import org.apache.flink.table.planner.plan.nodes.exec.stream.ProcessTableFunctionTestUtils.SetSemanticTableFunction;
 import org.apache.flink.table.planner.plan.nodes.exec.stream.ProcessTableFunctionTestUtils.SetSemanticTablePassThroughFunction;
+import org.apache.flink.table.planner.plan.nodes.exec.stream.ProcessTableFunctionTestUtils.SetSemanticTableRetractArgFunction;
 import org.apache.flink.table.planner.plan.nodes.exec.stream.ProcessTableFunctionTestUtils.TypedRowSemanticTableFunction;
 import org.apache.flink.table.planner.plan.nodes.exec.stream.ProcessTableFunctionTestUtils.TypedSetSemanticTableFunction;
 import org.apache.flink.table.planner.plan.nodes.exec.stream.ProcessTableFunctionTestUtils.UpdatingRetractRowSemanticFunction;
@@ -95,6 +96,11 @@ class ProcessTableFunctionTest extends TableTestBase {
                 .executeSql("CREATE VIEW t_type_diff AS SELECT 'Bob' AS name, TRUE AS isValid");
         util.tableEnv()
                 .executeSql("CREATE VIEW t_updating AS SELECT name, COUNT(*) FROM t GROUP BY name");
+
+        util.addTemporarySystemFunction("upsertPtf", UpdatingUpsertFunction.class);
+        util.tableEnv()
+                .executeSql(
+                        "CREATE VIEW t_upsert AS SELECT * FROM upsertPtf(r => TABLE t_updating PARTITION BY name)");
         util.tableEnv()
                 .executeSql(
                         "CREATE TABLE t_watermarked (name STRING, score INT, ts TIMESTAMP_LTZ(3), WATERMARK FOR ts AS ts) "
@@ -538,6 +544,13 @@ class ProcessTableFunctionTest extends TableTestBase {
                         UpdatingUpsertFunction.class,
                         "SELECT name, SUM(`count`) OVER (PARTITION BY name ORDER BY name) "
                                 + "FROM f(r => TABLE t_updating PARTITION BY name)",
+                        "Can't generate a valid execution plan for the given query:\n"),
+                ErrorSpec.ofSelect(
+                        // t_upsert produces an upsert changelog.
+                        // the table argument for f requires a retract changelog
+                        "retract requirement on an upsert table arg",
+                        SetSemanticTableRetractArgFunction.class,
+                        "SELECT * FROM f(r => TABLE t_upsert PARTITION BY name)",
                         "Can't generate a valid execution plan for the given query:\n"),
                 ErrorSpec.ofInsertInto(
                         "upsert conflict buried below a calc",


### PR DESCRIPTION
## What is the purpose of the change

When a process table function (PTF) has a table-argument input whose changelog mode cannot satisfy the required update mode, the planner silently dropped that input, leaving the PTF without inputs. This produced a malformed plan that later failed at job submission with an obscure IndexOutOfBoundsException. The query now fails during planning with a clear changelog mismatch error.

## Brief change log

- In the PTF branch of the update-kind visitor in FlinkChangelogModeInferenceProgram, propagate None when a table-argument input cannot satisfy the required update trait instead of flattening it away.

## Verifying this change

- ProcessTableFunctionTest

## Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): (no)
- The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
- The serializers: (no)
- The runtime per-record code paths (performance sensitive): (no)
- Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
- The S3 file system connector: (no)

## Documentation

- Does this pull request introduce a new feature? (no)
- If yes, how is the feature documented? (not applicable)

---

##### Was generative AI tooling used to co-author this PR?

- [x] Yes (please specify the tool below)

2.1.195 (Claude Code) with Opus 4.8