### PR TITLE
[FLINK-40022][table] Fix TableResult.await() hang on empty SELECT result

### DIFF
--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/ResultProvider.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/ResultProvider.java
@@ -53,10 +53,12 @@ public interface ResultProvider {
     RowDataToStringConverter getRowDataStringConverter();
 
     /**
-     * Return true if the first row is ready.
+     * Returns {@code true} once the result is ready to be consumed.
      *
-     * <p>The first row is ready when {@link CloseableIterator#hasNext} method returns true or
-     * {@link CloseableIterator#next()} method returns a row.
+     * <p>The result is ready when {@link CloseableIterator#hasNext()} returns {@code true} (a first
+     * row can be accessed) or {@link CloseableIterator#next()} returns a row, and when {@link
+     * CloseableIterator#hasNext()} returns {@code false} because the job has finished without
+     * producing rows.
      */
     boolean isFirstRowReady();
 

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/connectors/CollectDynamicSink.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/connectors/CollectDynamicSink.java
@@ -217,9 +217,14 @@ public final class CollectDynamicSink implements DynamicTableSink {
 
         @Override
         public boolean isFirstRowReady() {
-            return (this.rowDataIterator != null && this.rowDataIterator.firstRowProcessed)
-                    || (this.rowIterator != null && this.rowIterator.firstRowProcessed)
-                    || iterator.hasNext();
+            if ((this.rowDataIterator != null && this.rowDataIterator.firstRowProcessed)
+                    || (this.rowIterator != null && this.rowIterator.firstRowProcessed)) {
+                return true;
+            }
+            // hasNext() blocks until the first row is available or the job terminates. Once it
+            // returns we have a definitive answer, so the result is ready to be consumed.
+            iterator.hasNext();
+            return true;
         }
 
         @Override

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/connectors/CollectResultProviderITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/connectors/CollectResultProviderITCase.java
@@ -21,22 +21,26 @@ package org.apache.flink.table.planner.connectors;
 import org.apache.flink.table.api.EnvironmentSettings;
 import org.apache.flink.table.api.TableEnvironment;
 import org.apache.flink.table.api.TableResult;
+import org.apache.flink.test.junit5.MiniClusterExtension;
 import org.apache.flink.types.Row;
 import org.apache.flink.util.CloseableIterator;
 import org.apache.flink.util.CollectionUtil;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatCode;
 
 /**
- * Tests for collecting SELECT results via the Table API (backed by {@code
+ * ITCase for collecting SELECT results via the Table API (backed by {@code
  * CollectDynamicSink.CollectResultProvider}).
  */
-class CollectResultProviderTest {
+@ExtendWith(MiniClusterExtension.class)
+@Timeout(value = 30, unit = TimeUnit.SECONDS)
+class CollectResultProviderITCase {
 
     private static final String EMPTY_RESULT_QUERY =
             "SELECT * FROM (VALUES (1)) AS t(x) WHERE x < 0";
@@ -48,7 +52,7 @@ class CollectResultProviderTest {
 
         final TableResult result = tEnv.executeSql(EMPTY_RESULT_QUERY);
 
-        assertThatCode(() -> result.await(15, TimeUnit.SECONDS)).doesNotThrowAnyException();
+        result.await();
         try (CloseableIterator<Row> rows = result.collect()) {
             assertThat(rows.hasNext()).isFalse();
         }
@@ -62,7 +66,7 @@ class CollectResultProviderTest {
         final TableResult result =
                 tEnv.executeSql("SELECT x FROM (VALUES (1), (2), (3)) AS t(x) WHERE x > 1");
 
-        assertThatCode(() -> result.await(15, TimeUnit.SECONDS)).doesNotThrowAnyException();
+        result.await();
         try (CloseableIterator<Row> rows = result.collect()) {
             assertThat(CollectionUtil.iteratorToList(rows))
                     .containsExactlyInAnyOrder(Row.of(2), Row.of(3));
@@ -77,7 +81,7 @@ class CollectResultProviderTest {
 
         final TableResult result = tEnv.executeSql(EMPTY_RESULT_QUERY);
 
-        assertThatCode(() -> result.await(15, TimeUnit.SECONDS)).doesNotThrowAnyException();
+        result.await();
         try (CloseableIterator<Row> rows = result.collect()) {
             assertThat(rows.hasNext()).isFalse();
         }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/connectors/CollectResultProviderITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/connectors/CollectResultProviderITCase.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.connectors;
+
+import org.apache.flink.table.api.EnvironmentSettings;
+import org.apache.flink.table.api.TableEnvironment;
+import org.apache.flink.table.api.TableResult;
+import org.apache.flink.types.Row;
+import org.apache.flink.util.CloseableIterator;
+import org.apache.flink.util.CollectionUtil;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+/**
+ * ITCase for collecting SELECT results via the Table API (backed by {@code
+ * CollectDynamicSink.CollectResultProvider}).
+ */
+class CollectResultProviderITCase {
+
+    @Test
+    void awaitAndCollectCompleteForEmptyBatchResult() throws Exception {
+        final TableEnvironment tEnv =
+                TableEnvironment.create(EnvironmentSettings.newInstance().inBatchMode().build());
+
+        final TableResult result =
+                tEnv.executeSql("SELECT * FROM (VALUES (1)) AS t(x) WHERE x < 0");
+
+        assertThatCode(() -> result.await(15, TimeUnit.SECONDS)).doesNotThrowAnyException();
+        try (CloseableIterator<Row> rows = result.collect()) {
+            assertThat(rows.hasNext()).isFalse();
+        }
+    }
+
+    @Test
+    void awaitAndCollectCompleteForNonEmptyBatchResult() throws Exception {
+        final TableEnvironment tEnv =
+                TableEnvironment.create(EnvironmentSettings.newInstance().inBatchMode().build());
+
+        final TableResult result =
+                tEnv.executeSql("SELECT x FROM (VALUES (1), (2), (3)) AS t(x) WHERE x > 1");
+
+        assertThatCode(() -> result.await(15, TimeUnit.SECONDS)).doesNotThrowAnyException();
+        try (CloseableIterator<Row> rows = result.collect()) {
+            assertThat(CollectionUtil.iteratorToList(rows))
+                    .containsExactlyInAnyOrder(Row.of(2), Row.of(3));
+        }
+    }
+}

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/connectors/CollectResultProviderITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/connectors/CollectResultProviderITCase.java
@@ -39,7 +39,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * CollectDynamicSink.CollectResultProvider}).
  */
 @ExtendWith(MiniClusterExtension.class)
-@Timeout(value = 30, unit = TimeUnit.SECONDS)
+@Timeout(value = 60, unit = TimeUnit.SECONDS)
 class CollectResultProviderITCase {
 
     private static final String EMPTY_RESULT_QUERY =

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/connectors/CollectResultProviderTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/connectors/CollectResultProviderTest.java
@@ -33,18 +33,20 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 
 /**
- * ITCase for collecting SELECT results via the Table API (backed by {@code
+ * Tests for collecting SELECT results via the Table API (backed by {@code
  * CollectDynamicSink.CollectResultProvider}).
  */
-class CollectResultProviderITCase {
+class CollectResultProviderTest {
+
+    private static final String EMPTY_RESULT_QUERY =
+            "SELECT * FROM (VALUES (1)) AS t(x) WHERE x < 0";
 
     @Test
     void awaitAndCollectCompleteForEmptyBatchResult() throws Exception {
         final TableEnvironment tEnv =
                 TableEnvironment.create(EnvironmentSettings.newInstance().inBatchMode().build());
 
-        final TableResult result =
-                tEnv.executeSql("SELECT * FROM (VALUES (1)) AS t(x) WHERE x < 0");
+        final TableResult result = tEnv.executeSql(EMPTY_RESULT_QUERY);
 
         assertThatCode(() -> result.await(15, TimeUnit.SECONDS)).doesNotThrowAnyException();
         try (CloseableIterator<Row> rows = result.collect()) {
@@ -64,6 +66,20 @@ class CollectResultProviderITCase {
         try (CloseableIterator<Row> rows = result.collect()) {
             assertThat(CollectionUtil.iteratorToList(rows))
                     .containsExactlyInAnyOrder(Row.of(2), Row.of(3));
+        }
+    }
+
+    @Test
+    void awaitAndCollectCompleteForEmptyStreamingResult() throws Exception {
+        final TableEnvironment tEnv =
+                TableEnvironment.create(
+                        EnvironmentSettings.newInstance().inStreamingMode().build());
+
+        final TableResult result = tEnv.executeSql(EMPTY_RESULT_QUERY);
+
+        assertThatCode(() -> result.await(15, TimeUnit.SECONDS)).doesNotThrowAnyException();
+        try (CloseableIterator<Row> rows = result.collect()) {
+            assertThat(rows.hasNext()).isFalse();
         }
     }
 }


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

`TableResult.await()` on a batch `SELECT` that finishes with zero rows never returns. `awaitInternal()` polls `isFirstRowReady()`, which only reported ready once a first row was available; for an empty result no row ever arrives, so `await()` blocks forever and `await(timeout)` throws `TimeoutException`. This change makes the collect result provider treat a finished, zero-row result as ready.


## Brief change log

- `CollectDynamicSink.CollectResultProvider.isFirstRowReady()` now returns ready once `iterator.hasNext()` resolves
- `hasNext()` blocks until a first row is available or the job terminates, so an empty finished result is reported ready instead of leaving `await()` spinning
- Added `CollectResultProviderITCase` exercising `await()` + `collect()` for empty and non-empty batch results


## Verifying this change

This change added tests and can be verified as follows:

- Added an integration test `CollectResultProviderITCase` to verify empty and non-empty results still work as expected

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? n/a

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change the checkbox below to `[X]` followed by the name of the tool, and uncomment the
"Generated-by" line. See the ASF Generative Tooling Guidance for details:
https://www.apache.org/legal/generative-tooling.html

You are responsible for the quality and correctness of every change in this PR
regardless of the tooling used. Low-effort AI-generated PRs will be closed. See
AGENTS.md for the full guidance.
-->

No