### PR TITLE
[FLINK-39776][runtime][core] Expose JobInfo on SourceOperators

### DIFF
--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/hybrid/HybridSourceSplitEnumerator.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/hybrid/HybridSourceSplitEnumerator.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.connector.base.source.hybrid;
 
+import org.apache.flink.api.common.JobInfo;
 import org.apache.flink.api.connector.source.ReaderInfo;
 import org.apache.flink.api.connector.source.Source;
 import org.apache.flink.api.connector.source.SourceEvent;
@@ -338,6 +339,11 @@ public class HybridSourceSplitEnumerator
             this.readerSourceIndex = readerSourceIndex;
             this.switchedSources = switchedSources;
             this.sourceSize = sourceSize;
+        }
+
+        @Override
+        public JobInfo getJobInfo() {
+            return realContext.getJobInfo();
         }
 
         @Override

--- a/flink-core/src/main/java/org/apache/flink/api/connector/source/RichSourceReaderContext.java
+++ b/flink-core/src/main/java/org/apache/flink/api/connector/source/RichSourceReaderContext.java
@@ -19,6 +19,7 @@
 package org.apache.flink.api.connector.source;
 
 import org.apache.flink.annotation.Experimental;
+import org.apache.flink.api.common.JobInfo;
 import org.apache.flink.api.common.functions.RuntimeContext;
 import org.apache.flink.util.Preconditions;
 
@@ -38,5 +39,10 @@ public abstract class RichSourceReaderContext implements SourceReaderContext {
     public RuntimeContext getRuntimeContext() {
         Preconditions.checkNotNull(runtimeContext, "The runtime context must not be null.");
         return runtimeContext;
+    }
+
+    @Override
+    public JobInfo getJobInfo() {
+        return getRuntimeContext().getJobInfo();
     }
 }

--- a/flink-core/src/main/java/org/apache/flink/api/connector/source/SourceReaderContext.java
+++ b/flink-core/src/main/java/org/apache/flink/api/connector/source/SourceReaderContext.java
@@ -19,6 +19,8 @@
 package org.apache.flink.api.connector.source;
 
 import org.apache.flink.annotation.Public;
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.api.common.JobInfo;
 import org.apache.flink.api.common.watermark.Watermark;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.metrics.groups.SourceReaderMetricGroup;
@@ -27,6 +29,16 @@ import org.apache.flink.util.UserCodeClassLoader;
 /** The interface that exposes some context from runtime to the {@link SourceReader}. */
 @Public
 public interface SourceReaderContext {
+
+    /**
+     * Get the meta information of the current job.
+     *
+     * @return the job meta information.
+     */
+    @PublicEvolving
+    default JobInfo getJobInfo() {
+        throw new UnsupportedOperationException();
+    }
 
     /**
      * @return The metric group this source belongs to.

--- a/flink-core/src/main/java/org/apache/flink/api/connector/source/SplitEnumeratorContext.java
+++ b/flink-core/src/main/java/org/apache/flink/api/connector/source/SplitEnumeratorContext.java
@@ -20,6 +20,7 @@ package org.apache.flink.api.connector.source;
 
 import org.apache.flink.annotation.Public;
 import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.api.common.JobInfo;
 import org.apache.flink.metrics.groups.SplitEnumeratorMetricGroup;
 
 import java.util.Map;
@@ -40,6 +41,16 @@ import java.util.function.BiConsumer;
  */
 @Public
 public interface SplitEnumeratorContext<SplitT extends SourceSplit> {
+
+    /**
+     * Get the meta information of the current job.
+     *
+     * @return the job meta information.
+     */
+    @PublicEvolving
+    default JobInfo getJobInfo() {
+        throw new UnsupportedOperationException();
+    }
 
     SplitEnumeratorMetricGroup metricGroup();
 

--- a/flink-core/src/test/java/org/apache/flink/api/connector/source/mocks/MockSplitEnumeratorContext.java
+++ b/flink-core/src/test/java/org/apache/flink/api/connector/source/mocks/MockSplitEnumeratorContext.java
@@ -18,6 +18,9 @@ limitations under the License.
 
 package org.apache.flink.api.connector.source.mocks;
 
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.JobInfo;
+import org.apache.flink.api.common.JobInfoImpl;
 import org.apache.flink.api.connector.source.ReaderInfo;
 import org.apache.flink.api.connector.source.SourceEvent;
 import org.apache.flink.api.connector.source.SourceSplit;
@@ -66,6 +69,8 @@ public class MockSplitEnumeratorContext<SplitT extends SourceSplit>
 
     private final int parallelism;
 
+    private final JobInfo jobInfo = new JobInfoImpl(new JobID(), "mock-job");
+
     public MockSplitEnumeratorContext(int parallelism) {
         this.sentSourceEvent = new HashMap<>();
         this.registeredReaders = new ConcurrentHashMap<>();
@@ -81,6 +86,11 @@ public class MockSplitEnumeratorContext<SplitT extends SourceSplit>
         this.mainExecutor = getExecutor(mainThreadFactory);
         this.stoppedAcceptAsyncCalls = new AtomicBoolean(false);
         this.subtaskHasNoMoreSplits = new boolean[parallelism];
+    }
+
+    @Override
+    public JobInfo getJobInfo() {
+        return jobInfo;
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/InternalExecutionGraphAccessor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/InternalExecutionGraphAccessor.java
@@ -48,6 +48,8 @@ public interface InternalExecutionGraphAccessor {
 
     JobID getJobID();
 
+    String getJobName();
+
     BlobWriter getBlobWriter();
 
     /**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/OperatorCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/OperatorCoordinator.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.operators.coordination;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.JobInfo;
 import org.apache.flink.api.common.state.CheckpointListener;
 import org.apache.flink.metrics.groups.OperatorCoordinatorMetricGroup;
 import org.apache.flink.runtime.checkpoint.CheckpointCoordinator;
@@ -260,6 +261,9 @@ public interface OperatorCoordinator extends CheckpointListener, AutoCloseable {
 
         /** Gets the {@link JobID} of the job to which the coordinator belongs. */
         JobID getJobID();
+
+        /** Gets the {@link JobInfo} of the job to which the coordinator belongs. */
+        JobInfo getJobInfo();
 
         /** Gets the ID of the operator to which the coordinator belongs. */
         OperatorID getOperatorId();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/OperatorCoordinatorHolder.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/OperatorCoordinatorHolder.java
@@ -21,6 +21,8 @@ package org.apache.flink.runtime.operators.coordination;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.JobInfo;
+import org.apache.flink.api.common.JobInfoImpl;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.metrics.groups.OperatorCoordinatorMetricGroup;
 import org.apache.flink.runtime.checkpoint.CheckpointCoordinator;
@@ -500,6 +502,10 @@ public class OperatorCoordinatorHolder
             final SubtaskAccess.SubtaskAccessFactory taskAccesses =
                     new ExecutionSubtaskAccess.ExecutionJobVertexSubtaskAccess(jobVertex, opId);
 
+            final JobInfo jobInfo =
+                    new JobInfoImpl(
+                            jobVertex.getGraph().getJobID(), jobVertex.getGraph().getJobName());
+
             return create(
                     opId,
                     provider,
@@ -511,6 +517,7 @@ public class OperatorCoordinatorHolder
                     taskAccesses,
                     supportsConcurrentExecutionAttempts,
                     taskInformation,
+                    jobInfo,
                     metricGroup);
         }
     }
@@ -527,6 +534,7 @@ public class OperatorCoordinatorHolder
             final SubtaskAccess.SubtaskAccessFactory taskAccesses,
             final boolean supportsConcurrentExecutionAttempts,
             final TaskInformation taskInformation,
+            final JobInfo jobInfo,
             final JobManagerJobMetricGroup jobManagerJobMetricGroup)
             throws Exception {
         final MetricGroup parentMetricGroup =
@@ -537,7 +545,7 @@ public class OperatorCoordinatorHolder
                         operatorName);
         final LazyInitializedCoordinatorContext context =
                 new LazyInitializedCoordinatorContext(
-                        jobManagerJobMetricGroup.jobId(),
+                        jobInfo,
                         opId,
                         operatorName,
                         userCodeClassLoader,
@@ -576,7 +584,7 @@ public class OperatorCoordinatorHolder
         private static final Logger LOG =
                 LoggerFactory.getLogger(LazyInitializedCoordinatorContext.class);
 
-        private final JobID jobID;
+        private final JobInfo jobInfo;
         private final OperatorID operatorId;
         private final String operatorName;
         private final ClassLoader userCodeClassLoader;
@@ -592,7 +600,7 @@ public class OperatorCoordinatorHolder
         private volatile boolean failed;
 
         public LazyInitializedCoordinatorContext(
-                JobID jobID,
+                JobInfo jobInfo,
                 final OperatorID operatorId,
                 final String operatorName,
                 final ClassLoader userCodeClassLoader,
@@ -600,7 +608,7 @@ public class OperatorCoordinatorHolder
                 final CoordinatorStore coordinatorStore,
                 final boolean supportsConcurrentExecutionAttempts,
                 final OperatorCoordinatorMetricGroup metricGroup) {
-            this.jobID = jobID;
+            this.jobInfo = checkNotNull(jobInfo);
             this.operatorId = checkNotNull(operatorId);
             this.operatorName = checkNotNull(operatorName);
             this.userCodeClassLoader = checkNotNull(userCodeClassLoader);
@@ -641,7 +649,12 @@ public class OperatorCoordinatorHolder
 
         @Override
         public JobID getJobID() {
-            return jobID;
+            return jobInfo.getJobId();
+        }
+
+        @Override
+        public JobInfo getJobInfo() {
+            return jobInfo;
         }
 
         @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/RecreateOnResetOperatorCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/RecreateOnResetOperatorCoordinator.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.operators.coordination;
 
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.JobInfo;
 import org.apache.flink.metrics.groups.OperatorCoordinatorMetricGroup;
 import org.apache.flink.runtime.checkpoint.CheckpointCoordinator;
 import org.apache.flink.runtime.jobgraph.OperatorID;
@@ -247,6 +248,11 @@ public class RecreateOnResetOperatorCoordinator implements OperatorCoordinator {
         @Override
         public JobID getJobID() {
             return context.getJobID();
+        }
+
+        @Override
+        public JobInfo getJobInfo() {
+            return context.getJobInfo();
         }
 
         @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorContext.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorContext.java
@@ -22,6 +22,7 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.JobInfo;
 import org.apache.flink.api.connector.source.ReaderInfo;
 import org.apache.flink.api.connector.source.SourceEvent;
 import org.apache.flink.api.connector.source.SourceSplit;
@@ -179,6 +180,11 @@ public class SourceCoordinatorContext<SplitT extends SourceSplit>
     @Override
     public SplitEnumeratorMetricGroup metricGroup() {
         return new InternalSplitEnumeratorMetricGroup(operatorCoordinatorContext.metricGroup());
+    }
+
+    @Override
+    public JobInfo getJobInfo() {
+        return operatorCoordinatorContext.getJobInfo();
     }
 
     @Override

--- a/flink-runtime/src/test/java/org/apache/flink/api/connector/source/RichSourceReaderContextTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/api/connector/source/RichSourceReaderContextTest.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.connector.source;
+
+import org.apache.flink.api.common.JobInfo;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.metrics.groups.SourceReaderMetricGroup;
+import org.apache.flink.streaming.util.MockStreamingRuntimeContext;
+import org.apache.flink.util.UserCodeClassLoader;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Unit test for {@link RichSourceReaderContext}. */
+class RichSourceReaderContextTest {
+
+    @Test
+    void testGetJobInfoReturnsRuntimeContextJobInfo() {
+        MockStreamingRuntimeContext runtimeContext = new MockStreamingRuntimeContext(1, 0);
+        StubRichSourceReaderContext context = new StubRichSourceReaderContext();
+        context.setRuntimeContext(runtimeContext);
+
+        JobInfo jobInfo = context.getJobInfo();
+
+        assertThat(jobInfo).isSameAs(runtimeContext.getJobInfo());
+    }
+
+    @Test
+    void testGetJobInfoFailsWhenRuntimeContextNotSet() {
+        StubRichSourceReaderContext context = new StubRichSourceReaderContext();
+        assertThatThrownBy(context::getJobInfo)
+                .hasMessageContaining("runtime context must not be null");
+    }
+
+    private static class StubRichSourceReaderContext extends RichSourceReaderContext {
+        @Override
+        public SourceReaderMetricGroup metricGroup() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Configuration getConfiguration() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public String getLocalHostName() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public int getIndexOfSubtask() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void sendSplitRequest() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void sendSourceEventToCoordinator(SourceEvent sourceEvent) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public UserCodeClassLoader getUserCodeClassLoader() {
+            throw new UnsupportedOperationException();
+        }
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/MockOperatorCoordinatorContext.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/MockOperatorCoordinatorContext.java
@@ -19,6 +19,8 @@ limitations under the License.
 package org.apache.flink.runtime.operators.coordination;
 
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.JobInfo;
+import org.apache.flink.api.common.JobInfoImpl;
 import org.apache.flink.metrics.groups.OperatorCoordinatorMetricGroup;
 import org.apache.flink.runtime.checkpoint.CheckpointCoordinator;
 import org.apache.flink.runtime.jobgraph.OperatorID;
@@ -31,6 +33,7 @@ import java.util.concurrent.CompletableFuture;
 public class MockOperatorCoordinatorContext implements OperatorCoordinator.Context {
 
     private final JobID jobID = new JobID();
+    private final JobInfo jobInfo = new JobInfoImpl(jobID, "mock-job");
     private final OperatorID operatorID;
     private final ClassLoader userCodeClassLoader;
     private final int numSubtasks;
@@ -60,6 +63,11 @@ public class MockOperatorCoordinatorContext implements OperatorCoordinator.Conte
     @Override
     public JobID getJobID() {
         return jobID;
+    }
+
+    @Override
+    public JobInfo getJobInfo() {
+        return jobInfo;
     }
 
     @Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/OperatorCoordinatorHolderTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/OperatorCoordinatorHolderTest.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.operators.coordination;
 
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.JobInfoImpl;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.testutils.OneShotLatch;
 import org.apache.flink.runtime.checkpoint.CheckpointCoordinator;
@@ -541,6 +542,7 @@ class OperatorCoordinatorHolderTest {
                                 1,
                                 NoOpInvokable.class.getName(),
                                 new Configuration()),
+                        new JobInfoImpl(new JobID(), "test-job"),
                         UnregisteredMetricGroups.createUnregisteredJobManagerJobMetricGroup());
 
         JobID jobId = new JobID();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/ExecutingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/ExecutingTest.java
@@ -1195,6 +1195,11 @@ class ExecutingTest {
         }
 
         @Override
+        public String getJobName() {
+            return null;
+        }
+
+        @Override
         public BlobWriter getBlobWriter() {
             return null;
         }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorContextTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorContextTest.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.source.coordinator;
 
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.JobInfo;
 import org.apache.flink.api.connector.source.ReaderInfo;
 import org.apache.flink.api.connector.source.SplitsAssignment;
 import org.apache.flink.api.connector.source.mocks.MockSourceSplit;
@@ -44,6 +45,16 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /** Unit test for {@link SourceCoordinatorContext}. */
 class SourceCoordinatorContextTest extends SourceCoordinatorTestBase {
+
+    @Test
+    void testGetJobInfo() {
+        // Compare on JobID (and JobName) rather than full JobInfo because JobInfoImpl is
+        // @Internal and does not override equals().
+        JobInfo expected = operatorCoordinatorContext.getJobInfo();
+        JobInfo actual = context.getJobInfo();
+        assertThat(actual.getJobId()).isEqualTo(expected.getJobId());
+        assertThat(actual.getJobName()).isEqualTo(expected.getJobName());
+    }
 
     @Test
     void testRegisterReader() throws Exception {

--- a/flink-test-utils-parent/flink-connector-test-utils/src/main/java/org/apache/flink/connector/testutils/source/reader/TestingReaderContext.java
+++ b/flink-test-utils-parent/flink-connector-test-utils/src/main/java/org/apache/flink/connector/testutils/source/reader/TestingReaderContext.java
@@ -18,6 +18,9 @@
 
 package org.apache.flink.connector.testutils.source.reader;
 
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.JobInfo;
+import org.apache.flink.api.common.JobInfoImpl;
 import org.apache.flink.api.connector.source.SourceEvent;
 import org.apache.flink.api.connector.source.SourceReaderContext;
 import org.apache.flink.configuration.Configuration;
@@ -36,6 +39,8 @@ public class TestingReaderContext implements SourceReaderContext {
 
     private final Configuration config;
 
+    private final JobInfo jobInfo = new JobInfoImpl(new JobID(), "test-job");
+
     private final ArrayList<SourceEvent> sentEvents = new ArrayList<>();
 
     private int numSplitRequests;
@@ -50,6 +55,11 @@ public class TestingReaderContext implements SourceReaderContext {
     }
 
     // ------------------------------------------------------------------------
+
+    @Override
+    public JobInfo getJobInfo() {
+        return jobInfo;
+    }
 
     @Override
     public SourceReaderMetricGroup metricGroup() {

--- a/flink-test-utils-parent/flink-connector-test-utils/src/main/java/org/apache/flink/connector/testutils/source/reader/TestingSplitEnumeratorContext.java
+++ b/flink-test-utils-parent/flink-connector-test-utils/src/main/java/org/apache/flink/connector/testutils/source/reader/TestingSplitEnumeratorContext.java
@@ -18,6 +18,9 @@
 
 package org.apache.flink.connector.testutils.source.reader;
 
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.JobInfo;
+import org.apache.flink.api.common.JobInfoImpl;
 import org.apache.flink.api.connector.source.ReaderInfo;
 import org.apache.flink.api.connector.source.SourceEvent;
 import org.apache.flink.api.connector.source.SourceSplit;
@@ -57,6 +60,8 @@ public class TestingSplitEnumeratorContext<SplitT extends SourceSplit>
 
     private final int parallelism;
 
+    private final JobInfo jobInfo = new JobInfoImpl(new JobID(), "test-job");
+
     public TestingSplitEnumeratorContext(int parallelism) {
         this.parallelism = parallelism;
     }
@@ -90,6 +95,11 @@ public class TestingSplitEnumeratorContext<SplitT extends SourceSplit>
     // ------------------------------------------------------------------------
     //  SplitEnumeratorContext methods
     // ------------------------------------------------------------------------
+
+    @Override
+    public JobInfo getJobInfo() {
+        return jobInfo;
+    }
 
     @Override
     public SplitEnumeratorMetricGroup metricGroup() {


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

This PR implements [FLIP-583](https://cwiki.apache.org/confluence/spaces/FLINK/pages/430407938/FLIP-583+Expose+JobInfo+on+Source+contexts) . It exposes JobInfo on the Source API contexts. It makes sense because:
1. Multiple places in the code need an access to JobInfo (JobID).
2. SinkV2 already exposes this information, thus we will have a parity.


## Brief change log

Add a default method to both source contexts:
```
// SourceReaderContext
@PublicEvolving
default JobInfo getJobInfo() {
    throw new UnsupportedOperationException();
}
// SplitEnumeratorContext
@PublicEvolving
default JobInfo getJobInfo() {
    throw new UnsupportedOperationException();
}
```

And to implementations.

## Verifying this change

This change added tests and can be verified as follows:
- Added RichSourceReaderContextTest: it asserts the reader-side getJobInfo() returns the JobInfo from the runtime context, and that it fails fast when the runtime context is unset. 
- Added SourceCoordinatorContextTest#testGetJobInfo: asserts the enumerator-side getJobInfo() delegates to the underlying OperatorCoordinator.Context. 
- Updated OperatorCoordinatorHolderTest and ExecutingTest to match new signatures/methods.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes, adds @PublicEvolving default methods to the @Public interfaces SourceReaderContext and SplitEnumeratorContext)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: JM's components are "touched" but the change is pure addition and does not change behavior.  
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (JavaDocs + https://cwiki.apache.org/confluence/spaces/FLINK/pages/430407938/FLIP-583+Expose+JobInfo+on+Source+contexts)

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change the checkbox below to `[X]` followed by the name of the tool, and uncomment the
"Generated-by" line. See the ASF Generative Tooling Guidance for details:
https://www.apache.org/legal/generative-tooling.html

You are responsible for the quality and correctness of every change in this PR
regardless of the tooling used. Low-effort AI-generated PRs will be closed. See
AGENTS.md for the full guidance.
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name and Version]
-->
