### PR TITLE
[FLINK-38536][tests] Deploy synchronously to avoid deployment-callback race

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphFinishTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphFinishTest.java
@@ -19,42 +19,24 @@
 package org.apache.flink.runtime.executiongraph;
 
 import org.apache.flink.api.common.JobStatus;
-import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
 import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutorServiceAdapter;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobGraphTestUtils;
 import org.apache.flink.runtime.scheduler.DefaultSchedulerBuilder;
 import org.apache.flink.runtime.scheduler.SchedulerBase;
 import org.apache.flink.runtime.testtasks.NoOpInvokable;
-import org.apache.flink.testutils.TestingUtils;
-import org.apache.flink.testutils.executor.TestExecutorExtension;
+import org.apache.flink.runtime.testutils.DirectScheduledExecutorService;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.function.Supplier;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests the finish behaviour of the {@link ExecutionGraph}. */
 class ExecutionGraphFinishTest {
-
-    /**
-     * Dedicated single-threaded main-thread executor; using forMainThread() here would run the
-     * deployment callbacks on the I/O thread and race the test (FLINK-38536).
-     */
-    @RegisterExtension
-    static final TestExecutorExtension<ScheduledExecutorService> JM_MAIN_THREAD_EXECUTOR_RESOURCE =
-            TestingUtils.jmMainThreadExecutorExtension();
-
-    @RegisterExtension
-    static final TestExecutorExtension<ScheduledExecutorService> EXECUTOR_RESOURCE =
-            TestingUtils.defaultExecutorExtension();
 
     @Test
     void testJobFinishes() throws Exception {
@@ -63,82 +45,41 @@ class ExecutionGraphFinishTest {
                         ExecutionGraphTestUtils.createJobVertex("Task1", 2, NoOpInvokable.class),
                         ExecutionGraphTestUtils.createJobVertex("Task2", 2, NoOpInvokable.class));
 
-        final ComponentMainThreadExecutor mainThreadExecutor =
-                ComponentMainThreadExecutorServiceAdapter.forSingleThreadExecutor(
-                        JM_MAIN_THREAD_EXECUTOR_RESOURCE.getExecutor());
-
+        // Use a direct future executor so the asynchronous deployment callbacks complete inline
+        // before the manual state transitions below, avoiding the FLINK-38536 race.
         SchedulerBase scheduler =
                 new DefaultSchedulerBuilder(
-                                jobGraph, mainThreadExecutor, EXECUTOR_RESOURCE.getExecutor())
+                                jobGraph,
+                                ComponentMainThreadExecutorServiceAdapter.forMainThread(),
+                                new DirectScheduledExecutorService())
                         .build();
 
         ExecutionGraph eg = scheduler.getExecutionGraph();
 
-        runInMainThread(mainThreadExecutor, scheduler::startScheduling);
-        runInMainThread(
-                mainThreadExecutor, () -> ExecutionGraphTestUtils.switchAllVerticesToRunning(eg));
+        scheduler.startScheduling();
+        ExecutionGraphTestUtils.switchAllVerticesToRunning(eg);
 
-        final ExecutionJobVertex[] orderedVertices =
-                supplyInMainThread(
-                        mainThreadExecutor,
-                        () -> {
-                            Iterator<ExecutionJobVertex> jobVertices =
-                                    eg.getVerticesTopologically().iterator();
-                            return new ExecutionJobVertex[] {
-                                jobVertices.next(), jobVertices.next()
-                            };
-                        });
-        ExecutionJobVertex sender = orderedVertices[0];
-        ExecutionJobVertex receiver = orderedVertices[1];
+        Iterator<ExecutionJobVertex> jobVertices = eg.getVerticesTopologically().iterator();
 
-        List<ExecutionVertex> senderVertices =
-                supplyInMainThread(
-                        mainThreadExecutor, () -> Arrays.asList(sender.getTaskVertices()));
-        List<ExecutionVertex> receiverVertices =
-                supplyInMainThread(
-                        mainThreadExecutor, () -> Arrays.asList(receiver.getTaskVertices()));
+        ExecutionJobVertex sender = jobVertices.next();
+        ExecutionJobVertex receiver = jobVertices.next();
+
+        List<ExecutionVertex> senderVertices = Arrays.asList(sender.getTaskVertices());
+        List<ExecutionVertex> receiverVertices = Arrays.asList(receiver.getTaskVertices());
 
         // test getNumExecutionVertexFinished
-        runInMainThread(
-                mainThreadExecutor,
-                () -> senderVertices.get(0).getCurrentExecutionAttempt().markFinished());
-        assertThat(supplyInMainThread(mainThreadExecutor, sender::getNumExecutionVertexFinished))
-                .isOne();
-        assertThat(supplyInMainThread(mainThreadExecutor, eg::getState))
-                .isEqualTo(JobStatus.RUNNING);
+        senderVertices.get(0).getCurrentExecutionAttempt().markFinished();
+        assertThat(sender.getNumExecutionVertexFinished()).isOne();
+        assertThat(eg.getState()).isEqualTo(JobStatus.RUNNING);
 
-        runInMainThread(
-                mainThreadExecutor,
-                () -> senderVertices.get(1).getCurrentExecutionAttempt().markFinished());
-        assertThat(supplyInMainThread(mainThreadExecutor, sender::getNumExecutionVertexFinished))
-                .isEqualTo(2);
-        assertThat(supplyInMainThread(mainThreadExecutor, eg::getState))
-                .isEqualTo(JobStatus.RUNNING);
+        senderVertices.get(1).getCurrentExecutionAttempt().markFinished();
+        assertThat(sender.getNumExecutionVertexFinished()).isEqualTo(2);
+        assertThat(eg.getState()).isEqualTo(JobStatus.RUNNING);
 
         // test job finishes
-        runInMainThread(
-                mainThreadExecutor,
-                () -> {
-                    receiverVertices.get(0).getCurrentExecutionAttempt().markFinished();
-                    receiverVertices.get(1).getCurrentExecutionAttempt().markFinished();
-                });
-        assertThat(eg.waitUntilTerminal()).isEqualTo(JobStatus.FINISHED);
-        assertThat(supplyInMainThread(mainThreadExecutor, eg::getNumFinishedVertices)).isEqualTo(4);
-        assertThat(supplyInMainThread(mainThreadExecutor, eg::getState))
-                .isEqualTo(JobStatus.FINISHED);
-    }
-
-    /** Runs the action on the JobManager main thread and blocks until it completes. */
-    private static void runInMainThread(
-            final ComponentMainThreadExecutor mainThreadExecutor, final Runnable action)
-            throws Exception {
-        CompletableFuture.runAsync(action, mainThreadExecutor).get();
-    }
-
-    /** Reads the value on the JobManager main thread and blocks until it is available. */
-    private static <T> T supplyInMainThread(
-            final ComponentMainThreadExecutor mainThreadExecutor, final Supplier<T> supplier)
-            throws Exception {
-        return CompletableFuture.supplyAsync(supplier, mainThreadExecutor).get();
+        receiverVertices.get(0).getCurrentExecutionAttempt().markFinished();
+        receiverVertices.get(1).getCurrentExecutionAttempt().markFinished();
+        assertThat(eg.getNumFinishedVertices()).isEqualTo(4);
+        assertThat(eg.getState()).isEqualTo(JobStatus.FINISHED);
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/FinalizeOnMasterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/FinalizeOnMasterTest.java
@@ -19,22 +19,15 @@
 package org.apache.flink.runtime.executiongraph;
 
 import org.apache.flink.api.common.JobStatus;
-import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
 import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutorServiceAdapter;
 import org.apache.flink.runtime.jobgraph.JobGraphTestUtils;
 import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.jobgraph.JobVertex.FinalizeOnMasterContext;
 import org.apache.flink.runtime.scheduler.SchedulerBase;
 import org.apache.flink.runtime.testtasks.NoOpInvokable;
-import org.apache.flink.testutils.TestingUtils;
-import org.apache.flink.testutils.executor.TestExecutorExtension;
+import org.apache.flink.runtime.testutils.DirectScheduledExecutorService;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
-
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.function.Supplier;
 
 import static org.apache.flink.runtime.scheduler.SchedulerTestingUtils.createScheduler;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -49,18 +42,6 @@ import static org.mockito.Mockito.verify;
  */
 class FinalizeOnMasterTest {
 
-    /**
-     * Dedicated single-threaded main-thread executor; using forMainThread() here would run the
-     * deployment callbacks on the I/O thread and race the test (FLINK-38536).
-     */
-    @RegisterExtension
-    static final TestExecutorExtension<ScheduledExecutorService> JM_MAIN_THREAD_EXECUTOR_RESOURCE =
-            TestingUtils.jmMainThreadExecutorExtension();
-
-    @RegisterExtension
-    static final TestExecutorExtension<ScheduledExecutorService> EXECUTOR_RESOURCE =
-            TestingUtils.defaultExecutorExtension();
-
     @Test
     void testFinalizeIsCalledUponSuccess() throws Exception {
         final JobVertex vertex1 = spy(new JobVertex("test vertex 1"));
@@ -71,35 +52,28 @@ class FinalizeOnMasterTest {
         vertex2.setInvokableClass(NoOpInvokable.class);
         vertex2.setParallelism(2);
 
-        final ComponentMainThreadExecutor mainThreadExecutor =
-                ComponentMainThreadExecutorServiceAdapter.forSingleThreadExecutor(
-                        JM_MAIN_THREAD_EXECUTOR_RESOURCE.getExecutor());
-
+        // Use a direct future executor so the asynchronous deployment callbacks complete inline
+        // before the manual state transitions below, avoiding the FLINK-38536 race.
         final SchedulerBase scheduler =
                 createScheduler(
                         JobGraphTestUtils.streamingJobGraph(vertex1, vertex2),
-                        mainThreadExecutor,
-                        EXECUTOR_RESOURCE.getExecutor());
+                        ComponentMainThreadExecutorServiceAdapter.forMainThread(),
+                        new DirectScheduledExecutorService());
+        scheduler.startScheduling();
 
         final ExecutionGraph eg = scheduler.getExecutionGraph();
+        assertThat(eg.getState()).isEqualTo(JobStatus.RUNNING);
 
-        runInMainThread(mainThreadExecutor, scheduler::startScheduling);
-        assertThat(supplyInMainThread(mainThreadExecutor, eg::getState))
-                .isEqualTo(JobStatus.RUNNING);
-
-        runInMainThread(
-                mainThreadExecutor, () -> ExecutionGraphTestUtils.switchAllVerticesToRunning(eg));
+        ExecutionGraphTestUtils.switchAllVerticesToRunning(eg);
 
         // move all vertices to finished state
-        runInMainThread(mainThreadExecutor, () -> ExecutionGraphTestUtils.finishAllVertices(eg));
+        ExecutionGraphTestUtils.finishAllVertices(eg);
         assertThat(eg.waitUntilTerminal()).isEqualTo(JobStatus.FINISHED);
 
-        // waitUntilTerminal acts as the barrier, so the assertions below are safe off the main
-        // thread.
         verify(vertex1, times(1)).finalizeOnMaster(any(FinalizeOnMasterContext.class));
         verify(vertex2, times(1)).finalizeOnMaster(any(FinalizeOnMasterContext.class));
 
-        assertThat(supplyInMainThread(mainThreadExecutor, eg::getRegisteredExecutions)).isEmpty();
+        assertThat(eg.getRegisteredExecutions()).isEmpty();
     }
 
     @Test
@@ -108,54 +82,30 @@ class FinalizeOnMasterTest {
         vertex.setInvokableClass(NoOpInvokable.class);
         vertex.setParallelism(1);
 
-        final ComponentMainThreadExecutor mainThreadExecutor =
-                ComponentMainThreadExecutorServiceAdapter.forSingleThreadExecutor(
-                        JM_MAIN_THREAD_EXECUTOR_RESOURCE.getExecutor());
-
+        // Use a direct future executor so the asynchronous deployment callbacks complete inline
+        // before the manual state transitions below, avoiding the FLINK-38536 race.
         final SchedulerBase scheduler =
                 createScheduler(
                         JobGraphTestUtils.streamingJobGraph(vertex),
-                        mainThreadExecutor,
-                        EXECUTOR_RESOURCE.getExecutor());
+                        ComponentMainThreadExecutorServiceAdapter.forMainThread(),
+                        new DirectScheduledExecutorService());
+        scheduler.startScheduling();
 
         final ExecutionGraph eg = scheduler.getExecutionGraph();
 
-        runInMainThread(mainThreadExecutor, scheduler::startScheduling);
-        assertThat(supplyInMainThread(mainThreadExecutor, eg::getState))
-                .isEqualTo(JobStatus.RUNNING);
+        assertThat(eg.getState()).isEqualTo(JobStatus.RUNNING);
 
-        runInMainThread(
-                mainThreadExecutor, () -> ExecutionGraphTestUtils.switchAllVerticesToRunning(eg));
+        ExecutionGraphTestUtils.switchAllVerticesToRunning(eg);
 
         // fail the execution
-        runInMainThread(
-                mainThreadExecutor,
-                () -> {
-                    final Execution exec =
-                            eg.getJobVertex(vertex.getID())
-                                    .getTaskVertices()[0]
-                                    .getCurrentExecutionAttempt();
-                    exec.fail(new Exception("test"));
-                });
+        final Execution exec =
+                eg.getJobVertex(vertex.getID()).getTaskVertices()[0].getCurrentExecutionAttempt();
+        exec.fail(new Exception("test"));
 
         assertThat(eg.waitUntilTerminal()).isEqualTo(JobStatus.FAILED);
 
         verify(vertex, times(0)).finalizeOnMaster(any(FinalizeOnMasterContext.class));
 
-        assertThat(supplyInMainThread(mainThreadExecutor, eg::getRegisteredExecutions)).isEmpty();
-    }
-
-    /** Runs the action on the JobManager main thread and blocks until it completes. */
-    private static void runInMainThread(
-            final ComponentMainThreadExecutor mainThreadExecutor, final Runnable action)
-            throws Exception {
-        CompletableFuture.runAsync(action, mainThreadExecutor).get();
-    }
-
-    /** Reads the value on the JobManager main thread and blocks until it is available. */
-    private static <T> T supplyInMainThread(
-            final ComponentMainThreadExecutor mainThreadExecutor, final Supplier<T> supplier)
-            throws Exception {
-        return CompletableFuture.supplyAsync(supplier, mainThreadExecutor).get();
+        assertThat(eg.getRegisteredExecutions()).isEmpty();
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

Fixes a test flakiness regression introduced by FLINK-38536 (#28350) and observed in nightly build [76520](https://dev.azure.com/apache-flink/apache-flink/_build/results?buildId=76520&view=results) (legs `test_cron_azure core` and `test_cron_hadoop313 core`):

```
ExecutionGraphFinishTest.testJobFinishes:114
expected: 2
 but was: 1
```

**Root cause.** Both `ExecutionGraphFinishTest` and `FinalizeOnMasterTest` build the scheduler with a real future executor. `Execution.deploy()` sets `DEPLOYING` synchronously, but offloads `TaskDeploymentDescriptor` creation to that future executor and syncs the deploy-completion callback back to the main thread asynchronously. `Execution.tryGetTaskDeploymentDescriptorForSlot` fails the deployment (via `markFailed`) when it runs and finds the execution is no longer `DEPLOYING`. The tests drive executions to `RUNNING` (`switchAllVerticesToRunning`) before that callback runs, so it fails the deployment; with the default `NoRestartBackoffTimeStrategy` the job fails and a vertex never reaches `FINISHED`, leaving `getNumExecutionVertexFinished()` short by one.

The #28350 rewrite (a dedicated single-thread main executor with blocking `runInMainThread`/`supplyInMainThread` helpers) addressed the original main-thread-assertion race but left this async deployment-callback race, and the tight blocking calls made it more likely to trip.

## Brief change log

  - Run scheduling and deployment synchronously on the test thread by building the scheduler with `ComponentMainThreadExecutorServiceAdapter.forMainThread()` and a `DirectScheduledExecutorService` future executor, so the deployment callbacks complete inline while executions are still `DEPLOYING`. This is the established idiom in the package (e.g. `DefaultExecutionGraphDeploymentTest`).
  - Supersede the `forSingleThreadExecutor` approach from #28350 and remove the `runInMainThread`/`supplyInMainThread` helpers it introduced.

Note: removing `eg.waitUntilTerminal()` in `ExecutionGraphFinishTest.testJobFinishes` is safe and equivalent here, because deployment and the final state transition are now reached synchronously by the last `markFinished()`.

## Verifying this change

This change is already covered by the existing tests `ExecutionGraphFinishTest` and `FinalizeOnMasterTest`, and was verified by reproducing the flake before the fix and confirming it is gone after:

  - Before the fix, `ExecutionGraphFinishTest#testJobFinishes` (run as `@RepeatedTest(2000)`) failed ~2% of repetitions; temporary instrumentation in `tryGetTaskDeploymentDescriptorForSlot` showed every failure was preceded by the callback running while the execution was already `RUNNING`.
  - With the fix, `ExecutionGraphFinishTest` (2000 repetitions) and `FinalizeOnMasterTest` (2000 repetitions per method) pass with zero failures and zero instrumentation hits.
  - `mvn -pl flink-runtime spotless:check` passes.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no (test-only change)
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: Claude Opus 4.8 (1M context)
