### PR TITLE
[FLINK-40036][tests] Support custom MockEnvironment in multi-input harness…

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/MockEnvironment.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/MockEnvironment.java
@@ -179,13 +179,14 @@ public class MockEnvironment implements Environment, AutoCloseable {
             TaskManagerRuntimeInfo taskManagerRuntimeInfo,
             MemoryManager memManager,
             ExternalResourceInfoProvider externalResourceInfoProvider,
-            ChannelStateWriteRequestExecutorFactory channelStateExecutorFactory) {
+            ChannelStateWriteRequestExecutorFactory channelStateExecutorFactory,
+            Configuration jobConfiguration) {
 
         this.jobInfo = new JobInfoImpl(jobID, jobName);
         this.jobVertexID = jobVertexID;
         this.jobType = jobType;
         this.taskInfo = new TaskInfoImpl(taskName, maxParallelism, subtaskIndex, parallelism, 0);
-        this.jobConfiguration = new Configuration();
+        this.jobConfiguration = jobConfiguration;
         this.taskConfiguration = taskConfiguration;
         this.inputs = new LinkedList<>();
         this.outputs = new LinkedList<ResultPartitionWriter>();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/MockEnvironmentBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/MockEnvironmentBuilder.java
@@ -67,6 +67,7 @@ public class MockEnvironmentBuilder {
             ExternalResourceInfoProvider.NO_EXTERNAL_RESOURCES;
     private ChannelStateWriteRequestExecutorFactory channelStateExecutorFactory =
             new ChannelStateWriteRequestExecutorFactory(jobID);
+    private Configuration jobConfiguration = new Configuration();
 
     private MemoryManager buildMemoryManager(long memorySize) {
         return MemoryManagerBuilder.newBuilder().setMemorySize(memorySize).build();
@@ -181,6 +182,11 @@ public class MockEnvironmentBuilder {
         return this;
     }
 
+    public MockEnvironmentBuilder setJobConfiguration(Configuration jobConfiguration) {
+        this.jobConfiguration = jobConfiguration;
+        return this;
+    }
+
     public MockEnvironment build() {
         if (ioManager == null) {
             ioManager = new IOManagerAsync();
@@ -206,6 +212,7 @@ public class MockEnvironmentBuilder {
                 taskManagerRuntimeInfo,
                 memoryManager,
                 externalResourceInfoProvider,
-                channelStateExecutorFactory);
+                channelStateExecutorFactory,
+                jobConfiguration);
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/streaming/util/KeyedMultiInputStreamOperatorTestHarness.java
+++ b/flink-runtime/src/test/java/org/apache/flink/streaming/util/KeyedMultiInputStreamOperatorTestHarness.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.ClosureCleaner;
 import org.apache.flink.api.java.functions.KeySelector;
+import org.apache.flink.runtime.operators.testutils.MockEnvironment;
 import org.apache.flink.streaming.api.operators.MultipleInputStreamOperator;
 import org.apache.flink.streaming.api.operators.StreamOperatorFactory;
 
@@ -38,6 +39,17 @@ public class KeyedMultiInputStreamOperatorTestHarness<KEY, OUT>
     public KeyedMultiInputStreamOperatorTestHarness(
             StreamOperatorFactory<OUT> operator, TypeInformation<KEY> keyType) throws Exception {
         this(operator, 1, 1, 0);
+        config.setStateKeySerializer(
+                keyType.createSerializer(executionConfig.getSerializerConfig()));
+        config.serializeAllConfigs();
+    }
+
+    public KeyedMultiInputStreamOperatorTestHarness(
+            StreamOperatorFactory<OUT> operator,
+            TypeInformation<KEY> keyType,
+            MockEnvironment environment)
+            throws Exception {
+        super(operator, environment);
         config.setStateKeySerializer(
                 keyType.createSerializer(executionConfig.getSerializerConfig()));
         config.serializeAllConfigs();

--- a/flink-runtime/src/test/java/org/apache/flink/streaming/util/MultiInputStreamOperatorTestHarness.java
+++ b/flink-runtime/src/test/java/org/apache/flink/streaming/util/MultiInputStreamOperatorTestHarness.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.streaming.util;
 
+import org.apache.flink.runtime.operators.testutils.MockEnvironment;
 import org.apache.flink.streaming.api.operators.Input;
 import org.apache.flink.streaming.api.operators.MultipleInputStreamOperator;
 import org.apache.flink.streaming.api.operators.StreamOperatorFactory;
@@ -48,6 +49,12 @@ public class MultiInputStreamOperatorTestHarness<OUT>
             int subtaskIndex)
             throws Exception {
         super(operatorFactory, maxParallelism, numSubtasks, subtaskIndex);
+    }
+
+    public MultiInputStreamOperatorTestHarness(
+            StreamOperatorFactory<OUT> operatorFactory, MockEnvironment environment)
+            throws Exception {
+        super(operatorFactory, environment);
     }
 
     public void processElement(int idx, StreamRecord<?> element) throws Exception {

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/join/stream/multijoin/StreamingMultiJoinOperatorTestBase.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/join/stream/multijoin/StreamingMultiJoinOperatorTestBase.java
@@ -20,6 +20,7 @@ package org.apache.flink.table.runtime.operators.join.stream.multijoin;
 
 import org.apache.flink.api.common.functions.AbstractRichFunction;
 import org.apache.flink.api.java.functions.KeySelector;
+import org.apache.flink.runtime.operators.testutils.MockEnvironment;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.util.KeyedMultiInputStreamOperatorTestHarness;
 import org.apache.flink.table.data.RowData;
@@ -157,7 +158,9 @@ public abstract class StreamingMultiJoinOperatorTestBase extends StateParameteri
     @AfterEach
     protected void afterEach() throws Exception {
         if (testHarness != null) {
+            MockEnvironment environment = testHarness.getEnvironment();
             testHarness.close();
+            environment.close();
         }
     }
 
@@ -404,7 +407,8 @@ public abstract class StreamingMultiJoinOperatorTestBase extends StateParameteri
                         this.joinAttributeMap);
 
         KeyedMultiInputStreamOperatorTestHarness<RowData, RowData> harness =
-                new KeyedMultiInputStreamOperatorTestHarness<>(factory, partitionKeyTypeInfo);
+                new KeyedMultiInputStreamOperatorTestHarness<>(
+                        factory, partitionKeyTypeInfo, createMockEnvironment());
 
         setupKeySelectorsForTestHarness(harness);
 

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/util/StateParameterizedHarnessTestBase.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/util/StateParameterizedHarnessTestBase.java
@@ -18,7 +18,12 @@
 
 package org.apache.flink.table.runtime.util;
 
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.configuration.CheckpointingOptions;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.MemorySize;
+import org.apache.flink.runtime.operators.testutils.MockEnvironment;
+import org.apache.flink.runtime.operators.testutils.MockEnvironmentBuilder;
 import org.apache.flink.runtime.state.CheckpointStorage;
 import org.apache.flink.runtime.state.StateBackend;
 import org.apache.flink.runtime.state.hashmap.HashMapStateBackend;
@@ -36,6 +41,13 @@ import java.util.Arrays;
 import java.util.Collection;
 
 public abstract class StateParameterizedHarnessTestBase {
+
+    /**
+     * Managed memory for the harness environment. Sized for state backends that reserve managed
+     * memory per keyed-state DB (the harness default of 3 MB is too small for them); harmless for
+     * the others.
+     */
+    private static final MemorySize MANAGED_MEMORY = MemorySize.ofMebiBytes(128);
 
     @Rule public TemporaryFolder tempFolder = new TemporaryFolder();
 
@@ -93,6 +105,35 @@ public abstract class StateParameterizedHarnessTestBase {
             default:
                 throw new IllegalArgumentException("Unknown mode: " + mode);
         }
+    }
+
+    /**
+     * Builds the {@link MockEnvironment} the test harness is constructed with. The harness would
+     * otherwise build its own with only 3 MB of managed memory and no checkpoint storage. We
+     * configure it the same way for every backend: enough managed memory, and a filesystem
+     * checkpoint storage (so a backend that resolves a task-owned state directory from it works).
+     */
+    protected MockEnvironment createMockEnvironment() {
+        String checkpointPath = "file://" + tempFolder.getRoot().getAbsolutePath();
+
+        Configuration jobConfig = new Configuration();
+        jobConfig.set(CheckpointingOptions.CHECKPOINTS_DIRECTORY, checkpointPath);
+
+        MockEnvironment environment =
+                new MockEnvironmentBuilder()
+                        .setManagedMemorySize(MANAGED_MEMORY.getBytes())
+                        .setJobConfiguration(jobConfig)
+                        .build();
+
+        try {
+            environment.setCheckpointStorageAccess(
+                    new FileSystemCheckpointStorage(checkpointPath)
+                            .createCheckpointStorage(new JobID()));
+        } catch (IOException e) {
+            throw new RuntimeException(
+                    "Cannot create checkpoint storage for the test environment", e);
+        }
+        return environment;
     }
 
     @Parameters(name = "StateBackend={0}")


### PR DESCRIPTION
## What is the purpose of the change

Some state-backend implementations need the test harness to run with a properly
configured `MockEnvironment` (e.g. more managed memory than the 3 MB default, a
job configuration, and checkpoint storage access) rather than the bare environment
the harness builds for itself. Today there is no way to inject such an environment
into the multi-input test harnesses, and `MockEnvironmentBuilder` cannot set a job
configuration.

This change adds that capability as a generic test utility so harness-based tests
can construct the operator with a custom `MockEnvironment`.

## Brief change log

  - `MockEnvironmentBuilder`: add `setJobConfiguration(...)` and pass the job
    configuration through to `MockEnvironment` (previously hardcoded to an empty
    `Configuration`).
  - `MultiInputStreamOperatorTestHarness` / `KeyedMultiInputStreamOperatorTestHarness`:
    add constructors that accept a `MockEnvironment`.
  - `StateParameterizedHarnessTestBase`: add a `createMockEnvironment()` helper that
    builds an environment with sufficient managed memory and a filesystem checkpoint
    storage, reusable across backends.
  - `StreamingMultiJoinOperatorTestBase`: build the harness with the custom
    environment and close the environment in `afterEach`.

## Verifying this change

This change is a test-only utility change and is covered by the existing
`StateParameterizedHarnessTestBase`-based tests (e.g. the streaming multi-join
operator tests), which continue to pass with the HEAP and ROCKSDB backends.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (Claude Code)

Claude Code (Opus 4.8)