### PR TITLE
[FLINK-40027][state] Align SavepointKeyFilter with the State Processor API generic convention

### DIFF
--- a/docs/content.zh/docs/libs/state_processor_api.md
+++ b/docs/content.zh/docs/libs/state_processor_api.md
@@ -252,7 +252,8 @@ DataStream<KeyedState> keyRange = savepoint.readKeyedState(
 `SavepointKeyFilter` provides the following factory methods:
 
 * `SavepointKeyFilter.exact(K key)` / `SavepointKeyFilter.exact(Set<K> keys)` — match a single key or a finite set of keys.
-* `SavepointKeyFilter.range(K lower, boolean lowerInclusive, K upper, boolean upperInclusive)` — match a range (`K` must implement `Comparable<K>`). Either bound may be `null` to leave that side unbounded.
+* `SavepointKeyFilter.range(K lower, boolean lowerInclusive, K upper, boolean upperInclusive)` — match a range; `K` must implement `Comparable<K>`. Either bound may be `null` to leave that side unbounded.
+* `SavepointKeyFilter.range(K lower, boolean lowerInclusive, K upper, boolean upperInclusive, Comparator<K> comparator)` — same, but with an explicit comparator for key types that do not implement `Comparable<K>`.
 * `SavepointKeyFilter.empty()` — match no keys. Not intended for direct use — it only serves as an internal building block for the Table API filter pushdown.
 
 When the built-in filters are not enough, you can implement the `SavepointKeyFilter<K>` interface yourself.

--- a/docs/content.zh/docs/libs/state_processor_api.md
+++ b/docs/content.zh/docs/libs/state_processor_api.md
@@ -251,20 +251,20 @@ DataStream<KeyedState> keyRange = savepoint.readKeyedState(
 
 `SavepointKeyFilter` provides the following factory methods:
 
-* `SavepointKeyFilter.exact(Object key)` / `SavepointKeyFilter.exact(Set<Object> keys)` — match a single key or a finite set of keys.
-* `SavepointKeyFilter.range(Comparable<?> lower, boolean lowerInclusive, Comparable<?> upper, boolean upperInclusive)` — match a range. Either bound may be `null` to leave that side unbounded.
+* `SavepointKeyFilter.exact(K key)` / `SavepointKeyFilter.exact(Set<K> keys)` — match a single key or a finite set of keys.
+* `SavepointKeyFilter.range(K lower, boolean lowerInclusive, K upper, boolean upperInclusive)` — match a range (`K` must implement `Comparable<K>`). Either bound may be `null` to leave that side unbounded.
 * `SavepointKeyFilter.empty()` — match no keys. Not intended for direct use — it only serves as an internal building block for the Table API filter pushdown.
 
-When the built-in filters are not enough, you can implement the `SavepointKeyFilter` interface yourself.
-For use with the DataStream API, only `test(Object key)` has to be implemented; it is called for every key in each opened split and decides whether that key will be read.
+When the built-in filters are not enough, you can implement the `SavepointKeyFilter<K>` interface yourself.
+For use with the DataStream API, only `test(K key)` has to be implemented; it is called for every key in each opened split and decides whether that key will be read.
 
 ```java
 // Reads the state only for even keys
-public class EvenKeyFilter implements SavepointKeyFilter {
+public class EvenKeyFilter implements SavepointKeyFilter<Integer> {
 
     @Override
-    public boolean test(Object key) {
-        return ((Integer) key) % 2 == 0;
+    public boolean test(Integer key) {
+        return key % 2 == 0;
     }
 }
 
@@ -281,7 +281,7 @@ If your filter resolves to a finite set of keys, additionally override `getExact
 
 ```java
 // Reads the state only for keys 0..max
-public class UpToKeyFilter implements SavepointKeyFilter {
+public class UpToKeyFilter implements SavepointKeyFilter<Integer> {
 
     private final int max;
 
@@ -290,15 +290,14 @@ public class UpToKeyFilter implements SavepointKeyFilter {
     }
 
     @Override
-    public boolean test(Object key) {
-        int k = (Integer) key;
-        return k >= 0 && k <= max;
+    public boolean test(Integer key) {
+        return key >= 0 && key <= max;
     }
 
     @Override
-    public Set<Object> getExactKeys() {
+    public Set<Integer> getExactKeys() {
         // Enumerate the finite key set so Flink can prune splits up front
-        Set<Object> keys = new HashSet<>();
+        Set<Integer> keys = new HashSet<>();
         for (int k = 0; k <= max; k++) {
             keys.add(k);
         }

--- a/docs/content.zh/docs/libs/state_processor_api.md
+++ b/docs/content.zh/docs/libs/state_processor_api.md
@@ -253,7 +253,7 @@ DataStream<KeyedState> keyRange = savepoint.readKeyedState(
 
 * `SavepointKeyFilter.exact(K key)` / `SavepointKeyFilter.exact(Set<K> keys)` — match a single key or a finite set of keys.
 * `SavepointKeyFilter.range(K lower, boolean lowerInclusive, K upper, boolean upperInclusive)` — match a range; `K` must implement `Comparable<K>`. Either bound may be `null` to leave that side unbounded.
-* `SavepointKeyFilter.range(K lower, boolean lowerInclusive, K upper, boolean upperInclusive, Comparator<K> comparator)` — same, but with an explicit comparator for key types that do not implement `Comparable<K>`.
+* `SavepointKeyFilter.range(K lower, boolean lowerInclusive, K upper, boolean upperInclusive, SerializableComparator<K> comparator)` — same, but with an explicit comparator for key types that do not implement `Comparable<K>`. The comparator must be serializable because the filter is shipped with the job; lambdas and method references assigned to `SerializableComparator` satisfy this automatically.
 * `SavepointKeyFilter.empty()` — match no keys. Not intended for direct use — it only serves as an internal building block for the Table API filter pushdown.
 
 When the built-in filters are not enough, you can implement the `SavepointKeyFilter<K>` interface yourself.

--- a/docs/content/docs/libs/state_processor_api.md
+++ b/docs/content/docs/libs/state_processor_api.md
@@ -267,7 +267,7 @@ DataStream<KeyedState> keyRange = savepoint.readKeyedState(
 
 * `SavepointKeyFilter.exact(K key)` / `SavepointKeyFilter.exact(Set<K> keys)` — match a single key or a finite set of keys.
 * `SavepointKeyFilter.range(K lower, boolean lowerInclusive, K upper, boolean upperInclusive)` — match a range; `K` must implement `Comparable<K>`. Either bound may be `null` to leave that side unbounded.
-* `SavepointKeyFilter.range(K lower, boolean lowerInclusive, K upper, boolean upperInclusive, Comparator<K> comparator)` — same, but with an explicit comparator for key types that do not implement `Comparable<K>`.
+* `SavepointKeyFilter.range(K lower, boolean lowerInclusive, K upper, boolean upperInclusive, SerializableComparator<K> comparator)` — same, but with an explicit comparator for key types that do not implement `Comparable<K>`. The comparator must be serializable because the filter is shipped with the job; lambdas and method references assigned to `SerializableComparator` satisfy this automatically.
 * `SavepointKeyFilter.empty()` — match no keys. Not intended for direct use — it only serves as an internal building block for the Table API filter pushdown.
 
 When the built-in filters are not enough, you can implement the `SavepointKeyFilter<K>` interface yourself.

--- a/docs/content/docs/libs/state_processor_api.md
+++ b/docs/content/docs/libs/state_processor_api.md
@@ -265,20 +265,20 @@ DataStream<KeyedState> keyRange = savepoint.readKeyedState(
 
 `SavepointKeyFilter` provides the following factory methods:
 
-* `SavepointKeyFilter.exact(Object key)` / `SavepointKeyFilter.exact(Set<Object> keys)` — match a single key or a finite set of keys.
-* `SavepointKeyFilter.range(Comparable<?> lower, boolean lowerInclusive, Comparable<?> upper, boolean upperInclusive)` — match a range. Either bound may be `null` to leave that side unbounded.
+* `SavepointKeyFilter.exact(K key)` / `SavepointKeyFilter.exact(Set<K> keys)` — match a single key or a finite set of keys.
+* `SavepointKeyFilter.range(K lower, boolean lowerInclusive, K upper, boolean upperInclusive)` — match a range (`K` must implement `Comparable<K>`). Either bound may be `null` to leave that side unbounded.
 * `SavepointKeyFilter.empty()` — match no keys. Not intended for direct use — it only serves as an internal building block for the Table API filter pushdown.
 
-When the built-in filters are not enough, you can implement the `SavepointKeyFilter` interface yourself.
-For use with the DataStream API, only `test(Object key)` has to be implemented; it is called for every key in each opened split and decides whether that key will be read.
+When the built-in filters are not enough, you can implement the `SavepointKeyFilter<K>` interface yourself.
+For use with the DataStream API, only `test(K key)` has to be implemented; it is called for every key in each opened split and decides whether that key will be read.
 
 ```java
 // Reads the state only for even keys
-public class EvenKeyFilter implements SavepointKeyFilter {
+public class EvenKeyFilter implements SavepointKeyFilter<Integer> {
 
     @Override
-    public boolean test(Object key) {
-        return ((Integer) key) % 2 == 0;
+    public boolean test(Integer key) {
+        return key % 2 == 0;
     }
 }
 
@@ -295,7 +295,7 @@ If your filter resolves to a finite set of keys, additionally override `getExact
 
 ```java
 // Reads the state only for keys 0..max
-public class UpToKeyFilter implements SavepointKeyFilter {
+public class UpToKeyFilter implements SavepointKeyFilter<Integer> {
 
     private final int max;
 
@@ -304,15 +304,14 @@ public class UpToKeyFilter implements SavepointKeyFilter {
     }
 
     @Override
-    public boolean test(Object key) {
-        int k = (Integer) key;
-        return k >= 0 && k <= max;
+    public boolean test(Integer key) {
+        return key >= 0 && key <= max;
     }
 
     @Override
-    public Set<Object> getExactKeys() {
+    public Set<Integer> getExactKeys() {
         // Enumerate the finite key set so Flink can prune splits up front
-        Set<Object> keys = new HashSet<>();
+        Set<Integer> keys = new HashSet<>();
         for (int k = 0; k <= max; k++) {
             keys.add(k);
         }

--- a/docs/content/docs/libs/state_processor_api.md
+++ b/docs/content/docs/libs/state_processor_api.md
@@ -266,7 +266,8 @@ DataStream<KeyedState> keyRange = savepoint.readKeyedState(
 `SavepointKeyFilter` provides the following factory methods:
 
 * `SavepointKeyFilter.exact(K key)` / `SavepointKeyFilter.exact(Set<K> keys)` — match a single key or a finite set of keys.
-* `SavepointKeyFilter.range(K lower, boolean lowerInclusive, K upper, boolean upperInclusive)` — match a range (`K` must implement `Comparable<K>`). Either bound may be `null` to leave that side unbounded.
+* `SavepointKeyFilter.range(K lower, boolean lowerInclusive, K upper, boolean upperInclusive)` — match a range; `K` must implement `Comparable<K>`. Either bound may be `null` to leave that side unbounded.
+* `SavepointKeyFilter.range(K lower, boolean lowerInclusive, K upper, boolean upperInclusive, Comparator<K> comparator)` — same, but with an explicit comparator for key types that do not implement `Comparable<K>`.
 * `SavepointKeyFilter.empty()` — match no keys. Not intended for direct use — it only serves as an internal building block for the Table API filter pushdown.
 
 When the built-in filters are not enough, you can implement the `SavepointKeyFilter<K>` interface yourself.

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/SavepointReader.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/SavepointReader.java
@@ -428,7 +428,7 @@ public class SavepointReader {
             KeyedStateReaderFunction<K, OUT> function,
             TypeInformation<K> keyTypeInfo,
             TypeInformation<OUT> outTypeInfo,
-            @Nullable SavepointKeyFilter keyFilter)
+            @Nullable SavepointKeyFilter<K> keyFilter)
             throws IOException {
 
         OperatorState operatorState = metadata.getOperatorState(identifier);

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/filter/BoundInfo.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/filter/BoundInfo.java
@@ -24,18 +24,18 @@ import java.io.Serializable;
 
 /** Information about a bound in a range filter. */
 @Experimental
-public final class BoundInfo implements Serializable {
+public final class BoundInfo<K> implements Serializable {
     private static final long serialVersionUID = 4L;
 
-    private final Comparable<?> value;
+    private final K value;
     private final boolean inclusive;
 
-    public BoundInfo(Comparable<?> value, boolean inclusive) {
+    public BoundInfo(K value, boolean inclusive) {
         this.value = value;
         this.inclusive = inclusive;
     }
 
-    public Comparable<?> getValue() {
+    public K getValue() {
         return value;
     }
 

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/filter/EmptyKeyFilter.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/filter/EmptyKeyFilter.java
@@ -22,16 +22,22 @@ import java.util.Collections;
 import java.util.Set;
 
 /** A filter that rejects every key. */
-final class EmptyKeyFilter implements SavepointKeyFilter {
+final class EmptyKeyFilter<K> implements SavepointKeyFilter<K> {
 
     private static final long serialVersionUID = 1L;
 
-    static final EmptyKeyFilter INSTANCE = new EmptyKeyFilter();
+    @SuppressWarnings("rawtypes")
+    private static final EmptyKeyFilter INSTANCE = new EmptyKeyFilter<>();
 
     private EmptyKeyFilter() {}
 
+    @SuppressWarnings("unchecked")
+    static <K> EmptyKeyFilter<K> instance() {
+        return (EmptyKeyFilter<K>) INSTANCE;
+    }
+
     @Override
-    public boolean test(Object key) {
+    public boolean test(K key) {
         return false;
     }
 
@@ -41,12 +47,12 @@ final class EmptyKeyFilter implements SavepointKeyFilter {
     }
 
     @Override
-    public Set<Object> getExactKeys() {
+    public Set<K> getExactKeys() {
         return Collections.emptySet();
     }
 
     @Override
-    public SavepointKeyFilter intersect(SavepointKeyFilter other) {
+    public SavepointKeyFilter<K> intersect(SavepointKeyFilter<K> other) {
         return this;
     }
 

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/filter/ExactKeyFilter.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/filter/ExactKeyFilter.java
@@ -22,34 +22,34 @@ import java.util.HashSet;
 import java.util.Set;
 
 /** A filter that accepts a finite set of keys. */
-final class ExactKeyFilter implements SavepointKeyFilter {
+final class ExactKeyFilter<K> implements SavepointKeyFilter<K> {
 
     private static final long serialVersionUID = 2L;
 
-    private final Set<Object> keys;
+    private final Set<K> keys;
 
-    ExactKeyFilter(Set<Object> keys) {
+    ExactKeyFilter(Set<K> keys) {
         this.keys = Set.copyOf(keys);
     }
 
     @Override
-    public boolean test(Object key) {
+    public boolean test(K key) {
         return keys.contains(key);
     }
 
     @Override
-    public Set<Object> getExactKeys() {
+    public Set<K> getExactKeys() {
         return keys;
     }
 
     @Override
-    public SavepointKeyFilter intersect(SavepointKeyFilter other) {
+    public SavepointKeyFilter<K> intersect(SavepointKeyFilter<K> other) {
         if (other.isEmpty()) {
             return other;
         }
-        final Set<Object> otherKeys = other.getExactKeys();
+        final Set<K> otherKeys = other.getExactKeys();
         if (otherKeys != null) {
-            final Set<Object> intersection = new HashSet<>(keys);
+            final Set<K> intersection = new HashSet<>(keys);
             intersection.retainAll(otherKeys);
             return SavepointKeyFilter.exact(intersection);
         }

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/filter/RangeKeyFilter.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/filter/RangeKeyFilter.java
@@ -20,17 +20,21 @@ package org.apache.flink.state.api.filter;
 
 import javax.annotation.Nullable;
 
+import java.util.Comparator;
 import java.util.Set;
 
-/** A filter based on a comparable range. */
-final class RangeKeyFilter<K extends Comparable<K>> implements SavepointKeyFilter<K> {
+/** A filter based on a range with an injected comparator. */
+final class RangeKeyFilter<K> implements SavepointKeyFilter<K> {
 
     private static final long serialVersionUID = 3L;
 
-    @Nullable private final BoundInfo lower;
-    @Nullable private final BoundInfo upper;
+    private final Comparator<K> comparator;
+    @Nullable private final BoundInfo<K> lower;
+    @Nullable private final BoundInfo<K> upper;
 
-    RangeKeyFilter(@Nullable BoundInfo lower, @Nullable BoundInfo upper) {
+    RangeKeyFilter(
+            Comparator<K> comparator, @Nullable BoundInfo<K> lower, @Nullable BoundInfo<K> upper) {
+        this.comparator = comparator;
         this.lower = lower;
         this.upper = upper;
     }
@@ -38,13 +42,13 @@ final class RangeKeyFilter<K extends Comparable<K>> implements SavepointKeyFilte
     @Override
     public boolean test(K key) {
         if (lower != null) {
-            int cmp = compare(lower.getValue(), key);
+            int cmp = comparator.compare(lower.getValue(), key);
             if (cmp > 0 || (cmp == 0 && !lower.isInclusive())) {
                 return false;
             }
         }
         if (upper != null) {
-            int cmp = compare(upper.getValue(), key);
+            int cmp = comparator.compare(upper.getValue(), key);
             if (cmp < 0 || (cmp == 0 && !upper.isInclusive())) {
                 return false;
             }
@@ -52,18 +56,13 @@ final class RangeKeyFilter<K extends Comparable<K>> implements SavepointKeyFilte
         return true;
     }
 
-    @SuppressWarnings("unchecked")
-    private static int compare(Comparable<?> a, Object b) {
-        return ((Comparable<Object>) a).compareTo(b);
-    }
-
     @Override
-    public BoundInfo getLowerBound() {
+    public BoundInfo<K> getLowerBound() {
         return lower;
     }
 
     @Override
-    public BoundInfo getUpperBound() {
+    public BoundInfo<K> getUpperBound() {
         return upper;
     }
 
@@ -80,12 +79,12 @@ final class RangeKeyFilter<K extends Comparable<K>> implements SavepointKeyFilte
     }
 
     private SavepointKeyFilter<K> intersectRange(
-            @Nullable BoundInfo otherLower, @Nullable BoundInfo otherUpper) {
-        BoundInfo newLower = tighter(lower, otherLower, true);
-        BoundInfo newUpper = tighter(upper, otherUpper, false);
+            @Nullable BoundInfo<K> otherLower, @Nullable BoundInfo<K> otherUpper) {
+        BoundInfo<K> newLower = tighter(lower, otherLower, true);
+        BoundInfo<K> newUpper = tighter(upper, otherUpper, false);
 
         if (newLower != null && newUpper != null) {
-            int cmp = compare(newLower.getValue(), newUpper.getValue());
+            int cmp = comparator.compare(newLower.getValue(), newUpper.getValue());
             if (cmp > 0) {
                 return SavepointKeyFilter.empty();
             }
@@ -93,21 +92,21 @@ final class RangeKeyFilter<K extends Comparable<K>> implements SavepointKeyFilte
                 return SavepointKeyFilter.empty();
             }
         }
-        return new RangeKeyFilter<>(newLower, newUpper);
+        return new RangeKeyFilter<>(comparator, newLower, newUpper);
     }
 
     @Nullable
-    private static BoundInfo tighter(
-            @Nullable BoundInfo a, @Nullable BoundInfo b, boolean preferHigher) {
+    private BoundInfo<K> tighter(
+            @Nullable BoundInfo<K> a, @Nullable BoundInfo<K> b, boolean preferHigher) {
         if (a == null) {
             return b;
         }
         if (b == null) {
             return a;
         }
-        int c = compare(a.getValue(), b.getValue());
+        int c = comparator.compare(a.getValue(), b.getValue());
         if (c == 0) {
-            return new BoundInfo(a.getValue(), a.isInclusive() && b.isInclusive());
+            return new BoundInfo<>(a.getValue(), a.isInclusive() && b.isInclusive());
         }
         boolean aWins = preferHigher ? c > 0 : c < 0;
         return aWins ? a : b;

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/filter/RangeKeyFilter.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/filter/RangeKeyFilter.java
@@ -20,7 +20,6 @@ package org.apache.flink.state.api.filter;
 
 import javax.annotation.Nullable;
 
-import java.util.Comparator;
 import java.util.Set;
 
 /** A filter based on a range with an injected comparator. */
@@ -28,12 +27,14 @@ final class RangeKeyFilter<K> implements SavepointKeyFilter<K> {
 
     private static final long serialVersionUID = 3L;
 
-    private final Comparator<K> comparator;
+    private final SerializableComparator<K> comparator;
     @Nullable private final BoundInfo<K> lower;
     @Nullable private final BoundInfo<K> upper;
 
     RangeKeyFilter(
-            Comparator<K> comparator, @Nullable BoundInfo<K> lower, @Nullable BoundInfo<K> upper) {
+            SerializableComparator<K> comparator,
+            @Nullable BoundInfo<K> lower,
+            @Nullable BoundInfo<K> upper) {
         this.comparator = comparator;
         this.lower = lower;
         this.upper = upper;

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/filter/RangeKeyFilter.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/filter/RangeKeyFilter.java
@@ -23,7 +23,7 @@ import javax.annotation.Nullable;
 import java.util.Set;
 
 /** A filter based on a comparable range. */
-final class RangeKeyFilter implements SavepointKeyFilter {
+final class RangeKeyFilter<K extends Comparable<K>> implements SavepointKeyFilter<K> {
 
     private static final long serialVersionUID = 3L;
 
@@ -36,7 +36,7 @@ final class RangeKeyFilter implements SavepointKeyFilter {
     }
 
     @Override
-    public boolean test(Object key) {
+    public boolean test(K key) {
         if (lower != null) {
             int cmp = compare(lower.getValue(), key);
             if (cmp > 0 || (cmp == 0 && !lower.isInclusive())) {
@@ -68,18 +68,18 @@ final class RangeKeyFilter implements SavepointKeyFilter {
     }
 
     @Override
-    public SavepointKeyFilter intersect(SavepointKeyFilter other) {
+    public SavepointKeyFilter<K> intersect(SavepointKeyFilter<K> other) {
         if (other.isEmpty()) {
             return other;
         }
-        final Set<Object> otherExactKeys = other.getExactKeys();
+        final Set<K> otherExactKeys = other.getExactKeys();
         if (otherExactKeys != null) {
             return SavepointKeyFilter.filterKeys(otherExactKeys, this);
         }
         return intersectRange(other.getLowerBound(), other.getUpperBound());
     }
 
-    private SavepointKeyFilter intersectRange(
+    private SavepointKeyFilter<K> intersectRange(
             @Nullable BoundInfo otherLower, @Nullable BoundInfo otherUpper) {
         BoundInfo newLower = tighter(lower, otherLower, true);
         BoundInfo newUpper = tighter(upper, otherUpper, false);
@@ -93,7 +93,7 @@ final class RangeKeyFilter implements SavepointKeyFilter {
                 return SavepointKeyFilter.empty();
             }
         }
-        return new RangeKeyFilter(newLower, newUpper);
+        return new RangeKeyFilter<>(newLower, newUpper);
     }
 
     @Nullable

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/filter/SavepointKeyFilter.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/filter/SavepointKeyFilter.java
@@ -23,7 +23,6 @@ import org.apache.flink.annotation.Experimental;
 import javax.annotation.Nullable;
 
 import java.io.Serializable;
-import java.util.Comparator;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -112,7 +111,7 @@ public interface SavepointKeyFilter<K> extends Serializable {
 
     static <K extends Comparable<K>> SavepointKeyFilter<K> range(
             @Nullable K lower, boolean lowerInclusive, @Nullable K upper, boolean upperInclusive) {
-        return range(lower, lowerInclusive, upper, upperInclusive, Comparator.naturalOrder());
+        return range(lower, lowerInclusive, upper, upperInclusive, new NaturalOrderComparator<>());
     }
 
     static <K> SavepointKeyFilter<K> range(
@@ -120,7 +119,7 @@ public interface SavepointKeyFilter<K> extends Serializable {
             boolean lowerInclusive,
             @Nullable K upper,
             boolean upperInclusive,
-            Comparator<K> comparator) {
+            SerializableComparator<K> comparator) {
         BoundInfo<K> lowerBoundInfo = lower != null ? new BoundInfo<>(lower, lowerInclusive) : null;
         BoundInfo<K> upperBoundInfo = upper != null ? new BoundInfo<>(upper, upperInclusive) : null;
         return new RangeKeyFilter<>(comparator, lowerBoundInfo, upperBoundInfo);
@@ -128,5 +127,25 @@ public interface SavepointKeyFilter<K> extends Serializable {
 
     static <K> SavepointKeyFilter<K> empty() {
         return EmptyKeyFilter.instance();
+    }
+
+    final class NaturalOrderComparator<K extends Comparable<K>>
+            implements SerializableComparator<K> {
+        private static final long serialVersionUID = 1L;
+
+        @Override
+        public int compare(K a, K b) {
+            return a.compareTo(b);
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            return o instanceof NaturalOrderComparator;
+        }
+
+        @Override
+        public int hashCode() {
+            return NaturalOrderComparator.class.hashCode();
+        }
     }
 }

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/filter/SavepointKeyFilter.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/filter/SavepointKeyFilter.java
@@ -23,6 +23,7 @@ import org.apache.flink.annotation.Experimental;
 import javax.annotation.Nullable;
 
 import java.io.Serializable;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -62,7 +63,7 @@ public interface SavepointKeyFilter<K> extends Serializable {
      * <p>Used only while combining filters during push-down translation, not during the scan.
      */
     @Nullable
-    default BoundInfo getLowerBound() {
+    default BoundInfo<K> getLowerBound() {
         return null;
     }
 
@@ -73,7 +74,7 @@ public interface SavepointKeyFilter<K> extends Serializable {
      * <p>Used only while combining filters during push-down translation, not during the scan.
      */
     @Nullable
-    default BoundInfo getUpperBound() {
+    default BoundInfo<K> getUpperBound() {
         return null;
     }
 
@@ -111,9 +112,18 @@ public interface SavepointKeyFilter<K> extends Serializable {
 
     static <K extends Comparable<K>> SavepointKeyFilter<K> range(
             @Nullable K lower, boolean lowerInclusive, @Nullable K upper, boolean upperInclusive) {
-        BoundInfo lowerBoundInfo = lower != null ? new BoundInfo(lower, lowerInclusive) : null;
-        BoundInfo upperBoundInfo = upper != null ? new BoundInfo(upper, upperInclusive) : null;
-        return new RangeKeyFilter<>(lowerBoundInfo, upperBoundInfo);
+        return range(lower, lowerInclusive, upper, upperInclusive, Comparator.naturalOrder());
+    }
+
+    static <K> SavepointKeyFilter<K> range(
+            @Nullable K lower,
+            boolean lowerInclusive,
+            @Nullable K upper,
+            boolean upperInclusive,
+            Comparator<K> comparator) {
+        BoundInfo<K> lowerBoundInfo = lower != null ? new BoundInfo<>(lower, lowerInclusive) : null;
+        BoundInfo<K> upperBoundInfo = upper != null ? new BoundInfo<>(upper, upperInclusive) : null;
+        return new RangeKeyFilter<>(comparator, lowerBoundInfo, upperBoundInfo);
     }
 
     static <K> SavepointKeyFilter<K> empty() {

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/filter/SavepointKeyFilter.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/filter/SavepointKeyFilter.java
@@ -26,12 +26,16 @@ import java.io.Serializable;
 import java.util.HashSet;
 import java.util.Set;
 
-/** Represents a key filter that can be pushed down into a savepoint scan. */
+/**
+ * Represents a key filter that can be pushed down into a savepoint scan.
+ *
+ * @param <K> The type of the key.
+ */
 @Experimental
-public interface SavepointKeyFilter extends Serializable {
+public interface SavepointKeyFilter<K> extends Serializable {
 
     /** Returns {@code true} if the given key passes this filter. */
-    boolean test(Object key);
+    boolean test(K key);
 
     /**
      * Returns {@code true} if this filter rejects every key.
@@ -47,7 +51,7 @@ public interface SavepointKeyFilter extends Serializable {
      * resolve to a finite key set.
      */
     @Nullable
-    default Set<Object> getExactKeys() {
+    default Set<K> getExactKeys() {
         return null;
     }
 
@@ -79,14 +83,14 @@ public interface SavepointKeyFilter extends Serializable {
      *
      * <p>Used only while combining filters during push-down translation, not during the scan.
      */
-    default SavepointKeyFilter intersect(SavepointKeyFilter other) {
+    default SavepointKeyFilter<K> intersect(SavepointKeyFilter<K> other) {
         throw new UnsupportedOperationException(
                 getClass().getSimpleName() + " does not support intersect()");
     }
 
-    static SavepointKeyFilter filterKeys(Set<Object> keys, SavepointKeyFilter predicate) {
-        final Set<Object> retained = new HashSet<>();
-        for (Object key : keys) {
+    static <K> SavepointKeyFilter<K> filterKeys(Set<K> keys, SavepointKeyFilter<K> predicate) {
+        final Set<K> retained = new HashSet<>();
+        for (K key : keys) {
             if (predicate.test(key)) {
                 retained.add(key);
             }
@@ -94,28 +98,25 @@ public interface SavepointKeyFilter extends Serializable {
         return exact(retained);
     }
 
-    static SavepointKeyFilter exact(Set<Object> keys) {
+    static <K> SavepointKeyFilter<K> exact(Set<K> keys) {
         if (keys.isEmpty()) {
-            return EmptyKeyFilter.INSTANCE;
+            return EmptyKeyFilter.instance();
         }
-        return new ExactKeyFilter(keys);
+        return new ExactKeyFilter<>(keys);
     }
 
-    static SavepointKeyFilter exact(Object value) {
-        return new ExactKeyFilter(Set.of(value));
+    static <K> SavepointKeyFilter<K> exact(K value) {
+        return new ExactKeyFilter<>(Set.of(value));
     }
 
-    static SavepointKeyFilter range(
-            @Nullable Comparable<?> lower,
-            boolean lowerInclusive,
-            @Nullable Comparable<?> upper,
-            boolean upperInclusive) {
+    static <K extends Comparable<K>> SavepointKeyFilter<K> range(
+            @Nullable K lower, boolean lowerInclusive, @Nullable K upper, boolean upperInclusive) {
         BoundInfo lowerBoundInfo = lower != null ? new BoundInfo(lower, lowerInclusive) : null;
         BoundInfo upperBoundInfo = upper != null ? new BoundInfo(upper, upperInclusive) : null;
-        return new RangeKeyFilter(lowerBoundInfo, upperBoundInfo);
+        return new RangeKeyFilter<>(lowerBoundInfo, upperBoundInfo);
     }
 
-    static SavepointKeyFilter empty() {
-        return EmptyKeyFilter.INSTANCE;
+    static <K> SavepointKeyFilter<K> empty() {
+        return EmptyKeyFilter.instance();
     }
 }

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/filter/SerializableComparator.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/filter/SerializableComparator.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.state.api.filter;
+
+import org.apache.flink.annotation.Experimental;
+
+import java.io.Serializable;
+import java.util.Comparator;
+
+/**
+ * A {@link Comparator} that is also {@link Serializable}.
+ *
+ * <p>Required when passing a custom comparator to {@link SavepointKeyFilter#range} because the
+ * filter is serialized and shipped with the job. Lambdas and method references assigned to this
+ * type are automatically serializable.
+ *
+ * @param <K> The type of keys being compared.
+ */
+@Experimental
+@FunctionalInterface
+public interface SerializableComparator<K> extends Comparator<K>, Serializable {
+    long serialVersionUID = 1L;
+}

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/input/KeyedStateInputFormat.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/input/KeyedStateInputFormat.java
@@ -86,7 +86,7 @@ public class KeyedStateInputFormat<K, N, OUT>
 
     private final SerializedValue<ExecutionConfig> serializedExecutionConfig;
 
-    @Nullable private final SavepointKeyFilter keyFilter;
+    @Nullable private final SavepointKeyFilter<K> keyFilter;
 
     private transient CloseableRegistry registry;
 
@@ -127,7 +127,7 @@ public class KeyedStateInputFormat<K, N, OUT>
             Configuration configuration,
             StateReaderOperator<?, K, N, OUT> operator,
             ExecutionConfig executionConfig,
-            @Nullable SavepointKeyFilter keyFilter)
+            @Nullable SavepointKeyFilter<K> keyFilter)
             throws IOException {
         Preconditions.checkNotNull(operatorState, "The operator state cannot be null");
         Preconditions.checkNotNull(configuration, "The configuration cannot be null");
@@ -164,7 +164,7 @@ public class KeyedStateInputFormat<K, N, OUT>
         final List<KeyGroupRange> keyGroups = sortedKeyGroupRanges(minNumSplits, maxParallelism);
 
         if (keyFilter != null) {
-            Set<Object> exactKeys = keyFilter.getExactKeys();
+            Set<K> exactKeys = keyFilter.getExactKeys();
             if (exactKeys != null) {
                 return pruneByExactKeys(keyGroups, exactKeys, maxParallelism);
             }
@@ -179,13 +179,13 @@ public class KeyedStateInputFormat<K, N, OUT>
     }
 
     private KeyGroupRangeInputSplit[] pruneByExactKeys(
-            List<KeyGroupRange> keyGroups, Set<Object> exactKeys, int maxParallelism) {
+            List<KeyGroupRange> keyGroups, Set<K> exactKeys, int maxParallelism) {
         if (exactKeys.isEmpty()) {
             return new KeyGroupRangeInputSplit[0];
         }
 
         final Set<Integer> targetKeyGroups = new HashSet<>();
-        for (Object key : exactKeys) {
+        for (K key : exactKeys) {
             targetKeyGroups.add(KeyGroupRangeAssignment.assignToKeyGroup(key, maxParallelism));
         }
 

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/table/SavepointFilterTranslator.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/table/SavepointFilterTranslator.java
@@ -43,6 +43,7 @@ import java.util.function.BiFunction;
  * Converts {@link ResolvedExpression} key filter predicates into {@link SavepointKeyFilter}
  * instances that can be used to prune key groups and key iterations during savepoint reads.
  */
+@SuppressWarnings({"rawtypes", "unchecked"})
 class SavepointFilterTranslator {
 
     private static final Logger LOG = LoggerFactory.getLogger(SavepointFilterTranslator.class);
@@ -200,8 +201,8 @@ class SavepointFilterTranslator {
             return null;
         }
         return SavepointKeyFilter.range(
-                (Comparable<?>) lower, true,
-                (Comparable<?>) upper, true);
+                (Comparable) lower, true,
+                (Comparable) upper, true);
     }
 
     @Nullable
@@ -247,7 +248,7 @@ class SavepointFilterTranslator {
                     bound.getClass().getName());
             return null;
         }
-        Comparable<?> b = (Comparable<?>) bound;
+        Comparable b = (Comparable) bound;
         Comparison keyLeftCmp = keyOnLeft ? cmp : cmp.flip();
         switch (keyLeftCmp) {
             case GT:

--- a/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/api/SavepointReaderKeyedStateITCase.java
+++ b/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/api/SavepointReaderKeyedStateITCase.java
@@ -226,6 +226,29 @@ public abstract class SavepointReaderKeyedStateITCase<B extends StateBackend>
         assertThat(result.counter).isZero();
     }
 
+    @Test
+    public void testReadKeyedStateWithCustomComparatorRangeFilter() throws Exception {
+        Tuple2<Configuration, B> backendTuple = getStateBackendTuple();
+        StreamExecutionEnvironment env =
+                StreamExecutionEnvironment.getExecutionEnvironment(backendTuple.f0);
+        env.setParallelism(4);
+
+        applyStatefulPipeline(env);
+
+        String savepointPath = takeSavepoint(env);
+
+        SavepointReader savepoint = SavepointReader.read(env, savepointPath, backendTuple.f1);
+        // Descending order: bounds [6, 3] are valid and cover keys 3, 4, 5, 6.
+        // Under natural order the same bounds would produce an empty range (6 > 3).
+        CountingReadResult result =
+                readKeyedStateWithCountingReader(
+                        savepoint,
+                        SavepointKeyFilter.range(
+                                6, true, 3, true, (a, b) -> Integer.compare(b, a)));
+        assertThat(result.values).containsExactlyInAnyOrder(3, 4, 5, 6);
+        assertThat(result.counter).isEqualTo(4);
+    }
+
     private void applyStatefulPipeline(StreamExecutionEnvironment env) {
         env.addSource(createSource(elements))
                 .returns(Pojo.class)

--- a/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/api/SavepointReaderKeyedStateITCase.java
+++ b/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/api/SavepointReaderKeyedStateITCase.java
@@ -237,7 +237,7 @@ public abstract class SavepointReaderKeyedStateITCase<B extends StateBackend>
     }
 
     private CountingReadResult readKeyedStateWithCountingReader(
-            SavepointReader savepoint, SavepointKeyFilter keyFilter) throws Exception {
+            SavepointReader savepoint, SavepointKeyFilter<Integer> keyFilter) throws Exception {
         DataStream<Integer> stateValues =
                 savepoint.readKeyedState(
                         OperatorIdentifier.forUid(uid),

--- a/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/table/SavepointFilterTranslatorTest.java
+++ b/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/table/SavepointFilterTranslatorTest.java
@@ -329,6 +329,27 @@ class SavepointFilterTranslatorTest {
     }
 
     // -------------------------------------------------------------------------
+    //  Custom comparator
+    // -------------------------------------------------------------------------
+
+    @Test
+    void rangeWithCustomComparatorIsUsed() {
+        // Orders strings by length — clearly not the natural String order.
+        SavepointKeyFilter<String> filter =
+                SavepointKeyFilter.range(
+                        "aa",
+                        true,
+                        "cccc",
+                        true,
+                        (a, b) -> Integer.compare(a.length(), b.length()));
+
+        // Length in [2, 4]: "abc" (3), passes; "a" (1) and "ccccc" (5), fail.
+        assertThat(filter.test("abc")).isTrue();
+        assertThat(filter.test("a")).isFalse();
+        assertThat(filter.test("ccccc")).isFalse();
+    }
+
+    // -------------------------------------------------------------------------
     //  SavepointFilters.apply — intersection handling
     // -------------------------------------------------------------------------
 

--- a/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/table/SavepointFilterTranslatorTest.java
+++ b/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/table/SavepointFilterTranslatorTest.java
@@ -53,7 +53,7 @@ class SavepointFilterTranslatorTest {
 
     @Test
     void equalsKeyOnLeft() {
-        SavepointKeyFilter filter = keyFilterOf(eq(longKeyRef(), longLit(42L)));
+        SavepointKeyFilter<Object> filter = keyFilterOf(eq(longKeyRef(), longLit(42L)));
         assertNotNull(filter);
         assertThat(filter.getExactKeys()).containsExactly(42L);
         assertThat(filter.test(42L)).isTrue();
@@ -62,7 +62,7 @@ class SavepointFilterTranslatorTest {
 
     @Test
     void equalsKeyOnRight() {
-        SavepointKeyFilter filter = keyFilterOf(eq(longLit(42L), longKeyRef()));
+        SavepointKeyFilter<Object> filter = keyFilterOf(eq(longLit(42L), longKeyRef()));
         assertNotNull(filter);
         assertThat(filter.getExactKeys()).containsExactly(42L);
         assertThat(filter.test(42L)).isTrue();
@@ -71,13 +71,13 @@ class SavepointFilterTranslatorTest {
 
     @Test
     void equalsNeitherSideIsKeyColumn_returnsNull() {
-        SavepointKeyFilter filter = keyFilterOf(eq(otherRef(), longLit(42L)));
+        SavepointKeyFilter<Object> filter = keyFilterOf(eq(otherRef(), longLit(42L)));
         assertThat(filter).isNull();
     }
 
     @Test
     void equalsNeitherSideIsLiteral_returnsNull() {
-        SavepointKeyFilter filter = keyFilterOf(eq(longKeyRef(), otherRef()));
+        SavepointKeyFilter<Object> filter = keyFilterOf(eq(longKeyRef(), otherRef()));
         assertThat(filter).isNull();
     }
 
@@ -93,7 +93,7 @@ class SavepointFilterTranslatorTest {
                         eq(longKeyRef(), longLit(2L)),
                         eq(longLit(3L), longKeyRef()));
 
-        SavepointKeyFilter filter = keyFilterOf(expr);
+        SavepointKeyFilter<Object> filter = keyFilterOf(expr);
         assertNotNull(filter);
         assertThat(filter.getExactKeys()).containsExactlyInAnyOrder(1L, 2L, 3L);
         assertThat(filter.test(4L)).isFalse();
@@ -112,7 +112,8 @@ class SavepointFilterTranslatorTest {
 
     @Test
     void betweenProducesInclusiveRange() {
-        SavepointKeyFilter filter = keyFilterOf(between(longKeyRef(), longLit(10L), longLit(20L)));
+        SavepointKeyFilter<Object> filter =
+                keyFilterOf(between(longKeyRef(), longLit(10L), longLit(20L)));
 
         assertNotNull(filter);
         assertThat(filter.getExactKeys()).isNull();
@@ -125,7 +126,8 @@ class SavepointFilterTranslatorTest {
 
     @Test
     void betweenWithNonKeyField_returnsNull() {
-        SavepointKeyFilter filter = keyFilterOf(between(otherRef(), longLit(1L), longLit(10L)));
+        SavepointKeyFilter<Object> filter =
+                keyFilterOf(between(otherRef(), longLit(1L), longLit(10L)));
         assertThat(filter).isNull();
     }
 
@@ -135,7 +137,7 @@ class SavepointFilterTranslatorTest {
 
     @Test
     void greaterThanProducesExclusiveLowerBound() {
-        SavepointKeyFilter filter = keyFilterOf(gt(longKeyRef(), longLit(5L)));
+        SavepointKeyFilter<Object> filter = keyFilterOf(gt(longKeyRef(), longLit(5L)));
         assertNotNull(filter);
         assertThat(filter.getExactKeys()).isNull();
         assertThat(filter.test(5L)).isFalse();
@@ -144,7 +146,7 @@ class SavepointFilterTranslatorTest {
 
     @Test
     void greaterThanOrEqualProducesInclusiveLowerBound() {
-        SavepointKeyFilter filter = keyFilterOf(gte(longKeyRef(), longLit(5L)));
+        SavepointKeyFilter<Object> filter = keyFilterOf(gte(longKeyRef(), longLit(5L)));
         assertNotNull(filter);
         assertThat(filter.getExactKeys()).isNull();
         assertThat(filter.test(4L)).isFalse();
@@ -154,7 +156,7 @@ class SavepointFilterTranslatorTest {
 
     @Test
     void lessThanProducesExclusiveUpperBound() {
-        SavepointKeyFilter filter = keyFilterOf(lt(longKeyRef(), longLit(10L)));
+        SavepointKeyFilter<Object> filter = keyFilterOf(lt(longKeyRef(), longLit(10L)));
         assertNotNull(filter);
         assertThat(filter.getExactKeys()).isNull();
         assertThat(filter.test(9L)).isTrue();
@@ -163,7 +165,7 @@ class SavepointFilterTranslatorTest {
 
     @Test
     void lessThanOrEqualProducesInclusiveUpperBound() {
-        SavepointKeyFilter filter = keyFilterOf(lte(longKeyRef(), longLit(10L)));
+        SavepointKeyFilter<Object> filter = keyFilterOf(lte(longKeyRef(), longLit(10L)));
         assertNotNull(filter);
         assertThat(filter.getExactKeys()).isNull();
         assertThat(filter.test(10L)).isTrue();
@@ -173,7 +175,7 @@ class SavepointFilterTranslatorTest {
     @Test
     void comparisonWithLiteralOnLeft_flipsDirection() {
         // literal > key  →  key < literal  →  upper bound (exclusive)
-        SavepointKeyFilter filter = keyFilterOf(gt(longLit(10L), longKeyRef()));
+        SavepointKeyFilter<Object> filter = keyFilterOf(gt(longLit(10L), longKeyRef()));
         assertNotNull(filter);
         assertThat(filter.getExactKeys()).isNull();
         assertThat(filter.test(9L)).isTrue();
@@ -183,7 +185,7 @@ class SavepointFilterTranslatorTest {
     @Test
     void comparisonWithLiteralOnLeft_lte_flipsDirection() {
         // literal <= key  →  key >= literal  →  lower bound (inclusive)
-        SavepointKeyFilter filter = keyFilterOf(lte(longLit(5L), longKeyRef()));
+        SavepointKeyFilter<Object> filter = keyFilterOf(lte(longLit(5L), longKeyRef()));
         assertThat(filter.getExactKeys()).isNull();
         assertThat(filter.test(4L)).isFalse();
         assertThat(filter.test(5L)).isTrue();
@@ -197,7 +199,7 @@ class SavepointFilterTranslatorTest {
     void andOfTwoRangesProducesIntersection() {
         // key >= 5 AND key <= 10
         CallExpression expr = and(gte(longKeyRef(), longLit(5L)), lte(longKeyRef(), longLit(10L)));
-        SavepointKeyFilter filter = keyFilterOf(expr);
+        SavepointKeyFilter<Object> filter = keyFilterOf(expr);
 
         assertNotNull(filter);
         assertThat(filter.getExactKeys()).isNull();
@@ -211,7 +213,7 @@ class SavepointFilterTranslatorTest {
     void andWithProvablyEmptyIntersection_matchesNothing() {
         // key > 10 AND key < 5 — disjoint
         CallExpression expr = and(gt(longKeyRef(), longLit(10L)), lt(longKeyRef(), longLit(5L)));
-        SavepointKeyFilter filter = keyFilterOf(expr);
+        SavepointKeyFilter<Object> filter = keyFilterOf(expr);
 
         assertNotNull(filter);
         assertThat(filter.isEmpty()).isTrue();
@@ -249,7 +251,7 @@ class SavepointFilterTranslatorTest {
 
     @Test
     void rangeFilterOnStringKey() {
-        SavepointKeyFilter filter =
+        SavepointKeyFilter<Object> filter =
                 keyFilterOf(between(stringKeyRef(), stringLit("beta"), stringLit("delta")));
 
         assertNotNull(filter);
@@ -269,7 +271,7 @@ class SavepointFilterTranslatorTest {
         FieldReferenceExpression floatKey =
                 new FieldReferenceExpression("key", DataTypes.FLOAT().notNull(), 0, KEY_COL);
 
-        SavepointKeyFilter filter = keyFilterOf(between(floatKey, floatLower, floatUpper));
+        SavepointKeyFilter<Object> filter = keyFilterOf(between(floatKey, floatLower, floatUpper));
 
         assertNotNull(filter);
         assertThat(filter.test(1.5f)).isTrue();
@@ -286,9 +288,9 @@ class SavepointFilterTranslatorTest {
     @Test
     void intersectNarrowsBounds() {
         // [5, ∞) ∩ (-∞, 10] = [5, 10]
-        SavepointKeyFilter lower = SavepointKeyFilter.range(5L, true, null, true);
-        SavepointKeyFilter upper = SavepointKeyFilter.range(null, true, 10L, true);
-        SavepointKeyFilter result = lower.intersect(upper);
+        SavepointKeyFilter<Long> lower = SavepointKeyFilter.range(5L, true, null, true);
+        SavepointKeyFilter<Long> upper = SavepointKeyFilter.range(null, true, 10L, true);
+        SavepointKeyFilter<Long> result = lower.intersect(upper);
 
         assertThat(result.isEmpty()).isFalse();
         assertThat(result.getExactKeys()).isNull();
@@ -301,17 +303,17 @@ class SavepointFilterTranslatorTest {
     @Test
     void intersectDisjointRangesReturnsEmpty() {
         // [10, ∞) ∩ (-∞, 5] — disjoint
-        SavepointKeyFilter a = SavepointKeyFilter.range(10L, true, null, true);
-        SavepointKeyFilter b = SavepointKeyFilter.range(null, true, 5L, true);
+        SavepointKeyFilter<Long> a = SavepointKeyFilter.range(10L, true, null, true);
+        SavepointKeyFilter<Long> b = SavepointKeyFilter.range(null, true, 5L, true);
         assertThat(a.intersect(b).isEmpty()).isTrue();
     }
 
     @Test
     void intersectEqualBoundsInclusiveIsNonEmpty() {
         // [7, ∞) ∩ (-∞, 7] = [7, 7]
-        SavepointKeyFilter a = SavepointKeyFilter.range(7L, true, null, true);
-        SavepointKeyFilter b = SavepointKeyFilter.range(null, true, 7L, true);
-        SavepointKeyFilter result = a.intersect(b);
+        SavepointKeyFilter<Long> a = SavepointKeyFilter.range(7L, true, null, true);
+        SavepointKeyFilter<Long> b = SavepointKeyFilter.range(null, true, 7L, true);
+        SavepointKeyFilter<Long> result = a.intersect(b);
         assertThat(result.isEmpty()).isFalse();
         assertThat(result.test(7L)).isTrue();
         assertThat(result.test(6L)).isFalse();
@@ -321,8 +323,8 @@ class SavepointFilterTranslatorTest {
     @Test
     void intersectEqualBoundsOneExclusiveIsEmpty() {
         // (7, ∞) ∩ (-∞, 7] — empty because lower is exclusive
-        SavepointKeyFilter a = SavepointKeyFilter.range(7L, false, null, true);
-        SavepointKeyFilter b = SavepointKeyFilter.range(null, true, 7L, true);
+        SavepointKeyFilter<Long> a = SavepointKeyFilter.range(7L, false, null, true);
+        SavepointKeyFilter<Long> b = SavepointKeyFilter.range(null, true, 7L, true);
         assertThat(a.intersect(b).isEmpty()).isTrue();
     }
 
@@ -336,7 +338,7 @@ class SavepointFilterTranslatorTest {
                 apply(
                         List.of(gte(longKeyRef(), longLit(3L)), lte(longKeyRef(), longLit(8L))),
                         LONG_KEY_TYPE);
-        SavepointKeyFilter result = applied.keyFilter();
+        SavepointKeyFilter<Object> result = applied.keyFilter();
         assertNotNull(result);
 
         assertThat(applied.accepted()).hasSize(2);
@@ -361,7 +363,7 @@ class SavepointFilterTranslatorTest {
                                         eq(longKeyRef(), longLit(3L)),
                                         eq(longKeyRef(), longLit(4L)))),
                         LONG_KEY_TYPE);
-        SavepointKeyFilter result = applied.keyFilter();
+        SavepointKeyFilter<Object> result = applied.keyFilter();
 
         assertNotNull(result);
         assertThat(applied.accepted()).hasSize(2);
@@ -375,7 +377,7 @@ class SavepointFilterTranslatorTest {
                 apply(
                         List.of(eq(longKeyRef(), longLit(1L)), eq(longKeyRef(), longLit(2L))),
                         LONG_KEY_TYPE);
-        SavepointKeyFilter result = applied.keyFilter();
+        SavepointKeyFilter<Object> result = applied.keyFilter();
 
         assertNotNull(result);
         assertThat(applied.accepted()).hasSize(2);
@@ -395,7 +397,7 @@ class SavepointFilterTranslatorTest {
                                         eq(longKeyRef(), longLit(15L))),
                                 between(longKeyRef(), longLit(4L), longLit(12L))),
                         LONG_KEY_TYPE);
-        SavepointKeyFilter result = applied.keyFilter();
+        SavepointKeyFilter<Object> result = applied.keyFilter();
 
         assertNotNull(result);
         assertThat(applied.accepted()).hasSize(2);
@@ -415,7 +417,7 @@ class SavepointFilterTranslatorTest {
                                         eq(longKeyRef(), longLit(10L)),
                                         eq(longKeyRef(), longLit(15L)))),
                         LONG_KEY_TYPE);
-        SavepointKeyFilter result = applied.keyFilter();
+        SavepointKeyFilter<Object> result = applied.keyFilter();
 
         assertNotNull(result);
         assertThat(applied.accepted()).hasSize(2);
@@ -429,7 +431,7 @@ class SavepointFilterTranslatorTest {
 
     @Test
     void emptyKeyFilter_rejectsEverything() {
-        SavepointKeyFilter empty = SavepointKeyFilter.empty();
+        SavepointKeyFilter<Object> empty = SavepointKeyFilter.empty();
         assertThat(empty.isEmpty()).isTrue();
         assertThat(empty.getExactKeys()).isEmpty();
         assertThat(empty.test(42L)).isFalse();
@@ -438,13 +440,13 @@ class SavepointFilterTranslatorTest {
 
     @Test
     void exactWithEmptySetReturnsEmptyKeyFilter() {
-        SavepointKeyFilter filter = SavepointKeyFilter.exact(Collections.emptySet());
+        SavepointKeyFilter<Object> filter = SavepointKeyFilter.exact(Collections.emptySet());
         assertThat(filter.isEmpty()).isTrue();
     }
 
     @Test
     void emptyKeyFilterSingletonPreservedAcrossSerialization() throws Exception {
-        SavepointKeyFilter original = SavepointKeyFilter.empty();
+        SavepointKeyFilter<Object> original = SavepointKeyFilter.empty();
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         try (ObjectOutputStream oos = new ObjectOutputStream(baos)) {
             oos.writeObject(original);
@@ -463,7 +465,7 @@ class SavepointFilterTranslatorTest {
 
     @Test
     void exactSingleValueFactory() {
-        SavepointKeyFilter filter = SavepointKeyFilter.exact(42L);
+        SavepointKeyFilter<Long> filter = SavepointKeyFilter.exact(42L);
         assertThat(filter.getExactKeys()).containsExactly(42L);
         assertThat(filter.test(42L)).isTrue();
         assertThat(filter.test(43L)).isFalse();
@@ -481,7 +483,7 @@ class SavepointFilterTranslatorTest {
                         gte(longKeyRef(), longLit(3L)),
                         lte(longKeyRef(), longLit(20L)),
                         lt(longKeyRef(), longLit(10L)));
-        SavepointKeyFilter filter = keyFilterOf(expr);
+        SavepointKeyFilter<Object> filter = keyFilterOf(expr);
 
         assertNotNull(filter);
         assertThat(filter.getExactKeys()).isNull();
@@ -499,7 +501,7 @@ class SavepointFilterTranslatorTest {
     @Test
     void orWithSingleChild_returnsExactFilter() {
         CallExpression expr = or(eq(longKeyRef(), longLit(7L)));
-        SavepointKeyFilter filter = keyFilterOf(expr);
+        SavepointKeyFilter<Object> filter = keyFilterOf(expr);
 
         assertNotNull(filter);
         assertThat(filter.getExactKeys()).containsExactly(7L);
@@ -527,7 +529,7 @@ class SavepointFilterTranslatorTest {
                                 and(gt(longKeyRef(), longLit(10L)), lt(longKeyRef(), longLit(5L))),
                                 lte(longKeyRef(), longLit(10L))),
                         LONG_KEY_TYPE);
-        SavepointKeyFilter result = applied.keyFilter();
+        SavepointKeyFilter<Object> result = applied.keyFilter();
 
         assertNotNull(result);
         assertThat(applied.accepted()).hasSize(2);
@@ -543,7 +545,7 @@ class SavepointFilterTranslatorTest {
                                 lte(longKeyRef(), longLit(10L)),
                                 and(gt(longKeyRef(), longLit(10L)), lt(longKeyRef(), longLit(5L)))),
                         LONG_KEY_TYPE);
-        SavepointKeyFilter result = applied.keyFilter();
+        SavepointKeyFilter<Object> result = applied.keyFilter();
 
         assertNotNull(result);
         assertThat(applied.accepted()).hasSize(2);
@@ -559,7 +561,7 @@ class SavepointFilterTranslatorTest {
                                 and(gt(longKeyRef(), longLit(10L)), lt(longKeyRef(), longLit(5L))),
                                 eq(longKeyRef(), longLit(1L))),
                         LONG_KEY_TYPE);
-        SavepointKeyFilter result = applied.keyFilter();
+        SavepointKeyFilter<Object> result = applied.keyFilter();
 
         assertNotNull(result);
         assertThat(applied.accepted()).hasSize(2);
@@ -573,7 +575,7 @@ class SavepointFilterTranslatorTest {
                 apply(
                         List.of(eq(longKeyRef(), longLit(1L)), eq(longKeyRef(), longLit(2L))),
                         LONG_KEY_TYPE);
-        SavepointKeyFilter result = applied.keyFilter();
+        SavepointKeyFilter<Object> result = applied.keyFilter();
 
         assertNotNull(result);
         assertThat(applied.accepted()).hasSize(2);
@@ -639,7 +641,7 @@ class SavepointFilterTranslatorTest {
     @Test
     void equalsWithIntLiteralIsWidenedToBigintKeyAndPushed() {
         ValueLiteralExpression intLit = new ValueLiteralExpression(5, DataTypes.INT().notNull());
-        SavepointKeyFilter filter = keyFilterOf(eq(longKeyRef(), intLit));
+        SavepointKeyFilter<Object> filter = keyFilterOf(eq(longKeyRef(), intLit));
 
         assertNotNull(filter);
         assertThat(filter.getExactKeys()).containsExactly(5L);
@@ -651,7 +653,7 @@ class SavepointFilterTranslatorTest {
     void betweenWithIntLiteralBoundsIsWidenedToBigintKeyAndPushed() {
         ValueLiteralExpression lower = new ValueLiteralExpression(1, DataTypes.INT().notNull());
         ValueLiteralExpression upper = new ValueLiteralExpression(10, DataTypes.INT().notNull());
-        SavepointKeyFilter filter = keyFilterOf(between(longKeyRef(), lower, upper));
+        SavepointKeyFilter<Object> filter = keyFilterOf(between(longKeyRef(), lower, upper));
 
         assertNotNull(filter);
         assertThat(filter.getExactKeys()).isNull();
@@ -667,7 +669,7 @@ class SavepointFilterTranslatorTest {
                 new FieldReferenceExpression("key", DataTypes.DOUBLE().notNull(), 0, KEY_COL);
         ValueLiteralExpression intLit = new ValueLiteralExpression(5, DataTypes.INT().notNull());
 
-        SavepointKeyFilter filter = keyFilterOf(eq(doubleKey, intLit));
+        SavepointKeyFilter<Object> filter = keyFilterOf(eq(doubleKey, intLit));
 
         assertNotNull(filter);
         assertThat(filter.getExactKeys()).containsExactly(5.0d);
@@ -695,7 +697,7 @@ class SavepointFilterTranslatorTest {
                 new ValueLiteralExpression(
                         new BigDecimal("5.00"), DataTypes.DECIMAL(10, 2).notNull());
 
-        SavepointKeyFilter filter = keyFilterOf(eq(decKey, lit));
+        SavepointKeyFilter<Object> filter = keyFilterOf(eq(decKey, lit));
 
         assertNotNull(filter);
         // Literal scale is preserved, so exact matching is scale sensitive: 5.00 matches, 5.0 not.
@@ -708,7 +710,7 @@ class SavepointFilterTranslatorTest {
     //  Expression helpers
     // -------------------------------------------------------------------------
 
-    private static SavepointKeyFilter keyFilterOf(ResolvedExpression expr) {
+    private static SavepointKeyFilter<Object> keyFilterOf(ResolvedExpression expr) {
         DataType keyType = findKeyType(expr);
         return apply(Collections.singletonList(expr), keyType).keyFilter();
     }


### PR DESCRIPTION
## What is the purpose of the change

The `SavepointKeyFilter` interface introduced in FLINK-39637 used raw `Object` references
throughout (e.g., `boolean test(Object key)`, `Set<Object> getExactKeys()`), which does not fit
the existing State Processor API design: `SavepointReader.readKeyedState` and
`KeyedStateReaderFunction` are both fully parameterized on `K`. This change makes
`SavepointKeyFilter<K>` a proper generic interface so that the key type is enforced by the
compiler end-to-end on the DataStream API path, consistent with the rest of the State Processor
API.

`BoundInfo<K>` is a plain typed container (`getValue()` returns `K`) and `RangeKeyFilter<K>`
is made fully type-safe by injecting a `SerializableComparator<K>` rather than requiring
`K extends Comparable<K>`. This keeps the `@PublicEvolving` `readKeyedState` signature
unconstrained while eliminating all unchecked casts from the filter package. A new
`SerializableComparator<K>` interface (extends `Comparator<K>` and `Serializable`) ensures
that lambdas passed to `SavepointKeyFilter.range()` are automatically serializable when the
filter is shipped with the job.

At the same time, the Table API connector layer (`SavepointFilterTranslator`,
`SavepointDynamicTableSource`, `SavepointDataStreamScanProvider`) intentionally keeps raw
`SavepointKeyFilter` -- see "Brief change log" for the rationale.


## Brief change log

- `SerializableComparator<K>`: new `@Experimental` `@FunctionalInterface` extending
  `Comparator<K>` and `Serializable`; lambdas assigned to it are automatically serializable
- `BoundInfo<K>`: plain typed container, `getValue()` returns `K`, no `Comparable` bound
- `SavepointKeyFilter<K>`: added type parameter; `test`, `getExactKeys`, `intersect`, `exact`,
  `filterKeys`, and `empty` are all typed on `K`; `getLowerBound()`/`getUpperBound()` return
  `BoundInfo<K>`; two `range()` overloads: convenience (`K extends Comparable<K>`, backed by
  `NaturalOrderComparator`) and general (`SerializableComparator<K>`)
- `EmptyKeyFilter<K>`, `ExactKeyFilter<K>`: parameterized accordingly
- `RangeKeyFilter<K>`: holds a `SerializableComparator<K>` field; all range logic uses
  `comparator.compare()` -- no unchecked casts anywhere in the filter package
- `KeyedStateInputFormat<K,N,OUT>`: field and constructor parameter changed to
  `SavepointKeyFilter<K>`; `pruneByExactKeys` and the key-iteration loop now operate on `K`
  instead of `Object`
- `SavepointReader.readKeyedState`: `@Nullable SavepointKeyFilter<K> keyFilter` parameter
- Documentation updated in both English and Chinese for the new `range()` overloads and
  `SerializableComparator`

**Why the Table API layer stays raw:**

Four sites deliberately remain raw:

1. `EmptyKeyFilter.INSTANCE` -- a static final field cannot carry a type variable after erasure;
   the standard erasure-safe singleton pattern (`@SuppressWarnings("rawtypes")` on the field,
   unchecked cast in the `instance()` accessor) is used, same as `Collections.EMPTY_LIST`.

2. `SavepointFilterTranslator` internal methods (`apply`, `extractFilter`, `fromEquals`,
   `fromOr`, `fromAnd`, `fromBetween`, `from*Comparison`, FILTERS map) -- this class operates
   entirely in the SQL planner layer. Literal values are extracted via
   `ValueLiteralExpression.getValueAs(literalClass)`, which returns `Object`. The Java type
   parameter `K` is not available at compile time here; only a `DataType` is known at runtime.
   Parameterizing `SavepointFilterTranslator<K>` would be meaningless because no caller can
   supply a `K`.

3. `SavepointFilterTranslator.Result` -- bridges the SQL layer to the connector layer; has no
   `K` to propagate.

4. `SavepointDynamicTableSource` and `SavepointDataStreamScanProvider` -- the Table API
   connector framework (`DynamicTableSource`, `DataStreamScanProvider`) carries no type
   parameter, and `TypeInformation keyTypeInfo` in these classes was already raw before this
   change. Using raw `SavepointKeyFilter` is consistent with that pre-existing constraint. Type
   safety across this boundary is guaranteed at runtime: the key filter and the key type info are
   both derived from the same `DataType` inside `SavepointFilterTranslator`.


## Verifying this change

This change added tests and can be verified as follows:

- Existing unit tests in `SavepointFilterTranslatorTest` are updated to use typed
  `SavepointKeyFilter<Object>` / `SavepointKeyFilter<Long>` variables; compilation itself
  verifies generic correctness on the translator output path.
- New unit test `rangeWithCustomComparatorIsUsed` in `SavepointFilterTranslatorTest` verifies
  that a custom (string-by-length) comparator changes filter membership independent of natural
  order.
- Existing integration tests in `SavepointReaderKeyedStateITCase` cover exact-key, multi-key,
  inclusive/exclusive range, and empty filter scenarios end-to-end with `SavepointKeyFilter<Integer>`.
- New integration test `testReadKeyedStateWithCustomComparatorRangeFilter` in
  `SavepointReaderKeyedStateITCase` verifies end-to-end that a custom comparator is respected:
  `range(6, true, 3, true, reverseOrder)` correctly returns keys 3-6 (which would be empty under
  natural order).


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes --
    `SavepointKeyFilter`, `BoundInfo`, and `SerializableComparator` are `@Experimental`; the
    `@PublicEvolving` `readKeyedState` signature is unchanged
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: no
  - The S3 file system connector: no


## Documentation

  - Does this pull request introduce a new feature? no (refines a feature from FLINK-39637)
  - If yes, how is the feature documented? not applicable

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (Claude code)
