### PR TITLE
[FLINK-20746][csv] Add csv.ignore-first-line for filesystem CSV connector

### DIFF
--- a/docs/content.zh/docs/connectors/table/formats/csv.md
+++ b/docs/content.zh/docs/connectors/table/formats/csv.md
@@ -205,7 +205,7 @@ Format 参数
       <td>否</td>
       <td style="word-wrap: break-word;">false</td>
       <td>Boolean</td>
-      <td>可选标志，用于在反序列化时跳过每个 CSV 文件的第一条记录（默认禁用）。仅 filesystem 连接器支持。表 schema 不会从被跳过的记录中推断。仅影响反序列化。</td>
+      <td>可选标志，用于跳过每个输入 CSV 文件的第一条记录（默认值为 false）。仅支持 filesystem 连接器。仅影响反序列化。</td>
     </tr>
     </tbody>
 </table>

--- a/docs/content.zh/docs/connectors/table/formats/csv.md
+++ b/docs/content.zh/docs/connectors/table/formats/csv.md
@@ -199,6 +199,14 @@ Format 参数
       <td>Boolean</td>
       <td>可选标志，用于将空字符串值视为 null（默认禁用）。仅影响反序列化。</td>
     </tr>
+    <tr>
+      <td><h5>csv.ignore-first-line</h5></td>
+      <td>可选</td>
+      <td>否</td>
+      <td style="word-wrap: break-word;">false</td>
+      <td>Boolean</td>
+      <td>可选标志，用于在反序列化时跳过每个 CSV 文件的第一条记录（默认禁用）。仅 filesystem 连接器支持。表 schema 不会从被跳过的记录中推断。仅影响反序列化。</td>
+    </tr>
     </tbody>
 </table>
 

--- a/docs/content/docs/connectors/table/formats/csv.md
+++ b/docs/content/docs/connectors/table/formats/csv.md
@@ -206,7 +206,7 @@ Format Options
       <td>no</td>
       <td style="word-wrap: break-word;">false</td>
       <td>Boolean</td>
-      <td>Optional flag to skip the first CSV record of each file during deserialization (disabled by default). Only supported by the filesystem connector. The table schema is not derived from the skipped record. Only affects deserialization.</td>
+      <td>Optional flag to skip the first CSV record of each input file (false by default). Only supported by the filesystem connector. Only affects deserialization.</td>
     </tr>
     </tbody>
 </table>

--- a/docs/content/docs/connectors/table/formats/csv.md
+++ b/docs/content/docs/connectors/table/formats/csv.md
@@ -200,6 +200,14 @@ Format Options
       <td>Boolean</td>
       <td>Optional flag to treat empty string values as null (disabled by default). Only affects deserialization.</td>
     </tr>
+    <tr>
+      <td><h5>csv.ignore-first-line</h5></td>
+      <td>optional</td>
+      <td>no</td>
+      <td style="word-wrap: break-word;">false</td>
+      <td>Boolean</td>
+      <td>Optional flag to skip the first CSV record of each file during deserialization (disabled by default). Only supported by the filesystem connector. The table schema is not derived from the skipped record. Only affects deserialization.</td>
+    </tr>
     </tbody>
 </table>
 

--- a/flink-formats/flink-csv/src/main/java/org/apache/flink/formats/csv/CsvFileFormatFactory.java
+++ b/flink-formats/flink-csv/src/main/java/org/apache/flink/formats/csv/CsvFileFormatFactory.java
@@ -58,6 +58,7 @@ import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.dataformat.csv.Csv
 import org.apache.commons.text.StringEscapeUtils;
 
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -69,6 +70,7 @@ import static org.apache.flink.formats.csv.CsvFormatOptions.EMPTY_STRING_AS_NULL
 import static org.apache.flink.formats.csv.CsvFormatOptions.ESCAPE_CHARACTER;
 import static org.apache.flink.formats.csv.CsvFormatOptions.FAIL_ON_MISSING_COLUMNS;
 import static org.apache.flink.formats.csv.CsvFormatOptions.FIELD_DELIMITER;
+import static org.apache.flink.formats.csv.CsvFormatOptions.IGNORE_FIRST_LINE;
 import static org.apache.flink.formats.csv.CsvFormatOptions.IGNORE_PARSE_ERRORS;
 import static org.apache.flink.formats.csv.CsvFormatOptions.IGNORE_TRAILING_UNMAPPABLE;
 import static org.apache.flink.formats.csv.CsvFormatOptions.NULL_LITERAL;
@@ -92,7 +94,9 @@ public class CsvFileFormatFactory implements BulkReaderFormatFactory, BulkWriter
 
     @Override
     public Set<ConfigOption<?>> optionalOptions() {
-        return CsvCommons.optionalOptions();
+        Set<ConfigOption<?>> options = new HashSet<>(CsvCommons.optionalOptions());
+        options.add(IGNORE_FIRST_LINE);
+        return options;
     }
 
     @Override
@@ -130,7 +134,11 @@ public class CsvFileFormatFactory implements BulkReaderFormatFactory, BulkWriter
             final RowType projectedRowType = (RowType) projectedDataType.getLogicalType();
 
             final RowType physicalRowType = (RowType) physicalDataType.getLogicalType();
-            final CsvSchema schema = buildCsvSchema(physicalRowType, formatOptions);
+            CsvSchema builtSchema = buildCsvSchema(physicalRowType, formatOptions);
+            if (formatOptions.get(IGNORE_FIRST_LINE)) {
+                builtSchema = builtSchema.rebuild().setSkipFirstDataRow(true).build();
+            }
+            final CsvSchema schema = builtSchema;
 
             final boolean ignoreParseErrors = formatOptions.get(IGNORE_PARSE_ERRORS);
             final Converter<JsonNode, RowData, Void> converter =

--- a/flink-formats/flink-csv/src/main/java/org/apache/flink/formats/csv/CsvFileFormatFactory.java
+++ b/flink-formats/flink-csv/src/main/java/org/apache/flink/formats/csv/CsvFileFormatFactory.java
@@ -134,11 +134,7 @@ public class CsvFileFormatFactory implements BulkReaderFormatFactory, BulkWriter
             final RowType projectedRowType = (RowType) projectedDataType.getLogicalType();
 
             final RowType physicalRowType = (RowType) physicalDataType.getLogicalType();
-            CsvSchema builtSchema = buildCsvSchema(physicalRowType, formatOptions);
-            if (formatOptions.get(IGNORE_FIRST_LINE)) {
-                builtSchema = builtSchema.rebuild().setSkipFirstDataRow(true).build();
-            }
-            final CsvSchema schema = builtSchema;
+            final CsvSchema schema = buildCsvSchema(physicalRowType, formatOptions);
 
             final boolean ignoreParseErrors = formatOptions.get(IGNORE_PARSE_ERRORS);
             final Converter<JsonNode, RowData, Void> converter =
@@ -219,6 +215,8 @@ public class CsvFileFormatFactory implements BulkReaderFormatFactory, BulkWriter
         }
 
         options.getOptional(ALLOW_COMMENTS).ifPresent(csvBuilder::setAllowComments);
+
+        options.getOptional(IGNORE_FIRST_LINE).ifPresent(csvBuilder::setSkipFirstDataRow);
 
         options.getOptional(ARRAY_ELEMENT_DELIMITER)
                 .ifPresent(csvBuilder::setArrayElementSeparator);

--- a/flink-formats/flink-csv/src/main/java/org/apache/flink/formats/csv/CsvFormatOptions.java
+++ b/flink-formats/flink-csv/src/main/java/org/apache/flink/formats/csv/CsvFormatOptions.java
@@ -144,8 +144,8 @@ public class CsvFormatOptions {
                     .booleanType()
                     .defaultValue(false)
                     .withDescription(
-                            "Optional flag to skip the first CSV record of each file "
-                                    + "(disabled by default). "
+                            "Optional flag to skip the first CSV record of each input file "
+                                    + "(false by default). "
                                     + "Only affects deserialization.");
 
     private CsvFormatOptions() {}

--- a/flink-formats/flink-csv/src/main/java/org/apache/flink/formats/csv/CsvFormatOptions.java
+++ b/flink-formats/flink-csv/src/main/java/org/apache/flink/formats/csv/CsvFormatOptions.java
@@ -139,5 +139,14 @@ public class CsvFormatOptions {
                                     + "(disabled by default). "
                                     + "Only affects deserialization.");
 
+    public static final ConfigOption<Boolean> IGNORE_FIRST_LINE =
+            ConfigOptions.key("ignore-first-line")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription(
+                            "Optional flag to skip the first CSV record of each file "
+                                    + "(disabled by default). "
+                                    + "Only affects deserialization.");
+
     private CsvFormatOptions() {}
 }

--- a/flink-formats/flink-csv/src/test/java/org/apache/flink/formats/csv/CsvFormatFactoryTest.java
+++ b/flink-formats/flink-csv/src/test/java/org/apache/flink/formats/csv/CsvFormatFactoryTest.java
@@ -23,6 +23,8 @@ import org.apache.flink.api.common.serialization.SerializationSchema;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.connector.file.src.FileSourceSplit;
 import org.apache.flink.connector.file.src.reader.BulkFormat;
+import org.apache.flink.connector.file.src.util.Utils;
+import org.apache.flink.core.fs.Path;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.catalog.Column;
@@ -36,11 +38,17 @@ import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.factories.TestDynamicTableFactory;
 import org.apache.flink.table.runtime.connector.source.ScanRuntimeProviderContext;
 import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
+import org.apache.flink.table.types.DataType;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
+import java.io.File;
 import java.io.IOException;
 import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -61,6 +69,15 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Tests for {@link CsvFormatFactory}. */
 class CsvFormatFactoryTest {
+
+    private static final DataType HEADER_ROW_DATA_TYPE =
+            ResolvedSchema.of(
+                            Column.physical("id", DataTypes.STRING()),
+                            Column.physical("name", DataTypes.STRING()),
+                            Column.physical("amount", DataTypes.STRING()))
+                    .toPhysicalRowDataType();
+
+    private static final String CSV_WITH_HEADER = "id,name,amount\n1,Alice,100\n2,Bob,200";
 
     @Test
     void testSeDeSchema() {
@@ -456,6 +473,43 @@ class CsvFormatFactoryTest {
         assertThat(bulkFormat).isNotNull();
     }
 
+    @Test
+    void testIgnoreFirstLineSkipsFirstRecord(@TempDir java.nio.file.Path tempDir) throws Exception {
+        final File file = tempDir.resolve("with-header.csv").toFile();
+        Files.writeString(file.toPath(), CSV_WITH_HEADER, StandardCharsets.UTF_8);
+
+        final Configuration formatOptions = new Configuration();
+        formatOptions.set(CsvFormatOptions.IGNORE_FIRST_LINE, true);
+
+        final List<RowData> rows = readBulkFormatRows(formatOptions, file, HEADER_ROW_DATA_TYPE);
+
+        assertThat(rows).hasSize(2);
+        assertThat(rows.get(0).getString(0).toString()).isEqualTo("1");
+        assertThat(rows.get(0).getString(1).toString()).isEqualTo("Alice");
+        assertThat(rows.get(0).getString(2).toString()).isEqualTo("100");
+        assertThat(rows.get(1).getString(0).toString()).isEqualTo("2");
+        assertThat(rows.get(1).getString(1).toString()).isEqualTo("Bob");
+        assertThat(rows.get(1).getString(2).toString()).isEqualTo("200");
+    }
+
+    @Test
+    void testIgnoreFirstLineDisabledByDefault(@TempDir java.nio.file.Path tempDir)
+            throws Exception {
+        final File file = tempDir.resolve("with-header.csv").toFile();
+        Files.writeString(file.toPath(), CSV_WITH_HEADER, StandardCharsets.UTF_8);
+
+        final List<RowData> rows =
+                readBulkFormatRows(new Configuration(), file, HEADER_ROW_DATA_TYPE);
+
+        assertThat(rows).hasSize(3);
+        assertThat(rows.get(0).getString(0).toString()).isEqualTo("id");
+        assertThat(rows.get(0).getString(1).toString()).isEqualTo("name");
+        assertThat(rows.get(0).getString(2).toString()).isEqualTo("amount");
+        assertThat(rows.get(1).getString(0).toString()).isEqualTo("1");
+        assertThat(rows.get(1).getString(2).toString()).isEqualTo("100");
+        assertThat(rows.get(2).getString(1).toString()).isEqualTo("Bob");
+    }
+
     // ------------------------------------------------------------------------
     //  Utilities
     // ------------------------------------------------------------------------
@@ -488,6 +542,33 @@ class CsvFormatFactoryTest {
         options.put("csv.null-literal", "n/a");
         options.put("csv.write-bigdecimal-in-scientific-notation", "true");
         return options;
+    }
+
+    private static List<RowData> readBulkFormatRows(
+            Configuration formatOptions, File file, DataType dataType) throws IOException {
+        final CsvFileFormatFactory.CsvBulkDecodingFormat bulkDecodingFormat =
+                new CsvFileFormatFactory.CsvBulkDecodingFormat(formatOptions);
+        final BulkFormat<RowData, FileSourceSplit> bulkFormat =
+                bulkDecodingFormat.createRuntimeDecoder(
+                        ScanRuntimeProviderContext.INSTANCE,
+                        dataType,
+                        Projection.all(dataType).toNestedIndexes());
+
+        final FileSourceSplit split =
+                new FileSourceSplit(
+                        "split-0",
+                        new Path(file.toURI()),
+                        0,
+                        file.length(),
+                        file.lastModified(),
+                        file.length());
+
+        final List<RowData> rows = new ArrayList<>();
+        try (BulkFormat.Reader<RowData> reader =
+                bulkFormat.createReader(new Configuration(), split)) {
+            Utils.forEachRemaining(reader, rows::add);
+        }
+        return rows;
     }
 
     private static DeserializationSchema<RowData> createDeserializationSchema(


### PR DESCRIPTION
## What is the purpose of the change

This pull request adds support for `csv.ignore-first-line` for the **filesystem** CSV Table connector ([FLINK-20746](https://issues.apache.org/jira/browse/FLINK-20746)).

The filesystem CSV connector currently treats the first CSV record as data. When reading CSV files with a header row, users must preprocess the files or rely on `csv.ignore-parse-errors`, which still attempts to deserialize the header.

This change introduces a new format option, `csv.ignore-first-line`, that skips the first CSV record of each input file during deserialization. The table schema is **not** derived from the skipped record; this option only skips the first record and does not enable header-based schema inference.

The option defaults to `false`, preserving the existing behavior. It is supported only for the filesystem CSV connector and does not affect message-based CSV formats.

Example:

```sql
CREATE TABLE my_csv (
  id STRING,
  name STRING,
  amount STRING
) WITH (
  'connector' = 'filesystem',
  'path' = '/path/to/csv',
  'format' = 'csv',
  'csv.ignore-first-line' = 'true'
);
```

## Brief change log

- Added a new CSV format option `csv.ignore-first-line` (default: `false`).
- Registered the option only for the filesystem CSV connector.
- Applied the option during filesystem CSV deserialization.
- Added unit tests covering the default behavior and the new option.
- Updated both English and Chinese CSV connector documentation.

## Verifying this change

This change added tests and can be verified as follows:

- Added `CsvFormatFactoryTest#testIgnoreFirstLineSkipsFirstRecord`, verifying that enabling `csv.ignore-first-line` skips the first CSV record.
- Added `CsvFormatFactoryTest#testIgnoreFirstLineDisabledByDefault`, verifying that the default behavior remains unchanged.
- Verified the module locally using:

```bash
./mvnw -pl flink-formats/flink-csv -Dtest=CsvFormatFactoryTest#testIgnoreFirstLineSkipsFirstRecord,CsvFormatFactoryTest#testIgnoreFirstLineDisabledByDefault test

./mvnw -pl flink-formats/flink-csv verify
```

## Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): **no**
- The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **yes** (adds a new `ConfigOption` to `CsvFormatOptions`)
- The serializers: **no**
- The runtime per-record code paths (performance sensitive): **yes** (only when `csv.ignore-first-line=true`; default behavior is unchanged)
- Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: **no**
- The S3 file system connector: **no**

## Documentation

- Does this pull request introduce a new feature? **yes**
- If yes, how is the feature documented? **docs** (English and Chinese CSV connector documentation updated)

---

##### Was generative AI tooling used to co-author this PR?

- [ ] Yes (please specify the tool below)