### PR TITLE
[FLINK-40031][runtime-web] Fix Exceptions view crash navigating to an unassigned TaskManager

### DIFF
--- a/flink-runtime-web/web-dashboard/src/app/interfaces/job-exception.ts
+++ b/flink-runtime-web/web-dashboard/src/app/interfaces/job-exception.ts
@@ -46,7 +46,7 @@ export interface ExceptionInfo {
   failureLabels: Map<string, string>;
   taskName: string;
   endpoint: string;
-  taskManagerId: string;
+  taskManagerId?: string;
 }
 
 export interface RootExceptionInfo extends ExceptionInfo {

--- a/flink-runtime-web/web-dashboard/src/app/pages/job/exceptions/job-exceptions.component.ts
+++ b/flink-runtime-web/web-dashboard/src/app/pages/job/exceptions/job-exceptions.component.ts
@@ -155,8 +155,8 @@ export class JobExceptionsComponent implements OnInit, OnDestroy {
       });
   }
 
-  public navigateTo(taskManagerId: string | null): void {
-    if (taskManagerId !== null) {
+  public navigateTo(taskManagerId?: string): void {
+    if (taskManagerId) {
       this.router.navigate(['task-manager', taskManagerId, 'metrics']).then();
     }
   }


### PR DESCRIPTION
## What is the purpose of the change

The job Exceptions view crashes with `NG04008: The requested path contains undefined segment at index 1` when the user clicks the *Location* cell of an exception that has no assigned TaskManager (rendered as `(unassigned)`).

`navigateTo()` only guarded against `null`, so an `undefined` `taskManagerId` reached `router.navigate(['task-manager', undefined, 'metrics'])`, which the Angular router rejects. In addition, `ExceptionInfo.taskManagerId` was typed as `string` even though the REST API can omit the field entirely.

## Brief change log

- `job-exceptions.component.ts`: replace the `taskManagerId !== null` guard in `navigateTo()` with a falsy check, so both `null` and `undefined` are handled and no navigation is attempted for unassigned TaskManagers.
- `interfaces/job-exception.ts`: type `ExceptionInfo.taskManagerId` as optional (`taskManagerId?: string`), since the REST API omits the field (`@JsonInclude(NON_NULL)`) rather than sending `null`.
- Reviewed the `application-exceptions` component for the same navigation pattern: it has no `navigateTo` / Location cell, so no change is required there.

## Verifying this change

This change is a trivial fix to the web frontend and can be verified manually:

- Run a job that produces an exception without an assigned TaskManager, open the job's *Exceptions* tab, and click the `(unassigned)` Location cell. Previously this crashed the view with NG04008; now nothing happens (no invalid navigation).
- `eslint` and the production `ng build` both pass.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (Claude Code)

Generated-by: Claude Code (claude-opus-4-8)
