### PR TITLE
[FLINK-40048][e2e] Replace Kafka with filesystem connector in SqlClientITCase

### DIFF
--- a/flink-end-to-end-tests/flink-sql-client-test/pom.xml
+++ b/flink-end-to-end-tests/flink-sql-client-test/pom.xml
@@ -51,32 +51,6 @@ under the License.
 			<version>${project.version}</version>
 		</dependency>
 
-		<!-- The following dependencies are for connector/format sql-jars that
-			we copy using the maven-dependency-plugin. When extending the test
- 			to cover more connectors/formats, add a dependency here and an entry
-			to the dependency-plugin configuration below.
-			This ensures that all modules we actually need (as defined by the
- 			dependency-plugin configuration) are built before this module. -->
-		<dependency>
-			<!-- Used by maven-dependency-plugin -->
-			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-sql-connector-kafka</artifactId>
-			<version>3.0.0-1.17</version>
-			<scope>provided</scope>
-		</dependency>
-
-		<dependency>
-			<groupId>org.apache.kafka</groupId>
-			<artifactId>kafka-clients</artifactId>
-			<version>3.9.2</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.testcontainers</groupId>
-			<artifactId>testcontainers-kafka</artifactId>
-			<scope>test</scope>
-		</dependency>
-
 		<dependency>
 			<groupId>commons-codec</groupId>
 			<artifactId>commons-codec</artifactId>
@@ -84,18 +58,6 @@ under the License.
 		</dependency>
 
 	</dependencies>
-
-	<dependencyManagement>
-		<dependencies>
-			<dependency>
-				<!-- Pick an arbitrary version here to satisfy the enforcer-plugin,
-					as we neither access nor package the kafka dependencies -->
-				<groupId>org.apache.kafka</groupId>
-				<artifactId>kafka-clients</artifactId>
-				<version>2.2.2</version>
-			</dependency>
-		</dependencies>
-	</dependencyManagement>
 
 	<build>
 		<plugins>
@@ -135,12 +97,6 @@ under the License.
 								When extending this list please also add a dependency
 								for the respective module. -->
 							<artifactItems>
-								<artifactItem>
-									<groupId>org.apache.flink</groupId>
-									<artifactId>flink-sql-connector-kafka</artifactId>
-									<version>3.0.0-1.17</version>
-									<type>jar</type>
-								</artifactItem>
 								<artifactItem>
 									<groupId>org.apache.flink</groupId>
 									<artifactId>flink-test-utils</artifactId>

--- a/flink-end-to-end-tests/flink-sql-client-test/src/test/java/SqlClientITCase.java
+++ b/flink-end-to-end-tests/flink-sql-client-test/src/test/java/SqlClientITCase.java
@@ -42,7 +42,6 @@ import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 
@@ -87,7 +86,7 @@ class SqlClientITCase {
         String outputFilepath = "/flink/records-upsert.out";
 
         List<String> sqlLines =
-                Arrays.asList(
+                List.of(
                         "SET 'execution.runtime-mode' = 'batch';",
                         "",
                         "CREATE TABLE UpsertSinkTable (",
@@ -125,7 +124,7 @@ class SqlClientITCase {
         String outputFilepath = "/flink/records-append.out";
 
         List<String> sqlLines =
-                Arrays.asList(
+                List.of(
                         "SET 'execution.runtime-mode' = 'batch';",
                         "",
                         "CREATE TABLE AppendSinkTable (",
@@ -160,19 +159,18 @@ class SqlClientITCase {
         String outputFilepath = "/flink/records-matchrecognize.out";
         String inputFilepath = "/tmp/test-json.jsonl";
 
-        String[] messages =
-                new String[] {
-                    "{\"timestamp\": \"2018-03-12T08:00:00Z\", \"user\": \"Alice\", \"event\": { \"type\": \"WARNING\", \"message\": \"This is a warning.\"}}",
-                    "{\"timestamp\": \"2018-03-12T08:10:00Z\", \"user\": \"Alice\", \"event\": { \"type\": \"WARNING\", \"message\": \"This is a warning.\"}}",
-                    "{\"timestamp\": \"2018-03-12T09:00:00Z\", \"user\": \"Bob\", \"event\": { \"type\": \"WARNING\", \"message\": \"This is another warning.\"}}",
-                    "{\"timestamp\": \"2018-03-12T09:10:00Z\", \"user\": \"Alice\", \"event\": { \"type\": \"INFO\", \"message\": \"This is a info.\"}}",
-                    "{\"timestamp\": \"2018-03-12T09:20:00Z\", \"user\": \"Steve\", \"event\": { \"type\": \"INFO\", \"message\": \"This is another info.\"}}",
-                    "{\"timestamp\": \"2018-03-12T09:30:00Z\", \"user\": \"Steve\", \"event\": { \"type\": \"INFO\", \"message\": \"This is another info.\"}}",
-                    "{\"timestamp\": \"2018-03-12T09:30:00Z\", \"user\": null, \"event\": { \"type\": \"WARNING\", \"message\": \"This is a bad message because the user is missing.\"}}",
-                    "{\"timestamp\": \"2018-03-12T10:40:00Z\", \"user\": \"Bob\", \"event\": { \"type\": \"ERROR\", \"message\": \"This is an error.\"}}"
-                };
+        List<String> messages =
+                List.of(
+                        "{\"timestamp\": \"2018-03-12T08:00:00Z\", \"user\": \"Alice\", \"event\": { \"type\": \"WARNING\", \"message\": \"This is a warning.\"}}",
+                        "{\"timestamp\": \"2018-03-12T08:10:00Z\", \"user\": \"Alice\", \"event\": { \"type\": \"WARNING\", \"message\": \"This is a warning.\"}}",
+                        "{\"timestamp\": \"2018-03-12T09:00:00Z\", \"user\": \"Bob\", \"event\": { \"type\": \"WARNING\", \"message\": \"This is another warning.\"}}",
+                        "{\"timestamp\": \"2018-03-12T09:10:00Z\", \"user\": \"Alice\", \"event\": { \"type\": \"INFO\", \"message\": \"This is a info.\"}}",
+                        "{\"timestamp\": \"2018-03-12T09:20:00Z\", \"user\": \"Steve\", \"event\": { \"type\": \"INFO\", \"message\": \"This is another info.\"}}",
+                        "{\"timestamp\": \"2018-03-12T09:30:00Z\", \"user\": \"Steve\", \"event\": { \"type\": \"INFO\", \"message\": \"This is another info.\"}}",
+                        "{\"timestamp\": \"2018-03-12T09:30:00Z\", \"user\": null, \"event\": { \"type\": \"WARNING\", \"message\": \"This is a bad message because the user is missing.\"}}",
+                        "{\"timestamp\": \"2018-03-12T10:40:00Z\", \"user\": \"Bob\", \"event\": { \"type\": \"ERROR\", \"message\": \"This is an error.\"}}");
         File inputFile = new File(tempDir, "test-json.jsonl");
-        Files.write(inputFile.toPath(), Arrays.asList(messages));
+        Files.write(inputFile.toPath(), messages);
         MountableFile mountableFile = MountableFile.forHostPath(inputFile.toPath());
         flink.getJobManager().copyFileToContainer(mountableFile, inputFilepath);
         for (GenericContainer<?> taskManager : flink.getTaskManagers()) {
@@ -180,7 +178,7 @@ class SqlClientITCase {
         }
 
         List<String> sqlLines =
-                Arrays.asList(
+                List.of(
                         // MATCH_RECOGNIZE requires streaming mode; the bounded filesystem source
                         // emits MAX_WATERMARK at end of input which flushes the pending match
                         "SET 'execution.runtime-mode' = 'streaming';",

--- a/flink-end-to-end-tests/flink-sql-client-test/src/test/java/SqlClientITCase.java
+++ b/flink-end-to-end-tests/flink-sql-client-test/src/test/java/SqlClientITCase.java
@@ -16,74 +16,45 @@
  * limitations under the License.
  */
 
+import org.apache.flink.api.common.JobStatus;
+import org.apache.flink.client.deployment.StandaloneClusterId;
+import org.apache.flink.client.program.rest.RestClusterClient;
 import org.apache.flink.configuration.CheckpointingOptions;
 import org.apache.flink.connector.testframe.container.FlinkContainers;
 import org.apache.flink.connector.testframe.container.FlinkContainersSettings;
 import org.apache.flink.connector.testframe.container.TestcontainersSettings;
 import org.apache.flink.connector.upserttest.sink.UpsertTestFileUtil;
+import org.apache.flink.core.testutils.CommonTestUtils;
+import org.apache.flink.runtime.client.JobStatusMessage;
 import org.apache.flink.test.resources.ResourceTestUtils;
 import org.apache.flink.test.util.SQLJobSubmission;
-import org.apache.flink.util.DockerImageVersions;
 
-import org.apache.kafka.clients.admin.AdminClient;
-import org.apache.kafka.clients.admin.NewTopic;
-import org.apache.kafka.clients.producer.KafkaProducer;
-import org.apache.kafka.clients.producer.Producer;
-import org.apache.kafka.clients.producer.ProducerConfig;
-import org.apache.kafka.clients.producer.ProducerRecord;
-import org.apache.kafka.common.serialization.BytesSerializer;
-import org.apache.kafka.common.serialization.StringSerializer;
-import org.apache.kafka.common.utils.Bytes;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.containers.Network;
-import org.testcontainers.containers.output.Slf4jLogConsumer;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
-import org.testcontainers.kafka.ConfluentKafkaContainer;
-import org.testcontainers.utility.DockerImageName;
+import org.testcontainers.utility.MountableFile;
 
 import java.io.File;
-import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.Arrays;
-import java.util.Collections;
+import java.util.Collection;
 import java.util.List;
-import java.util.Properties;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** E2E Test for SqlClient. */
-@Testcontainers
 class SqlClientITCase {
 
     private static final Logger LOG = LoggerFactory.getLogger(SqlClientITCase.class);
 
-    private static final String INTER_CONTAINER_KAFKA_ALIAS = "kafka";
-
-    private static final Slf4jLogConsumer LOG_CONSUMER = new Slf4jLogConsumer(LOG);
-    private static final Path sqlToolBoxJar = ResourceTestUtils.getResource(".*/SqlToolbox\\.jar");
-
-    private final Path sqlConnectorKafkaJar = ResourceTestUtils.getResource(".*kafka.*\\.jar");
-
     private final Path sqlConnectorUpsertTestJar =
             ResourceTestUtils.getResource(".*flink-test-utils.*\\.jar");
-
-    private static final Network NETWORK = Network.newNetwork();
-
-    @Container
-    private static final ConfluentKafkaContainer KAFKA =
-            new ConfluentKafkaContainer(DockerImageName.parse(DockerImageVersions.KAFKA))
-                    .withNetwork(NETWORK)
-                    .withListener(INTER_CONTAINER_KAFKA_ALIAS + ":19092")
-                    .withLogConsumer(LOG_CONSUMER);
 
     private final FlinkContainers flink =
             FlinkContainers.builder()
@@ -96,11 +67,7 @@ class SqlClientITCase {
                                             Duration.ofMillis(500))
                                     .build())
                     .withTestcontainersSettings(
-                            TestcontainersSettings.builder()
-                                    .network(NETWORK)
-                                    .logger(LOG)
-                                    .dependsOn(KAFKA)
-                                    .build())
+                            TestcontainersSettings.builder().logger(LOG).build())
                     .build();
 
     @TempDir private File tempDir;
@@ -189,9 +156,9 @@ class SqlClientITCase {
     }
 
     @Test
-    @Disabled("Disable due to Kafka connector need to release a new version 2.0.")
     void testMatchRecognize() throws Exception {
         String outputFilepath = "/flink/records-matchrecognize.out";
+        String inputFilepath = "/tmp/test-json.jsonl";
 
         String[] messages =
                 new String[] {
@@ -204,11 +171,19 @@ class SqlClientITCase {
                     "{\"timestamp\": \"2018-03-12T09:30:00Z\", \"user\": null, \"event\": { \"type\": \"WARNING\", \"message\": \"This is a bad message because the user is missing.\"}}",
                     "{\"timestamp\": \"2018-03-12T10:40:00Z\", \"user\": \"Bob\", \"event\": { \"type\": \"ERROR\", \"message\": \"This is an error.\"}}"
                 };
-        sendMessages("test-json", messages);
+        File inputFile = new File(tempDir, "test-json.jsonl");
+        Files.write(inputFile.toPath(), Arrays.asList(messages));
+        MountableFile mountableFile = MountableFile.forHostPath(inputFile.toPath());
+        flink.getJobManager().copyFileToContainer(mountableFile, inputFilepath);
+        for (GenericContainer<?> taskManager : flink.getTaskManagers()) {
+            taskManager.copyFileToContainer(mountableFile, inputFilepath);
+        }
 
         List<String> sqlLines =
                 Arrays.asList(
-                        "CREATE FUNCTION RegReplace AS 'org.apache.flink.table.toolbox.StringRegexReplaceFunction';",
+                        // MATCH_RECOGNIZE requires streaming mode; the bounded filesystem source
+                        // emits MAX_WATERMARK at end of input which flushes the pending match
+                        "SET 'execution.runtime-mode' = 'streaming';",
                         "",
                         "CREATE TABLE JsonSourceTable (",
                         "    `timestamp` TIMESTAMP_LTZ(3),",
@@ -217,12 +192,8 @@ class SqlClientITCase {
                         "    `rowtime` AS `timestamp`,",
                         "    WATERMARK FOR `rowtime` AS `rowtime` - INTERVAL '2' SECOND",
                         ") WITH (",
-                        "    'connector' = 'kafka',",
-                        "    'topic' = 'test-json',",
-                        "    'properties.bootstrap.servers' = '"
-                                + INTER_CONTAINER_KAFKA_ALIAS
-                                + ":19092',",
-                        "    'scan.startup.mode' = 'earliest-offset',",
+                        "    'connector' = 'filesystem',",
+                        "    'path' = 'file://" + inputFilepath + "',",
                         "    'format' = 'json',",
                         "    'json.timestamp-format.standard' = 'ISO-8601'",
                         ");",
@@ -257,60 +228,42 @@ class SqlClientITCase {
         verifyNumberOfResultRecords(outputFilepath, 1);
     }
 
-    // duplicated from KafkaContainerClient@flink-end-to-end-tests-common
-    private void sendMessages(String topic, String... messages) {
-        Properties props = new Properties();
-        props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, KAFKA.getBootstrapServers());
-        props.put(ProducerConfig.ACKS_CONFIG, "all");
-
-        final int numPartitions = 1;
-        final short replicationFactor = 1;
-        try (AdminClient admin = AdminClient.create(props)) {
-            admin.createTopics(
-                            Collections.singletonList(
-                                    new NewTopic(topic, numPartitions, replicationFactor)))
-                    .all()
-                    .get();
-        } catch (Exception e) {
-            throw new IllegalStateException(
-                    String.format(
-                            "Fail to create topic [%s partitions: %d replicas: %d].",
-                            topic, numPartitions, replicationFactor),
-                    e);
-        }
-
-        try (Producer<Bytes, String> producer =
-                new KafkaProducer<>(props, new BytesSerializer(), new StringSerializer())) {
-            for (String message : messages) {
-                producer.send(new ProducerRecord<>(topic, message));
-            }
-        }
-    }
-
     private void verifyNumberOfResultRecords(String resultFilePath, int expectedNumberOfRecords)
-            throws IOException, InterruptedException {
+            throws Exception {
+        RestClusterClient<StandaloneClusterId> clusterClient = flink.getRestClusterClient();
+        // the sink flushes all records at the latest when the bounded job finishes, so the
+        // result file is complete once the job reaches a terminal state
+        CommonTestUtils.waitUntilIgnoringExceptions(
+                () -> {
+                    try {
+                        Collection<JobStatusMessage> jobs = clusterClient.listJobs().get();
+                        return !jobs.isEmpty()
+                                && jobs.stream()
+                                        .allMatch(
+                                                job -> job.getJobState().isGloballyTerminalState());
+                    } catch (Exception e) {
+                        throw new RuntimeException(e);
+                    }
+                },
+                Duration.ofMinutes(2),
+                Duration.ofMillis(100),
+                "Job did not terminate within 2 minutes");
+        Collection<JobStatusMessage> jobs = clusterClient.listJobs().get();
+        assertThat(jobs).hasSize(1);
+        assertThat(jobs.iterator().next().getJobState()).isEqualTo(JobStatus.FINISHED);
+
         File tempOutputFile = new File(tempDir, "records.out");
-        String tempOutputFilepath = tempOutputFile.toString();
-        GenericContainer<?> taskManager = flink.getTaskManagers().get(0);
-        int numberOfResultRecords;
-        while (true) {
-            Thread.sleep(50); // prevent NotFoundException: Status 404
-            try {
-                taskManager.copyFileFromContainer(resultFilePath, tempOutputFilepath);
-                numberOfResultRecords = UpsertTestFileUtil.getNumberOfRecords(tempOutputFile);
-                if (numberOfResultRecords == expectedNumberOfRecords) {
-                    break;
-                }
-            } catch (Exception ignored) {
-            }
-        }
-        assertThat(numberOfResultRecords).isEqualTo(expectedNumberOfRecords);
+        flink.getTaskManagers()
+                .get(0)
+                .copyFileFromContainer(resultFilePath, tempOutputFile.toString());
+        assertThat(UpsertTestFileUtil.getNumberOfRecords(tempOutputFile))
+                .isEqualTo(expectedNumberOfRecords);
     }
 
     private void executeSql(List<String> sqlLines) throws Exception {
         flink.submitSQLJob(
                 new SQLJobSubmission.SQLJobSubmissionBuilder(sqlLines)
-                        .addJars(sqlConnectorUpsertTestJar, sqlConnectorKafkaJar, sqlToolBoxJar)
+                        .addJars(sqlConnectorUpsertTestJar)
                         .build());
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

`SqlClientITCase#testMatchRecognize` has been `@Disabled` since the Kafka connector was externalized (FLINK-30859) and was never re-enabled. The module still carried `flink-sql-connector-kafka:3.0.0-1.17` (a Flink 1.17-era version of the externalized connector), `kafka-clients`, and `testcontainers-kafka`, and started a Kafka container on every test class, all for a test that never ran. This also caused recurring maintenance such as kafka-clients version bumps (see #27924).

This PR re-enables the test using the built-in filesystem connector, preserving the original intent (SQL Client submission of a streaming job with event-time watermarks and MATCH_RECOGNIZE), and removes the dead Kafka infrastructure.

## Brief change log

  - Rewrite `testMatchRecognize` to read the 8 test records from a JSON Lines file staged into the JobManager container (the `SourceCoordinator` enumerates splits there) and each TaskManager container, using the `filesystem` connector in explicit streaming mode; remove `@Disabled`.
  - Rework `verifyNumberOfResultRecords`: wait for the bounded job to reach `FINISHED` via `RestClusterClient` and read the sink output once, instead of polling the result file in an unbounded loop that swallowed job failures. The sink flushes all records at the latest when the bounded job finishes, so a failing job now surfaces immediately with its actual state.
  - Drop the dead `RegReplace` function registration: its invocation moved to the Kafka-specific script in FLINK-10624 (2018), and `CREATE FUNCTION` register-and-invoke coverage lives in `flink-end-to-end-tests-sql` (`UsingRemoteJarITCase`, `CreateTableAsITCase`, `PlannerScalaFreeITCase`), which still consumes the `SqlToolbox.jar` built by this module.
  - Remove `flink-sql-connector-kafka`, `kafka-clients`, and `testcontainers-kafka` from the pom, including the `dependencyManagement` pin and the sql-jars copy entry; keep `commons-codec` (needed by `FlinkImageBuilder`).

## Verifying this change

This change is covered by the module's own E2E tests: all 3 tests in `SqlClientITCase` pass locally under `-Prun-end-to-end-tests` (~75s total), including the re-enabled `testMatchRecognize`, which was additionally run 3 more times in isolation to check stability.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no (removes test-only dependencies; no NOTICE impact)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no (test-only change)
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: Claude Code (Sonnet 4.6)