### PR TITLE
[FLINK-40016][checkpoint] Prevent recovered buffers from being persisted twice in LocalInputChannel

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannel.java
@@ -329,10 +329,10 @@ public class LocalInputChannel extends InputChannel implements BufferAvailabilit
                                 seq++));
             }
 
-            return getBufferAndAvailability(toBeConsumedBuffers.removeFirst());
+            return Optional.of(getBufferAndAvailability(toBeConsumedBuffers.removeFirst()));
         }
 
-        return getBufferAndAvailability(next);
+        return Optional.of(getBufferAndAvailability(next));
     }
 
     /**
@@ -366,12 +366,13 @@ public class LocalInputChannel extends InputChannel implements BufferAvailabilit
                 }
             }
 
-            return getBufferAndAvailability(
-                    new BufferAndBacklog(
-                            next.buffer(),
-                            next.buffersInBacklog(),
-                            expectedNextDataType,
-                            next.getSequenceNumber()));
+            return Optional.of(
+                    getBufferAndAvailability(
+                            new BufferAndBacklog(
+                                    next.buffer(),
+                                    next.buffersInBacklog(),
+                                    expectedNextDataType,
+                                    next.getSequenceNumber())));
         }
 
         BufferAndBacklog next = toBeConsumedBuffers.removeFirst();
@@ -394,10 +395,10 @@ public class LocalInputChannel extends InputChannel implements BufferAvailabilit
                                 next.getSequenceNumber());
             }
         }
-        return getBufferAndAvailability(next);
+        return Optional.of(getBufferAndAvailability(next));
     }
 
-    private Optional<BufferAndAvailability> getBufferAndAvailability(BufferAndBacklog next)
+    private BufferAndAvailability getBufferAndAvailability(BufferAndBacklog next)
             throws IOException {
         Buffer buffer = next.buffer();
         if (buffer instanceof FileRegionBuffer) {
@@ -419,12 +420,8 @@ public class LocalInputChannel extends InputChannel implements BufferAvailabilit
                 channelInfo,
                 channelStatePersister,
                 next.getSequenceNumber());
-        return Optional.of(
-                new BufferAndAvailability(
-                        buffer,
-                        next.getNextDataType(),
-                        next.buffersInBacklog(),
-                        next.getSequenceNumber()));
+        return new BufferAndAvailability(
+                buffer, next.getNextDataType(), next.buffersInBacklog(), next.getSequenceNumber());
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannel.java
@@ -332,7 +332,10 @@ public class LocalInputChannel extends InputChannel implements BufferAvailabilit
             return Optional.of(getBufferAndAvailability(toBeConsumedBuffers.removeFirst()));
         }
 
-        return Optional.of(getBufferAndAvailability(next));
+        BufferAndAvailability bufferAndAvailability = getBufferAndAvailability(next);
+        channelStatePersister.checkForBarrier(bufferAndAvailability.buffer());
+        channelStatePersister.maybePersist(bufferAndAvailability.buffer());
+        return Optional.of(bufferAndAvailability);
     }
 
     /**
@@ -411,8 +414,6 @@ public class LocalInputChannel extends InputChannel implements BufferAvailabilit
 
         numBytesIn.inc(buffer.readableBytes());
         numBuffersIn.inc();
-        channelStatePersister.checkForBarrier(buffer);
-        channelStatePersister.maybePersist(buffer);
         NetworkActionsLogger.traceInput(
                 "LocalInputChannel#getNextBuffer",
                 buffer,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannelTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannelTest.java
@@ -794,6 +794,54 @@ class LocalInputChannelTest {
     }
 
     @Test
+    void testRecoveredBuffersNotPersistedAgainWhenConsumedDuringCheckpoint() throws Exception {
+        // given: Channel with 2 recovered buffers
+        SingleInputGate inputGate = new SingleInputGateBuilder().build();
+
+        ArrayDeque<Buffer> recoveredBuffers = new ArrayDeque<>();
+        recoveredBuffers.add(TestBufferFactory.createBuffer(10));
+        recoveredBuffers.add(TestBufferFactory.createBuffer(20));
+
+        RecordingChannelStateWriter stateWriter = new RecordingChannelStateWriter();
+
+        LocalInputChannel channel =
+                new LocalInputChannel(
+                        inputGate,
+                        0,
+                        new ResultPartitionID(),
+                        new ResultSubpartitionIndexSet(0),
+                        new ResultPartitionManager(),
+                        new TaskEventDispatcher(),
+                        0,
+                        0,
+                        new SimpleCounter(),
+                        new SimpleCounter(),
+                        stateWriter,
+                        recoveredBuffers);
+
+        inputGate.setInputChannels(channel);
+
+        // when: Checkpoint starts — checkpointStarted spills recovered buffers as inflight data
+        CheckpointOptions options =
+                CheckpointOptions.unaligned(CheckpointType.CHECKPOINT, getDefault());
+        stateWriter.start(1L, options);
+        channel.checkpointStarted(new CheckpointBarrier(1L, 0L, options));
+
+        // then: exactly 2 buffers persisted so far
+        assertThat(stateWriter.getAddedInput().get(channel.getChannelInfo())).hasSize(2);
+
+        // when: Consume the recovered buffers while checkpoint is still in BARRIER_PENDING state
+        channel.getNextBuffer();
+        channel.getNextBuffer();
+
+        // then: total persisted count must still be 2 — recovered buffers must not be
+        // re-persisted via maybePersist() when consumed (that would make it 4 without the fix)
+        assertThat(stateWriter.getAddedInput().get(channel.getChannelInfo()))
+                .as("recovered buffers must not be persisted again when consumed")
+                .hasSize(2);
+    }
+
+    @Test
     void testPriorityEventConsumedBeforeRecoveredBuffers() throws Exception {
         RecordingChannelStateWriter stateWriter = new RecordingChannelStateWriter();
         ChannelAndSubpartition ctx = createChannelWithRecoveredBuffers(stateWriter, 10, 20);


### PR DESCRIPTION
backporting https://github.com/apache/flink/pull/28605 to 2.3