### PR TITLE
[FLINK-40053] Update Log4j to 2.26.1

### DIFF
--- a/docs/content.zh/docs/dev/configuration/overview.md
+++ b/docs/content.zh/docs/dev/configuration/overview.md
@@ -102,7 +102,7 @@ ext {
     flinkVersion = '{{< version >}}'
     scalaBinaryVersion = '{{< scala_version >}}'
     slf4jVersion = '1.7.36'
-    log4jVersion = '2.25.3'
+    log4jVersion = '2.26.1'
 }
 sourceCompatibility = javaVersion
 targetCompatibility = javaVersion

--- a/docs/content/docs/dev/configuration/overview.md
+++ b/docs/content/docs/dev/configuration/overview.md
@@ -104,7 +104,7 @@ ext {
     flinkVersion = '{{< version >}}'
     scalaBinaryVersion = '{{< scala_version >}}'
     slf4jVersion = '1.7.36'
-    log4jVersion = '2.25.3'
+    log4jVersion = '2.26.1'
 }
 sourceCompatibility = javaVersion
 targetCompatibility = javaVersion

--- a/flink-walkthroughs/flink-walkthrough-table-java/src/main/resources/archetype-resources/pom.xml
+++ b/flink-walkthroughs/flink-walkthrough-table-java/src/main/resources/archetype-resources/pom.xml
@@ -34,7 +34,7 @@ under the License.
 		<target.java.version>11</target.java.version>
 		<maven.compiler.source>${target.java.version}</maven.compiler.source>
 		<maven.compiler.target>${target.java.version}</maven.compiler.target>
-		<log4j.version>2.25.3</log4j.version>
+		<log4j.version>@log4j.version@</log4j.version>
 		<junit.version>5.14.1</junit.version>
 	</properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -134,7 +134,7 @@ under the License.
 		<source.java.version>11</source.java.version>
 		<target.java.version>17</target.java.version>
 		<slf4j.version>1.7.36</slf4j.version>
-		<log4j.version>2.25.4</log4j.version>
+		<log4j.version>2.26.1</log4j.version>
 		<!-- Overwrite default values from parent pom.
 			 IntelliJ IDEA is (sometimes?) using those values to choose target language level
 			 and thus is changing back to java 1.6 on each maven re-import -->

--- a/tools/releasing/NOTICE-binary_PREAMBLE.txt
+++ b/tools/releasing/NOTICE-binary_PREAMBLE.txt
@@ -8,11 +8,11 @@ Copyright 2014-2026 The Apache Software Foundation
 
 This project bundles the following dependencies under the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-- org.apache.logging.log4j:log4j-api:2.25.4
-- org.apache.logging.log4j:log4j-core:2.25.4
-- org.apache.logging.log4j:log4j-slf4j-impl:2.25.4
-- org.apache.logging.log4j:log4j-1.2-api:2.25.4
-- org.apache.logging.log4j:log4j-layout-template-json:2.25.4
+- org.apache.logging.log4j:log4j-api:2.26.1
+- org.apache.logging.log4j:log4j-core:2.26.1
+- org.apache.logging.log4j:log4j-slf4j-impl:2.26.1
+- org.apache.logging.log4j:log4j-1.2-api:2.26.1
+- org.apache.logging.log4j:log4j-layout-template-json:2.26.1
 
 This project bundles the following dependencies under the BSD license.
 See bundled license files for details.


### PR DESCRIPTION
## What is the purpose of the change

Updates Log4j from 2.25.4 to 2.26.1, the latest release of the 2.x line. No CVEs are involved; this picks up upstream bug fixes ([2.26.0](https://github.com/apache/logging-log4j2/releases/tag/rel%2F2.26.0), [2.26.1](https://github.com/apache/logging-log4j2/releases/tag/rel%2F2.26.1)) and brings two spots missed by the previous bump (FLINK-39580) back in sync: the Gradle dependency example in the docs and the `flink-walkthrough-table-java` archetype.

Supersedes #27925 and #27914, which target the already-applied 2.25.4 bump.

## Brief change log

  - Bump `log4j.version` to 2.26.1 in the root pom
  - Update the Log4j entries in `tools/releasing/NOTICE-binary_PREAMBLE.txt`
  - Update the Gradle example in `docs/dev/configuration/overview.md` (English and Chinese)
  - Replace the hardcoded Log4j version in the `flink-walkthrough-table-java` archetype with the `@log4j.version@` filtered placeholder used by the other archetypes, so it can no longer go stale on future bumps

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

Verified locally: built `flink-runtime` and its dependencies against 2.26.1, and confirmed the packaged `flink-walkthrough-table-java` archetype jar now contains `<log4j.version>2.26.1</log4j.version>` after resource filtering.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): yes
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (Claude Code with Claude Fable 5)

Generated-by: Claude Code (Claude Fable 5)
