### PR TITLE
[FLINK-40054] Update aircompressor to 2.0.3

### DIFF
--- a/flink-runtime/pom.xml
+++ b/flink-runtime/pom.xml
@@ -249,7 +249,7 @@ under the License.
 		<dependency>
 			<groupId>io.airlift</groupId>
 			<artifactId>aircompressor</artifactId>
-			<version>0.27</version>
+			<version>2.0.3</version>
 			<optional>${flink.markBundledAsOptional}</optional>
 		</dependency>
 

--- a/flink-runtime/src/main/resources/META-INF/NOTICE
+++ b/flink-runtime/src/main/resources/META-INF/NOTICE
@@ -6,4 +6,4 @@ The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0. (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-- io.airlift:aircompressor:0.27
+- io.airlift:aircompressor:2.0.3


### PR DESCRIPTION
## What is the purpose of the change

Updates `io.airlift:aircompressor` from 0.27 to 2.0.3 in `flink-runtime`, where it provides the LZO and ZSTD codecs for network shuffle buffer compression.

2.0.3 is the latest release of the Java-8-compatible maintenance line (branch [`release-2.x`](https://github.com/airlift/aircompressor/tree/release-2.x)): 0.27 plus backported fixes for CVE-2025-67721 (uninitialized-memory data leak in the Snappy and LZ4 decompressors when the match offset is zero). Flink only invokes aircompressor's LZO and ZSTD implementations, so the vulnerable code is bundled but not on Flink's code path; this is dependency hygiene. Packages, API and bytecode level are unchanged, making it a drop-in replacement.

The actively developed `aircompressor-v3` artifact is not an option: it requires Java 25 bytecode (earlier 3.x required Java 22) and renamed its packages to `io.airlift.compress.v3.*`, while Flink supports Java 11/17/21. See FLINK-40054 for the full rationale, including alternatives considered.

Supersedes #27676, which misses the required NOTICE update.

## Brief change log

  - Update `io.airlift:aircompressor` from 0.27 to 2.0.3 in `flink-runtime/pom.xml`
  - Update `flink-runtime/src/main/resources/META-INF/NOTICE` accordingly

## Verifying this change

This change is already covered by existing tests: `org.apache.flink.runtime.io.compression.BlockCompressionTest` (LZO and ZSTD round-trips through the new version).

Verified locally: clean compile of `flink-runtime` against 2.0.3, and confirmed the shaded `flink-runtime` jar relocates all aircompressor classes under `org.apache.flink.shaded.io.airlift.compress` with none left unrelocated.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): yes
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (Claude Code with Claude Fable 5)

Generated-by: Claude Code (Claude Fable 5)
