### PR TITLE
[FLINK-34376][table] Fix DECIMAL precision loss in multiplication type inference

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/utils/LogicalTypeMerging.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/utils/LogicalTypeMerging.java
@@ -231,7 +231,9 @@ public final class LogicalTypeMerging {
     public static DecimalType findMultiplicationDecimalType(
             int precision1, int scale1, int precision2, int scale2) {
         int scale = scale1 + scale2;
-        int precision = precision1 + precision2 + 1;
+        // The integer part of the product has at most (p1-s1)+(p2-s2) digits, and the fractional
+        // part has exactly s1+s2 digits, so the total is p1+p2 digits (no +1 needed).
+        int precision = precision1 + precision2;
         return adjustPrecisionScale(precision, scale);
     }
 

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/inference/strategies/DecimalTypeStrategyTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/inference/strategies/DecimalTypeStrategyTest.java
@@ -39,7 +39,7 @@ class DecimalTypeStrategyTest extends TypeStrategiesTestBase {
                         .expectDataType(DataTypes.DECIMAL(11, 8).notNull()),
                 TestSpec.forStrategy("Find a decimal product", SpecificTypeStrategies.DECIMAL_TIMES)
                         .inputTypes(DataTypes.DECIMAL(5, 4), DataTypes.DECIMAL(3, 2))
-                        .expectDataType(DataTypes.DECIMAL(9, 6).notNull()),
+                        .expectDataType(DataTypes.DECIMAL(8, 6).notNull()),
                 TestSpec.forStrategy("Find a decimal modulo", SpecificTypeStrategies.DECIMAL_MOD)
                         .inputTypes(DataTypes.DECIMAL(5, 4), DataTypes.DECIMAL(3, 2))
                         .expectDataType(DataTypes.DECIMAL(5, 4).notNull()));

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/logical/utils/LogicalTypeMergingTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/logical/utils/LogicalTypeMergingTest.java
@@ -50,9 +50,13 @@ class LogicalTypeMergingTest {
         assertThat(LogicalTypeMerging.findMultiplicationDecimalType(30, 10, 30, 10))
                 .hasPrecisionAndScale(38, 6);
         assertThat(LogicalTypeMerging.findMultiplicationDecimalType(30, 20, 30, 20))
-                .hasPrecisionAndScale(38, 17);
+                .hasPrecisionAndScale(38, 18);
         assertThat(LogicalTypeMerging.findMultiplicationDecimalType(38, 2, 38, 3))
                 .hasPrecisionAndScale(38, 5);
+        // DECIMAL(38,18) * INTEGER(10,0): integer part is at most (38-18)+(10-0)=30 digits,
+        // so scale must be at least 38-30=8 to avoid losing integer digits.
+        assertThat(LogicalTypeMerging.findMultiplicationDecimalType(38, 18, 10, 0))
+                .hasPrecisionAndScale(38, 8);
     }
 
     @Test

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/expressions/DecimalTypeTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/expressions/DecimalTypeTest.scala
@@ -234,7 +234,7 @@ class DecimalTypeTest extends ExpressionTestBase {
     testAllApis(
       'f26 * 'f26,
       "f26 * f26",
-      "0.00010000000000000"
+      "0.000100000000000000"
     )
 
     // (76, 20) -> (38, 6), 0.0000006 is rounding to 0.000001
@@ -253,11 +253,11 @@ class DecimalTypeTest extends ExpressionTestBase {
       "NULL"
     )
 
-    // (60,40) => (38,17), scale part is reduced to make more space for integral part
+    // (60,40) => (38,18), scale part is reduced to make more space for integral part
     testAllApis(
       'f30 * 'f30,
       "f30 * f30",
-      "1.00000000000000000"
+      "1.000000000000000000"
     )
   }
 

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/DecimalITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/DecimalITCase.scala
@@ -209,6 +209,15 @@ class DecimalITCase extends BatchTestBase {
       "select sum(f0) from Table1",
       Seq(DECIMAL(38, 0)),
       s1r(null))
+
+    // SUM(DECIMAL(38,18) * integer literal): multiplication type must not aggressively reduce
+    // scale, otherwise digits in positions beyond the reduced scale are silently lost.
+    checkQuery1(
+      Seq(DECIMAL(38, 18)),
+      s1r(d"9.123456789000000000"),
+      "select cast(sum(f0 * 10) as varchar) from Table1",
+      Seq(STRING),
+      s1r("91.23456789"))
   }
 
   @Test


### PR DESCRIPTION
## What is the purpose of the change

Fix DECIMAL multiplication type inference losing fractional precision when the inferred precision exceeds the maximum DECIMAL precision.

## Brief change log

- Change `LogicalTypeMerging#findMultiplicationDecimalType` to derive multiplication precision as `p1 + p2` instead of `p1 + p2 + 1`, avoiding unnecessary scale reduction in `adjustPrecisionScale`.

## Verifying this change

Updated `LogicalTypeMergingTest` and `DecimalTypeStrategyTest` to assert the corrected DECIMAL multiplication result types. Added `DecimalITCase` coverage for `SUM(DECIMAL(38,18) * integer literal)` to verify the SQL result keeps the expected fractional digits.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable