### PR TITLE
[FLINK-40058][ci] Free up disk space in nightly dist deployment jobs

### DIFF
--- a/tools/azure-pipelines/build-nightly-dist.yml
+++ b/tools/azure-pipelines/build-nightly-dist.yml
@@ -24,6 +24,11 @@ jobs:
     workspace:
       clean: all
     steps:
+      # free up disk space on the hosted agent; the full dist build plus the
+      # Maven cache does not fit in the ~16 GB the image leaves free
+      - script: ./tools/azure-pipelines/free_disk_space.sh
+        target: host
+        displayName: Free up disk space
       - task: Cache@2
         displayName: Cache Maven local repo
         inputs:
@@ -77,6 +82,11 @@ jobs:
     workspace:
       clean: all
     steps:
+      # free up disk space on the hosted agent; the snapshot deploy build plus
+      # the Maven cache does not fit in the ~16 GB the image leaves free
+      - script: ./tools/azure-pipelines/free_disk_space.sh
+        target: host
+        displayName: Free up disk space
       - task: Cache@2
         displayName: Cache Maven local repo
         inputs:


### PR DESCRIPTION
## What is the purpose of the change

The nightly `cron_snapshot_deployment_binary` and `cron_snapshot_deployment_maven` jobs emit repeated "Free disk space on / is lower than 5%" warnings; in [build 76675](https://dev.azure.com/apache-flink/apache-flink/_build/results?buildId=76675&view=results) usage peaked at 99.18% (binary) and 97.35% (maven). Both jobs run on Microsoft-hosted `ubuntu-24.04` agents, which start with only ~16 GB free, and then add the multi-JDK `flink-ci-docker` image, a 4.2 GB restored Maven cache, a near-full Flink build (`-pl flink-dist -am`) and the dist tgz copies. Every other hosted-agent job (`jobs-template.yml`, `e2e-template.yml`) already runs `tools/azure-pipelines/free_disk_space.sh` as its first step, freeing ~34 GB; `build-nightly-dist.yml` is the one hosted-agent template that never got this step.

## Brief change log

  - Run `free_disk_space.sh` (with `target: host`, since the jobs run inside the build container) as the first step of both jobs in `tools/azure-pipelines/build-nightly-dist.yml`

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

Verified by the next scheduled nightly run: the "Free up disk space" step should succeed in both `cron_snapshot_deployment` jobs and the low-disk-space warnings should disappear from the build timeline.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (Claude Code)

Generated-by: Claude Code (Fable 5)
