### PR TITLE
[FLINK-40059][examples] Bump flink-connector-kafka to 5.0.0-2.2

### DIFF
--- a/flink-end-to-end-tests/flink-confluent-schema-registry/pom.xml
+++ b/flink-end-to-end-tests/flink-confluent-schema-registry/pom.xml
@@ -51,14 +51,7 @@ under the License.
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-connector-kafka</artifactId>
-			<version>3.0.0-1.17</version>
-		</dependency>
-		<!-- Make sure that Shaded Guava matches the one used in the flink-connector-kafka,
-		 or remove when FLINK-32462 is resolved -->
-		<dependency>
-			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-shaded-guava</artifactId>
-			<version>30.1.1-jre-16.1</version>
+			<version>5.0.0-2.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.flink</groupId>

--- a/flink-examples/flink-examples-build-helper/flink-examples-streaming-state-machine/src/main/resources/META-INF/NOTICE
+++ b/flink-examples/flink-examples-build-helper/flink-examples-streaming-state-machine/src/main/resources/META-INF/NOTICE
@@ -6,4 +6,4 @@ The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0. (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-- org.apache.kafka:kafka-clients:3.2.3
+- org.apache.kafka:kafka-clients:4.2.0

--- a/flink-examples/flink-examples-streaming/pom.xml
+++ b/flink-examples/flink-examples-streaming/pom.xml
@@ -67,7 +67,7 @@ under the License.
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-connector-kafka</artifactId>
-			<version>3.0.0-1.17</version>
+			<version>5.0.0-2.2</version>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
## What is the purpose of the change

The binary distribution ships `examples/streaming/StateMachineExample.jar` with flink-connector-kafka 3.0.0-1.17 shaded in. That connector is built against Flink 1.17 and cannot link against the Flink 2.x runtime: running the example with `--kafka-topic` fails on job start with

```
java.lang.NoSuchMethodError: 'void org.apache.flink.connector.base.source.reader.fetcher
    .SingleThreadFetcherManager.<init>(FutureCompletingBlockingQueue, Supplier, Configuration, Consumer)'
  at org.apache.flink.connector.kafka.source.reader.fetcher.KafkaSourceFetcherManager.<init>(KafkaSourceFetcherManager.java:72)
  at org.apache.flink.connector.kafka.source.KafkaSource.createReader(KafkaSource.java:163)
```

(the constructor was removed from flink-connector-base in 2.0 by FLINK-31324). This PR bumps the connector to the `Flink-2.x`-compatible `5.0.0-2.2`.

## Brief change log

- Bump flink-connector-kafka 3.0.0-1.17 → 5.0.0-2.2 in `flink-examples-streaming` and `flink-end-to-end-tests/flink-confluent-schema-registry`
- Remove the `flink-shaded-guava` pin from the schema-registry e2e module; its comment said to drop it once FLINK-32462 was resolved, and connector 5.x no longer depends on flink-shaded
- Update the NOTICE of `flink-examples-streaming-state-machine` for the bundled kafka-clients (3.2.3 → 4.2.0)

## Verifying this change

Manually verified on a local cluster against a single-node Kafka 3.9 broker: with the old connector, `StateMachineExample --kafka-topic` fails on job start with the `NoSuchMethodError` above; with this change the job runs, the source is assigned its partitions, and the state machine processes produced events end-to-end. Both affected modules and the shaded example jar build cleanly.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes — upgrades flink-connector-kafka in the streaming examples and one e2e test module)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes: Claude Code

Generated-by: Claude Code (claude-fable-5)
