### PR TITLE
[FLINK-40069][tests] Stabilize OpenTelemetryMetricReporterProtocolTest against collector startup race

### DIFF
--- a/flink-metrics/flink-metrics-otel/src/test/java/org/apache/flink/events/otel/OpenTelemetryEventReporterProtocolTest.java
+++ b/flink-metrics/flink-metrics-otel/src/test/java/org/apache/flink/events/otel/OpenTelemetryEventReporterProtocolTest.java
@@ -45,7 +45,7 @@ public class OpenTelemetryEventReporterProtocolTest
     }
 
     @Override
-    protected void setupAndReport(MetricConfig config) {
+    protected void setupReporter(MetricConfig config) {
         reporter.open(config);
         EventBuilder eventBuilder =
                 Event.builder(this.getClass(), TEST_EVENT_NAME)

--- a/flink-metrics/flink-metrics-otel/src/test/java/org/apache/flink/metrics/otel/AbstractOpenTelemetryReporterProtocolTest.java
+++ b/flink-metrics/flink-metrics-otel/src/test/java/org/apache/flink/metrics/otel/AbstractOpenTelemetryReporterProtocolTest.java
@@ -53,28 +53,28 @@ public abstract class AbstractOpenTelemetryReporterProtocolTest<T> extends OpenT
     @Test
     public void testExplicitGrpcProtocol() throws Exception {
         MetricConfig config = createConfig("gRPC");
-        setupAndReport(config);
+        setupReporter(config);
         assertReported();
     }
 
     @Test
     public void testHttpProtocol() throws Exception {
         MetricConfig config = createConfig("HTTP");
-        setupAndReport(config);
+        setupReporter(config);
         assertReported();
     }
 
     @Test
     public void testHttpProtocolWithLowerCase() throws Exception {
         MetricConfig config = createConfig("http");
-        setupAndReport(config);
+        setupReporter(config);
         assertReported();
     }
 
     @Test
     public void testGrpcProtocolWithLowerCase() throws Exception {
         MetricConfig config = createConfig("grpc");
-        setupAndReport(config);
+        setupReporter(config);
         assertReported();
     }
 
@@ -84,7 +84,7 @@ public abstract class AbstractOpenTelemetryReporterProtocolTest<T> extends OpenT
         config.setProperty(
                 OpenTelemetryReporterOptions.EXPORTER_COMPRESSION.key(),
                 OpenTelemetryReporterOptions.COMPRESSION_GZIP);
-        setupAndReport(config);
+        setupReporter(config);
         assertReported();
     }
 
@@ -94,7 +94,7 @@ public abstract class AbstractOpenTelemetryReporterProtocolTest<T> extends OpenT
         config.setProperty(
                 OpenTelemetryReporterOptions.EXPORTER_COMPRESSION.key(),
                 OpenTelemetryReporterOptions.COMPRESSION_GZIP);
-        setupAndReport(config);
+        setupReporter(config);
         assertReported();
     }
 
@@ -102,7 +102,7 @@ public abstract class AbstractOpenTelemetryReporterProtocolTest<T> extends OpenT
     public void testInvalidCompressionMethodThrows() {
         MetricConfig config = createConfig("grpc");
         config.setProperty(OpenTelemetryReporterOptions.EXPORTER_COMPRESSION.key(), "invalid");
-        assertThatThrownBy(() -> setupAndReport(config))
+        assertThatThrownBy(() -> setupReporter(config))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("Unsupported compression method");
     }
@@ -124,7 +124,11 @@ public abstract class AbstractOpenTelemetryReporterProtocolTest<T> extends OpenT
 
     protected abstract void closeReporter(T reporter);
 
-    protected abstract void setupAndReport(MetricConfig config);
+    /**
+     * Opens the reporter and registers the data to be exported; {@link #assertReported()} verifies
+     * the export.
+     */
+    protected abstract void setupReporter(MetricConfig config);
 
     protected abstract void assertReported() throws Exception;
 }

--- a/flink-metrics/flink-metrics-otel/src/test/java/org/apache/flink/metrics/otel/OpenTelemetryMetricReporterProtocolTest.java
+++ b/flink-metrics/flink-metrics-otel/src/test/java/org/apache/flink/metrics/otel/OpenTelemetryMetricReporterProtocolTest.java
@@ -57,13 +57,15 @@ public class OpenTelemetryMetricReporterProtocolTest
         reporter.open(config);
         SimpleCounter counter = new SimpleCounter();
         reporter.notifyOfAddedMetric(counter, TEST_METRIC_NAME, metricGroup);
-        reporter.report();
-        reporter.waitForLastReportToComplete();
     }
 
     @Override
     protected void assertReported() throws Exception {
         eventuallyConsumeJson(
+                () -> {
+                    reporter.report();
+                    reporter.waitForLastReportToComplete();
+                },
                 json -> assertThat(extractMetricNames(json)).contains(EXPECTED_METRIC_NAME));
     }
 

--- a/flink-metrics/flink-metrics-otel/src/test/java/org/apache/flink/metrics/otel/OpenTelemetryMetricReporterProtocolTest.java
+++ b/flink-metrics/flink-metrics-otel/src/test/java/org/apache/flink/metrics/otel/OpenTelemetryMetricReporterProtocolTest.java
@@ -53,7 +53,7 @@ public class OpenTelemetryMetricReporterProtocolTest
     }
 
     @Override
-    protected void setupAndReport(MetricConfig config) {
+    protected void setupReporter(MetricConfig config) {
         reporter.open(config);
         SimpleCounter counter = new SimpleCounter();
         reporter.notifyOfAddedMetric(counter, TEST_METRIC_NAME, metricGroup);

--- a/flink-metrics/flink-metrics-otel/src/test/java/org/apache/flink/metrics/otel/OpenTelemetryTestBase.java
+++ b/flink-metrics/flink-metrics-otel/src/test/java/org/apache/flink/metrics/otel/OpenTelemetryTestBase.java
@@ -90,8 +90,20 @@ public class OpenTelemetryTestBase {
 
     public static void eventuallyConsumeJson(ThrowingConsumer<JsonNode, Exception> jsonConsumer)
             throws Exception {
+        eventuallyConsumeJson(() -> {}, jsonConsumer);
+    }
+
+    /**
+     * Runs {@code beforeAttempt} at the start of every retry iteration, so on-demand reporters can
+     * re-export instead of letting a single failed export doom the whole retry budget.
+     */
+    public static void eventuallyConsumeJson(
+            ThrowingRunnable<Exception> beforeAttempt,
+            ThrowingConsumer<JsonNode, Exception> jsonConsumer)
+            throws Exception {
         eventually(
                 () -> {
+                    beforeAttempt.run();
                     // otel-collector dumps every report in a new line, so in order to re-use the
                     // same collector across multiple tests, let's read only the last line
                     getOtelContainer()

--- a/flink-metrics/flink-metrics-otel/src/test/java/org/apache/flink/metrics/otel/OtelTestContainer.java
+++ b/flink-metrics/flink-metrics-otel/src/test/java/org/apache/flink/metrics/otel/OtelTestContainer.java
@@ -20,6 +20,7 @@ package org.apache.flink.metrics.otel;
 
 import com.github.dockerjava.api.command.InspectContainerResponse;
 import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.utility.Base58;
 import org.testcontainers.utility.DockerImageName;
 import org.testcontainers.utility.MountableFile;
@@ -27,6 +28,7 @@ import org.testcontainers.utility.MountableFile;
 import java.io.File;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.time.Duration;
 import java.util.Locale;
 
 /** {@link OtelTestContainer} provides an {@code Otel} test instance. */
@@ -53,6 +55,14 @@ class OtelTestContainer extends GenericContainer<OtelTestContainer> {
                         new File(outputDir.toFile(), LOG_FILE).getAbsolutePath(), 755),
                 getOutputLogPath().toString());
         withCommand("--config", "otel-config.yaml");
+        // The default HostPortWaitStrategy reports this shell-less image as ready before the OTLP
+        // receiver accepts connections; the readiness log line is only emitted after all
+        // components, including the receivers, have started.
+        waitingFor(
+                Wait.forLogMessage(
+                                ".*Everything is ready\\. Begin running and processing data\\..*",
+                                1)
+                        .withStartupTimeout(Duration.ofMinutes(1)));
     }
 
     public Path getOutputLogPath() {

--- a/flink-metrics/flink-metrics-otel/src/test/java/org/apache/flink/traces/otel/OpenTelemetryTraceReporterProtocolTest.java
+++ b/flink-metrics/flink-metrics-otel/src/test/java/org/apache/flink/traces/otel/OpenTelemetryTraceReporterProtocolTest.java
@@ -46,7 +46,7 @@ public class OpenTelemetryTraceReporterProtocolTest
     }
 
     @Override
-    protected void setupAndReport(MetricConfig config) {
+    protected void setupReporter(MetricConfig config) {
         reporter.open(config);
         SpanBuilder spanBuilder =
                 Span.builder(this.getClass(), TEST_SPAN_NAME)


### PR DESCRIPTION
## What is the purpose of the change

Fixes intermittent failures of `OpenTelemetryMetricReporterProtocolTest.testGzipCompressionGrpc/Http` (`MismatchedInputException: No content to map due to end-of-input` after exhausting the full 2-minute retry budget; Azure build 76609, leg `test_cron_jdk21_connect`). Two issues combined: (1) `OtelTestContainer` used the default `HostPortWaitStrategy`, which false-reports readiness for the shell-less collector image (its internal exec check cannot run), so the reporter's export, invoked ~160ms before the collector logged readiness, began against a not-yet-listening OTLP receiver and failed; (2) the test exported exactly once before polling, so that single failed export left the collector output file empty for the entire timeout. Gzip is incidental: those two tests simply ran first against the cold container.

## Brief change log

  - `OtelTestContainer`: wait for the collector's "Everything is ready. Begin running and processing data." log line (emitted only after all components including the OTLP receivers have started, unlike the health_check extension which can report healthy independently of receiver readiness) with a bounded 1-minute startup timeout.
  - `OpenTelemetryTestBase`: add an `eventuallyConsumeJson` overload with a pre-attempt hook; the existing single-arg method delegates with a no-op.
  - `OpenTelemetryMetricReporterProtocolTest`: re-export (`report()` + `waitForLastReportToComplete()`) inside the retry loop rather than once beforehand; this also covers transient export failures such as an observed one-off HTTP 404.

## Verifying this change

This change is already covered by existing tests. Verified locally with Docker: the three protocol classes (metrics/events/traces) and both ITCases pass twice in a row (29 tests, 0 failures), with the metrics protocol class completing in seconds versus the 256s two-error CI failure.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (Claude Opus 4.8 and Claude Fable 5, via Claude Code)

Generated-by: Claude Opus 4.8 (1M context)
Generated-by: Claude Fable 5

