### PR TITLE
[FLINK-40071][build] Bump jackson-bom to 2.22.2

### DIFF
--- a/flink-filesystems/flink-azure-fs-hadoop/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-azure-fs-hadoop/src/main/resources/META-INF/NOTICE
@@ -6,7 +6,7 @@ The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-- com.fasterxml.jackson.core:jackson-core:2.21.4
+- com.fasterxml.jackson.core:jackson-core:2.21.5
 - com.google.guava:guava:20.0
 - commons-codec:commons-codec:1.15
 - commons-logging:commons-logging:1.1.3

--- a/flink-filesystems/flink-azure-fs-hadoop/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-azure-fs-hadoop/src/main/resources/META-INF/NOTICE
@@ -6,7 +6,7 @@ The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-- com.fasterxml.jackson.core:jackson-core:2.21.3
+- com.fasterxml.jackson.core:jackson-core:2.21.4
 - com.google.guava:guava:20.0
 - commons-codec:commons-codec:1.15
 - commons-logging:commons-logging:1.1.3

--- a/flink-filesystems/flink-azure-fs-hadoop/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-azure-fs-hadoop/src/main/resources/META-INF/NOTICE
@@ -6,7 +6,7 @@ The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-- com.fasterxml.jackson.core:jackson-core:2.21.3
+- com.fasterxml.jackson.core:jackson-core:2.22.2
 - com.google.guava:guava:20.0
 - commons-codec:commons-codec:1.15
 - commons-logging:commons-logging:1.1.3

--- a/flink-filesystems/flink-fs-hadoop-shaded/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-fs-hadoop-shaded/src/main/resources/META-INF/NOTICE
@@ -7,8 +7,8 @@ The Apache Software Foundation (http://www.apache.org/).
 This project bundles the following dependencies under the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 - com.fasterxml.jackson.core:jackson-annotations:2.21
-- com.fasterxml.jackson.core:jackson-core:2.21.4
-- com.fasterxml.jackson.core:jackson-databind:2.21.4
+- com.fasterxml.jackson.core:jackson-core:2.21.5
+- com.fasterxml.jackson.core:jackson-databind:2.21.5
 - com.fasterxml.woodstox:woodstox-core:5.3.0
 - com.google.guava:failureaccess:1.0
 - com.google.guava:guava:27.0-jre

--- a/flink-filesystems/flink-fs-hadoop-shaded/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-fs-hadoop-shaded/src/main/resources/META-INF/NOTICE
@@ -7,8 +7,8 @@ The Apache Software Foundation (http://www.apache.org/).
 This project bundles the following dependencies under the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 - com.fasterxml.jackson.core:jackson-annotations:2.21
-- com.fasterxml.jackson.core:jackson-core:2.21.3
-- com.fasterxml.jackson.core:jackson-databind:2.21.3
+- com.fasterxml.jackson.core:jackson-core:2.21.4
+- com.fasterxml.jackson.core:jackson-databind:2.21.4
 - com.fasterxml.woodstox:woodstox-core:5.3.0
 - com.google.guava:failureaccess:1.0
 - com.google.guava:guava:27.0-jre

--- a/flink-filesystems/flink-fs-hadoop-shaded/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-fs-hadoop-shaded/src/main/resources/META-INF/NOTICE
@@ -6,9 +6,9 @@ The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-- com.fasterxml.jackson.core:jackson-annotations:2.21
-- com.fasterxml.jackson.core:jackson-core:2.21.3
-- com.fasterxml.jackson.core:jackson-databind:2.21.3
+- com.fasterxml.jackson.core:jackson-annotations:2.22
+- com.fasterxml.jackson.core:jackson-core:2.22.2
+- com.fasterxml.jackson.core:jackson-databind:2.22.2
 - com.fasterxml.woodstox:woodstox-core:5.3.0
 - com.google.guava:failureaccess:1.0
 - com.google.guava:guava:27.0-jre

--- a/flink-filesystems/flink-gs-fs-hadoop/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-gs-fs-hadoop/src/main/resources/META-INF/NOTICE
@@ -7,10 +7,10 @@ The Apache Software Foundation (http://www.apache.org/).
 This project bundles the following dependencies under the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 - com.fasterxml.jackson.core:jackson-annotations:2.21
-- com.fasterxml.jackson.core:jackson-core:2.21.4
-- com.fasterxml.jackson.core:jackson-databind:2.21.4
-- com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.21.4
-- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.21.4
+- com.fasterxml.jackson.core:jackson-core:2.21.5
+- com.fasterxml.jackson.core:jackson-databind:2.21.5
+- com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.21.5
+- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.21.5
 - com.fasterxml.woodstox:woodstox-core:7.0.0
 - com.google.android:annotations:4.1.1.4
 - com.google.api-client:google-api-client-jackson2:2.0.1

--- a/flink-filesystems/flink-gs-fs-hadoop/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-gs-fs-hadoop/src/main/resources/META-INF/NOTICE
@@ -7,10 +7,10 @@ The Apache Software Foundation (http://www.apache.org/).
 This project bundles the following dependencies under the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 - com.fasterxml.jackson.core:jackson-annotations:2.21
-- com.fasterxml.jackson.core:jackson-core:2.21.3
-- com.fasterxml.jackson.core:jackson-databind:2.21.3
-- com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.21.3
-- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.21.3
+- com.fasterxml.jackson.core:jackson-core:2.21.4
+- com.fasterxml.jackson.core:jackson-databind:2.21.4
+- com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.21.4
+- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.21.4
 - com.fasterxml.woodstox:woodstox-core:7.0.0
 - com.google.android:annotations:4.1.1.4
 - com.google.api-client:google-api-client-jackson2:2.0.1

--- a/flink-filesystems/flink-gs-fs-hadoop/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-gs-fs-hadoop/src/main/resources/META-INF/NOTICE
@@ -6,11 +6,11 @@ The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-- com.fasterxml.jackson.core:jackson-annotations:2.21
-- com.fasterxml.jackson.core:jackson-core:2.21.3
-- com.fasterxml.jackson.core:jackson-databind:2.21.3
-- com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.21.3
-- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.21.3
+- com.fasterxml.jackson.core:jackson-annotations:2.22
+- com.fasterxml.jackson.core:jackson-core:2.22.2
+- com.fasterxml.jackson.core:jackson-databind:2.22.2
+- com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.22.2
+- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.22.2
 - com.fasterxml.woodstox:woodstox-core:7.0.0
 - com.google.android:annotations:4.1.1.4
 - com.google.api-client:google-api-client-jackson2:2.0.1

--- a/flink-filesystems/flink-s3-fs-hadoop/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-s3-fs-hadoop/src/main/resources/META-INF/NOTICE
@@ -10,9 +10,9 @@ This project bundles the following dependencies under the Apache Software Licens
 - com.amazonaws:aws-java-sdk-sts:1.12.779
 - com.amazonaws:jmespath-java:1.12.779
 - com.fasterxml.jackson.core:jackson-annotations:2.21
-- com.fasterxml.jackson.core:jackson-core:2.21.3
-- com.fasterxml.jackson.core:jackson-databind:2.21.3
-- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.21.3
+- com.fasterxml.jackson.core:jackson-core:2.21.4
+- com.fasterxml.jackson.core:jackson-databind:2.21.4
+- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.21.4
 - com.fasterxml.woodstox:woodstox-core:5.3.0
 - com.google.guava:failureaccess:1.0
 - com.google.guava:guava:27.0-jre

--- a/flink-filesystems/flink-s3-fs-hadoop/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-s3-fs-hadoop/src/main/resources/META-INF/NOTICE
@@ -10,9 +10,9 @@ This project bundles the following dependencies under the Apache Software Licens
 - com.amazonaws:aws-java-sdk-sts:1.12.779
 - com.amazonaws:jmespath-java:1.12.779
 - com.fasterxml.jackson.core:jackson-annotations:2.21
-- com.fasterxml.jackson.core:jackson-core:2.21.4
-- com.fasterxml.jackson.core:jackson-databind:2.21.4
-- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.21.4
+- com.fasterxml.jackson.core:jackson-core:2.21.5
+- com.fasterxml.jackson.core:jackson-databind:2.21.5
+- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.21.5
 - com.fasterxml.woodstox:woodstox-core:5.3.0
 - com.google.guava:failureaccess:1.0
 - com.google.guava:guava:27.0-jre

--- a/flink-filesystems/flink-s3-fs-hadoop/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-s3-fs-hadoop/src/main/resources/META-INF/NOTICE
@@ -9,10 +9,10 @@ This project bundles the following dependencies under the Apache Software Licens
 - com.amazonaws:aws-java-sdk-s3:1.12.779
 - com.amazonaws:aws-java-sdk-sts:1.12.779
 - com.amazonaws:jmespath-java:1.12.779
-- com.fasterxml.jackson.core:jackson-annotations:2.21
-- com.fasterxml.jackson.core:jackson-core:2.21.3
-- com.fasterxml.jackson.core:jackson-databind:2.21.3
-- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.21.3
+- com.fasterxml.jackson.core:jackson-annotations:2.22
+- com.fasterxml.jackson.core:jackson-core:2.22.2
+- com.fasterxml.jackson.core:jackson-databind:2.22.2
+- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.22.2
 - com.fasterxml.woodstox:woodstox-core:5.3.0
 - com.google.guava:failureaccess:1.0
 - com.google.guava:guava:27.0-jre

--- a/flink-filesystems/flink-s3-fs-presto/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-s3-fs-presto/src/main/resources/META-INF/NOTICE
@@ -23,9 +23,9 @@ This project bundles the following dependencies under the Apache Software Licens
 - com.facebook.presto:presto-hive-metastore:0.294
 - com.facebook.presto:presto-hdfs-core:0.294
 - com.fasterxml.jackson.core:jackson-annotations:2.21
-- com.fasterxml.jackson.core:jackson-core:2.21.4
-- com.fasterxml.jackson.core:jackson-databind:2.21.4
-- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.21.4
+- com.fasterxml.jackson.core:jackson-core:2.21.5
+- com.fasterxml.jackson.core:jackson-databind:2.21.5
+- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.21.5
 - com.fasterxml.woodstox:woodstox-core:5.3.0
 - com.google.guava:guava:32.1.0-jre
 - com.google.guava:failureaccess:1.0.1

--- a/flink-filesystems/flink-s3-fs-presto/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-s3-fs-presto/src/main/resources/META-INF/NOTICE
@@ -23,9 +23,9 @@ This project bundles the following dependencies under the Apache Software Licens
 - com.facebook.presto:presto-hive-metastore:0.294
 - com.facebook.presto:presto-hdfs-core:0.294
 - com.fasterxml.jackson.core:jackson-annotations:2.21
-- com.fasterxml.jackson.core:jackson-core:2.21.3
-- com.fasterxml.jackson.core:jackson-databind:2.21.3
-- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.21.3
+- com.fasterxml.jackson.core:jackson-core:2.21.4
+- com.fasterxml.jackson.core:jackson-databind:2.21.4
+- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.21.4
 - com.fasterxml.woodstox:woodstox-core:5.3.0
 - com.google.guava:guava:32.1.0-jre
 - com.google.guava:failureaccess:1.0.1

--- a/flink-filesystems/flink-s3-fs-presto/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-s3-fs-presto/src/main/resources/META-INF/NOTICE
@@ -22,10 +22,10 @@ This project bundles the following dependencies under the Apache Software Licens
 - com.facebook.presto:presto-hive-common:0.294
 - com.facebook.presto:presto-hive-metastore:0.294
 - com.facebook.presto:presto-hdfs-core:0.294
-- com.fasterxml.jackson.core:jackson-annotations:2.21
-- com.fasterxml.jackson.core:jackson-core:2.21.3
-- com.fasterxml.jackson.core:jackson-databind:2.21.3
-- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.21.3
+- com.fasterxml.jackson.core:jackson-annotations:2.22
+- com.fasterxml.jackson.core:jackson-core:2.22.2
+- com.fasterxml.jackson.core:jackson-databind:2.22.2
+- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.22.2
 - com.fasterxml.woodstox:woodstox-core:5.3.0
 - com.google.guava:guava:32.1.0-jre
 - com.google.guava:failureaccess:1.0.1

--- a/flink-formats/flink-sql-avro-confluent-registry/src/main/resources/META-INF/NOTICE
+++ b/flink-formats/flink-sql-avro-confluent-registry/src/main/resources/META-INF/NOTICE
@@ -7,8 +7,8 @@ The Apache Software Foundation (http://www.apache.org/).
 This project bundles the following dependencies under the Apache Software License 2.0. (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 - com.fasterxml.jackson.core:jackson-annotations:2.21
-- com.fasterxml.jackson.core:jackson-core:2.21.3
-- com.fasterxml.jackson.core:jackson-databind:2.21.3
+- com.fasterxml.jackson.core:jackson-core:2.21.4
+- com.fasterxml.jackson.core:jackson-databind:2.21.4
 - com.google.guava:guava:32.0.1-jre
 - commons-io:commons-io:2.15.1
 - io.confluent:common-utils:7.5.3

--- a/flink-formats/flink-sql-avro-confluent-registry/src/main/resources/META-INF/NOTICE
+++ b/flink-formats/flink-sql-avro-confluent-registry/src/main/resources/META-INF/NOTICE
@@ -7,8 +7,8 @@ The Apache Software Foundation (http://www.apache.org/).
 This project bundles the following dependencies under the Apache Software License 2.0. (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 - com.fasterxml.jackson.core:jackson-annotations:2.21
-- com.fasterxml.jackson.core:jackson-core:2.21.4
-- com.fasterxml.jackson.core:jackson-databind:2.21.4
+- com.fasterxml.jackson.core:jackson-core:2.21.5
+- com.fasterxml.jackson.core:jackson-databind:2.21.5
 - com.google.guava:guava:32.0.1-jre
 - commons-io:commons-io:2.15.1
 - io.confluent:common-utils:7.5.3

--- a/flink-formats/flink-sql-avro-confluent-registry/src/main/resources/META-INF/NOTICE
+++ b/flink-formats/flink-sql-avro-confluent-registry/src/main/resources/META-INF/NOTICE
@@ -6,9 +6,9 @@ The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0. (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-- com.fasterxml.jackson.core:jackson-annotations:2.21
-- com.fasterxml.jackson.core:jackson-core:2.21.3
-- com.fasterxml.jackson.core:jackson-databind:2.21.3
+- com.fasterxml.jackson.core:jackson-annotations:2.22
+- com.fasterxml.jackson.core:jackson-core:2.22.2
+- com.fasterxml.jackson.core:jackson-databind:2.22.2
 - com.google.guava:guava:32.0.1-jre
 - commons-io:commons-io:2.15.1
 - io.confluent:common-utils:7.5.3

--- a/flink-formats/flink-sql-avro/src/main/resources/META-INF/NOTICE
+++ b/flink-formats/flink-sql-avro/src/main/resources/META-INF/NOTICE
@@ -7,7 +7,7 @@ The Apache Software Foundation (http://www.apache.org/).
 This project bundles the following dependencies under the Apache Software License 2.0. (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 - org.apache.avro:avro:1.11.5
-- com.fasterxml.jackson.core:jackson-core:2.21.3
-- com.fasterxml.jackson.core:jackson-databind:2.21.3
+- com.fasterxml.jackson.core:jackson-core:2.21.4
+- com.fasterxml.jackson.core:jackson-databind:2.21.4
 - com.fasterxml.jackson.core:jackson-annotations:2.21
 - org.apache.commons:commons-compress:1.26.0

--- a/flink-formats/flink-sql-avro/src/main/resources/META-INF/NOTICE
+++ b/flink-formats/flink-sql-avro/src/main/resources/META-INF/NOTICE
@@ -7,7 +7,7 @@ The Apache Software Foundation (http://www.apache.org/).
 This project bundles the following dependencies under the Apache Software License 2.0. (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 - org.apache.avro:avro:1.11.5
-- com.fasterxml.jackson.core:jackson-core:2.21.4
-- com.fasterxml.jackson.core:jackson-databind:2.21.4
+- com.fasterxml.jackson.core:jackson-core:2.21.5
+- com.fasterxml.jackson.core:jackson-databind:2.21.5
 - com.fasterxml.jackson.core:jackson-annotations:2.21
 - org.apache.commons:commons-compress:1.26.0

--- a/flink-formats/flink-sql-avro/src/main/resources/META-INF/NOTICE
+++ b/flink-formats/flink-sql-avro/src/main/resources/META-INF/NOTICE
@@ -7,7 +7,7 @@ The Apache Software Foundation (http://www.apache.org/).
 This project bundles the following dependencies under the Apache Software License 2.0. (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 - org.apache.avro:avro:1.11.5
-- com.fasterxml.jackson.core:jackson-core:2.21.3
-- com.fasterxml.jackson.core:jackson-databind:2.21.3
-- com.fasterxml.jackson.core:jackson-annotations:2.21
+- com.fasterxml.jackson.core:jackson-core:2.22.2
+- com.fasterxml.jackson.core:jackson-databind:2.22.2
+- com.fasterxml.jackson.core:jackson-annotations:2.22
 - org.apache.commons:commons-compress:1.26.0

--- a/flink-kubernetes/src/main/resources/META-INF/NOTICE
+++ b/flink-kubernetes/src/main/resources/META-INF/NOTICE
@@ -7,10 +7,10 @@ The Apache Software Foundation (http://www.apache.org/).
 This project bundles the following dependencies under the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 - com.fasterxml.jackson.core:jackson-annotations:2.21
-- com.fasterxml.jackson.core:jackson-core:2.21.3
-- com.fasterxml.jackson.core:jackson-databind:2.21.3
-- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.21.3
-- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.21.3
+- com.fasterxml.jackson.core:jackson-core:2.21.4
+- com.fasterxml.jackson.core:jackson-databind:2.21.4
+- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.21.4
+- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.21.4
 - com.squareup.okhttp3:logging-interceptor:3.14.9
 - com.squareup.okhttp3:okhttp:3.14.9
 - com.squareup.okio:okio:1.17.2

--- a/flink-kubernetes/src/main/resources/META-INF/NOTICE
+++ b/flink-kubernetes/src/main/resources/META-INF/NOTICE
@@ -7,10 +7,10 @@ The Apache Software Foundation (http://www.apache.org/).
 This project bundles the following dependencies under the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 - com.fasterxml.jackson.core:jackson-annotations:2.21
-- com.fasterxml.jackson.core:jackson-core:2.21.4
-- com.fasterxml.jackson.core:jackson-databind:2.21.4
-- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.21.4
-- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.21.4
+- com.fasterxml.jackson.core:jackson-core:2.21.5
+- com.fasterxml.jackson.core:jackson-databind:2.21.5
+- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.21.5
+- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.21.5
 - com.squareup.okhttp3:logging-interceptor:3.14.9
 - com.squareup.okhttp3:okhttp:3.14.9
 - com.squareup.okio:okio:1.17.2

--- a/flink-kubernetes/src/main/resources/META-INF/NOTICE
+++ b/flink-kubernetes/src/main/resources/META-INF/NOTICE
@@ -6,11 +6,11 @@ The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-- com.fasterxml.jackson.core:jackson-annotations:2.21
-- com.fasterxml.jackson.core:jackson-core:2.21.3
-- com.fasterxml.jackson.core:jackson-databind:2.21.3
-- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.21.3
-- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.21.3
+- com.fasterxml.jackson.core:jackson-annotations:2.22
+- com.fasterxml.jackson.core:jackson-core:2.22.2
+- com.fasterxml.jackson.core:jackson-databind:2.22.2
+- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.22.2
+- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.22.2
 - com.squareup.okhttp3:logging-interceptor:3.14.9
 - com.squareup.okhttp3:okhttp:3.14.9
 - com.squareup.okio:okio:1.17.2

--- a/flink-models/flink-model-openai/src/main/resources/META-INF/NOTICE
+++ b/flink-models/flink-model-openai/src/main/resources/META-INF/NOTICE
@@ -7,11 +7,11 @@ The Apache Software Foundation (http://www.apache.org/).
 This project bundles the following dependencies under the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 - com.fasterxml.jackson.core:jackson-annotations:2.21
-- com.fasterxml.jackson.core:jackson-core:2.21.3
-- com.fasterxml.jackson.core:jackson-databind:2.21.3
-- com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.21.3
-- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.21.3
-- com.fasterxml.jackson.module:jackson-module-kotlin:2.21.3
+- com.fasterxml.jackson.core:jackson-core:2.21.4
+- com.fasterxml.jackson.core:jackson-databind:2.21.4
+- com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.21.4
+- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.21.4
+- com.fasterxml.jackson.module:jackson-module-kotlin:2.21.4
 - com.google.errorprone:error_prone_annotations:2.33.0
 - com.openai:openai-java:1.6.1
 - com.openai:openai-java-client-okhttp:1.6.1

--- a/flink-models/flink-model-openai/src/main/resources/META-INF/NOTICE
+++ b/flink-models/flink-model-openai/src/main/resources/META-INF/NOTICE
@@ -7,11 +7,11 @@ The Apache Software Foundation (http://www.apache.org/).
 This project bundles the following dependencies under the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 - com.fasterxml.jackson.core:jackson-annotations:2.21
-- com.fasterxml.jackson.core:jackson-core:2.21.4
-- com.fasterxml.jackson.core:jackson-databind:2.21.4
-- com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.21.4
-- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.21.4
-- com.fasterxml.jackson.module:jackson-module-kotlin:2.21.4
+- com.fasterxml.jackson.core:jackson-core:2.21.5
+- com.fasterxml.jackson.core:jackson-databind:2.21.5
+- com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.21.5
+- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.21.5
+- com.fasterxml.jackson.module:jackson-module-kotlin:2.21.5
 - com.google.errorprone:error_prone_annotations:2.33.0
 - com.openai:openai-java:1.6.1
 - com.openai:openai-java-client-okhttp:1.6.1

--- a/flink-models/flink-model-openai/src/main/resources/META-INF/NOTICE
+++ b/flink-models/flink-model-openai/src/main/resources/META-INF/NOTICE
@@ -6,12 +6,12 @@ The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-- com.fasterxml.jackson.core:jackson-annotations:2.21
-- com.fasterxml.jackson.core:jackson-core:2.21.3
-- com.fasterxml.jackson.core:jackson-databind:2.21.3
-- com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.21.3
-- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.21.3
-- com.fasterxml.jackson.module:jackson-module-kotlin:2.21.3
+- com.fasterxml.jackson.core:jackson-annotations:2.22
+- com.fasterxml.jackson.core:jackson-core:2.22.2
+- com.fasterxml.jackson.core:jackson-databind:2.22.2
+- com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.22.2
+- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.22.2
+- com.fasterxml.jackson.module:jackson-module-kotlin:2.22.2
 - com.google.errorprone:error_prone_annotations:2.33.0
 - com.openai:openai-java:1.6.1
 - com.openai:openai-java-client-okhttp:1.6.1

--- a/flink-models/flink-model-triton/src/main/resources/META-INF/NOTICE
+++ b/flink-models/flink-model-triton/src/main/resources/META-INF/NOTICE
@@ -7,8 +7,8 @@ The Apache Software Foundation (http://www.apache.org/).
 This project bundles the following dependencies under the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 - com.fasterxml.jackson.core:jackson-annotations:2.21
-- com.fasterxml.jackson.core:jackson-core:2.21.3
-- com.fasterxml.jackson.core:jackson-databind:2.21.3
+- com.fasterxml.jackson.core:jackson-core:2.21.4
+- com.fasterxml.jackson.core:jackson-databind:2.21.4
 - com.squareup.okhttp3:okhttp:4.12.0
 - com.squareup.okio:okio:3.6.0
 - com.squareup.okio:okio-jvm:3.6.0

--- a/flink-models/flink-model-triton/src/main/resources/META-INF/NOTICE
+++ b/flink-models/flink-model-triton/src/main/resources/META-INF/NOTICE
@@ -7,8 +7,8 @@ The Apache Software Foundation (http://www.apache.org/).
 This project bundles the following dependencies under the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 - com.fasterxml.jackson.core:jackson-annotations:2.21
-- com.fasterxml.jackson.core:jackson-core:2.21.4
-- com.fasterxml.jackson.core:jackson-databind:2.21.4
+- com.fasterxml.jackson.core:jackson-core:2.21.5
+- com.fasterxml.jackson.core:jackson-databind:2.21.5
 - com.squareup.okhttp3:okhttp:4.12.0
 - com.squareup.okio:okio:3.6.0
 - com.squareup.okio:okio-jvm:3.6.0

--- a/flink-models/flink-model-triton/src/main/resources/META-INF/NOTICE
+++ b/flink-models/flink-model-triton/src/main/resources/META-INF/NOTICE
@@ -6,9 +6,9 @@ The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-- com.fasterxml.jackson.core:jackson-annotations:2.21
-- com.fasterxml.jackson.core:jackson-core:2.21.3
-- com.fasterxml.jackson.core:jackson-databind:2.21.3
+- com.fasterxml.jackson.core:jackson-annotations:2.22
+- com.fasterxml.jackson.core:jackson-core:2.22.2
+- com.fasterxml.jackson.core:jackson-databind:2.22.2
 - com.squareup.okhttp3:okhttp:4.12.0
 - com.squareup.okio:okio:3.6.0
 - com.squareup.okio:okio-jvm:3.6.0

--- a/flink-python/src/main/resources/META-INF/NOTICE
+++ b/flink-python/src/main/resources/META-INF/NOTICE
@@ -7,9 +7,9 @@ The Apache Software Foundation (http://www.apache.org/).
 This project bundles the following dependencies under the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 - com.fasterxml.jackson.core:jackson-annotations:2.21
-- com.fasterxml.jackson.core:jackson-core:2.21.3
-- com.fasterxml.jackson.core:jackson-databind:2.21.3
-- com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.21.3
+- com.fasterxml.jackson.core:jackson-core:2.21.4
+- com.fasterxml.jackson.core:jackson-databind:2.21.4
+- com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.21.4
 - com.google.flatbuffers:flatbuffers-java:25.2.10
 - joda-time:joda-time:2.5
 - org.apache.arrow:arrow-format:19.0.0

--- a/flink-python/src/main/resources/META-INF/NOTICE
+++ b/flink-python/src/main/resources/META-INF/NOTICE
@@ -7,9 +7,9 @@ The Apache Software Foundation (http://www.apache.org/).
 This project bundles the following dependencies under the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 - com.fasterxml.jackson.core:jackson-annotations:2.21
-- com.fasterxml.jackson.core:jackson-core:2.21.4
-- com.fasterxml.jackson.core:jackson-databind:2.21.4
-- com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.21.4
+- com.fasterxml.jackson.core:jackson-core:2.21.5
+- com.fasterxml.jackson.core:jackson-databind:2.21.5
+- com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.21.5
 - com.google.flatbuffers:flatbuffers-java:25.2.10
 - joda-time:joda-time:2.5
 - org.apache.arrow:arrow-format:19.0.0

--- a/flink-python/src/main/resources/META-INF/NOTICE
+++ b/flink-python/src/main/resources/META-INF/NOTICE
@@ -6,10 +6,10 @@ The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-- com.fasterxml.jackson.core:jackson-annotations:2.21
-- com.fasterxml.jackson.core:jackson-core:2.21.3
-- com.fasterxml.jackson.core:jackson-databind:2.21.3
-- com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.21.3
+- com.fasterxml.jackson.core:jackson-annotations:2.22
+- com.fasterxml.jackson.core:jackson-core:2.22.2
+- com.fasterxml.jackson.core:jackson-databind:2.22.2
+- com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.22.2
 - com.google.flatbuffers:flatbuffers-java:25.2.10
 - joda-time:joda-time:2.5
 - io.opentelemetry:opentelemetry-api:1.62.0

--- a/pom.xml
+++ b/pom.xml
@@ -151,7 +151,7 @@ under the License.
 		<avro.version>1.11.5</avro.version>
 		<!-- Version for transitive Jackson dependencies that are not used within Flink itself.-->
 		<jackson.mapper.asl.version>1.9.14.jdk17-redhat-00001</jackson.mapper.asl.version>
-		<jackson-bom.version>2.21.4</jackson-bom.version>
+		<jackson-bom.version>2.21.5</jackson-bom.version>
 		<javax.activation.api.version>1.2.0</javax.activation.api.version>
 		<jaxb.api.version>2.3.1</jaxb.api.version>
 		<junit4.version>4.13.2</junit4.version>

--- a/pom.xml
+++ b/pom.xml
@@ -151,7 +151,7 @@ under the License.
 		<avro.version>1.11.5</avro.version>
 		<!-- Version for transitive Jackson dependencies that are not used within Flink itself.-->
 		<jackson.mapper.asl.version>1.9.14.jdk17-redhat-00001</jackson.mapper.asl.version>
-		<jackson-bom.version>2.21.3</jackson-bom.version>
+		<jackson-bom.version>2.21.4</jackson-bom.version>
 		<javax.activation.api.version>1.2.0</javax.activation.api.version>
 		<jaxb.api.version>2.3.1</jaxb.api.version>
 		<junit4.version>4.13.2</junit4.version>

--- a/pom.xml
+++ b/pom.xml
@@ -154,7 +154,7 @@ under the License.
 		<avro.version>1.11.5</avro.version>
 		<!-- Version for transitive Jackson dependencies that are not used within Flink itself.-->
 		<jackson.mapper.asl.version>1.9.14.jdk17-redhat-00001</jackson.mapper.asl.version>
-		<jackson-bom.version>2.21.3</jackson-bom.version>
+		<jackson-bom.version>2.22.2</jackson-bom.version>
 		<javax.activation.api.version>1.2.0</javax.activation.api.version>
 		<jaxb.api.version>2.3.1</jaxb.api.version>
 		<junit4.version>4.13.2</junit4.version>


### PR DESCRIPTION
## What is the purpose of the change

flink-shaded 22.0 now bundles jackson 2.22.2. This bumps the non-shaded jackson to the same version so the two stay in sync. It also supersedes the earlier 2.21.5 revision of this PR: jackson-databind 2.21.3 was affected by CVE-2026-54512 through 54518, and 2.22.2 is a superset of the 2.21.5 fixes, so it clears all seven.

## Brief change log

- `jackson-bom.version` 2.21.3 → 2.22.2 in the root pom
- Updated the NOTICE files of the 11 modules bundling non-shaded jackson (jackson-annotations 2.21 → 2.22, everything else 2.21.3 → 2.22.2)

## Verifying this change

Dependency version bump, no code changes. The set of jackson artifacts bundled by each module is unchanged from the 2.21.x line — jackson-databind 2.22.2 still depends only on jackson-core and jackson-annotations at runtime — so only the version strings move. NOTICE correctness is enforced by the NoticeFileChecker in CI.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes — jackson 2.21.3 → 2.22.2, aligning with flink-shaded 22.0)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes: Claude Code
