### PR TITLE
[FLINK-40019][core][runtime] Support per-job delegation tokens

### DIFF
--- a/docs/layouts/shortcodes/generated/security_configuration.html
+++ b/docs/layouts/shortcodes/generated/security_configuration.html
@@ -45,6 +45,12 @@
             <td>Ratio of the tokens's expiration time when new credentials should be re-obtained.</td>
         </tr>
         <tr>
+            <td><h5>security.delegation.tokens.reobtain.cooldown</h5></td>
+            <td style="word-wrap: break-word;">30 s</td>
+            <td>Duration</td>
+            <td>Minimum time between two consecutive on-demand token re-obtain cycles, such as those triggered when a job is registered. Requests arriving within the cooldown are coalesced and deferred until it elapses. Does not affect the periodic renewal.</td>
+        </tr>
+        <tr>
             <td><h5>security.kerberos.access.hadoopFileSystems</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>List&lt;String&gt;</td>

--- a/docs/layouts/shortcodes/generated/security_delegation_token_section.html
+++ b/docs/layouts/shortcodes/generated/security_delegation_token_section.html
@@ -33,6 +33,12 @@
             <td>Ratio of the tokens's expiration time when new credentials should be re-obtained.</td>
         </tr>
         <tr>
+            <td><h5>security.delegation.tokens.reobtain.cooldown</h5></td>
+            <td style="word-wrap: break-word;">30 s</td>
+            <td>Duration</td>
+            <td>Minimum time between two consecutive on-demand token re-obtain cycles, such as those triggered when a job is registered. Requests arriving within the cooldown are coalesced and deferred until it elapses. Does not affect the periodic renewal.</td>
+        </tr>
+        <tr>
             <td><h5>security.delegation.token.provider.&lt;serviceName&gt;.enabled</h5></td>
             <td style="word-wrap: break-word;">true</td>
             <td>Boolean</td>

--- a/flink-core/src/main/java/org/apache/flink/configuration/SecurityOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/SecurityOptions.java
@@ -180,8 +180,19 @@ public class SecurityOptions {
                     .withDescription(
                             "Ratio of the tokens's expiration time when new credentials should be re-obtained.");
 
-    @Documentation.SuffixOption(DELEGATION_TOKEN_PROVIDER_PREFIX)
     @Documentation.Section(value = Documentation.Sections.SECURITY_DELEGATION_TOKEN, position = 5)
+    public static final ConfigOption<Duration> DELEGATION_TOKENS_REOBTAIN_COOLDOWN =
+            key("security.delegation.tokens.reobtain.cooldown")
+                    .durationType()
+                    .defaultValue(Duration.ofSeconds(30))
+                    .withDescription(
+                            "Minimum time between two consecutive on-demand token re-obtain "
+                                    + "cycles, such as those triggered when a job is registered. "
+                                    + "Requests arriving within the cooldown are coalesced and "
+                                    + "deferred until it elapses. Does not affect the periodic renewal.");
+
+    @Documentation.SuffixOption(DELEGATION_TOKEN_PROVIDER_PREFIX)
+    @Documentation.Section(value = Documentation.Sections.SECURITY_DELEGATION_TOKEN, position = 6)
     public static final ConfigOption<Boolean> DELEGATION_TOKEN_PROVIDER_ENABLED =
             key("enabled")
                     .booleanType()

--- a/flink-core/src/main/java/org/apache/flink/core/security/token/DelegationTokenManagerCallback.java
+++ b/flink-core/src/main/java/org/apache/flink/core/security/token/DelegationTokenManagerCallback.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.core.security.token;
+
+import org.apache.flink.annotation.Experimental;
+
+/**
+ * Handed to a {@link DelegationTokenProvider} at {@link
+ * DelegationTokenProvider#init(org.apache.flink.configuration.Configuration,
+ * DelegationTokenManagerCallback) init} time, giving the provider a way to ask the delegation token
+ * manager to re-obtain tokens. The provider may retain the callback and invoke it later, outside
+ * the {@code init}/{@code registerJob} call stack.
+ */
+@Experimental
+public interface DelegationTokenManagerCallback {
+
+    /**
+     * Requests an asynchronous token re-obtain and redistribution to all receivers,
+     * bringing the next obtain cycle forward instead of waiting for the periodic renewal.
+     *
+     * <p>May be called from any thread at any time after {@code init}. The manager coalesces
+     * requests and may apply a cooldown, so a call does not necessarily map to one obtain
+     * cycle. Returns immediately and does not wait for completion.
+     */
+    void reobtainDelegationTokens();
+}

--- a/flink-core/src/main/java/org/apache/flink/core/security/token/DelegationTokenManagerCallback.java
+++ b/flink-core/src/main/java/org/apache/flink/core/security/token/DelegationTokenManagerCallback.java
@@ -31,12 +31,12 @@ import org.apache.flink.annotation.Experimental;
 public interface DelegationTokenManagerCallback {
 
     /**
-     * Requests an asynchronous token re-obtain and redistribution to all receivers,
-     * bringing the next obtain cycle forward instead of waiting for the periodic renewal.
+     * Requests an asynchronous token re-obtain and redistribution to all receivers, bringing the
+     * next obtain cycle forward instead of waiting for the periodic renewal.
      *
      * <p>May be called from any thread at any time after {@code init}. The manager coalesces
-     * requests and may apply a cooldown, so a call does not necessarily map to one obtain
-     * cycle. Returns immediately and does not wait for completion.
+     * requests and may apply a cooldown, so a call does not necessarily map to one obtain cycle.
+     * Returns immediately and does not wait for completion.
      */
     void reobtainDelegationTokens();
 }

--- a/flink-core/src/main/java/org/apache/flink/core/security/token/DelegationTokenProvider.java
+++ b/flink-core/src/main/java/org/apache/flink/core/security/token/DelegationTokenProvider.java
@@ -163,10 +163,12 @@ public interface DelegationTokenProvider {
     /**
      * Stops the provider. Any resources should be closed.
      *
-     * <p>Called once during manager shutdown. Note that an obtain-and-broadcast cycle started just
-     * before shutdown may still be running on another thread when this is invoked, so {@code
-     * stop()} may overlap an in-flight {@link #obtainDelegationTokens()}; implementations must
-     * release resources in a way that is safe with respect to that overlap.
+     * <p>Called at most once, when the manager is closed at process shutdown. It is not called on
+     * ResourceManager leadership changes, those only stop and restart the manager's obtain session
+     * and the provider instance stays in use. An obtain cycle started just before shutdown may
+     * still be running, so {@code stop()} may overlap an in-flight {@link
+     * #obtainDelegationTokens()} and implementations must release resources in a way that is safe
+     * with respect to that overlap.
      */
     default void stop() {}
 }

--- a/flink-core/src/main/java/org/apache/flink/core/security/token/DelegationTokenProvider.java
+++ b/flink-core/src/main/java/org/apache/flink/core/security/token/DelegationTokenProvider.java
@@ -136,10 +136,10 @@ public interface DelegationTokenProvider {
      * <p>Must be idempotent: it may be called more than once for the same {@code jobId} (e.g. on
      * JobManager or ResourceManager failover, when the JobMaster re-registers).
      *
-     * <p>Should not throw: a thrown (unchecked) exception rejects the job's registration (the job
-     * does not start) and triggers {@link #unregisterJob(JobID)} on all providers to roll back.
-     * Prefer deferring the real fetch to the (retrying) obtain cycle over a synchronous fetch, so a
-     * transient failure does not fail the job.
+     * <p>Should not throw: a thrown (unchecked) exception or linkage error rejects the job's
+     * registration (the job does not start) and triggers {@link #unregisterJob(JobID)} on all
+     * providers to roll back. Prefer deferring the real fetch to the (retrying) obtain cycle over a
+     * synchronous fetch, so a transient failure does not fail the job.
      *
      * @param jobId The job id of the job.
      * @param jobConfiguration The job configuration.
@@ -149,8 +149,9 @@ public interface DelegationTokenProvider {
     /**
      * Called when the job is being removed — it reached a globally terminal state, or its
      * job-leader registration timed out — and its per-job state should be released. Must be
-     * idempotent. Exceptions are caught and logged by the framework (one provider's failure does
-     * not abort cleanup of the others), but implementations should still avoid throwing.
+     * idempotent. Exceptions and linkage errors are caught and logged by the framework (one
+     * provider's failure does not abort cleanup of the others), but implementations should still
+     * avoid throwing.
      *
      * @param jobId The job id of the job.
      */

--- a/flink-core/src/main/java/org/apache/flink/core/security/token/DelegationTokenProvider.java
+++ b/flink-core/src/main/java/org/apache/flink/core/security/token/DelegationTokenProvider.java
@@ -30,16 +30,15 @@ import java.util.Optional;
  * responsible to produce the serialized form of tokens which will be handled by {@link
  * DelegationTokenReceiver} instances both on JobManager and TaskManager side.
  *
- * <p><b>Threading contract.</b> A single instance per provider implementation is created and
- * {@link #init(Configuration, DelegationTokenManagerCallback) initialized} once and then shared
- * for the lifetime of the manager. {@link #obtainDelegationTokens()} runs on the manager's IO
- * executor, while {@link
- * #registerJob(JobID, Configuration)} and {@link #unregisterJob(JobID)} are invoked from the
- * ResourceManager main thread; these can therefore run concurrently. {@link
+ * <p><b>Threading contract.</b> A single instance per provider implementation is created and {@link
+ * #init(Configuration, DelegationTokenManagerCallback) initialized} once and then shared for the
+ * lifetime of the manager. {@link #obtainDelegationTokens()} runs on the manager's IO executor,
+ * while {@link #registerJob(JobID, Configuration)} and {@link #unregisterJob(JobID)} are invoked
+ * from the ResourceManager main thread. These can therefore run concurrently. {@link
  * DelegationTokenManagerCallback#reobtainDelegationTokens()} may be invoked from any thread.
  * Implementations must keep any per-job state thread-safe, and {@code registerJob}/{@code
- * unregisterJob} must be non-blocking so they do not stall the ResourceManager — defer real work
- * to {@link #obtainDelegationTokens()}.
+ * unregisterJob} must be non-blocking so they do not stall the ResourceManager — defer real work to
+ * {@link #obtainDelegationTokens()}.
  */
 @Experimental
 public interface DelegationTokenProvider {
@@ -98,7 +97,7 @@ public interface DelegationTokenProvider {
      * DelegationTokenManagerCallback#reobtainDelegationTokens()} when needed.
      *
      * @param configuration Configuration to initialize the provider.
-     * @param callback Used to ask the manager to re-obtain tokens; may be retained and called
+     * @param callback Used to ask the manager to re-obtain tokens. May be retained and called
      *     later.
      */
     default void init(Configuration configuration, DelegationTokenManagerCallback callback)
@@ -129,7 +128,7 @@ public interface DelegationTokenProvider {
      *
      * <p>A provider that requests a re-obtain must record this job's per-job state <em>before</em>
      * invoking {@link DelegationTokenManagerCallback#reobtainDelegationTokens()}. That call merely
-     * schedules (or coalesces into) an obtain cycle that runs later on another thread; recording
+     * schedules (or coalesces into) an obtain cycle that runs later on another thread. Recording
      * first establishes the happens-before that lets the serving cycle observe this job's state.
      * Recording afterwards races with the cycle and the job's tokens may be skipped until the next
      * periodic renewal.

--- a/flink-core/src/main/java/org/apache/flink/core/security/token/DelegationTokenProvider.java
+++ b/flink-core/src/main/java/org/apache/flink/core/security/token/DelegationTokenProvider.java
@@ -19,6 +19,7 @@
 package org.apache.flink.core.security.token;
 
 import org.apache.flink.annotation.Experimental;
+import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.Configuration;
 
 import java.util.Optional;
@@ -28,6 +29,17 @@ import java.util.Optional;
  * DelegationTokenManager through service loader. Basically the implementation of this interface is
  * responsible to produce the serialized form of tokens which will be handled by {@link
  * DelegationTokenReceiver} instances both on JobManager and TaskManager side.
+ *
+ * <p><b>Threading contract.</b> A single instance per provider implementation is created and
+ * {@link #init(Configuration, DelegationTokenManagerCallback) initialized} once and then shared
+ * for the lifetime of the manager. {@link #obtainDelegationTokens()} runs on the manager's IO
+ * executor, while {@link
+ * #registerJob(JobID, Configuration)} and {@link #unregisterJob(JobID)} are invoked from the
+ * ResourceManager main thread; these can therefore run concurrently. {@link
+ * DelegationTokenManagerCallback#reobtainDelegationTokens()} may be invoked from any thread.
+ * Implementations must keep any per-job state thread-safe, and {@code registerJob}/{@code
+ * unregisterJob} must be non-blocking so they do not stall the ResourceManager — defer real work
+ * to {@link #obtainDelegationTokens()}.
  */
 @Experimental
 public interface DelegationTokenProvider {
@@ -76,6 +88,25 @@ public interface DelegationTokenProvider {
     void init(Configuration configuration) throws Exception;
 
     /**
+     * Called by DelegationTokenManager to initialize the provider after construction, additionally
+     * handing it a {@link DelegationTokenManagerCallback} it can use to request a token re-obtain.
+     *
+     * <p>This is the entry point the manager actually calls. The default implementation ignores the
+     * callback and delegates to {@link #init(Configuration)}, so providers that do not need to
+     * trigger re-obtains keep implementing only {@link #init(Configuration)}. A provider that wants
+     * to request re-obtains overrides this method, retains the callback, and invokes {@link
+     * DelegationTokenManagerCallback#reobtainDelegationTokens()} when needed.
+     *
+     * @param configuration Configuration to initialize the provider.
+     * @param callback Used to ask the manager to re-obtain tokens; may be retained and called
+     *     later.
+     */
+    default void init(Configuration configuration, DelegationTokenManagerCallback callback)
+            throws Exception {
+        init(configuration);
+    }
+
+    /**
      * Return whether delegation tokens are required for this service.
      *
      * @return true if delegation tokens are required.
@@ -88,4 +119,51 @@ public interface DelegationTokenProvider {
      * @return the obtained delegation tokens.
      */
     ObtainedDelegationTokens obtainDelegationTokens() throws Exception;
+
+    /**
+     * Called when a job has started, before its tasks are scheduled, with its configuration.
+     *
+     * <p>To get the job's tokens distributed without waiting for the periodic renewal, call {@link
+     * DelegationTokenManagerCallback#reobtainDelegationTokens()} on the callback handed to {@link
+     * #init(Configuration, DelegationTokenManagerCallback)} to request an immediate obtain cycle.
+     *
+     * <p>A provider that requests a re-obtain must record this job's per-job state <em>before</em>
+     * invoking {@link DelegationTokenManagerCallback#reobtainDelegationTokens()}. That call merely
+     * schedules (or coalesces into) an obtain cycle that runs later on another thread; recording
+     * first establishes the happens-before that lets the serving cycle observe this job's state.
+     * Recording afterwards races with the cycle and the job's tokens may be skipped until the next
+     * periodic renewal.
+     *
+     * <p>Must be idempotent: it may be called more than once for the same {@code jobId} (e.g. on
+     * JobManager or ResourceManager failover, when the JobMaster re-registers).
+     *
+     * <p>Should not throw: a thrown (unchecked) exception rejects the job's registration (the job
+     * does not start) and triggers {@link #unregisterJob(JobID)} on all providers to roll back.
+     * Prefer deferring the real fetch to the (retrying) obtain cycle over a synchronous fetch, so a
+     * transient failure does not fail the job.
+     *
+     * @param jobId The job id of the job.
+     * @param jobConfiguration The job configuration.
+     */
+    default void registerJob(JobID jobId, Configuration jobConfiguration) {}
+
+    /**
+     * Called when the job is being removed — it reached a globally terminal state, or its
+     * job-leader registration timed out — and its per-job state should be released. Must be
+     * idempotent. Exceptions are caught and logged by the framework (one provider's failure does
+     * not abort cleanup of the others), but implementations should still avoid throwing.
+     *
+     * @param jobId The job id of the job.
+     */
+    default void unregisterJob(JobID jobId) {}
+
+    /**
+     * Stops the provider. Any resources should be closed.
+     *
+     * <p>Called once during manager shutdown. Note that an obtain-and-broadcast cycle started just
+     * before shutdown may still be running on another thread when this is invoked, so {@code
+     * stop()} may overlap an in-flight {@link #obtainDelegationTokens()}; implementations must
+     * release resources in a way that is safe with respect to that overlap.
+     */
+    default void stop() {}
 }

--- a/flink-core/src/main/java/org/apache/flink/core/security/token/DelegationTokenProvider.java
+++ b/flink-core/src/main/java/org/apache/flink/core/security/token/DelegationTokenProvider.java
@@ -32,9 +32,12 @@ import java.util.Optional;
  *
  * <p><b>Threading contract.</b> A single instance per provider implementation is created and {@link
  * #init(Configuration, DelegationTokenManagerCallback) initialized} once and then shared for the
- * lifetime of the manager. {@link #obtainDelegationTokens()} runs on the manager's IO executor,
- * while {@link #registerJob(JobID, Configuration)} and {@link #unregisterJob(JobID)} are invoked
- * from the ResourceManager main thread. These can therefore run concurrently. {@link
+ * lifetime of the manager. {@link #obtainDelegationTokens()} usually runs on the manager's IO
+ * executor, but the first cycle runs on the thread that starts the manager (the ResourceManager
+ * main thread) and one-shot obtains run on the caller's thread, so implementations must not assume
+ * a particular thread. {@link #registerJob(JobID, Configuration)} and {@link #unregisterJob(JobID)}
+ * are invoked from the ResourceManager main thread. These can therefore run concurrently with
+ * {@link #obtainDelegationTokens()}. {@link
  * DelegationTokenManagerCallback#reobtainDelegationTokens()} may be invoked from any thread.
  * Implementations must keep any per-job state thread-safe, and {@code registerJob}/{@code
  * unregisterJob} must be non-blocking so they do not stall the ResourceManager — defer real work to

--- a/flink-core/src/main/java/org/apache/flink/core/security/token/DelegationTokenProvider.java
+++ b/flink-core/src/main/java/org/apache/flink/core/security/token/DelegationTokenProvider.java
@@ -161,14 +161,14 @@ public interface DelegationTokenProvider {
     default void unregisterJob(JobID jobId) {}
 
     /**
-     * Stops the provider. Any resources should be closed.
+     * Closes the provider. Any resources should be released.
      *
      * <p>Called at most once, when the manager is closed at process shutdown. It is not called on
      * ResourceManager leadership changes, those only stop and restart the manager's obtain session
      * and the provider instance stays in use. An obtain cycle started just before shutdown may
-     * still be running, so {@code stop()} may overlap an in-flight {@link
+     * still be running, so {@code close()} may overlap an in-flight {@link
      * #obtainDelegationTokens()} and implementations must release resources in a way that is safe
      * with respect to that overlap.
      */
-    default void stop() {}
+    default void close() {}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypoint.java
@@ -496,6 +496,16 @@ public abstract class ClusterEntrypoint implements AutoCloseableAsync, FatalErro
 
             final Collection<CompletableFuture<Void>> terminationFutures = new ArrayList<>(3);
 
+            if (delegationTokenManager != null) {
+                try {
+                    // Terminal teardown of the delegation token providers. The per-session
+                    // manager stop() already ran when the ResourceManager component closed.
+                    delegationTokenManager.close();
+                } catch (Throwable t) {
+                    exception = ExceptionUtils.firstOrSuppressed(t, exception);
+                }
+            }
+
             if (blobServer != null) {
                 try {
                     blobServer.close();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
@@ -1599,6 +1599,7 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId>
                             jobManagerResourceID,
                             jobManagerRpcAddress,
                             jobID,
+                            executionPlan.getJobConfiguration(),
                             timeout);
                 }
             };

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniCluster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniCluster.java
@@ -1372,6 +1372,17 @@ public class MiniCluster implements AutoCloseableAsync {
         Exception exception = null;
 
         synchronized (lock) {
+            if (delegationTokenManager != null) {
+                try {
+                    // Terminal teardown of the delegation token providers. The per-session
+                    // manager stop() already ran when the ResourceManager component closed.
+                    delegationTokenManager.close();
+                } catch (Exception e) {
+                    exception = ExceptionUtils.firstOrSuppressed(e, exception);
+                }
+                delegationTokenManager = null;
+            }
+
             if (blobCacheService != null) {
                 try {
                     blobCacheService.close();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
@@ -430,7 +430,7 @@ public abstract class ResourceManager<WorkerType extends ResourceIDRetrievable>
                             jobMasterIdFuture,
                             (JobMasterGateway jobMasterGateway, JobMasterId leadingJobMasterId) -> {
                                 if (Objects.equals(leadingJobMasterId, jobMasterId)) {
-                                    // Register with the delegation token manager first; a
+                                    // Register with the delegation token manager first. A
                                     // provider failure rejects this registration so the job
                                     // never starts without the tokens it requires.
                                     try {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
@@ -22,6 +22,7 @@ import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.blob.TransientBlobKey;
 import org.apache.flink.runtime.blocklist.BlockedNode;
 import org.apache.flink.runtime.blocklist.BlocklistContext;
@@ -115,8 +116,8 @@ import static org.apache.flink.util.Preconditions.checkState;
  * <p>It offers the following methods as part of its rpc interface to interact with him remotely:
  *
  * <ul>
- *   <li>{@link #registerJobMaster(JobMasterId, ResourceID, String, JobID, Duration)} registers a
- *       {@link JobMaster} at the resource manager
+ *   <li>{@link #registerJobMaster(JobMasterId, ResourceID, String, JobID, Configuration, Duration)}
+ *       registers a {@link JobMaster} at the resource manager
  * </ul>
  */
 public abstract class ResourceManager<WorkerType extends ResourceIDRetrievable>
@@ -366,12 +367,14 @@ public abstract class ResourceManager<WorkerType extends ResourceIDRetrievable>
             final ResourceID jobManagerResourceId,
             final String jobManagerAddress,
             final JobID jobId,
+            final Configuration jobConfiguration,
             final Duration timeout) {
 
         checkNotNull(jobMasterId);
         checkNotNull(jobManagerResourceId);
         checkNotNull(jobManagerAddress);
         checkNotNull(jobId);
+        checkNotNull(jobConfiguration);
 
         try (MdcCloseable ignored = MdcUtils.withContext(MdcUtils.asContextData(jobId))) {
             if (!jobLeaderIdService.containsJob(jobId)) {
@@ -427,6 +430,14 @@ public abstract class ResourceManager<WorkerType extends ResourceIDRetrievable>
                             jobMasterIdFuture,
                             (JobMasterGateway jobMasterGateway, JobMasterId leadingJobMasterId) -> {
                                 if (Objects.equals(leadingJobMasterId, jobMasterId)) {
+                                    // Register with the delegation token manager first; a
+                                    // provider failure rejects this registration so the job
+                                    // never starts without the tokens it requires.
+                                    try {
+                                        delegationTokenManager.registerJob(jobId, jobConfiguration);
+                                    } catch (Exception e) {
+                                        return new RegistrationResponse.Failure(e);
+                                    }
                                     return registerJobMasterInternal(
                                             jobMasterGateway,
                                             jobId,
@@ -1222,6 +1233,15 @@ public abstract class ResourceManager<WorkerType extends ResourceIDRetrievable>
 
         if (jobManagerRegistrations.containsKey(jobId)) {
             closeJobManagerConnection(jobId, ResourceRequirementHandling.CLEAR, cause);
+        }
+
+        try {
+            delegationTokenManager.unregisterJob(jobId);
+        } catch (Exception e) {
+            log.warn(
+                    "Could not properly remove the job {} from the delegation token manager.",
+                    jobId,
+                    e);
         }
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
@@ -430,13 +430,21 @@ public abstract class ResourceManager<WorkerType extends ResourceIDRetrievable>
                             jobMasterIdFuture,
                             (JobMasterGateway jobMasterGateway, JobMasterId leadingJobMasterId) -> {
                                 if (Objects.equals(leadingJobMasterId, jobMasterId)) {
-                                    // Register with the delegation token manager first. A
-                                    // provider failure rejects this registration so the job
-                                    // never starts without the tokens it requires.
+                                    // Register with the delegation token manager first, so a
+                                    // provider failure rejects the registration and the job does
+                                    // not start without the tokens it requires. LinkageError is
+                                    // caught so a plugin classpath failure is reported the same
+                                    // way.
                                     try {
                                         delegationTokenManager.registerJob(jobId, jobConfiguration);
-                                    } catch (Exception e) {
-                                        return new RegistrationResponse.Failure(e);
+                                    } catch (Exception | LinkageError e) {
+                                        return new RegistrationResponse.Failure(
+                                                new FlinkException(
+                                                        "Failed to register job "
+                                                                + jobId
+                                                                + " with the delegation token "
+                                                                + "manager",
+                                                        e));
                                     }
                                     return registerJobMasterInternal(
                                             jobMasterGateway,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManagerGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManagerGateway.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.resourcemanager;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.blob.BlobServer;
 import org.apache.flink.runtime.blob.TransientBlobKey;
 import org.apache.flink.runtime.blocklist.BlocklistListener;
@@ -63,10 +64,42 @@ public interface ResourceManagerGateway
     /**
      * Register a {@link JobMaster} at the resource manager.
      *
+     * <p>Backward-compatible overload that registers without a job configuration. Equivalent to
+     * calling {@link #registerJobMaster(JobMasterId, ResourceID, String, JobID, Configuration,
+     * Duration)} with an empty configuration.
+     *
      * @param jobMasterId The fencing token for the JobMaster leader
      * @param jobMasterResourceId The resource ID of the JobMaster that registers
      * @param jobMasterAddress The address of the JobMaster that registers
      * @param jobId The Job ID of the JobMaster that registers
+     * @param timeout Timeout for the future to complete
+     * @return Future registration response
+     */
+    default CompletableFuture<RegistrationResponse> registerJobMaster(
+            JobMasterId jobMasterId,
+            ResourceID jobMasterResourceId,
+            String jobMasterAddress,
+            JobID jobId,
+            @RpcTimeout Duration timeout) {
+        return registerJobMaster(
+                jobMasterId,
+                jobMasterResourceId,
+                jobMasterAddress,
+                jobId,
+                new Configuration(),
+                timeout);
+    }
+
+    /**
+     * Register a {@link JobMaster} at the resource manager, supplying the job's {@link
+     * Configuration} so implementations can perform per-job initialization (e.g. obtaining
+     * job-scoped delegation tokens).
+     *
+     * @param jobMasterId The fencing token for the JobMaster leader
+     * @param jobMasterResourceId The resource ID of the JobMaster that registers
+     * @param jobMasterAddress The address of the JobMaster that registers
+     * @param jobId The Job ID of the JobMaster that registers
+     * @param jobConfiguration The job's configuration, used for per-job initialization
      * @param timeout Timeout for the future to complete
      * @return Future registration response
      */
@@ -75,6 +108,7 @@ public interface ResourceManagerGateway
             ResourceID jobMasterResourceId,
             String jobMasterAddress,
             JobID jobId,
+            Configuration jobConfiguration,
             @RpcTimeout Duration timeout);
 
     /**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/security/token/DefaultDelegationTokenManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/security/token/DefaultDelegationTokenManager.java
@@ -138,9 +138,9 @@ public class DefaultDelegationTokenManager implements DelegationTokenManager {
     private boolean reobtainScheduled;
 
     /**
-     * Clock time (millis) of the last on-demand re-obtain request, used to enforce the cooldown;
-     * {@link #NO_PREVIOUS_REOBTAIN} until the first request. Only on-demand re-obtains update this
-     * (not the periodic renewal), so the cooldown spaces requests, not obtain executions.
+     * Clock time (millis) of the last on-demand re-obtain request, used to enforce the cooldown.
+     * Holds {@link #NO_PREVIOUS_REOBTAIN} until the first request. Only on-demand re-obtains update
+     * this (not the periodic renewal), so the cooldown spaces requests, not obtain executions.
      */
     @GuardedBy("tokensUpdateFutureLock")
     private long lastReobtainAtMillis = NO_PREVIOUS_REOBTAIN;
@@ -427,7 +427,7 @@ public class DefaultDelegationTokenManager implements DelegationTokenManager {
 
     /**
      * Schedules a one-shot token-obtain-and-broadcast cycle after {@code delayMs}, replacing any
-     * pending renewal; a delay of {@code 0} brings the next cycle forward to now. Must only be
+     * pending renewal. A delay of {@code 0} brings the next cycle forward to now. Must only be
      * called after {@link #start(Listener)} (the scheduled and IO executors are non-null then) and
      * while holding {@link #tokensUpdateFutureLock}.
      */
@@ -453,10 +453,10 @@ public class DefaultDelegationTokenManager implements DelegationTokenManager {
                             delayMs,
                             TimeUnit.MILLISECONDS);
         } catch (RejectedExecutionException e) {
-            // Scheduled executor is shutting down: no cycle will run, so undo the bookkeeping this
-            // method set. Clearing reobtainScheduled keeps a coalesced re-obtain from getting stuck;
-            // nextScheduledAtMillis returns to the no-cycle-pending marker (stopTokensUpdate() above
-            // already nulled tokensUpdateFuture).
+            // Scheduled executor is shutting down: no cycle will run, so undo the bookkeeping
+            // this method set. Clearing reobtainScheduled keeps a coalesced re-obtain from
+            // getting stuck. nextScheduledAtMillis returns to the no-cycle-pending marker
+            // (stopTokensUpdate() above already nulled tokensUpdateFuture).
             reobtainScheduled = false;
             nextScheduledAtMillis = Long.MAX_VALUE;
             LOG.debug("Tokens update task rejected by scheduled executor", e);
@@ -595,7 +595,7 @@ public class DefaultDelegationTokenManager implements DelegationTokenManager {
             // pending and scheduled to fire sooner than the cooldown-deferred time, fire at that
             // earlier time instead of pushing it later — otherwise a short-lived token could expire
             // before it is renewed. The nextScheduledAtMillis > now guard skips an already-fired
-            // future that has not yet been re-armed, so this never bypasses the cooldown.
+            // future that has not yet been rescheduled, so this never bypasses the cooldown.
             if (tokensUpdateFuture != null
                     && nextScheduledAtMillis > now
                     && nextScheduledAtMillis - now < delayMillis) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/security/token/DefaultDelegationTokenManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/security/token/DefaultDelegationTokenManager.java
@@ -46,6 +46,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.ServiceLoader;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledFuture;
@@ -138,9 +139,9 @@ public class DefaultDelegationTokenManager implements DelegationTokenManager {
     private boolean reobtainScheduled;
 
     /**
-     * Clock time (millis) of the last on-demand re-obtain request, used to enforce the cooldown.
-     * Holds {@link #NO_PREVIOUS_REOBTAIN} until the first request. Only on-demand re-obtains update
-     * this (not the periodic renewal), so the cooldown spaces requests, not obtain executions.
+     * Clock time (millis) at which the last on-demand re-obtain cycle was scheduled to execute, or
+     * {@link #NO_PREVIOUS_REOBTAIN}. Anchored to the execution time rather than the request time,
+     * so the cooldown spaces cycle executions. Updated only by on-demand re-obtains.
      */
     @GuardedBy("tokensUpdateFutureLock")
     private long lastReobtainAtMillis = NO_PREVIOUS_REOBTAIN;
@@ -152,7 +153,19 @@ public class DefaultDelegationTokenManager implements DelegationTokenManager {
     @GuardedBy("tokensUpdateFutureLock")
     private boolean running;
 
-    @Nullable private Listener listener;
+    @GuardedBy("tokensUpdateFutureLock")
+    @VisibleForTesting
+    @Nullable
+    Listener listener;
+
+    /**
+     * Jobs for which providers may hold per-job state. A job is added on successful registration
+     * (or when a failed rollback left provider state behind) and removed when every provider
+     * unregistered it cleanly. Lets a failed re-registration keep the previous state and lets
+     * {@link #stop()} unregister the jobs of the ending session. All checks and updates run on the
+     * ResourceManager main thread, and leadership sessions are serialized.
+     */
+    private final Set<JobID> registeredJobs = ConcurrentHashMap.newKeySet();
 
     public DefaultDelegationTokenManager(
             Configuration configuration,
@@ -370,6 +383,14 @@ public class DefaultDelegationTokenManager implements DelegationTokenManager {
             running = true;
         }
 
+        // A new session must not inherit the previous session's retry backoff or renewal
+        // deadline. obtainLock orders this reset after any still-running previous cycle. Not
+        // nested in the block above to keep the obtainLock -> tokensUpdateFutureLock order.
+        synchronized (obtainLock) {
+            currentRetryBackoff = renewalRetryInitialBackoff;
+            lastKnownNextRenewal = Long.MAX_VALUE;
+        }
+
         startTokensUpdate();
     }
 
@@ -393,12 +414,26 @@ public class DefaultDelegationTokenManager implements DelegationTokenManager {
                 Optional<Long> nextRenewal = obtainDelegationTokensAndGetNextRenewal(container);
 
                 if (container.hasTokens()) {
-                    delegationTokenReceiverRepository.onNewTokensObtained(container);
+                    // stop() does not wait for an in-flight cycle. Re-check so a cycle resuming
+                    // after stop() does not notify the stopped session's listener (the disposed
+                    // ResourceManager). A stop() right after this read still lets one delivery
+                    // through, which is benign.
+                    final Listener currentListener;
+                    synchronized (tokensUpdateFutureLock) {
+                        currentListener = running ? listener : null;
+                    }
+                    if (currentListener != null) {
+                        delegationTokenReceiverRepository.onNewTokensObtained(container);
 
-                    LOG.info("Notifying listener about new tokens");
-                    checkNotNull(listener, "Listener must not be null");
-                    listener.onNewTokensObtained(InstantiationUtil.serializeObject(container));
-                    LOG.info("Listener notified successfully");
+                        LOG.info("Notifying listener about new tokens");
+                        currentListener.onNewTokensObtained(
+                                InstantiationUtil.serializeObject(container));
+                        LOG.info("Listener notified successfully");
+                    } else {
+                        LOG.info(
+                                "Manager stopped while the tokens were being obtained, skipping "
+                                        + "notifications");
+                    }
                 } else {
                     LOG.warn("No tokens obtained so skipping notifications");
                 }
@@ -512,8 +547,9 @@ public class DefaultDelegationTokenManager implements DelegationTokenManager {
                 long pendingInMillis = Math.max(0L, nextScheduledAtMillis - clock.millis());
                 if (delayMs < pendingInMillis) {
                     // Bring the pending on-demand cycle forward. scheduleRenewalLocked() leaves
-                    // reobtainScheduled set, so coalescing still holds and the earlier cycle
-                    // serves the coalesced on-demand requests too.
+                    // reobtainScheduled set, so coalescing still holds. Move the cooldown anchor
+                    // to the time the cycle now actually runs.
+                    lastReobtainAtMillis = clock.millis() + delayMs;
                     scheduleRenewalLocked(delayMs);
                     return delayMs;
                 }
@@ -578,7 +614,10 @@ public class DefaultDelegationTokenManager implements DelegationTokenManager {
         this.clock = clock;
     }
 
-    /** Stops re-occurring token obtain task. */
+    /**
+     * Stops the re-occurring token obtain task, releases the listener, and unregisters the jobs of
+     * the ending session. See the interface javadoc.
+     */
     @Override
     public void stop() {
         LOG.info("Stopping credential renewal");
@@ -591,6 +630,21 @@ public class DefaultDelegationTokenManager implements DelegationTokenManager {
             stopTokensUpdate();
             reobtainScheduled = false;
             lastReobtainAtMillis = NO_PREVIOUS_REOBTAIN;
+            // Release the listener: keeping it would pin the disposed ResourceManager of a
+            // revoked leadership session, forever on a standby that never regains leadership.
+            listener = null;
+        }
+
+        // Unregister all jobs: running jobs re-register with the next session, ended jobs never
+        // would and their entries would leak in the providers.
+        for (JobID jobId : registeredJobs) {
+            try {
+                unregisterJobInternal(jobId);
+            } catch (Exception | LinkageError e) {
+                // Guards the cleanup against pathological errors from a broken plugin's
+                // serviceName().
+                LOG.error("Failed to unregister job {} while stopping the manager", jobId, e);
+            }
         }
 
         for (DelegationTokenProvider provider : delegationTokenProviders.values()) {
@@ -610,8 +664,8 @@ public class DefaultDelegationTokenManager implements DelegationTokenManager {
             if (scheduledExecutor == null || ioExecutor == null) {
                 LOG.debug(
                         "A re-obtain of delegation tokens was requested but the manager was "
-                                + "constructed without executors (one-shot obtain path); the "
-                                + "request is ignored.");
+                                + "constructed without executors (one-shot obtain path), "
+                                + "ignoring the request.");
                 return;
             }
             if (!running) {
@@ -621,10 +675,9 @@ public class DefaultDelegationTokenManager implements DelegationTokenManager {
                                 + "request.");
                 return;
             }
-            // Dedupe: if an on-demand re-obtain is already scheduled and has not started yet, the
-            // newly registered job(s) will be covered by it, so coalesce this request into it.
+            // An already scheduled re-obtain that has not started yet covers this request too.
             if (reobtainScheduled) {
-                LOG.debug("A re-obtain of delegation tokens is already scheduled; coalescing.");
+                LOG.debug("A re-obtain of delegation tokens is already scheduled, coalescing.");
                 return;
             }
             // Cooldown: bound how often on-demand re-obtains can run by deferring this cycle until
@@ -634,20 +687,20 @@ public class DefaultDelegationTokenManager implements DelegationTokenManager {
                     lastReobtainAtMillis == NO_PREVIOUS_REOBTAIN
                             ? 0L
                             : Math.max(0L, lastReobtainAtMillis + reobtainCooldownMillis - now);
-            // Only bring the next cycle forward: if a cycle (e.g. the periodic renewal) is still
-            // pending and scheduled to fire sooner than the cooldown-deferred time, fire at that
-            // earlier time instead of pushing it later — otherwise a short-lived token could expire
-            // before it is renewed. The nextScheduledAtMillis > now guard skips an already-fired
-            // future that has not yet been rescheduled, so this never bypasses the cooldown.
+            // Only bring the next cycle forward, never push a pending cycle later, or a
+            // short-lived token could expire before it is renewed. The nextScheduledAtMillis >
+            // now guard skips an already-fired future, so this never bypasses the cooldown.
             if (tokensUpdateFuture != null
                     && nextScheduledAtMillis > now
                     && nextScheduledAtMillis - now < delayMillis) {
                 delayMillis = nextScheduledAtMillis - now;
             }
-            lastReobtainAtMillis = now;
+            // Anchor the cooldown to when the cycle will run, not to this request, so a request
+            // arriving right after a deferred cycle fired cannot run a second cycle back to back.
+            lastReobtainAtMillis = now + delayMillis;
             reobtainScheduled = true;
             LOG.debug(
-                    "Re-obtain of delegation tokens requested; scheduling an obtain cycle in {}",
+                    "Re-obtain of delegation tokens requested, scheduling an obtain cycle in {}",
                     TimeUtils.formatWithHighestUnit(Duration.ofMillis(delayMillis)));
             scheduleRenewalLocked(delayMillis);
         }
@@ -655,36 +708,70 @@ public class DefaultDelegationTokenManager implements DelegationTokenManager {
 
     @Override
     public void registerJob(JobID jobId, Configuration jobConfiguration) throws Exception {
+        // Hand providers a copy so plugin code cannot mutate the caller's live job configuration.
+        // clone() locks the backing map. Like the copy constructor, the copy is shallow.
+        final Configuration providerJobConfiguration = jobConfiguration.clone();
+        final boolean previouslyRegistered = registeredJobs.contains(jobId);
         DelegationTokenProvider failedProvider = null;
         try {
             for (DelegationTokenProvider provider : delegationTokenProviders.values()) {
                 failedProvider = provider;
-                provider.registerJob(jobId, jobConfiguration);
+                provider.registerJob(jobId, providerJobConfiguration);
             }
+            registeredJobs.add(jobId);
         } catch (Exception | LinkageError e) {
-            // Roll the job back from all providers (unregisterJob is idempotent) and rethrow.
-            // The rollback must never mask the original failure. LinkageError is included
-            // because provider plugin code can fail class resolution.
-            try {
-                unregisterJob(jobId);
-            } catch (Exception | LinkageError rollbackException) {
-                LOG.error("Failed to roll back registration of job {}", jobId, rollbackException);
+            // LinkageError is included because provider plugin code can fail class resolution.
+            if (previouslyRegistered) {
+                // A failed re-registration must not roll back: the job registered successfully
+                // before and its tasks may still be running.
+                LOG.error(
+                        "Failed to re-register job {} for provider {}, keeping the previous "
+                                + "registration",
+                        jobId,
+                        failedProvider == null ? "<none>" : failedProvider.serviceName(),
+                        e);
+            } else {
+                // First registration: roll back from all providers (unregisterJob is idempotent).
+                // The rollback must never mask the original failure.
+                try {
+                    if (!unregisterJobInternal(jobId)) {
+                        // Keep the job tracked so stop() or a registration retry can release the
+                        // provider state left behind.
+                        registeredJobs.add(jobId);
+                    }
+                } catch (Exception | LinkageError rollbackException) {
+                    LOG.error(
+                            "Failed to roll back registration of job {}", jobId, rollbackException);
+                }
+                LOG.error(
+                        "Failed to register job {} for provider {}",
+                        jobId,
+                        failedProvider == null ? "<none>" : failedProvider.serviceName(),
+                        e);
             }
-            LOG.error(
-                    "Failed to register job {} for provider {}",
-                    jobId,
-                    failedProvider == null ? "<none>" : failedProvider.serviceName(),
-                    e);
             throw e;
         }
     }
 
     @Override
     public void unregisterJob(JobID jobId) throws Exception {
+        unregisterJobInternal(jobId);
+    }
+
+    /**
+     * Unregisters the job from all providers, swallowing per-provider failures. The job leaves
+     * {@link #registeredJobs} only when every provider unregistered cleanly, so state a failed
+     * provider may still hold stays tracked for another attempt.
+     *
+     * @return whether every provider unregistered the job without failure.
+     */
+    private boolean unregisterJobInternal(JobID jobId) {
+        boolean fullyUnregistered = true;
         for (DelegationTokenProvider provider : delegationTokenProviders.values()) {
             try {
                 provider.unregisterJob(jobId);
             } catch (Exception | LinkageError e) {
+                fullyUnregistered = false;
                 LOG.error(
                         "Failed to unregister job {} for provider {}",
                         jobId,
@@ -692,5 +779,9 @@ public class DefaultDelegationTokenManager implements DelegationTokenManager {
                         e);
             }
         }
+        if (fullyUnregistered) {
+            registeredJobs.remove(jobId);
+        }
+        return fullyUnregistered;
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/security/token/DefaultDelegationTokenManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/security/token/DefaultDelegationTokenManager.java
@@ -20,9 +20,11 @@ package org.apache.flink.runtime.security.token;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.SecurityOptions;
 import org.apache.flink.core.plugin.PluginManager;
+import org.apache.flink.core.security.token.DelegationTokenManagerCallback;
 import org.apache.flink.core.security.token.DelegationTokenProvider;
 import org.apache.flink.core.security.token.DelegationTokenReceiver;
 import org.apache.flink.util.FlinkRuntimeException;
@@ -45,6 +47,7 @@ import java.util.Optional;
 import java.util.ServiceLoader;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
@@ -54,6 +57,7 @@ import java.util.stream.Stream;
 import static org.apache.flink.configuration.SecurityOptions.DELEGATION_TOKENS_RENEWAL_RETRY_INITIAL_BACKOFF;
 import static org.apache.flink.configuration.SecurityOptions.DELEGATION_TOKENS_RENEWAL_RETRY_MAX_BACKOFF;
 import static org.apache.flink.configuration.SecurityOptions.DELEGATION_TOKENS_RENEWAL_TIME_RATIO;
+import static org.apache.flink.configuration.SecurityOptions.DELEGATION_TOKENS_REOBTAIN_COOLDOWN;
 import static org.apache.flink.configuration.SecurityOptions.DELEGATION_TOKEN_PROVIDER_ENABLED;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 import static org.apache.flink.util.Preconditions.checkState;
@@ -78,6 +82,8 @@ public class DefaultDelegationTokenManager implements DelegationTokenManager {
 
     private static final Logger LOG = LoggerFactory.getLogger(DefaultDelegationTokenManager.class);
 
+    private static final long NO_PREVIOUS_REOBTAIN = Long.MIN_VALUE;
+
     private final Configuration configuration;
 
     @Nullable private final PluginManager pluginManager;
@@ -92,6 +98,18 @@ public class DefaultDelegationTokenManager implements DelegationTokenManager {
 
     @VisibleForTesting long lastKnownNextRenewal = Long.MAX_VALUE;
 
+    private final long reobtainCooldownMillis;
+
+    /** Clock used for cooldown bookkeeping; overridable in tests. */
+    private volatile Clock clock = Clock.systemDefaultZone();
+
+    /**
+     * Serializes the obtain-and-broadcast cycle so that, even though {@code cancel(true)} does not
+     * wait for an in-flight cycle and the IO executor is multi-threaded, two cycles can never run
+     * concurrently and broadcast tokens out of order.
+     */
+    private final Object obtainLock = new Object();
+
     @VisibleForTesting final Map<String, DelegationTokenProvider> delegationTokenProviders;
 
     private final DelegationTokenReceiverRepository delegationTokenReceiverRepository;
@@ -105,6 +123,34 @@ public class DefaultDelegationTokenManager implements DelegationTokenManager {
     @GuardedBy("tokensUpdateFutureLock")
     @Nullable
     private ScheduledFuture<?> tokensUpdateFuture;
+
+    /**
+     * Clock time (millis) at which {@link #tokensUpdateFuture} is scheduled to fire, or {@link
+     * Long#MAX_VALUE} when no cycle is pending. Lets an on-demand re-obtain only ever bring the
+     * next obtain cycle <em>forward</em> and never push an already-scheduled (e.g. periodic)
+     * renewal later, which could otherwise let a short-lived token expire before it is renewed.
+     */
+    @GuardedBy("tokensUpdateFutureLock")
+    private long nextScheduledAtMillis = Long.MAX_VALUE;
+
+    /** Whether an on-demand re-obtain is scheduled but has not started executing yet (dedupe). */
+    @GuardedBy("tokensUpdateFutureLock")
+    private boolean reobtainScheduled;
+
+    /**
+     * Clock time (millis) of the last on-demand re-obtain request, used to enforce the cooldown;
+     * {@link #NO_PREVIOUS_REOBTAIN} until the first request. Only on-demand re-obtains update this
+     * (not the periodic renewal), so the cooldown spaces requests, not obtain executions.
+     */
+    @GuardedBy("tokensUpdateFutureLock")
+    private long lastReobtainAtMillis = NO_PREVIOUS_REOBTAIN;
+
+    /**
+     * Whether {@link #stop()} has been called. Reset by {@link #start(Listener)}. Prevents a late
+     * provider callback or an in-flight obtain cycle from scheduling new work after shutdown.
+     */
+    @GuardedBy("tokensUpdateFutureLock")
+    private boolean stopped;
 
     @Nullable private Listener listener;
 
@@ -121,6 +167,8 @@ public class DefaultDelegationTokenManager implements DelegationTokenManager {
         this.renewalRetryMaxBackoff =
                 configuration.get(DELEGATION_TOKENS_RENEWAL_RETRY_MAX_BACKOFF).toMillis();
         this.currentRetryBackoff = renewalRetryInitialBackoff;
+        this.reobtainCooldownMillis =
+                configuration.get(DELEGATION_TOKENS_REOBTAIN_COOLDOWN).toMillis();
         this.delegationTokenProviders = loadProviders();
         this.delegationTokenReceiverRepository =
                 new DelegationTokenReceiverRepository(configuration, pluginManager);
@@ -139,12 +187,15 @@ public class DefaultDelegationTokenManager implements DelegationTokenManager {
     private Map<String, DelegationTokenProvider> loadProviders() {
         LOG.info("Loading delegation token providers");
 
+        // Handed to every provider so it can request an immediate re-obtain later, from any
+        // thread, decoupled from the registerJob call stack.
+        final DelegationTokenManagerCallback callback = this::reobtainDelegationTokens;
         Map<String, DelegationTokenProvider> providers = new HashMap<>();
         Consumer<DelegationTokenProvider> loadProvider =
                 (provider) -> {
                     try {
                         if (isProviderEnabled(configuration, provider.serviceName())) {
-                            provider.init(configuration);
+                            provider.init(configuration, callback);
                             LOG.info(
                                     "Delegation token provider {} loaded and initialized",
                                     provider.serviceName());
@@ -310,6 +361,7 @@ public class DefaultDelegationTokenManager implements DelegationTokenManager {
         this.listener = checkNotNull(listener, "Listener must not be null");
         synchronized (tokensUpdateFutureLock) {
             checkState(tokensUpdateFuture == null, "Manager is already started");
+            stopped = false;
         }
 
         startTokensUpdate();
@@ -317,57 +369,119 @@ public class DefaultDelegationTokenManager implements DelegationTokenManager {
 
     @VisibleForTesting
     void startTokensUpdate() {
-        try {
-            LOG.info("Starting tokens update task");
-            DelegationTokenContainer container = new DelegationTokenContainer();
-            Optional<Long> nextRenewal = obtainDelegationTokensAndGetNextRenewal(container);
-
-            if (container.hasTokens()) {
-                delegationTokenReceiverRepository.onNewTokensObtained(container);
-
-                LOG.info("Notifying listener about new tokens");
-                checkNotNull(listener, "Listener must not be null");
-                listener.onNewTokensObtained(InstantiationUtil.serializeObject(container));
-                LOG.info("Listener notified successfully");
-            } else {
-                LOG.warn("No tokens obtained so skipping notifications");
+        synchronized (tokensUpdateFutureLock) {
+            // The obtain cycle is starting: clear the dedupe flag so later on-demand requests can
+            // schedule a fresh cycle.
+            reobtainScheduled = false;
+            // If stop() ran before this cycle (already handed to the IO executor) began, skip the
+            // obtain/broadcast: the providers may already be stopped. Safe via this lock's
+            // happens-before with stop(). The dedupe flag is cleared above, so it is never stuck.
+            if (stopped) {
+                return;
             }
+        }
+        // Serialize the obtain-and-broadcast so a re-obtain racing the periodic renewal cannot run
+        // two cycles concurrently on the (multi-threaded) IO executor and broadcast out of order.
+        synchronized (obtainLock) {
+            try {
+                LOG.info("Starting tokens update task");
+                DelegationTokenContainer container = new DelegationTokenContainer();
+                Optional<Long> nextRenewal = obtainDelegationTokensAndGetNextRenewal(container);
 
-            if (nextRenewal.isPresent()) {
-                lastKnownNextRenewal = nextRenewal.get();
-                currentRetryBackoff = renewalRetryInitialBackoff;
-                long renewalDelay =
-                        calculateRenewalDelay(Clock.systemDefaultZone(), nextRenewal.get());
-                synchronized (tokensUpdateFutureLock) {
-                    tokensUpdateFuture =
-                            scheduledExecutor.schedule(
-                                    () -> ioExecutor.execute(this::startTokensUpdate),
-                                    renewalDelay,
-                                    TimeUnit.MILLISECONDS);
+                if (container.hasTokens()) {
+                    delegationTokenReceiverRepository.onNewTokensObtained(container);
+
+                    LOG.info("Notifying listener about new tokens");
+                    checkNotNull(listener, "Listener must not be null");
+                    listener.onNewTokensObtained(InstantiationUtil.serializeObject(container));
+                    LOG.info("Listener notified successfully");
+                } else {
+                    LOG.warn("No tokens obtained so skipping notifications");
                 }
-                LOG.info(
-                        "Tokens update task started with {} delay",
-                        TimeUtils.formatWithHighestUnit(Duration.ofMillis(renewalDelay)));
-            } else {
+
+                if (nextRenewal.isPresent()) {
+                    lastKnownNextRenewal = nextRenewal.get();
+                    currentRetryBackoff = renewalRetryInitialBackoff;
+                    long renewalDelay = calculateRenewalDelay(clock, nextRenewal.get());
+                    maybeScheduleRenewal(renewalDelay);
+                    LOG.info(
+                            "Tokens update task started with {} delay",
+                            TimeUtils.formatWithHighestUnit(Duration.ofMillis(renewalDelay)));
+                } else {
+                    LOG.warn(
+                            "Tokens update task not started because either no tokens obtained or none of the tokens specified its renewal date");
+                }
+            } catch (InterruptedException e) {
+                // Ignore, may happen if shutting down.
+                LOG.debug("Interrupted", e);
+            } catch (Exception e) {
+                long delay = calculateRetryDelay(clock);
+                maybeScheduleRenewal(delay);
                 LOG.warn(
-                        "Tokens update task not started because either no tokens obtained or none of the tokens specified its renewal date");
+                        "Failed to update tokens, will try again in {}",
+                        TimeUtils.formatWithHighestUnit(Duration.ofMillis(delay)),
+                        e);
             }
-        } catch (InterruptedException e) {
-            // Ignore, may happen if shutting down.
-            LOG.debug("Interrupted", e);
-        } catch (Exception e) {
-            long delay = calculateRetryDelay(Clock.systemDefaultZone());
-            synchronized (tokensUpdateFutureLock) {
-                tokensUpdateFuture =
-                        scheduledExecutor.schedule(
-                                () -> ioExecutor.execute(this::startTokensUpdate),
-                                delay,
-                                TimeUnit.MILLISECONDS);
+        }
+    }
+
+    /**
+     * Schedules a one-shot token-obtain-and-broadcast cycle after {@code delayMs}, replacing any
+     * pending renewal; a delay of {@code 0} brings the next cycle forward to now. Must only be
+     * called after {@link #start(Listener)} (the scheduled and IO executors are non-null then) and
+     * while holding {@link #tokensUpdateFutureLock}.
+     */
+    @GuardedBy("tokensUpdateFutureLock")
+    private void scheduleRenewalLocked(long delayMs) {
+        stopTokensUpdate();
+        nextScheduledAtMillis = clock.millis() + delayMs;
+        try {
+            tokensUpdateFuture =
+                    scheduledExecutor.schedule(
+                            () -> {
+                                try {
+                                    ioExecutor.execute(this::startTokensUpdate);
+                                } catch (RejectedExecutionException e) {
+                                    // IO executor is shutting down: drop the cycle but release the
+                                    // dedupe flag so it cannot get stuck if the manager is reused.
+                                    synchronized (tokensUpdateFutureLock) {
+                                        reobtainScheduled = false;
+                                    }
+                                    LOG.debug("Tokens update task rejected by IO executor", e);
+                                }
+                            },
+                            delayMs,
+                            TimeUnit.MILLISECONDS);
+        } catch (RejectedExecutionException e) {
+            // Scheduled executor is shutting down: no cycle will run, so undo the bookkeeping this
+            // method set. Clearing reobtainScheduled keeps a coalesced re-obtain from getting stuck;
+            // nextScheduledAtMillis returns to the no-cycle-pending marker (stopTokensUpdate() above
+            // already nulled tokensUpdateFuture).
+            reobtainScheduled = false;
+            nextScheduledAtMillis = Long.MAX_VALUE;
+            LOG.debug("Tokens update task rejected by scheduled executor", e);
+        }
+    }
+
+    /**
+     * Schedules the next periodic renewal at the end of a completed obtain cycle, unless the
+     * manager was stopped or an on-demand re-obtain was scheduled while this cycle ran. A pending
+     * on-demand cycle already re-establishes the renewal schedule, so it is left in place rather
+     * than cancelled: the periodic renewal is folded into it, never dropped.
+     */
+    @VisibleForTesting
+    void maybeScheduleRenewal(long delayMs) {
+        synchronized (tokensUpdateFutureLock) {
+            if (stopped) {
+                return;
             }
-            LOG.warn(
-                    "Failed to update tokens, will try again in {}",
-                    TimeUtils.formatWithHighestUnit(Duration.ofMillis(delay)),
-                    e);
+            if (reobtainScheduled) {
+                LOG.debug(
+                        "An on-demand re-obtain is already scheduled; leaving it in place instead "
+                                + "of overwriting it with the periodic renewal.");
+                return;
+            }
+            scheduleRenewalLocked(delayMs);
         }
     }
 
@@ -377,6 +491,7 @@ public class DefaultDelegationTokenManager implements DelegationTokenManager {
             if (tokensUpdateFuture != null) {
                 tokensUpdateFuture.cancel(true);
                 tokensUpdateFuture = null;
+                nextScheduledAtMillis = Long.MAX_VALUE;
             }
         }
     }
@@ -416,13 +531,114 @@ public class DefaultDelegationTokenManager implements DelegationTokenManager {
         return renewalDelay;
     }
 
+    @VisibleForTesting
+    void setClock(Clock clock) {
+        this.clock = clock;
+    }
+
     /** Stops re-occurring token obtain task. */
     @Override
     public void stop() {
         LOG.info("Stopping credential renewal");
 
-        stopTokensUpdate();
+        synchronized (tokensUpdateFutureLock) {
+            // Mark stopped, cancel the pending cycle, and reset on-demand re-obtain bookkeeping
+            // atomically, so a concurrent reobtainDelegationTokens() cannot leave a live future
+            // orphaned after stop and a later start() does not inherit stale state.
+            stopped = true;
+            stopTokensUpdate();
+            reobtainScheduled = false;
+            lastReobtainAtMillis = NO_PREVIOUS_REOBTAIN;
+        }
+
+        for (DelegationTokenProvider provider : delegationTokenProviders.values()) {
+            try {
+                provider.stop();
+            } catch (Throwable t) {
+                LOG.error("Failed to stop delegation token provider {}", provider.serviceName(), t);
+            }
+        }
 
         LOG.info("Stopped credential renewal");
+    }
+
+    @Override
+    public void reobtainDelegationTokens() {
+        synchronized (tokensUpdateFutureLock) {
+            if (scheduledExecutor == null || ioExecutor == null) {
+                LOG.debug(
+                        "A re-obtain of delegation tokens was requested but the manager was "
+                                + "constructed without executors (one-shot obtain path); the "
+                                + "request is ignored.");
+                return;
+            }
+            if (stopped) {
+                LOG.debug(
+                        "A re-obtain of delegation tokens was requested after the manager was "
+                                + "stopped; the request is ignored.");
+                return;
+            }
+            // Dedupe: if an on-demand re-obtain is already scheduled and has not started yet, the
+            // newly registered job(s) will be covered by it, so coalesce this request into it.
+            if (reobtainScheduled) {
+                LOG.debug("A re-obtain of delegation tokens is already scheduled; coalescing.");
+                return;
+            }
+            // Cooldown: bound how often on-demand re-obtains can run by deferring this cycle until
+            // at least reobtainCooldownMillis have passed since the previous on-demand re-obtain.
+            long now = clock.millis();
+            long delayMillis =
+                    lastReobtainAtMillis == NO_PREVIOUS_REOBTAIN
+                            ? 0L
+                            : Math.max(0L, lastReobtainAtMillis + reobtainCooldownMillis - now);
+            // Only bring the next cycle forward: if a cycle (e.g. the periodic renewal) is still
+            // pending and scheduled to fire sooner than the cooldown-deferred time, fire at that
+            // earlier time instead of pushing it later — otherwise a short-lived token could expire
+            // before it is renewed. The nextScheduledAtMillis > now guard skips an already-fired
+            // future that has not yet been re-armed, so this never bypasses the cooldown.
+            if (tokensUpdateFuture != null
+                    && nextScheduledAtMillis > now
+                    && nextScheduledAtMillis - now < delayMillis) {
+                delayMillis = nextScheduledAtMillis - now;
+            }
+            lastReobtainAtMillis = now;
+            reobtainScheduled = true;
+            LOG.debug(
+                    "Re-obtain of delegation tokens requested; scheduling an obtain cycle in {}",
+                    TimeUtils.formatWithHighestUnit(Duration.ofMillis(delayMillis)));
+            scheduleRenewalLocked(delayMillis);
+        }
+    }
+
+    @Override
+    public void registerJob(JobID jobId, Configuration jobConfiguration) throws Exception {
+        try {
+            for (DelegationTokenProvider provider : delegationTokenProviders.values()) {
+                provider.registerJob(jobId, jobConfiguration);
+            }
+        } catch (Exception e) {
+            // If any of the providers fail to register, then unregister the job from them all.
+            // unregisterJob is idempotent, so it is safe to call it for providers that were never
+            // (or only partially) registered for this job before the failure. The rollback must
+            // never mask the original failure, so swallow any rollback exception.
+            try {
+                unregisterJob(jobId);
+            } catch (Exception rollbackException) {
+                LOG.error("Failed to roll back registration of job {}", jobId, rollbackException);
+            }
+            LOG.error("Failed to register job {}", jobId, e);
+            throw e;
+        }
+    }
+
+    @Override
+    public void unregisterJob(JobID jobId) throws Exception {
+        for (DelegationTokenProvider provider : delegationTokenProviders.values()) {
+            try {
+                provider.unregisterJob(jobId);
+            } catch (Exception e) {
+                LOG.error("Failed to unregister job for provider {}", provider.serviceName(), e);
+            }
+        }
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/security/token/DefaultDelegationTokenManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/security/token/DefaultDelegationTokenManager.java
@@ -103,7 +103,11 @@ public class DefaultDelegationTokenManager implements DelegationTokenManager {
 
     private final long reobtainCooldownMillis;
 
-    /** Clock used for renewal and cooldown timing. */
+    /**
+     * Clock used for renewal and cooldown timing. Renewal math reads absolute time (a token's
+     * validUntil is an absolute epoch), while scheduling and the cooldown read relative time, which
+     * wall-clock adjustments cannot distort. Never mix the two in one expression.
+     */
     private final Clock clock;
 
     /**
@@ -128,10 +132,11 @@ public class DefaultDelegationTokenManager implements DelegationTokenManager {
     private ScheduledFuture<?> tokensUpdateFuture;
 
     /**
-     * Clock time (millis) at which {@link #tokensUpdateFuture} is scheduled to fire, or {@link
-     * Long#MAX_VALUE} when no cycle is pending. Lets an on-demand re-obtain only ever bring the
-     * next obtain cycle <em>forward</em> and never push an already-scheduled (e.g. periodic)
-     * renewal later, which could otherwise let a short-lived token expire before it is renewed.
+     * Relative (monotonic) clock time (millis) at which {@link #tokensUpdateFuture} is scheduled to
+     * fire, or {@link Long#MAX_VALUE} when no cycle is pending. Lets an on-demand re-obtain only
+     * ever bring the next obtain cycle <em>forward</em> and never push an already-scheduled (e.g.
+     * periodic) renewal later, which could otherwise let a short-lived token expire before it is
+     * renewed.
      */
     @GuardedBy("tokensUpdateFutureLock")
     private long nextScheduledAtMillis = Long.MAX_VALUE;
@@ -141,9 +146,10 @@ public class DefaultDelegationTokenManager implements DelegationTokenManager {
     private boolean reobtainScheduled;
 
     /**
-     * Clock time (millis) at which the last on-demand re-obtain cycle was scheduled to execute, or
-     * {@link #NO_PREVIOUS_REOBTAIN}. Anchored to the execution time rather than the request time,
-     * so the cooldown spaces cycle executions. Updated only by on-demand re-obtains.
+     * Relative (monotonic) clock time (millis) at which the last on-demand re-obtain cycle was
+     * scheduled to execute, or {@link #NO_PREVIOUS_REOBTAIN}. Anchored to the execution time rather
+     * than the request time, so the cooldown spaces cycle executions. Updated only by on-demand
+     * re-obtains.
      */
     @GuardedBy("tokensUpdateFutureLock")
     private long lastReobtainAtMillis = NO_PREVIOUS_REOBTAIN;
@@ -154,6 +160,16 @@ public class DefaultDelegationTokenManager implements DelegationTokenManager {
      */
     @GuardedBy("tokensUpdateFutureLock")
     private boolean running;
+
+    /**
+     * Incremented by every {@link #start(Listener)}. An obtain cycle captures it when it begins and
+     * re-checks it before notifying, so a cycle that began under an earlier leadership session
+     * cannot deliver into a later session. The fence gates delivery only: a stale cycle's renewal
+     * state is cleared by start()'s reset, and a timer it scheduled just runs a fresh,
+     * fence-checked cycle later.
+     */
+    @GuardedBy("tokensUpdateFutureLock")
+    private long sessionEpoch;
 
     @GuardedBy("tokensUpdateFutureLock")
     @VisibleForTesting
@@ -393,18 +409,25 @@ public class DefaultDelegationTokenManager implements DelegationTokenManager {
      */
     @Override
     public void start(Listener listener) throws Exception {
-        checkState(
-                !closed.get(),
-                "The delegation token manager is already closed, its providers are stopped");
         checkNotNull(scheduledExecutor, "Scheduled executor must not be null");
         checkNotNull(ioExecutor, "IO executor must not be null");
         checkNotNull(listener, "Listener must not be null");
         synchronized (tokensUpdateFutureLock) {
+            // Checked under the lock so a start() arriving after close() fails instead of
+            // resurrecting a session against stopped providers. A start() racing close() can
+            // still slip past the check. close()'s stop() then ends its session under this
+            // lock, so its inline first cycle either skips on running == false or runs at most
+            // one obtain that cannot deliver or reschedule and may overlap the provider stop()
+            // (see close()).
+            checkState(
+                    !closed.get(),
+                    "The delegation token manager is already closed, its providers are stopped");
             if (running) {
                 LOG.warn("DelegationTokenManager is already started, ignoring redundant start()");
                 return;
             }
             this.listener = listener;
+            sessionEpoch++;
             // Set before the inline first cycle below: startTokensUpdate() and
             // maybeScheduleRenewal() gate on it.
             running = true;
@@ -423,6 +446,7 @@ public class DefaultDelegationTokenManager implements DelegationTokenManager {
 
     @VisibleForTesting
     void startTokensUpdate() {
+        final long cycleEpoch;
         synchronized (tokensUpdateFutureLock) {
             // Clear the dedupe flag so later on-demand requests can schedule a fresh cycle.
             reobtainScheduled = false;
@@ -431,6 +455,7 @@ public class DefaultDelegationTokenManager implements DelegationTokenManager {
             if (!running) {
                 return;
             }
+            cycleEpoch = sessionEpoch;
         }
         // Serialize the obtain-and-broadcast so a re-obtain racing the periodic renewal cannot run
         // two cycles concurrently on the (multi-threaded) IO executor and broadcast out of order.
@@ -441,13 +466,14 @@ public class DefaultDelegationTokenManager implements DelegationTokenManager {
                 Optional<Long> nextRenewal = obtainDelegationTokensAndGetNextRenewal(container);
 
                 if (container.hasTokens()) {
-                    // stop() does not wait for an in-flight cycle. Re-check so a cycle resuming
-                    // after stop() does not notify the stopped session's listener (the disposed
-                    // ResourceManager). A stop() right after this read still lets one delivery
-                    // through, which is benign.
+                    // stop() does not wait for an in-flight cycle: re-check running so a resumed
+                    // cycle does not notify the stopped session's listener, and compare epochs
+                    // so a cycle begun under an earlier session cannot deliver into the next
+                    // one (see sessionEpoch). A stop() right after this read still lets one
+                    // delivery through, which is benign.
                     final Listener currentListener;
                     synchronized (tokensUpdateFutureLock) {
-                        currentListener = running ? listener : null;
+                        currentListener = running && cycleEpoch == sessionEpoch ? listener : null;
                     }
                     if (currentListener != null) {
                         delegationTokenReceiverRepository.onNewTokensObtained(container);
@@ -518,7 +544,7 @@ public class DefaultDelegationTokenManager implements DelegationTokenManager {
     @GuardedBy("tokensUpdateFutureLock")
     private void scheduleRenewalLocked(long delayMs) {
         stopTokensUpdate();
-        nextScheduledAtMillis = clock.absoluteTimeMillis() + delayMs;
+        nextScheduledAtMillis = clock.relativeTimeMillis() + delayMs;
         try {
             tokensUpdateFuture =
                     scheduledExecutor.schedule(
@@ -572,12 +598,12 @@ public class DefaultDelegationTokenManager implements DelegationTokenManager {
             }
             if (reobtainScheduled) {
                 long pendingInMillis =
-                        Math.max(0L, nextScheduledAtMillis - clock.absoluteTimeMillis());
+                        Math.max(0L, nextScheduledAtMillis - clock.relativeTimeMillis());
                 if (delayMs < pendingInMillis) {
                     // Bring the pending on-demand cycle forward. scheduleRenewalLocked() leaves
                     // reobtainScheduled set, so coalescing still holds. Move the cooldown anchor
                     // to the time the cycle now actually runs.
-                    lastReobtainAtMillis = clock.absoluteTimeMillis() + delayMs;
+                    lastReobtainAtMillis = clock.relativeTimeMillis() + delayMs;
                     scheduleRenewalLocked(delayMs);
                     return delayMs;
                 }
@@ -681,9 +707,10 @@ public class DefaultDelegationTokenManager implements DelegationTokenManager {
      */
     @Override
     public void close() {
-        // Flip the flag before stopping anything: a concurrent start() then fails its
-        // !closed check instead of slipping in between the session stop and the provider
-        // teardown and running on providers that get stopped underneath it.
+        // Flip the flag before stopping anything. start() checks it under
+        // tokensUpdateFutureLock, so a racing start() either fails the check or has its
+        // session ended by the stop() below (see start()). At most one obtain may still
+        // overlap the provider stop() below, which the provider threading contract covers.
         if (!closed.compareAndSet(false, true)) {
             return;
         }
@@ -721,7 +748,7 @@ public class DefaultDelegationTokenManager implements DelegationTokenManager {
             }
             // Cooldown: bound how often on-demand re-obtains can run by deferring this cycle until
             // at least reobtainCooldownMillis have passed since the previous on-demand re-obtain.
-            long now = clock.absoluteTimeMillis();
+            long now = clock.relativeTimeMillis();
             long delayMillis =
                     lastReobtainAtMillis == NO_PREVIOUS_REOBTAIN
                             ? 0L

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/security/token/DefaultDelegationTokenManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/security/token/DefaultDelegationTokenManager.java
@@ -52,6 +52,7 @@ import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
 
@@ -166,6 +167,12 @@ public class DefaultDelegationTokenManager implements DelegationTokenManager {
      * ResourceManager main thread, and leadership sessions are serialized.
      */
     private final Set<JobID> registeredJobs = ConcurrentHashMap.newKeySet();
+
+    /**
+     * Set once by {@link #close()}. Keeps provider stop() at most once and rejects any later {@link
+     * #start(Listener)}.
+     */
+    private final AtomicBoolean closed = new AtomicBoolean(false);
 
     public DefaultDelegationTokenManager(
             Configuration configuration,
@@ -369,6 +376,9 @@ public class DefaultDelegationTokenManager implements DelegationTokenManager {
      */
     @Override
     public void start(Listener listener) throws Exception {
+        checkState(
+                !closed.get(),
+                "The delegation token manager is already closed, its providers are stopped");
         checkNotNull(scheduledExecutor, "Scheduled executor must not be null");
         checkNotNull(ioExecutor, "IO executor must not be null");
         checkNotNull(listener, "Listener must not be null");
@@ -616,7 +626,8 @@ public class DefaultDelegationTokenManager implements DelegationTokenManager {
 
     /**
      * Stops the re-occurring token obtain task, releases the listener, and unregisters the jobs of
-     * the ending session. See the interface javadoc.
+     * the ending session. Providers stay usable for a later {@link #start(Listener)}. Their
+     * teardown happens in {@link #close()}.
      */
     @Override
     public void stop() {
@@ -647,6 +658,23 @@ public class DefaultDelegationTokenManager implements DelegationTokenManager {
             }
         }
 
+        LOG.info("Stopped credential renewal");
+    }
+
+    /**
+     * Terminal teardown: ends any active session via {@link #stop()} and then stops all providers,
+     * exactly once. Called by the component that created the manager at process shutdown, not on
+     * ResourceManager leadership changes.
+     */
+    @Override
+    public void close() {
+        // Flip the flag before stopping anything: a concurrent start() then fails its
+        // !closed check instead of slipping in between the session stop and the provider
+        // teardown and running on providers that get stopped underneath it.
+        if (!closed.compareAndSet(false, true)) {
+            return;
+        }
+        stop();
         for (DelegationTokenProvider provider : delegationTokenProviders.values()) {
             try {
                 provider.stop();
@@ -654,8 +682,6 @@ public class DefaultDelegationTokenManager implements DelegationTokenManager {
                 LOG.error("Failed to stop delegation token provider {}", provider.serviceName(), t);
             }
         }
-
-        LOG.info("Stopped credential renewal");
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/security/token/DefaultDelegationTokenManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/security/token/DefaultDelegationTokenManager.java
@@ -146,11 +146,11 @@ public class DefaultDelegationTokenManager implements DelegationTokenManager {
     private long lastReobtainAtMillis = NO_PREVIOUS_REOBTAIN;
 
     /**
-     * Whether {@link #stop()} has been called. Reset by {@link #start(Listener)}. Prevents a late
-     * provider callback or an in-flight obtain cycle from scheduling new work after shutdown.
+     * Whether the manager is between {@link #start(Listener)} and {@link #stop()}. Defaults to
+     * false, so work arriving before the first start() is rejected the same way as after stop().
      */
     @GuardedBy("tokensUpdateFutureLock")
-    private boolean stopped;
+    private boolean running;
 
     @Nullable private Listener listener;
 
@@ -358,10 +358,16 @@ public class DefaultDelegationTokenManager implements DelegationTokenManager {
     public void start(Listener listener) throws Exception {
         checkNotNull(scheduledExecutor, "Scheduled executor must not be null");
         checkNotNull(ioExecutor, "IO executor must not be null");
-        this.listener = checkNotNull(listener, "Listener must not be null");
+        checkNotNull(listener, "Listener must not be null");
         synchronized (tokensUpdateFutureLock) {
-            checkState(tokensUpdateFuture == null, "Manager is already started");
-            stopped = false;
+            if (running) {
+                LOG.warn("DelegationTokenManager is already started, ignoring redundant start()");
+                return;
+            }
+            this.listener = listener;
+            // Set before the inline first cycle below: startTokensUpdate() and
+            // maybeScheduleRenewal() gate on it.
+            running = true;
         }
 
         startTokensUpdate();
@@ -370,13 +376,11 @@ public class DefaultDelegationTokenManager implements DelegationTokenManager {
     @VisibleForTesting
     void startTokensUpdate() {
         synchronized (tokensUpdateFutureLock) {
-            // The obtain cycle is starting: clear the dedupe flag so later on-demand requests can
-            // schedule a fresh cycle.
+            // Clear the dedupe flag so later on-demand requests can schedule a fresh cycle.
             reobtainScheduled = false;
-            // If stop() ran before this cycle (already handed to the IO executor) began, skip the
-            // obtain/broadcast: the providers may already be stopped. Safe via this lock's
-            // happens-before with stop(). The dedupe flag is cleared above, so it is never stuck.
-            if (stopped) {
+            // Stopped or never started: skip the cycle. The providers may already be stopped
+            // and the listener may not be set yet.
+            if (!running) {
                 return;
             }
         }
@@ -403,10 +407,14 @@ public class DefaultDelegationTokenManager implements DelegationTokenManager {
                     lastKnownNextRenewal = nextRenewal.get();
                     currentRetryBackoff = renewalRetryInitialBackoff;
                     long renewalDelay = calculateRenewalDelay(clock, nextRenewal.get());
-                    maybeScheduleRenewal(renewalDelay);
-                    LOG.info(
-                            "Tokens update task started with {} delay",
-                            TimeUtils.formatWithHighestUnit(Duration.ofMillis(renewalDelay)));
+                    long effectiveDelay = maybeScheduleRenewal(renewalDelay);
+                    if (effectiveDelay >= 0) {
+                        LOG.info(
+                                "Tokens update task started with {} delay",
+                                TimeUtils.formatWithHighestUnit(Duration.ofMillis(effectiveDelay)));
+                    } else {
+                        LOG.info("Tokens update task not rescheduled, the manager is not running");
+                    }
                 } else {
                     LOG.warn(
                             "Tokens update task not started because either no tokens obtained or none of the tokens specified its renewal date");
@@ -416,11 +424,25 @@ public class DefaultDelegationTokenManager implements DelegationTokenManager {
                 LOG.debug("Interrupted", e);
             } catch (Exception e) {
                 long delay = calculateRetryDelay(clock);
-                maybeScheduleRenewal(delay);
-                LOG.warn(
-                        "Failed to update tokens, will try again in {}",
-                        TimeUtils.formatWithHighestUnit(Duration.ofMillis(delay)),
-                        e);
+                long effectiveDelay;
+                try {
+                    effectiveDelay = maybeScheduleRenewal(delay);
+                } catch (Throwable schedulingFailure) {
+                    // The original failure was not logged yet, keep it attached.
+                    schedulingFailure.addSuppressed(e);
+                    throw schedulingFailure;
+                }
+                if (effectiveDelay >= 0) {
+                    LOG.warn(
+                            "Failed to update tokens, will try again in {}",
+                            TimeUtils.formatWithHighestUnit(Duration.ofMillis(effectiveDelay)),
+                            e);
+                } else {
+                    LOG.warn(
+                            "Failed to update tokens, no retry scheduled because the manager is "
+                                    + "not running",
+                            e);
+                }
             }
         }
     }
@@ -454,34 +476,54 @@ public class DefaultDelegationTokenManager implements DelegationTokenManager {
                             TimeUnit.MILLISECONDS);
         } catch (RejectedExecutionException e) {
             // Scheduled executor is shutting down: no cycle will run, so undo the bookkeeping
-            // this method set. Clearing reobtainScheduled keeps a coalesced re-obtain from
-            // getting stuck. nextScheduledAtMillis returns to the no-cycle-pending marker
-            // (stopTokensUpdate() above already nulled tokensUpdateFuture).
+            // this method set.
             reobtainScheduled = false;
             nextScheduledAtMillis = Long.MAX_VALUE;
             LOG.debug("Tokens update task rejected by scheduled executor", e);
+        } catch (Throwable t) {
+            // Undo the same bookkeeping as the rejection branch, or every later re-obtain would
+            // be coalesced against a cycle that never got scheduled. Rethrow to keep the failure
+            // visible.
+            reobtainScheduled = false;
+            nextScheduledAtMillis = Long.MAX_VALUE;
+            throw t;
         }
     }
 
     /**
-     * Schedules the next periodic renewal at the end of a completed obtain cycle, unless the
-     * manager was stopped or an on-demand re-obtain was scheduled while this cycle ran. A pending
-     * on-demand cycle already re-establishes the renewal schedule, so it is left in place rather
-     * than cancelled: the periodic renewal is folded into it, never dropped.
+     * Schedules the next cycle (periodic renewal or failure retry). A pending on-demand cycle is
+     * brought forward when {@code delayMs} is sooner and left in place otherwise, so a pending
+     * cycle is never delayed.
+     *
+     * @param delayMs requested delay in millis
+     * @return the delay in millis until the cycle that will actually run next, or -1 when nothing
+     *     is scheduled because the manager is not running.
      */
     @VisibleForTesting
-    void maybeScheduleRenewal(long delayMs) {
+    long maybeScheduleRenewal(long delayMs) {
+        // A negative delay (the token already passed its validUntil) means run now. Clamp it so
+        // it cannot be mistaken for the -1 not-running sentinel.
+        delayMs = Math.max(0L, delayMs);
         synchronized (tokensUpdateFutureLock) {
-            if (stopped) {
-                return;
+            if (!running) {
+                return -1L;
             }
             if (reobtainScheduled) {
+                long pendingInMillis = Math.max(0L, nextScheduledAtMillis - clock.millis());
+                if (delayMs < pendingInMillis) {
+                    // Bring the pending on-demand cycle forward. scheduleRenewalLocked() leaves
+                    // reobtainScheduled set, so coalescing still holds and the earlier cycle
+                    // serves the coalesced on-demand requests too.
+                    scheduleRenewalLocked(delayMs);
+                    return delayMs;
+                }
                 LOG.debug(
-                        "An on-demand re-obtain is already scheduled; leaving it in place instead "
-                                + "of overwriting it with the periodic renewal.");
-                return;
+                        "An on-demand re-obtain is already scheduled to fire sooner, leaving it "
+                                + "in place.");
+                return pendingInMillis;
             }
             scheduleRenewalLocked(delayMs);
+            return delayMs;
         }
     }
 
@@ -542,10 +584,10 @@ public class DefaultDelegationTokenManager implements DelegationTokenManager {
         LOG.info("Stopping credential renewal");
 
         synchronized (tokensUpdateFutureLock) {
-            // Mark stopped, cancel the pending cycle, and reset on-demand re-obtain bookkeeping
-            // atomically, so a concurrent reobtainDelegationTokens() cannot leave a live future
-            // orphaned after stop and a later start() does not inherit stale state.
-            stopped = true;
+            // Mark not running, cancel the pending cycle, and reset the re-obtain bookkeeping
+            // atomically, so a re-obtain racing shutdown cannot schedule a cycle for a manager
+            // that is shutting down.
+            running = false;
             stopTokensUpdate();
             reobtainScheduled = false;
             lastReobtainAtMillis = NO_PREVIOUS_REOBTAIN;
@@ -572,10 +614,11 @@ public class DefaultDelegationTokenManager implements DelegationTokenManager {
                                 + "request is ignored.");
                 return;
             }
-            if (stopped) {
+            if (!running) {
                 LOG.debug(
-                        "A re-obtain of delegation tokens was requested after the manager was "
-                                + "stopped; the request is ignored.");
+                        "A re-obtain of delegation tokens was requested while the manager is not "
+                                + "running (not started yet, or already stopped), ignoring the "
+                                + "request.");
                 return;
             }
             // Dedupe: if an on-demand re-obtain is already scheduled and has not started yet, the

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/security/token/DefaultDelegationTokenManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/security/token/DefaultDelegationTokenManager.java
@@ -659,14 +659,13 @@ public class DefaultDelegationTokenManager implements DelegationTokenManager {
             for (DelegationTokenProvider provider : delegationTokenProviders.values()) {
                 provider.registerJob(jobId, jobConfiguration);
             }
-        } catch (Exception e) {
-            // If any of the providers fail to register, then unregister the job from them all.
-            // unregisterJob is idempotent, so it is safe to call it for providers that were never
-            // (or only partially) registered for this job before the failure. The rollback must
-            // never mask the original failure, so swallow any rollback exception.
+        } catch (Exception | LinkageError e) {
+            // Roll the job back from all providers (unregisterJob is idempotent) and rethrow.
+            // The rollback must never mask the original failure. LinkageError is included
+            // because provider plugin code can fail class resolution.
             try {
                 unregisterJob(jobId);
-            } catch (Exception rollbackException) {
+            } catch (Exception | LinkageError rollbackException) {
                 LOG.error("Failed to roll back registration of job {}", jobId, rollbackException);
             }
             LOG.error("Failed to register job {}", jobId, e);
@@ -679,7 +678,7 @@ public class DefaultDelegationTokenManager implements DelegationTokenManager {
         for (DelegationTokenProvider provider : delegationTokenProviders.values()) {
             try {
                 provider.unregisterJob(jobId);
-            } catch (Exception e) {
+            } catch (Exception | LinkageError e) {
                 LOG.error("Failed to unregister job for provider {}", provider.serviceName(), e);
             }
         }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/security/token/DefaultDelegationTokenManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/security/token/DefaultDelegationTokenManager.java
@@ -655,8 +655,10 @@ public class DefaultDelegationTokenManager implements DelegationTokenManager {
 
     @Override
     public void registerJob(JobID jobId, Configuration jobConfiguration) throws Exception {
+        DelegationTokenProvider failedProvider = null;
         try {
             for (DelegationTokenProvider provider : delegationTokenProviders.values()) {
+                failedProvider = provider;
                 provider.registerJob(jobId, jobConfiguration);
             }
         } catch (Exception | LinkageError e) {
@@ -668,7 +670,11 @@ public class DefaultDelegationTokenManager implements DelegationTokenManager {
             } catch (Exception | LinkageError rollbackException) {
                 LOG.error("Failed to roll back registration of job {}", jobId, rollbackException);
             }
-            LOG.error("Failed to register job {}", jobId, e);
+            LOG.error(
+                    "Failed to register job {} for provider {}",
+                    jobId,
+                    failedProvider == null ? "<none>" : failedProvider.serviceName(),
+                    e);
             throw e;
         }
     }
@@ -679,7 +685,11 @@ public class DefaultDelegationTokenManager implements DelegationTokenManager {
             try {
                 provider.unregisterJob(jobId);
             } catch (Exception | LinkageError e) {
-                LOG.error("Failed to unregister job for provider {}", provider.serviceName(), e);
+                LOG.error(
+                        "Failed to unregister job {} for provider {}",
+                        jobId,
+                        provider.serviceName(),
+                        e);
             }
         }
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/security/token/DefaultDelegationTokenManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/security/token/DefaultDelegationTokenManager.java
@@ -30,6 +30,8 @@ import org.apache.flink.core.security.token.DelegationTokenReceiver;
 import org.apache.flink.util.FlinkRuntimeException;
 import org.apache.flink.util.InstantiationUtil;
 import org.apache.flink.util.TimeUtils;
+import org.apache.flink.util.clock.Clock;
+import org.apache.flink.util.clock.SystemClock;
 import org.apache.flink.util.concurrent.ScheduledExecutor;
 
 import org.slf4j.Logger;
@@ -38,7 +40,6 @@ import org.slf4j.LoggerFactory;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.GuardedBy;
 
-import java.time.Clock;
 import java.time.Duration;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -102,8 +103,8 @@ public class DefaultDelegationTokenManager implements DelegationTokenManager {
 
     private final long reobtainCooldownMillis;
 
-    /** Clock used for cooldown bookkeeping; overridable in tests. */
-    private volatile Clock clock = Clock.systemDefaultZone();
+    /** Clock used for renewal and cooldown timing. */
+    private final Clock clock;
 
     /**
      * Serializes the obtain-and-broadcast cycle so that, even though {@code cancel(true)} does not
@@ -179,7 +180,23 @@ public class DefaultDelegationTokenManager implements DelegationTokenManager {
             @Nullable PluginManager pluginManager,
             @Nullable ScheduledExecutor scheduledExecutor,
             @Nullable ExecutorService ioExecutor) {
+        this(
+                configuration,
+                pluginManager,
+                scheduledExecutor,
+                ioExecutor,
+                SystemClock.getInstance());
+    }
+
+    @VisibleForTesting
+    DefaultDelegationTokenManager(
+            Configuration configuration,
+            @Nullable PluginManager pluginManager,
+            @Nullable ScheduledExecutor scheduledExecutor,
+            @Nullable ExecutorService ioExecutor,
+            Clock clock) {
         this.configuration = checkNotNull(configuration, "Flink configuration must not be null");
+        this.clock = checkNotNull(clock, "Clock must not be null");
         this.pluginManager = pluginManager;
         this.tokensRenewalTimeRatio = configuration.get(DELEGATION_TOKENS_RENEWAL_TIME_RATIO);
         this.renewalRetryInitialBackoff =
@@ -501,7 +518,7 @@ public class DefaultDelegationTokenManager implements DelegationTokenManager {
     @GuardedBy("tokensUpdateFutureLock")
     private void scheduleRenewalLocked(long delayMs) {
         stopTokensUpdate();
-        nextScheduledAtMillis = clock.millis() + delayMs;
+        nextScheduledAtMillis = clock.absoluteTimeMillis() + delayMs;
         try {
             tokensUpdateFuture =
                     scheduledExecutor.schedule(
@@ -554,12 +571,13 @@ public class DefaultDelegationTokenManager implements DelegationTokenManager {
                 return -1L;
             }
             if (reobtainScheduled) {
-                long pendingInMillis = Math.max(0L, nextScheduledAtMillis - clock.millis());
+                long pendingInMillis =
+                        Math.max(0L, nextScheduledAtMillis - clock.absoluteTimeMillis());
                 if (delayMs < pendingInMillis) {
                     // Bring the pending on-demand cycle forward. scheduleRenewalLocked() leaves
                     // reobtainScheduled set, so coalescing still holds. Move the cooldown anchor
                     // to the time the cycle now actually runs.
-                    lastReobtainAtMillis = clock.millis() + delayMs;
+                    lastReobtainAtMillis = clock.absoluteTimeMillis() + delayMs;
                     scheduleRenewalLocked(delayMs);
                     return delayMs;
                 }
@@ -586,7 +604,7 @@ public class DefaultDelegationTokenManager implements DelegationTokenManager {
 
     @VisibleForTesting
     long calculateRetryDelay(Clock clock) {
-        long nowMillis = clock.millis();
+        long nowMillis = clock.absoluteTimeMillis();
         long effectiveMax;
         if (lastKnownNextRenewal != Long.MAX_VALUE) {
             long remaining = lastKnownNextRenewal - nowMillis;
@@ -608,7 +626,7 @@ public class DefaultDelegationTokenManager implements DelegationTokenManager {
 
     @VisibleForTesting
     long calculateRenewalDelay(Clock clock, long nextRenewal) {
-        long now = clock.millis();
+        long now = clock.absoluteTimeMillis();
         long renewalDelay = Math.round(tokensRenewalTimeRatio * (nextRenewal - now));
         LOG.debug(
                 "Calculated delay on renewal is {}, based on next renewal {} and the ratio {}, and current time {}",
@@ -617,11 +635,6 @@ public class DefaultDelegationTokenManager implements DelegationTokenManager {
                 tokensRenewalTimeRatio,
                 now);
         return renewalDelay;
-    }
-
-    @VisibleForTesting
-    void setClock(Clock clock) {
-        this.clock = clock;
     }
 
     /**
@@ -708,7 +721,7 @@ public class DefaultDelegationTokenManager implements DelegationTokenManager {
             }
             // Cooldown: bound how often on-demand re-obtains can run by deferring this cycle until
             // at least reobtainCooldownMillis have passed since the previous on-demand re-obtain.
-            long now = clock.millis();
+            long now = clock.absoluteTimeMillis();
             long delayMillis =
                     lastReobtainAtMillis == NO_PREVIOUS_REOBTAIN
                             ? 0L

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/security/token/DefaultDelegationTokenManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/security/token/DefaultDelegationTokenManager.java
@@ -186,8 +186,8 @@ public class DefaultDelegationTokenManager implements DelegationTokenManager {
     private final Set<JobID> registeredJobs = ConcurrentHashMap.newKeySet();
 
     /**
-     * Set once by {@link #close()}. Keeps provider stop() at most once and rejects any later {@link
-     * #start(Listener)}.
+     * Set once by {@link #close()}. Keeps provider close() at most once and rejects any later
+     * {@link #start(Listener)}.
      */
     private final AtomicBoolean closed = new AtomicBoolean(false);
 
@@ -414,14 +414,14 @@ public class DefaultDelegationTokenManager implements DelegationTokenManager {
         checkNotNull(listener, "Listener must not be null");
         synchronized (tokensUpdateFutureLock) {
             // Checked under the lock so a start() arriving after close() fails instead of
-            // resurrecting a session against stopped providers. A start() racing close() can
+            // resurrecting a session against closed providers. A start() racing close() can
             // still slip past the check. close()'s stop() then ends its session under this
             // lock, so its inline first cycle either skips on running == false or runs at most
-            // one obtain that cannot deliver or reschedule and may overlap the provider stop()
+            // one obtain that cannot deliver or reschedule and may overlap the provider close()
             // (see close()).
             checkState(
                     !closed.get(),
-                    "The delegation token manager is already closed, its providers are stopped");
+                    "The delegation token manager is already closed, its providers are closed");
             if (running) {
                 LOG.warn("DelegationTokenManager is already started, ignoring redundant start()");
                 return;
@@ -450,7 +450,7 @@ public class DefaultDelegationTokenManager implements DelegationTokenManager {
         synchronized (tokensUpdateFutureLock) {
             // Clear the dedupe flag so later on-demand requests can schedule a fresh cycle.
             reobtainScheduled = false;
-            // Stopped or never started: skip the cycle. The providers may already be stopped
+            // Stopped or never started: skip the cycle. The providers may already be closed
             // and the listener may not be set yet.
             if (!running) {
                 return;
@@ -701,7 +701,7 @@ public class DefaultDelegationTokenManager implements DelegationTokenManager {
     }
 
     /**
-     * Terminal teardown: ends any active session via {@link #stop()} and then stops all providers,
+     * Terminal teardown: ends any active session via {@link #stop()} and then closes all providers,
      * exactly once. Called by the component that created the manager at process shutdown, not on
      * ResourceManager leadership changes.
      */
@@ -710,16 +710,17 @@ public class DefaultDelegationTokenManager implements DelegationTokenManager {
         // Flip the flag before stopping anything. start() checks it under
         // tokensUpdateFutureLock, so a racing start() either fails the check or has its
         // session ended by the stop() below (see start()). At most one obtain may still
-        // overlap the provider stop() below, which the provider threading contract covers.
+        // overlap the provider close() below, which the provider threading contract covers.
         if (!closed.compareAndSet(false, true)) {
             return;
         }
         stop();
         for (DelegationTokenProvider provider : delegationTokenProviders.values()) {
             try {
-                provider.stop();
+                provider.close();
             } catch (Throwable t) {
-                LOG.error("Failed to stop delegation token provider {}", provider.serviceName(), t);
+                LOG.error(
+                        "Failed to close delegation token provider {}", provider.serviceName(), t);
             }
         }
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/security/token/DefaultDelegationTokenManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/security/token/DefaultDelegationTokenManager.java
@@ -24,7 +24,6 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.SecurityOptions;
 import org.apache.flink.core.plugin.PluginManager;
-import org.apache.flink.core.security.token.DelegationTokenManagerCallback;
 import org.apache.flink.core.security.token.DelegationTokenProvider;
 import org.apache.flink.core.security.token.DelegationTokenReceiver;
 import org.apache.flink.util.FlinkRuntimeException;
@@ -244,15 +243,12 @@ public class DefaultDelegationTokenManager implements DelegationTokenManager {
     private Map<String, DelegationTokenProvider> loadProviders() {
         LOG.info("Loading delegation token providers");
 
-        // Handed to every provider so it can request an immediate re-obtain later, from any
-        // thread, decoupled from the registerJob call stack.
-        final DelegationTokenManagerCallback callback = this::reobtainDelegationTokens;
         Map<String, DelegationTokenProvider> providers = new HashMap<>();
         Consumer<DelegationTokenProvider> loadProvider =
                 (provider) -> {
                     try {
                         if (isProviderEnabled(configuration, provider.serviceName())) {
-                            provider.init(configuration, callback);
+                            provider.init(configuration, this::reobtainDelegationTokens);
                             LOG.info(
                                     "Delegation token provider {} loaded and initialized",
                                     provider.serviceName());

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/security/token/DefaultDelegationTokenManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/security/token/DefaultDelegationTokenManager.java
@@ -97,9 +97,13 @@ public class DefaultDelegationTokenManager implements DelegationTokenManager {
 
     private final long renewalRetryMaxBackoff;
 
-    @VisibleForTesting long currentRetryBackoff;
+    @GuardedBy("renewalCycleLock")
+    @VisibleForTesting
+    long currentRetryBackoff;
 
-    @VisibleForTesting long lastKnownNextRenewal = Long.MAX_VALUE;
+    @GuardedBy("renewalCycleLock")
+    @VisibleForTesting
+    long lastKnownNextRenewal = Long.MAX_VALUE;
 
     private final long reobtainCooldownMillis;
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/security/token/DefaultDelegationTokenManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/security/token/DefaultDelegationTokenManager.java
@@ -115,7 +115,7 @@ public class DefaultDelegationTokenManager implements DelegationTokenManager {
      * wait for an in-flight cycle and the IO executor is multi-threaded, two cycles can never run
      * concurrently and broadcast tokens out of order.
      */
-    private final Object obtainLock = new Object();
+    private final Object renewalCycleLock = new Object();
 
     @VisibleForTesting final Map<String, DelegationTokenProvider> delegationTokenProviders;
 
@@ -125,9 +125,9 @@ public class DefaultDelegationTokenManager implements DelegationTokenManager {
 
     @Nullable private final ExecutorService ioExecutor;
 
-    private final Object tokensUpdateFutureLock = new Object();
+    private final Object schedulingLock = new Object();
 
-    @GuardedBy("tokensUpdateFutureLock")
+    @GuardedBy("schedulingLock")
     @Nullable
     private ScheduledFuture<?> tokensUpdateFuture;
 
@@ -138,11 +138,11 @@ public class DefaultDelegationTokenManager implements DelegationTokenManager {
      * periodic) renewal later, which could otherwise let a short-lived token expire before it is
      * renewed.
      */
-    @GuardedBy("tokensUpdateFutureLock")
+    @GuardedBy("schedulingLock")
     private long nextScheduledAtMillis = Long.MAX_VALUE;
 
     /** Whether an on-demand re-obtain is scheduled but has not started executing yet (dedupe). */
-    @GuardedBy("tokensUpdateFutureLock")
+    @GuardedBy("schedulingLock")
     private boolean reobtainScheduled;
 
     /**
@@ -151,14 +151,14 @@ public class DefaultDelegationTokenManager implements DelegationTokenManager {
      * than the request time, so the cooldown spaces cycle executions. Updated only by on-demand
      * re-obtains.
      */
-    @GuardedBy("tokensUpdateFutureLock")
+    @GuardedBy("schedulingLock")
     private long lastReobtainAtMillis = NO_PREVIOUS_REOBTAIN;
 
     /**
      * Whether the manager is between {@link #start(Listener)} and {@link #stop()}. Defaults to
      * false, so work arriving before the first start() is rejected the same way as after stop().
      */
-    @GuardedBy("tokensUpdateFutureLock")
+    @GuardedBy("schedulingLock")
     private boolean running;
 
     /**
@@ -168,10 +168,10 @@ public class DefaultDelegationTokenManager implements DelegationTokenManager {
      * state is cleared by start()'s reset, and a timer it scheduled just runs a fresh,
      * fence-checked cycle later.
      */
-    @GuardedBy("tokensUpdateFutureLock")
+    @GuardedBy("schedulingLock")
     private long sessionEpoch;
 
-    @GuardedBy("tokensUpdateFutureLock")
+    @GuardedBy("schedulingLock")
     @VisibleForTesting
     @Nullable
     Listener listener;
@@ -412,7 +412,7 @@ public class DefaultDelegationTokenManager implements DelegationTokenManager {
         checkNotNull(scheduledExecutor, "Scheduled executor must not be null");
         checkNotNull(ioExecutor, "IO executor must not be null");
         checkNotNull(listener, "Listener must not be null");
-        synchronized (tokensUpdateFutureLock) {
+        synchronized (schedulingLock) {
             // Checked under the lock so a start() arriving after close() fails instead of
             // resurrecting a session against closed providers. A start() racing close() can
             // still slip past the check. close()'s stop() then ends its session under this
@@ -434,9 +434,9 @@ public class DefaultDelegationTokenManager implements DelegationTokenManager {
         }
 
         // A new session must not inherit the previous session's retry backoff or renewal
-        // deadline. obtainLock orders this reset after any still-running previous cycle. Not
-        // nested in the block above to keep the obtainLock -> tokensUpdateFutureLock order.
-        synchronized (obtainLock) {
+        // deadline. renewalCycleLock orders this reset after any still-running previous cycle. Not
+        // nested in the block above to keep the renewalCycleLock -> schedulingLock order.
+        synchronized (renewalCycleLock) {
             currentRetryBackoff = renewalRetryInitialBackoff;
             lastKnownNextRenewal = Long.MAX_VALUE;
         }
@@ -447,7 +447,7 @@ public class DefaultDelegationTokenManager implements DelegationTokenManager {
     @VisibleForTesting
     void startTokensUpdate() {
         final long cycleEpoch;
-        synchronized (tokensUpdateFutureLock) {
+        synchronized (schedulingLock) {
             // Clear the dedupe flag so later on-demand requests can schedule a fresh cycle.
             reobtainScheduled = false;
             // Stopped or never started: skip the cycle. The providers may already be closed
@@ -459,7 +459,7 @@ public class DefaultDelegationTokenManager implements DelegationTokenManager {
         }
         // Serialize the obtain-and-broadcast so a re-obtain racing the periodic renewal cannot run
         // two cycles concurrently on the (multi-threaded) IO executor and broadcast out of order.
-        synchronized (obtainLock) {
+        synchronized (renewalCycleLock) {
             try {
                 LOG.info("Starting tokens update task");
                 DelegationTokenContainer container = new DelegationTokenContainer();
@@ -472,7 +472,7 @@ public class DefaultDelegationTokenManager implements DelegationTokenManager {
                     // one (see sessionEpoch). A stop() right after this read still lets one
                     // delivery through, which is benign.
                     final Listener currentListener;
-                    synchronized (tokensUpdateFutureLock) {
+                    synchronized (schedulingLock) {
                         currentListener = running && cycleEpoch == sessionEpoch ? listener : null;
                     }
                     if (currentListener != null) {
@@ -539,9 +539,9 @@ public class DefaultDelegationTokenManager implements DelegationTokenManager {
      * Schedules a one-shot token-obtain-and-broadcast cycle after {@code delayMs}, replacing any
      * pending renewal. A delay of {@code 0} brings the next cycle forward to now. Must only be
      * called after {@link #start(Listener)} (the scheduled and IO executors are non-null then) and
-     * while holding {@link #tokensUpdateFutureLock}.
+     * while holding {@link #schedulingLock}.
      */
-    @GuardedBy("tokensUpdateFutureLock")
+    @GuardedBy("schedulingLock")
     private void scheduleRenewalLocked(long delayMs) {
         stopTokensUpdate();
         nextScheduledAtMillis = clock.relativeTimeMillis() + delayMs;
@@ -554,7 +554,7 @@ public class DefaultDelegationTokenManager implements DelegationTokenManager {
                                 } catch (RejectedExecutionException e) {
                                     // IO executor is shutting down: drop the cycle but release the
                                     // dedupe flag so it cannot get stuck if the manager is reused.
-                                    synchronized (tokensUpdateFutureLock) {
+                                    synchronized (schedulingLock) {
                                         reobtainScheduled = false;
                                     }
                                     LOG.debug("Tokens update task rejected by IO executor", e);
@@ -592,7 +592,7 @@ public class DefaultDelegationTokenManager implements DelegationTokenManager {
         // A negative delay (the token already passed its validUntil) means run now. Clamp it so
         // it cannot be mistaken for the -1 not-running sentinel.
         delayMs = Math.max(0L, delayMs);
-        synchronized (tokensUpdateFutureLock) {
+        synchronized (schedulingLock) {
             if (!running) {
                 return -1L;
             }
@@ -619,7 +619,7 @@ public class DefaultDelegationTokenManager implements DelegationTokenManager {
 
     @VisibleForTesting
     void stopTokensUpdate() {
-        synchronized (tokensUpdateFutureLock) {
+        synchronized (schedulingLock) {
             if (tokensUpdateFuture != null) {
                 tokensUpdateFuture.cancel(true);
                 tokensUpdateFuture = null;
@@ -672,7 +672,7 @@ public class DefaultDelegationTokenManager implements DelegationTokenManager {
     public void stop() {
         LOG.info("Stopping credential renewal");
 
-        synchronized (tokensUpdateFutureLock) {
+        synchronized (schedulingLock) {
             // Mark not running, cancel the pending cycle, and reset the re-obtain bookkeeping
             // atomically, so a re-obtain racing shutdown cannot schedule a cycle for a manager
             // that is shutting down.
@@ -708,7 +708,7 @@ public class DefaultDelegationTokenManager implements DelegationTokenManager {
     @Override
     public void close() {
         // Flip the flag before stopping anything. start() checks it under
-        // tokensUpdateFutureLock, so a racing start() either fails the check or has its
+        // schedulingLock, so a racing start() either fails the check or has its
         // session ended by the stop() below (see start()). At most one obtain may still
         // overlap the provider close() below, which the provider threading contract covers.
         if (!closed.compareAndSet(false, true)) {
@@ -727,7 +727,7 @@ public class DefaultDelegationTokenManager implements DelegationTokenManager {
 
     @Override
     public void reobtainDelegationTokens() {
-        synchronized (tokensUpdateFutureLock) {
+        synchronized (schedulingLock) {
             if (scheduledExecutor == null || ioExecutor == null) {
                 LOG.debug(
                         "A re-obtain of delegation tokens was requested but the manager was "

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/security/token/DelegationTokenManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/security/token/DelegationTokenManager.java
@@ -61,7 +61,12 @@ public interface DelegationTokenManager {
      */
     void start(Listener listener) throws Exception;
 
-    /** Stops re-occurring token obtain task. */
+    /**
+     * Stops the re-occurring token obtain task. Implementations also release any per-job provider
+     * state accumulated through {@link #registerJob(JobID, Configuration)}, so stale registrations
+     * cannot outlive the stop (a job that is still running re-registers through the normal
+     * JobMaster registration retry).
+     */
     void stop();
 
     /**
@@ -78,10 +83,11 @@ public interface DelegationTokenManager {
 
     /**
      * Called when a job has started. Fans the event out to all loaded {@link
-     * org.apache.flink.core.security.token.DelegationTokenProvider}s. On failure the job is
-     * unregistered from all providers and the exception is rethrown so the caller can reject the
-     * job's registration. A provider that needs the new job's tokens distributed immediately
-     * requests it via {@link
+     * org.apache.flink.core.security.token.DelegationTokenProvider}s. On failure of the job's first
+     * registration, the job is unregistered from all providers and the exception is rethrown so the
+     * caller can reject the registration. A failed re-registration rethrows but keeps the job
+     * registered, so a running job's tokens are not dropped. A provider that needs the new job's
+     * tokens distributed immediately requests it via {@link
      * org.apache.flink.core.security.token.DelegationTokenManagerCallback#reobtainDelegationTokens()}.
      *
      * @param jobId The job id which just started.
@@ -91,7 +97,8 @@ public interface DelegationTokenManager {
 
     /**
      * Called when a job is being removed. Fans the event out to all loaded providers. Must be
-     * idempotent.
+     * idempotent. Per-provider failures are caught and logged (one provider's failure does not
+     * abort cleanup of the others), so in practice this does not throw for provider failures.
      *
      * @param jobId The job id of the job.
      */

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/security/token/DelegationTokenManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/security/token/DelegationTokenManager.java
@@ -19,6 +19,8 @@
 package org.apache.flink.runtime.security.token;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.configuration.Configuration;
 
 /**
  * Manager for delegation tokens in a Flink cluster.
@@ -61,4 +63,37 @@ public interface DelegationTokenManager {
 
     /** Stops re-occurring token obtain task. */
     void stop();
+
+    /**
+     * Requests an immediate, asynchronous token-obtain-and-distribute cycle, bringing the next
+     * cycle forward instead of waiting for the periodic renewal. May be called from any thread;
+     * it is a no-op on a manager constructed without executors (the one-shot obtain path).
+     * Concurrent requests are coalesced and a configurable cooldown may apply, so a call does
+     * not necessarily map to exactly one obtain.
+     *
+     * <p>Backs {@link
+     * org.apache.flink.core.security.token.DelegationTokenManagerCallback#reobtainDelegationTokens()}.
+     */
+    default void reobtainDelegationTokens() {}
+
+    /**
+     * Called when a job has started. Fans the event out to all loaded {@link
+     * org.apache.flink.core.security.token.DelegationTokenProvider}s. On failure the job is
+     * unregistered from all providers and the exception is rethrown so the caller can reject the
+     * job's registration. A provider that needs the new job's tokens distributed immediately
+     * requests it via {@link
+     * org.apache.flink.core.security.token.DelegationTokenManagerCallback#reobtainDelegationTokens()}.
+     *
+     * @param jobId The job id which just started.
+     * @param jobConfiguration The job's configuration.
+     */
+    default void registerJob(JobID jobId, Configuration jobConfiguration) throws Exception {}
+
+    /**
+     * Called when a job is being removed. Fans the event out to all loaded providers. Must be
+     * idempotent.
+     *
+     * @param jobId The job id of the job.
+     */
+    default void unregisterJob(JobID jobId) throws Exception {}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/security/token/DelegationTokenManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/security/token/DelegationTokenManager.java
@@ -66,10 +66,10 @@ public interface DelegationTokenManager {
 
     /**
      * Requests an immediate, asynchronous token-obtain-and-distribute cycle, bringing the next
-     * cycle forward instead of waiting for the periodic renewal. May be called from any thread;
-     * it is a no-op on a manager constructed without executors (the one-shot obtain path).
-     * Concurrent requests are coalesced and a configurable cooldown may apply, so a call does
-     * not necessarily map to exactly one obtain.
+     * cycle forward instead of waiting for the periodic renewal. May be called from any thread. It
+     * is a no-op on a manager constructed without executors (the one-shot obtain path). Concurrent
+     * requests are coalesced and a configurable cooldown may apply, so a call does not necessarily
+     * map to exactly one obtain.
      *
      * <p>Backs {@link
      * org.apache.flink.core.security.token.DelegationTokenManagerCallback#reobtainDelegationTokens()}.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/security/token/DelegationTokenManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/security/token/DelegationTokenManager.java
@@ -62,12 +62,21 @@ public interface DelegationTokenManager {
     void start(Listener listener) throws Exception;
 
     /**
-     * Stops the re-occurring token obtain task. Implementations also release any per-job provider
-     * state accumulated through {@link #registerJob(JobID, Configuration)}, so stale registrations
-     * cannot outlive the stop (a job that is still running re-registers through the normal
-     * JobMaster registration retry).
+     * Stops the re-occurring token obtain task. Implementations also unregister all jobs registered
+     * through {@link #registerJob(JobID, Configuration)}, so nothing leaks across leadership
+     * sessions (a job that is still running re-registers through the normal JobMaster registration
+     * retry). Providers are not stopped here and stay usable for a subsequent {@link
+     * #start(Listener)}. Their teardown happens in {@link #close()}.
      */
     void stop();
+
+    /**
+     * Terminal teardown of the manager: ends any active obtain session and releases the providers'
+     * resources, exactly once. Called by the component that created the manager at process
+     * shutdown, unlike {@link #stop()}, which may run once per ResourceManager leadership session.
+     * The manager must not be started after close.
+     */
+    default void close() {}
 
     /**
      * Requests an immediate, asynchronous token-obtain-and-distribute cycle, bringing the next

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerJobMasterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerJobMasterTest.java
@@ -188,8 +188,10 @@ class ResourceManagerJobMasterTest {
         final RegistrationResponse response =
                 registrationFuture.get(TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
         assertThat(response).isInstanceOf(RegistrationResponse.Failure.class);
-        assertThat(((RegistrationResponse.Failure) response).getReason().getMessage())
-                .contains("registerJob rejected by provider");
+        final Throwable reason = ((RegistrationResponse.Failure) response).getReason();
+        assertThat(reason.getMessage()).contains(jobId.toString());
+        assertThat(reason.getMessage()).contains("delegation token manager");
+        assertThat(reason.getCause().getMessage()).contains("registerJob rejected by provider");
     }
 
     @Test

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerJobMasterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerJobMasterTest.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.resourcemanager;
 
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
 import org.apache.flink.runtime.jobmaster.JobMaster;
@@ -34,6 +35,8 @@ import org.apache.flink.runtime.resourcemanager.exceptions.ResourceManagerExcept
 import org.apache.flink.runtime.rpc.RpcUtils;
 import org.apache.flink.runtime.rpc.TestingRpcService;
 import org.apache.flink.runtime.rpc.exceptions.FencingTokenException;
+import org.apache.flink.runtime.security.token.DelegationTokenManager;
+import org.apache.flink.runtime.security.token.NoOpDelegationTokenManager;
 import org.apache.flink.runtime.taskexecutor.TaskExecutorGateway;
 import org.apache.flink.runtime.taskexecutor.TestingTaskExecutorGatewayBuilder;
 import org.apache.flink.util.FlinkRuntimeException;
@@ -93,10 +96,16 @@ class ResourceManagerJobMasterTest {
     }
 
     private void createAndStartResourceManagerService() throws Exception {
+        createAndStartResourceManagerService(new NoOpDelegationTokenManager());
+    }
+
+    private void createAndStartResourceManagerService(DelegationTokenManager delegationTokenManager)
+            throws Exception {
         final TestingLeaderElection leaderElection = new TestingLeaderElection();
         resourceManagerService =
                 TestingResourceManagerService.newBuilder()
                         .setRpcService(rpcService)
+                        .setDelegationTokenManager(delegationTokenManager)
                         .setJmLeaderRetrieverFunction(
                                 requestedJobId -> {
                                     if (requestedJobId.equals(jobId)) {
@@ -150,6 +159,37 @@ class ResourceManagerJobMasterTest {
         assertThatFuture(successfulFuture)
                 .succeedsWithin(TIMEOUT.toMillis(), TimeUnit.MILLISECONDS)
                 .isInstanceOf(JobMasterRegistrationSuccess.class);
+    }
+
+    /**
+     * FLIP-588: if the delegation token manager rejects the job (its {@code registerJob} throws),
+     * the ResourceManager must reject the JobMaster registration so the job does not start without
+     * the tokens it requires. This also exercises the widened (6-arg) {@code registerJobMaster} RPC
+     * that carries the job {@link Configuration}.
+     */
+    @Test
+    void testRegisterJobMasterRejectedWhenDelegationTokenRegistrationFails() throws Exception {
+        // Rebuild the RM service with a delegation token manager that rejects registerJob.
+        resourceManagerService.rethrowFatalErrorIfAny();
+        resourceManagerService.cleanUp();
+        final FlinkRuntimeException failure =
+                new FlinkRuntimeException("registerJob rejected by provider");
+        createAndStartResourceManagerService(new RejectingDelegationTokenManager(failure));
+
+        final CompletableFuture<RegistrationResponse> registrationFuture =
+                resourceManagerGateway.registerJobMaster(
+                        jobMasterGateway.getFencingToken(),
+                        jobMasterResourceId,
+                        jobMasterGateway.getAddress(),
+                        jobId,
+                        new Configuration(),
+                        TIMEOUT);
+
+        final RegistrationResponse response =
+                registrationFuture.get(TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
+        assertThat(response).isInstanceOf(RegistrationResponse.Failure.class);
+        assertThat(((RegistrationResponse.Failure) response).getReason().getMessage())
+                .contains("registerJob rejected by provider");
     }
 
     @Test
@@ -294,5 +334,20 @@ class ResourceManagerJobMasterTest {
 
         // ignore the reported error
         resourceManagerService.ignoreFatalErrors();
+    }
+
+    /** A {@link DelegationTokenManager} whose {@code registerJob} always throws. */
+    private static final class RejectingDelegationTokenManager extends NoOpDelegationTokenManager {
+
+        private final Exception failure;
+
+        private RejectingDelegationTokenManager(Exception failure) {
+            this.failure = failure;
+        }
+
+        @Override
+        public void registerJob(JobID jobId, Configuration jobConfiguration) throws Exception {
+            throw failure;
+        }
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/TestingResourceManagerService.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/TestingResourceManagerService.java
@@ -33,6 +33,7 @@ import org.apache.flink.runtime.rpc.FencedRpcEndpoint;
 import org.apache.flink.runtime.rpc.RpcEndpoint;
 import org.apache.flink.runtime.rpc.RpcService;
 import org.apache.flink.runtime.rpc.TestingRpcService;
+import org.apache.flink.runtime.security.token.DelegationTokenManager;
 import org.apache.flink.runtime.security.token.NoOpDelegationTokenManager;
 import org.apache.flink.runtime.util.TestingFatalErrorHandler;
 import org.apache.flink.util.concurrent.FutureUtils;
@@ -149,6 +150,7 @@ public class TestingResourceManagerService implements ResourceManagerService {
         private boolean needStopRpcService = true;
         private TestingLeaderElection rmLeaderElection = null;
         private Function<JobID, LeaderRetrievalService> jmLeaderRetrieverFunction = null;
+        private DelegationTokenManager delegationTokenManager = new NoOpDelegationTokenManager();
 
         public Builder setRpcService(RpcService rpcService) {
             this.rpcService = checkNotNull(rpcService);
@@ -164,6 +166,11 @@ public class TestingResourceManagerService implements ResourceManagerService {
         public Builder setJmLeaderRetrieverFunction(
                 Function<JobID, LeaderRetrievalService> jmLeaderRetrieverFunction) {
             this.jmLeaderRetrieverFunction = checkNotNull(jmLeaderRetrieverFunction);
+            return this;
+        }
+
+        public Builder setDelegationTokenManager(DelegationTokenManager delegationTokenManager) {
+            this.delegationTokenManager = checkNotNull(delegationTokenManager);
             return this;
         }
 
@@ -189,7 +196,7 @@ public class TestingResourceManagerService implements ResourceManagerService {
                             rpcService,
                             haServices,
                             new TestingHeartbeatServices(),
-                            new NoOpDelegationTokenManager(),
+                            delegationTokenManager,
                             fatalErrorHandler,
                             new ClusterInformation("localhost", 1234),
                             null,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/utils/TestingResourceManagerGateway.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/utils/TestingResourceManagerGateway.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.tuple.Tuple3;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.blob.TransientBlobKey;
 import org.apache.flink.runtime.blocklist.BlockedNode;
 import org.apache.flink.runtime.clusterframework.ApplicationStatus;
@@ -274,6 +275,7 @@ public class TestingResourceManagerGateway implements ResourceManagerGateway {
             ResourceID jobMasterResourceId,
             String jobMasterAddress,
             JobID jobId,
+            Configuration jobConfiguration,
             Duration timeout) {
         final QuadFunction<
                         JobMasterId,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/security/token/DefaultDelegationTokenManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/security/token/DefaultDelegationTokenManagerTest.java
@@ -62,6 +62,7 @@ import static org.apache.flink.core.security.token.DelegationTokenProvider.CONFI
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -372,7 +373,7 @@ public class DefaultDelegationTokenManagerTest {
     }
 
     @Test
-    public void registerJobShouldRollBackAndRethrowWhenProviderThrows() throws Exception {
+    public void failedFirstRegistrationMustRethrowWithoutTouchingOtherJobs() throws Exception {
         Configuration configuration = new Configuration();
         DefaultDelegationTokenManager delegationTokenManager =
                 new DefaultDelegationTokenManager(configuration, null, null, null);
@@ -381,13 +382,19 @@ public class DefaultDelegationTokenManagerTest {
         delegationTokenManager.registerJob(jobId, new Configuration());
         assertEquals(1, ExceptionThrowingDelegationTokenProvider.registeredJobs.get().size());
 
-        // A provider that throws during registration must cause the job to be unregistered from
-        // all providers and the exception to be rethrown.
+        // A provider that throws during the FIRST registration of a job must cause that job to
+        // be unregistered from all providers and the exception to be rethrown, without touching
+        // other jobs' state. (A failed RE-registration keeps the previous registration instead,
+        // see failedReregistrationMustNotWipePreviousRegistration.)
         ExceptionThrowingDelegationTokenProvider.throwInRegister.set(true);
+        JobID otherJobId = JobID.generate();
         assertThrows(
                 IllegalArgumentException.class,
-                () -> delegationTokenManager.registerJob(jobId, new Configuration()));
-        assertEquals(0, ExceptionThrowingDelegationTokenProvider.registeredJobs.get().size());
+                () -> delegationTokenManager.registerJob(otherJobId, new Configuration()));
+        assertEquals(1, ExceptionThrowingDelegationTokenProvider.registeredJobs.get().size());
+        assertTrue(
+                ExceptionThrowingDelegationTokenProvider.registeredJobs.get().contains(jobId),
+                "A failed registration of another job must not affect this job's state");
     }
 
     @Test
@@ -870,6 +877,323 @@ public class DefaultDelegationTokenManagerTest {
         } finally {
             ioExecutor.shutdownNow();
         }
+    }
+
+    @Test
+    public void failedReregistrationMustNotWipePreviousRegistration() throws Exception {
+        DefaultDelegationTokenManager delegationTokenManager =
+                new DefaultDelegationTokenManager(new Configuration(), null, null, null);
+
+        // The job registers successfully when it starts...
+        JobID jobId = JobID.generate();
+        delegationTokenManager.registerJob(jobId, new Configuration());
+        assertEquals(1, ExceptionThrowingDelegationTokenProvider.registeredJobs.get().size());
+
+        // ...and later re-registers while still running (e.g. after a JobMaster<->RM heartbeat
+        // timeout). A transient provider failure during the re-registration must not roll back
+        // the per-job state the earlier successful registration established, or obtain cycles
+        // would broadcast token sets missing the running job until a registration retry
+        // succeeds.
+        ExceptionThrowingDelegationTokenProvider.throwInRegister.set(true);
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> delegationTokenManager.registerJob(jobId, new Configuration()));
+
+        assertEquals(
+                1,
+                ExceptionThrowingDelegationTokenProvider.registeredJobs.get().size(),
+                "A failed re-registration must keep the previous registration intact");
+    }
+
+    @Test
+    public void stopShouldUnregisterAllRegisteredJobs() throws Exception {
+        DefaultDelegationTokenManager delegationTokenManager =
+                new DefaultDelegationTokenManager(new Configuration(), null, null, null);
+
+        delegationTokenManager.registerJob(JobID.generate(), new Configuration());
+        delegationTokenManager.registerJob(JobID.generate(), new Configuration());
+        assertEquals(2, ExceptionThrowingDelegationTokenProvider.registeredJobs.get().size());
+
+        // stop() ends the manager's (leadership) session. Jobs still running re-register with
+        // the next session (registerJob is idempotent by contract), while jobs that reached a
+        // terminal state when no session was active never re-register, and their per-job provider
+        // state must be released here or it leaks for the process lifetime.
+        delegationTokenManager.stop();
+
+        assertEquals(
+                0,
+                ExceptionThrowingDelegationTokenProvider.registeredJobs.get().size(),
+                "stop() must release the per-job provider state of every registered job");
+    }
+
+    @Test
+    public void leftoverRollbackStateMustBeReleasedByStop() throws Exception {
+        DefaultDelegationTokenManager delegationTokenManager =
+                new DefaultDelegationTokenManager(new Configuration(), null, null, null);
+
+        // A FIRST registration fails after the provider recorded state (add-then-throw), and
+        // the rollback's unregister fails too: the state is left behind in the provider.
+        ExceptionThrowingDelegationTokenProvider.throwErrorInRegister.set(true);
+        ExceptionThrowingDelegationTokenProvider.throwInUnregister.set(true);
+        JobID jobId = JobID.generate();
+        assertThrows(
+                NoClassDefFoundError.class,
+                () -> delegationTokenManager.registerJob(jobId, new Configuration()));
+        assertEquals(1, ExceptionThrowingDelegationTokenProvider.registeredJobs.get().size());
+
+        // The job must have stayed tracked despite the failed rollback, so stop() releases the
+        // leftover state once the provider recovers.
+        ExceptionThrowingDelegationTokenProvider.throwErrorInRegister.set(false);
+        ExceptionThrowingDelegationTokenProvider.throwInUnregister.set(false);
+        delegationTokenManager.stop();
+        assertEquals(
+                0,
+                ExceptionThrowingDelegationTokenProvider.registeredJobs.get().size(),
+                "State left behind by a failed rollback must be released by stop()");
+    }
+
+    @Test
+    public void stopMustRetryFailedUnregistration() throws Exception {
+        DefaultDelegationTokenManager delegationTokenManager =
+                new DefaultDelegationTokenManager(new Configuration(), null, null, null);
+
+        JobID jobId = JobID.generate();
+        delegationTokenManager.registerJob(jobId, new Configuration());
+        assertEquals(1, ExceptionThrowingDelegationTokenProvider.registeredJobs.get().size());
+
+        // A provider fails its unregistration (swallowed by contract), so its per-job state
+        // survives. The manager must keep tracking the job instead of forgetting it.
+        ExceptionThrowingDelegationTokenProvider.throwInUnregister.set(true);
+        delegationTokenManager.unregisterJob(jobId);
+        assertEquals(1, ExceptionThrowingDelegationTokenProvider.registeredJobs.get().size());
+
+        // Once the provider recovers, stop() gets another attempt, without the retry
+        // the job's state would leak in the process-lifetime provider until process shutdown.
+        ExceptionThrowingDelegationTokenProvider.throwInUnregister.set(false);
+        delegationTokenManager.stop();
+        assertEquals(
+                0,
+                ExceptionThrowingDelegationTokenProvider.registeredJobs.get().size(),
+                "A job whose unregistration failed must be released by stop()");
+    }
+
+    @Test
+    public void cooldownMustSpaceObtainCycleExecutionsNotRequests() throws Exception {
+        final ManuallyTriggeredScheduledExecutor scheduledExecutor =
+                new ManuallyTriggeredScheduledExecutor();
+        final ManuallyTriggeredScheduledExecutorService scheduler =
+                new ManuallyTriggeredScheduledExecutorService();
+
+        DefaultDelegationTokenManager delegationTokenManager =
+                new DefaultDelegationTokenManager(
+                        hermeticCooldownConfig(Duration.ofMillis(60_000)),
+                        null,
+                        scheduledExecutor,
+                        scheduler);
+
+        long t0 = 1_000_000L;
+        delegationTokenManager.setClock(Clock.fixed(ofEpochMilli(t0), ZoneId.systemDefault()));
+        delegationTokenManager.start(tokens -> {});
+
+        // The first request runs immediately.
+        delegationTokenManager.reobtainDelegationTokens();
+        assertEquals(0L, onlyScheduledDelayMillis(scheduledExecutor));
+        scheduledExecutor.triggerScheduledTasks();
+        scheduler.triggerAll();
+
+        // A request at t0+1s is deferred by 59s: its obtain cycle runs at t0+60s.
+        delegationTokenManager.setClock(
+                Clock.fixed(ofEpochMilli(t0 + 1_000L), ZoneId.systemDefault()));
+        delegationTokenManager.reobtainDelegationTokens();
+        assertEquals(59_000L, onlyScheduledDelayMillis(scheduledExecutor));
+        delegationTokenManager.setClock(
+                Clock.fixed(ofEpochMilli(t0 + 60_000L), ZoneId.systemDefault()));
+        scheduledExecutor.triggerScheduledTasks();
+        scheduler.triggerAll();
+
+        // The option documents a minimum time between two consecutive on-demand obtain CYCLES,
+        // so a request arriving just after the deferred cycle ran must be deferred by a full
+        // cooldown measured from that cycle's execution, not run (almost) immediately because
+        // the previous REQUEST arrived one cooldown ago.
+        delegationTokenManager.setClock(
+                Clock.fixed(ofEpochMilli(t0 + 61_000L), ZoneId.systemDefault()));
+        delegationTokenManager.reobtainDelegationTokens();
+        assertEquals(
+                59_000L,
+                onlyScheduledDelayMillis(scheduledExecutor),
+                "The cooldown must space obtain cycle executions, not requests");
+    }
+
+    @Test
+    public void broughtForwardReobtainMustMoveCooldownAnchor() throws Exception {
+        final ManuallyTriggeredScheduledExecutor scheduledExecutor =
+                new ManuallyTriggeredScheduledExecutor();
+        final ManuallyTriggeredScheduledExecutorService scheduler =
+                new ManuallyTriggeredScheduledExecutorService();
+
+        DefaultDelegationTokenManager delegationTokenManager =
+                new DefaultDelegationTokenManager(
+                        hermeticCooldownConfig(Duration.ofMillis(60_000)),
+                        null,
+                        scheduledExecutor,
+                        scheduler);
+
+        long t0 = 1_000_000L;
+        delegationTokenManager.setClock(Clock.fixed(ofEpochMilli(t0), ZoneId.systemDefault()));
+        delegationTokenManager.start(tokens -> {});
+
+        delegationTokenManager.reobtainDelegationTokens();
+        scheduledExecutor.triggerScheduledTasks();
+        scheduler.triggerAll();
+
+        // 10s later a second request is cooldown-deferred by 50s (would run at t0+60s).
+        delegationTokenManager.setClock(
+                Clock.fixed(ofEpochMilli(t0 + 10_000L), ZoneId.systemDefault()));
+        delegationTokenManager.reobtainDelegationTokens();
+        assertEquals(50_000L, onlyScheduledDelayMillis(scheduledExecutor));
+
+        // A completed cycle (renewal or failure retry) brings the pending on-demand cycle
+        // forward to +5s, so the coalesced cycle actually executes at t0+15s.
+        delegationTokenManager.maybeScheduleRenewal(5_000L);
+        assertEquals(5_000L, onlyScheduledDelayMillis(scheduledExecutor));
+        delegationTokenManager.setClock(
+                Clock.fixed(ofEpochMilli(t0 + 15_000L), ZoneId.systemDefault()));
+        scheduledExecutor.triggerScheduledTasks();
+        scheduler.triggerAll();
+
+        // The next request must measure its cooldown from the brought-forward execution
+        // (t0+15s), not from the originally scheduled t0+60s. Otherwise it would defer
+        // beyond a full cooldown (104s here instead of 59s).
+        delegationTokenManager.setClock(
+                Clock.fixed(ofEpochMilli(t0 + 16_000L), ZoneId.systemDefault()));
+        delegationTokenManager.reobtainDelegationTokens();
+        assertEquals(
+                59_000L,
+                onlyScheduledDelayMillis(scheduledExecutor),
+                "The cooldown anchor must follow a brought-forward on-demand cycle");
+    }
+
+    @Test
+    public void startAfterStopMustResetRetryState() throws Exception {
+        final ManuallyTriggeredScheduledExecutor scheduledExecutor =
+                new ManuallyTriggeredScheduledExecutor();
+        final ManuallyTriggeredScheduledExecutorService scheduler =
+                new ManuallyTriggeredScheduledExecutorService();
+
+        Configuration configuration = hermeticCooldownConfig(Duration.ofMillis(60_000));
+        configuration.set(DELEGATION_TOKENS_RENEWAL_RETRY_INITIAL_BACKOFF, Duration.ofSeconds(1));
+        configuration.set(DELEGATION_TOKENS_RENEWAL_RETRY_MAX_BACKOFF, Duration.ofSeconds(64));
+        DefaultDelegationTokenManager delegationTokenManager =
+                new DefaultDelegationTokenManager(
+                        configuration, null, scheduledExecutor, scheduler);
+
+        delegationTokenManager.start(tokens -> {});
+        // The session escalates the retry state through repeated obtain failures.
+        delegationTokenManager.currentRetryBackoff = Duration.ofSeconds(64).toMillis();
+        delegationTokenManager.lastKnownNextRenewal = 123L;
+
+        // The manager instance is reused across leadership sessions: the next session must
+        // start from the configured initial backoff instead of inheriting the previous
+        // session's increased one (which would delay token recovery by up to the max backoff).
+        delegationTokenManager.stop();
+        delegationTokenManager.start(tokens -> {});
+
+        assertEquals(
+                Duration.ofSeconds(1).toMillis(),
+                delegationTokenManager.currentRetryBackoff,
+                "A new session must start from the initial retry backoff");
+        assertEquals(
+                Long.MAX_VALUE,
+                delegationTokenManager.lastKnownNextRenewal,
+                "A new session must not inherit the previous session's renewal deadline");
+    }
+
+    @Test
+    public void inFlightCycleMustNotNotifyListenerAfterStop() throws Exception {
+        final ManuallyTriggeredScheduledExecutor scheduledExecutor =
+                new ManuallyTriggeredScheduledExecutor();
+        final ManuallyTriggeredScheduledExecutorService scheduler =
+                new ManuallyTriggeredScheduledExecutorService();
+
+        // The "throw" provider stays enabled so its RECEIVER is loaded: the token added below
+        // must have a live receiver, or a regression that removes the broadcast gate would hide
+        // behind the missing-receiver IllegalStateException (swallowed by the cycle's catch) and
+        // this test would pass vacuously. The overridden obtain below bypasses the providers, so
+        // the throw provider itself never runs.
+        Configuration configuration = new Configuration();
+        configuration.set(getBooleanConfigOption(CONFIG_PREFIX + ".hadoopfs.enabled"), false);
+        configuration.set(getBooleanConfigOption(CONFIG_PREFIX + ".hbase.enabled"), false);
+
+        final CountDownLatch cycleInObtain = new CountDownLatch(1);
+        final CountDownLatch resumeObtain = new CountDownLatch(1);
+        DefaultDelegationTokenManager delegationTokenManager =
+                new DefaultDelegationTokenManager(
+                        configuration, null, scheduledExecutor, scheduler) {
+                    @Override
+                    protected Optional<Long> obtainDelegationTokensAndGetNextRenewal(
+                            DelegationTokenContainer container) {
+                        // Produce a token so the broadcast path is reached, then park until the
+                        // test has run stop(), simulating slow provider I/O overlapping shutdown.
+                        container.addToken("throw", new byte[] {1});
+                        cycleInObtain.countDown();
+                        try {
+                            resumeObtain.await(10, TimeUnit.SECONDS);
+                        } catch (InterruptedException e) {
+                            Thread.currentThread().interrupt();
+                        }
+                        return Optional.empty();
+                    }
+                };
+
+        AtomicInteger listenerNotifications = new AtomicInteger(0);
+        // start() runs the first obtain cycle inline, so it parks in the obtain above.
+        Thread starter =
+                new Thread(
+                        () -> {
+                            try {
+                                delegationTokenManager.start(
+                                        tokens -> listenerNotifications.incrementAndGet());
+                            } catch (Exception e) {
+                                throw new RuntimeException(e);
+                            }
+                        });
+        starter.start();
+        assertTrue(cycleInObtain.await(10, TimeUnit.SECONDS));
+
+        // stop() does not wait for the in-flight cycle. Once that cycle resumes it must notice
+        // the manager stopped: the stopped session's listener must not be notified, and the
+        // manager must not keep referencing it (it is the disposed ResourceManager).
+        delegationTokenManager.stop();
+        resumeObtain.countDown();
+        starter.join(10_000L);
+        assertFalse(starter.isAlive());
+
+        assertEquals(
+                0,
+                listenerNotifications.get(),
+                "An obtain cycle finishing after stop() must not notify the stopped session's"
+                        + " listener");
+        assertNull(delegationTokenManager.listener, "stop() must release the listener reference");
+    }
+
+    @Test
+    public void registerJobMustNotExposeCallersConfigurationToProviders() throws Exception {
+        DefaultDelegationTokenManager delegationTokenManager =
+                new DefaultDelegationTokenManager(new Configuration(), null, null, null);
+
+        // The caller's configuration object is the live job configuration (the ExecutionPlan's),
+        // which reaches the manager by reference over local RPC. Providers are plugin code and
+        // must receive a copy: a provider mutating it must not corrupt the runtime's state.
+        ExceptionThrowingDelegationTokenProvider.mutateJobConfiguration.set(true);
+        Configuration callerConfiguration = new Configuration();
+        JobID jobId = JobID.generate();
+        delegationTokenManager.registerJob(jobId, callerConfiguration);
+
+        assertTrue(ExceptionThrowingDelegationTokenProvider.registeredJobs.get().contains(jobId));
+        assertFalse(
+                callerConfiguration.containsKey(
+                        ExceptionThrowingDelegationTokenProvider.MUTATED_KEY),
+                "A provider-side mutation must not be visible in the caller's configuration");
     }
 
     /**

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/security/token/DefaultDelegationTokenManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/security/token/DefaultDelegationTokenManagerTest.java
@@ -24,6 +24,7 @@ import org.apache.flink.core.security.token.DelegationTokenProvider;
 import org.apache.flink.core.security.token.DelegationTokenReceiver;
 import org.apache.flink.core.testutils.ManuallyTriggeredScheduledExecutorService;
 import org.apache.flink.util.concurrent.ManuallyTriggeredScheduledExecutor;
+import org.apache.flink.util.concurrent.ScheduledExecutor;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -40,6 +41,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.BrokenBarrierException;
+import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.ExecutorService;
@@ -205,7 +207,7 @@ public class DefaultDelegationTokenManagerTest {
     }
 
     @Test
-    public void startTokensUpdateShouldScheduleRenewal() {
+    public void startTokensUpdateShouldScheduleRenewal() throws Exception {
         final ManuallyTriggeredScheduledExecutor scheduledExecutor =
                 new ManuallyTriggeredScheduledExecutor();
         final ManuallyTriggeredScheduledExecutorService scheduler =
@@ -214,6 +216,8 @@ public class DefaultDelegationTokenManagerTest {
         ExceptionThrowingDelegationTokenProvider.addToken.set(true);
         Configuration configuration = new Configuration();
         configuration.set(getBooleanConfigOption(CONFIG_PREFIX + ".throw.enabled"), true);
+        configuration.set(getBooleanConfigOption(CONFIG_PREFIX + ".hadoopfs.enabled"), false);
+        configuration.set(getBooleanConfigOption(CONFIG_PREFIX + ".hbase.enabled"), false);
         AtomicInteger startTokensUpdateCallCount = new AtomicInteger(0);
         DefaultDelegationTokenManager delegationTokenManager =
                 new DefaultDelegationTokenManager(
@@ -225,8 +229,9 @@ public class DefaultDelegationTokenManagerTest {
                     }
                 };
 
-        delegationTokenManager.startTokensUpdate();
+        // The first two cycles fail and schedule a retry each. The third succeeds.
         ExceptionThrowingDelegationTokenProvider.throwInUsage.set(true);
+        delegationTokenManager.start(tokens -> {});
         scheduledExecutor.triggerScheduledTasks();
         scheduler.triggerAll();
         ExceptionThrowingDelegationTokenProvider.throwInUsage.set(false);
@@ -324,6 +329,8 @@ public class DefaultDelegationTokenManagerTest {
 
         Configuration configuration = new Configuration();
         configuration.set(getBooleanConfigOption(CONFIG_PREFIX + ".throw.enabled"), true);
+        configuration.set(getBooleanConfigOption(CONFIG_PREFIX + ".hadoopfs.enabled"), false);
+        configuration.set(getBooleanConfigOption(CONFIG_PREFIX + ".hbase.enabled"), false);
         AtomicInteger startTokensUpdateCallCount = new AtomicInteger(0);
         DefaultDelegationTokenManager delegationTokenManager =
                 new DefaultDelegationTokenManager(
@@ -336,6 +343,10 @@ public class DefaultDelegationTokenManagerTest {
                 };
         // Ask the provider to request an immediate refresh when the job is registered.
         ExceptionThrowingDelegationTokenProvider.shouldReobtainOnRegister.set(true);
+
+        delegationTokenManager.start(tokens -> {});
+        // Only count the cycle triggered by the registration below, not start()'s inline cycle.
+        startTokensUpdateCallCount.set(0);
 
         JobID jobId = JobID.generate();
         delegationTokenManager.registerJob(jobId, new Configuration());
@@ -394,7 +405,7 @@ public class DefaultDelegationTokenManagerTest {
     }
 
     @Test
-    public void reobtainShouldCoalesceConcurrentRequests() {
+    public void reobtainShouldCoalesceConcurrentRequests() throws Exception {
         final ManuallyTriggeredScheduledExecutor scheduledExecutor =
                 new ManuallyTriggeredScheduledExecutor();
         final ManuallyTriggeredScheduledExecutorService scheduler =
@@ -403,13 +414,19 @@ public class DefaultDelegationTokenManagerTest {
         AtomicInteger startTokensUpdateCallCount = new AtomicInteger(0);
         DefaultDelegationTokenManager delegationTokenManager =
                 new DefaultDelegationTokenManager(
-                        new Configuration(), null, scheduledExecutor, scheduler) {
+                        hermeticCooldownConfig(Duration.ofMillis(60_000)),
+                        null,
+                        scheduledExecutor,
+                        scheduler) {
                     @Override
                     void startTokensUpdate() {
                         startTokensUpdateCallCount.incrementAndGet();
                         super.startTokensUpdate();
                     }
                 };
+        delegationTokenManager.start(tokens -> {});
+        // Only count the cycle serving the coalesced requests, not start()'s inline cycle.
+        startTokensUpdateCallCount.set(0);
 
         // Two requests before the cycle runs must be coalesced into a single scheduled obtain.
         delegationTokenManager.reobtainDelegationTokens();
@@ -426,7 +443,7 @@ public class DefaultDelegationTokenManagerTest {
     }
 
     @Test
-    public void periodicRenewalMustNotCancelPendingOnDemandReobtain() {
+    public void periodicRenewalMustNotCancelPendingOnDemandReobtain() throws Exception {
         final ManuallyTriggeredScheduledExecutor scheduledExecutor =
                 new ManuallyTriggeredScheduledExecutor();
         final ManuallyTriggeredScheduledExecutorService scheduler =
@@ -434,7 +451,11 @@ public class DefaultDelegationTokenManagerTest {
 
         DefaultDelegationTokenManager delegationTokenManager =
                 new DefaultDelegationTokenManager(
-                        new Configuration(), null, scheduledExecutor, scheduler);
+                        hermeticCooldownConfig(Duration.ofMillis(60_000)),
+                        null,
+                        scheduledExecutor,
+                        scheduler);
+        delegationTokenManager.start(tokens -> {});
 
         // An on-demand re-obtain is scheduled (e.g. a freshly registered job).
         delegationTokenManager.reobtainDelegationTokens();
@@ -460,7 +481,7 @@ public class DefaultDelegationTokenManagerTest {
     }
 
     @Test
-    public void reobtainShouldRunImmediatelyAfterCooldownWindowElapses() {
+    public void reobtainShouldRunImmediatelyAfterCooldownWindowElapses() throws Exception {
         final ManuallyTriggeredScheduledExecutor scheduledExecutor =
                 new ManuallyTriggeredScheduledExecutor();
         final ManuallyTriggeredScheduledExecutorService scheduler =
@@ -473,6 +494,7 @@ public class DefaultDelegationTokenManagerTest {
 
         long t0 = 1_000_000L;
         delegationTokenManager.setClock(Clock.fixed(ofEpochMilli(t0), ZoneId.systemDefault()));
+        delegationTokenManager.start(tokens -> {});
         delegationTokenManager.reobtainDelegationTokens();
         assertEquals(0L, onlyScheduledDelayMillis(scheduledExecutor));
         scheduledExecutor.triggerScheduledTasks();
@@ -499,6 +521,7 @@ public class DefaultDelegationTokenManagerTest {
 
         long t0 = 1_000_000L;
         delegationTokenManager.setClock(Clock.fixed(ofEpochMilli(t0), ZoneId.systemDefault()));
+        delegationTokenManager.start(tokens -> {});
         delegationTokenManager.reobtainDelegationTokens();
         assertEquals(0L, onlyScheduledDelayMillis(scheduledExecutor));
         scheduledExecutor.triggerScheduledTasks();
@@ -521,7 +544,7 @@ public class DefaultDelegationTokenManagerTest {
     }
 
     @Test
-    public void reobtainShouldRespectCooldown() {
+    public void reobtainShouldRespectCooldown() throws Exception {
         final ManuallyTriggeredScheduledExecutor scheduledExecutor =
                 new ManuallyTriggeredScheduledExecutor();
         final ManuallyTriggeredScheduledExecutorService scheduler =
@@ -534,6 +557,8 @@ public class DefaultDelegationTokenManagerTest {
 
         long t0 = 1_000_000L;
         delegationTokenManager.setClock(Clock.fixed(ofEpochMilli(t0), ZoneId.systemDefault()));
+
+        delegationTokenManager.start(tokens -> {});
 
         // First re-obtain after a quiet period runs immediately (no cooldown applies).
         delegationTokenManager.reobtainDelegationTokens();
@@ -556,6 +581,188 @@ public class DefaultDelegationTokenManagerTest {
                 new DefaultDelegationTokenManager(new Configuration(), null, null, null);
 
         assertDoesNotThrow(delegationTokenManager::reobtainDelegationTokens);
+    }
+
+    @Test
+    public void reobtainBeforeStartMustNotScheduleObtainCycle() {
+        final ManuallyTriggeredScheduledExecutor scheduledExecutor =
+                new ManuallyTriggeredScheduledExecutor();
+        final ManuallyTriggeredScheduledExecutorService scheduler =
+                new ManuallyTriggeredScheduledExecutorService();
+
+        DefaultDelegationTokenManager delegationTokenManager =
+                new DefaultDelegationTokenManager(
+                        hermeticCooldownConfig(Duration.ofMillis(60_000)),
+                        null,
+                        scheduledExecutor,
+                        scheduler);
+
+        // Providers receive the re-obtain callback already in the constructor (init), so a
+        // provider can invoke it before start(). The manager has no listener yet, so the
+        // request must be rejected instead of dispatching an obtain cycle that can only fail
+        // on the null listener and keep rescheduling itself through the retry path.
+        delegationTokenManager.reobtainDelegationTokens();
+
+        assertEquals(
+                0,
+                scheduledExecutor.getActiveScheduledTasks().size(),
+                "A re-obtain before start() must not schedule an obtain cycle");
+    }
+
+    @Test
+    public void schedulerFailureMustNotWedgeSubsequentReobtains() throws Exception {
+        final ManuallyTriggeredScheduledExecutor delegate =
+                new ManuallyTriggeredScheduledExecutor();
+        final ManuallyTriggeredScheduledExecutorService scheduler =
+                new ManuallyTriggeredScheduledExecutorService();
+
+        // Throws a plain RuntimeException (not a RejectedExecutionException) on the next
+        // schedule() call when the flag is set, then behaves normally again.
+        final AtomicBoolean throwNext = new AtomicBoolean(false);
+        ScheduledExecutor throwOnce =
+                new ScheduledExecutor() {
+                    @Override
+                    public ScheduledFuture<?> schedule(
+                            Runnable command, long delay, TimeUnit unit) {
+                        if (throwNext.compareAndSet(true, false)) {
+                            throw new RuntimeException("simulated scheduler failure");
+                        }
+                        return delegate.schedule(command, delay, unit);
+                    }
+
+                    @Override
+                    public <V> ScheduledFuture<V> schedule(
+                            Callable<V> callable, long delay, TimeUnit unit) {
+                        return delegate.schedule(callable, delay, unit);
+                    }
+
+                    @Override
+                    public ScheduledFuture<?> scheduleAtFixedRate(
+                            Runnable command, long initialDelay, long period, TimeUnit unit) {
+                        return delegate.scheduleAtFixedRate(command, initialDelay, period, unit);
+                    }
+
+                    @Override
+                    public ScheduledFuture<?> scheduleWithFixedDelay(
+                            Runnable command, long initialDelay, long delay, TimeUnit unit) {
+                        return delegate.scheduleWithFixedDelay(command, initialDelay, delay, unit);
+                    }
+
+                    @Override
+                    public void execute(Runnable command) {
+                        delegate.execute(command);
+                    }
+                };
+
+        DefaultDelegationTokenManager delegationTokenManager =
+                new DefaultDelegationTokenManager(
+                        hermeticCooldownConfig(Duration.ZERO), null, throwOnce, scheduler);
+        delegationTokenManager.start(tokens -> {});
+
+        // The first re-obtain hits a scheduler that blows up with something other than the
+        // handled RejectedExecutionException. The failure propagates to the caller.
+        throwNext.set(true);
+        assertThrows(RuntimeException.class, delegationTokenManager::reobtainDelegationTokens);
+
+        // The scheduler is healthy again. The next re-obtain must schedule a fresh obtain
+        // cycle instead of being coalesced against the cycle that never got scheduled.
+        delegationTokenManager.reobtainDelegationTokens();
+        assertEquals(
+                1,
+                delegate.getActiveScheduledTasks().size(),
+                "A re-obtain after a scheduler failure must schedule a fresh obtain cycle");
+    }
+
+    @Test
+    public void startShouldBeIdempotent() throws Exception {
+        final ManuallyTriggeredScheduledExecutor scheduledExecutor =
+                new ManuallyTriggeredScheduledExecutor();
+        final ManuallyTriggeredScheduledExecutorService scheduler =
+                new ManuallyTriggeredScheduledExecutorService();
+
+        // The throw provider produces tokens so the listener gets notified on every cycle.
+        ExceptionThrowingDelegationTokenProvider.addToken.set(true);
+        Configuration configuration = new Configuration();
+        configuration.set(getBooleanConfigOption(CONFIG_PREFIX + ".throw.enabled"), true);
+        configuration.set(getBooleanConfigOption(CONFIG_PREFIX + ".hadoopfs.enabled"), false);
+        configuration.set(getBooleanConfigOption(CONFIG_PREFIX + ".hbase.enabled"), false);
+
+        AtomicInteger startTokensUpdateCallCount = new AtomicInteger(0);
+        DefaultDelegationTokenManager delegationTokenManager =
+                new DefaultDelegationTokenManager(
+                        configuration, null, scheduledExecutor, scheduler) {
+                    @Override
+                    void startTokensUpdate() {
+                        startTokensUpdateCallCount.incrementAndGet();
+                        super.startTokensUpdate();
+                    }
+                };
+
+        AtomicInteger firstListenerNotifications = new AtomicInteger(0);
+        AtomicInteger secondListenerNotifications = new AtomicInteger(0);
+        delegationTokenManager.start(tokens -> firstListenerNotifications.incrementAndGet());
+        // A redundant start() (e.g. a buggy caller) must be ignored: no second inline obtain
+        // cycle, and the listener of the running manager must not be swapped.
+        delegationTokenManager.start(tokens -> secondListenerNotifications.incrementAndGet());
+
+        assertEquals(
+                1,
+                startTokensUpdateCallCount.get(),
+                "A redundant start() must not run another obtain cycle");
+        assertEquals(
+                1,
+                firstListenerNotifications.get(),
+                "The first start()'s inline cycle must notify the listener once");
+
+        // A later cycle must still notify the original listener, not the ignored one.
+        delegationTokenManager.reobtainDelegationTokens();
+        scheduledExecutor.triggerScheduledTasks();
+        scheduler.triggerAll();
+        assertEquals(
+                2,
+                firstListenerNotifications.get(),
+                "The original listener must keep receiving tokens");
+        assertEquals(
+                0,
+                secondListenerNotifications.get(),
+                "The listener from the ignored start() must never receive tokens");
+    }
+
+    @Test
+    public void retryMustBringPendingOnDemandReobtainForward() throws Exception {
+        final ManuallyTriggeredScheduledExecutor scheduledExecutor =
+                new ManuallyTriggeredScheduledExecutor();
+        final ManuallyTriggeredScheduledExecutorService scheduler =
+                new ManuallyTriggeredScheduledExecutorService();
+
+        Configuration configuration = hermeticCooldownConfig(Duration.ofMillis(60_000));
+        DefaultDelegationTokenManager delegationTokenManager =
+                new DefaultDelegationTokenManager(
+                        configuration, null, scheduledExecutor, scheduler);
+
+        long t0 = 1_000_000L;
+        delegationTokenManager.setClock(Clock.fixed(ofEpochMilli(t0), ZoneId.systemDefault()));
+        delegationTokenManager.start(tokens -> {});
+
+        delegationTokenManager.reobtainDelegationTokens();
+        scheduledExecutor.triggerScheduledTasks();
+        scheduler.triggerAll();
+
+        // 10s later a second re-obtain is cooldown-deferred by 50s.
+        delegationTokenManager.setClock(
+                Clock.fixed(ofEpochMilli(t0 + 10_000L), ZoneId.systemDefault()));
+        delegationTokenManager.reobtainDelegationTokens();
+        assertEquals(50_000L, onlyScheduledDelayMillis(scheduledExecutor));
+
+        // A failed cycle now wants a retry in 10s. The pending on-demand cycle must be brought
+        // forward to the sooner time instead of silently swallowing the retry, otherwise the
+        // effective retry would fire 50s out while the backoff (and its token-TTL cap) asked
+        // for 10s.
+        delegationTokenManager.maybeScheduleRenewal(10_000L);
+        assertEquals(
+                10_000L,
+                onlyScheduledDelayMillis(scheduledExecutor),
+                "A sooner retry must bring the pending on-demand cycle forward");
     }
 
     @Test
@@ -583,6 +790,9 @@ public class DefaultDelegationTokenManagerTest {
             final CyclicBarrier barrier = new CyclicBarrier(2);
             final AtomicBoolean concurrentObtainDetected = new AtomicBoolean(false);
             final CountDownLatch done = new CountDownLatch(2);
+            // Enabled only after start(): its inline first cycle must not wait at (and, by
+            // timing out, break) the barrier meant for the two concurrent cycles below.
+            final AtomicBoolean barrierEnabled = new AtomicBoolean(false);
 
             DefaultDelegationTokenManager delegationTokenManager =
                     new DefaultDelegationTokenManager(
@@ -590,6 +800,9 @@ public class DefaultDelegationTokenManagerTest {
                         @Override
                         protected Optional<Long> obtainDelegationTokensAndGetNextRenewal(
                                 DelegationTokenContainer container) {
+                            if (!barrierEnabled.get()) {
+                                return Optional.empty();
+                            }
                             try {
                                 barrier.await(200, TimeUnit.MILLISECONDS);
                                 // Reached only if both cycles met here concurrently.
@@ -602,6 +815,9 @@ public class DefaultDelegationTokenManagerTest {
                             return Optional.empty();
                         }
                     };
+
+            delegationTokenManager.start(tokens -> {});
+            barrierEnabled.set(true);
 
             ioExecutor.execute(
                     () -> {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/security/token/DefaultDelegationTokenManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/security/token/DefaultDelegationTokenManagerTest.java
@@ -23,6 +23,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.security.token.DelegationTokenProvider;
 import org.apache.flink.core.security.token.DelegationTokenReceiver;
 import org.apache.flink.core.testutils.ManuallyTriggeredScheduledExecutorService;
+import org.apache.flink.util.clock.Clock;
 import org.apache.flink.util.clock.ManualClock;
 import org.apache.flink.util.concurrent.ManuallyTriggeredScheduledExecutor;
 import org.apache.flink.util.concurrent.ScheduledExecutor;
@@ -50,6 +51,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.apache.flink.configuration.ConfigurationUtils.getBooleanConfigOption;
 import static org.apache.flink.configuration.SecurityOptions.DELEGATION_TOKENS_RENEWAL_RETRY_INITIAL_BACKOFF;
@@ -1231,6 +1234,159 @@ public class DefaultDelegationTokenManagerTest {
     }
 
     @Test
+    public void inFlightCycleMustNotDeliverIntoTheNextSession() throws Exception {
+        final ManuallyTriggeredScheduledExecutor scheduledExecutor =
+                new ManuallyTriggeredScheduledExecutor();
+        final ManuallyTriggeredScheduledExecutorService scheduler =
+                new ManuallyTriggeredScheduledExecutorService();
+
+        // Same setup rationale as inFlightCycleMustNotNotifyListenerAfterStop: keep the "throw"
+        // receiver loaded so the broadcast path is real. Unlike there, only the first obtain
+        // parks (the old session's inline cycle). The new session's first cycle must run
+        // through.
+        Configuration configuration = new Configuration();
+        configuration.set(getBooleanConfigOption(CONFIG_PREFIX + ".hadoopfs.enabled"), false);
+        configuration.set(getBooleanConfigOption(CONFIG_PREFIX + ".hbase.enabled"), false);
+
+        final CountDownLatch cycleInObtain = new CountDownLatch(1);
+        final CountDownLatch resumeObtain = new CountDownLatch(1);
+        final AtomicBoolean parkNextObtain = new AtomicBoolean(true);
+        DefaultDelegationTokenManager delegationTokenManager =
+                new DefaultDelegationTokenManager(
+                        configuration, null, scheduledExecutor, scheduler) {
+                    @Override
+                    protected Optional<Long> obtainDelegationTokensAndGetNextRenewal(
+                            DelegationTokenContainer container) {
+                        container.addToken("throw", new byte[] {1});
+                        if (parkNextObtain.compareAndSet(true, false)) {
+                            cycleInObtain.countDown();
+                            try {
+                                // Longer than the readiness-poll deadline below, so A cannot
+                                // resume on its own while the test is still waiting for B.
+                                resumeObtain.await(30, TimeUnit.SECONDS);
+                            } catch (InterruptedException e) {
+                                Thread.currentThread().interrupt();
+                            }
+                        }
+                        return Optional.empty();
+                    }
+                };
+
+        AtomicReference<Throwable> starterFailure = new AtomicReference<>();
+        AtomicInteger sessionANotifications = new AtomicInteger(0);
+        Thread starterA =
+                new Thread(
+                        () -> {
+                            try {
+                                delegationTokenManager.start(
+                                        tokens -> sessionANotifications.incrementAndGet());
+                            } catch (Throwable t) {
+                                starterFailure.compareAndSet(null, t);
+                            }
+                        });
+        starterA.start();
+        assertTrue(cycleInObtain.await(10, TimeUnit.SECONDS));
+
+        // Leadership changes while A's cycle is parked in the obtain: stop() ends session A and
+        // the next session starts before the cycle resumes. start(B) publishes B's listener
+        // under tokensUpdateFutureLock and then blocks on obtainLock behind A's cycle, so the
+        // resuming cycle observes running == true and B's listener.
+        delegationTokenManager.stop();
+        AtomicInteger sessionBNotifications = new AtomicInteger(0);
+        Thread starterB =
+                new Thread(
+                        () -> {
+                            try {
+                                delegationTokenManager.start(
+                                        tokens -> sessionBNotifications.incrementAndGet());
+                            } catch (Throwable t) {
+                                starterFailure.compareAndSet(null, t);
+                            }
+                        });
+        starterB.start();
+        // Wait until start(B) is parked on obtainLock behind A's cycle. B publishes its
+        // listener under the manager's lock strictly before it can block there, so a durable
+        // BLOCKED state implies the listener is in place without reading the lock-guarded
+        // field unsynchronized. This gates when to resume A's parked cycle, so A's re-check
+        // exercises the epoch fence, not the running flag.
+        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(10);
+        while (starterB.getState() != Thread.State.BLOCKED && System.nanoTime() < deadline) {
+            Thread.sleep(1);
+        }
+        assertEquals(Thread.State.BLOCKED, starterB.getState());
+
+        resumeObtain.countDown();
+        starterA.join(10_000L);
+        starterB.join(10_000L);
+        assertFalse(starterA.isAlive());
+        assertFalse(starterB.isAlive());
+        if (starterFailure.get() != null) {
+            throw new AssertionError("start() failed in a session thread", starterFailure.get());
+        }
+
+        assertEquals(
+                0,
+                sessionANotifications.get(),
+                "Session A's listener was released by stop() and must not be notified");
+        assertEquals(
+                1,
+                sessionBNotifications.get(),
+                "A cycle that began under an earlier session must not deliver into the next"
+                        + " session: only the next session's own first cycle may notify it");
+    }
+
+    @Test
+    public void cooldownMustBeImmuneToWallClockJumps() throws Exception {
+        final ManuallyTriggeredScheduledExecutor scheduledExecutor =
+                new ManuallyTriggeredScheduledExecutor();
+        final ManuallyTriggeredScheduledExecutorService scheduler =
+                new ManuallyTriggeredScheduledExecutorService();
+
+        JumpableClock clock = new JumpableClock(1_000_000L);
+        DefaultDelegationTokenManager delegationTokenManager =
+                new DefaultDelegationTokenManager(
+                        hermeticCooldownConfig(Duration.ofMillis(60_000)),
+                        null,
+                        scheduledExecutor,
+                        scheduler,
+                        clock);
+
+        delegationTokenManager.start(tokens -> {});
+        delegationTokenManager.reobtainDelegationTokens();
+        assertEquals(0L, onlyScheduledDelayMillis(scheduledExecutor));
+        scheduledExecutor.triggerScheduledTasks();
+        scheduler.triggerAll();
+
+        // 10s of real time pass, then NTP steps the wall clock back by an hour. The cooldown is
+        // a process-local interval, so the next request must still be deferred by the remaining
+        // 50s, not by the wall-clock difference.
+        clock.advance(Duration.ofSeconds(10));
+        clock.jumpWallClock(Duration.ofHours(-1));
+        delegationTokenManager.reobtainDelegationTokens();
+        assertEquals(
+                50_000L,
+                onlyScheduledDelayMillis(scheduledExecutor),
+                "The cooldown must be computed on monotonic time: a wall-clock rollback must"
+                        + " not extend it");
+
+        // Let the deferred cycle run at its due time (the anchor sits at its execution time).
+        clock.advance(Duration.ofSeconds(50));
+        scheduledExecutor.triggerScheduledTasks();
+        scheduler.triggerAll();
+
+        // 10s later the wall clock jumps two hours forward. Under wall-clock math that would
+        // zero the remaining cooldown. The monotonic cooldown must still defer by 50s.
+        clock.advance(Duration.ofSeconds(10));
+        clock.jumpWallClock(Duration.ofHours(2));
+        delegationTokenManager.reobtainDelegationTokens();
+        assertEquals(
+                50_000L,
+                onlyScheduledDelayMillis(scheduledExecutor),
+                "The cooldown must be computed on monotonic time: a wall-clock jump forward"
+                        + " must not bypass it");
+    }
+
+    @Test
     public void registerJobMustNotExposeCallersConfigurationToProviders() throws Exception {
         DefaultDelegationTokenManager delegationTokenManager =
                 new DefaultDelegationTokenManager(new Configuration(), null, null, null);
@@ -1271,5 +1427,44 @@ public class DefaultDelegationTokenManagerTest {
         Collection<ScheduledFuture<?>> tasks = scheduledExecutor.getActiveScheduledTasks();
         assertEquals(1, tasks.size());
         return tasks.iterator().next().getDelay(TimeUnit.MILLISECONDS);
+    }
+
+    /**
+     * A clock whose absolute (wall) time can jump independently of its relative (monotonic) time,
+     * simulating an NTP step or a manual clock adjustment. {@link ManualClock} cannot express this:
+     * it drives both flavors from one counter.
+     */
+    private static final class JumpableClock extends Clock {
+        private final AtomicLong absoluteMillis;
+        private final AtomicLong relativeNanos = new AtomicLong();
+
+        JumpableClock(long absoluteMillis) {
+            this.absoluteMillis = new AtomicLong(absoluteMillis);
+        }
+
+        @Override
+        public long absoluteTimeMillis() {
+            return absoluteMillis.get();
+        }
+
+        @Override
+        public long relativeTimeMillis() {
+            return relativeNanos.get() / 1_000_000L;
+        }
+
+        @Override
+        public long relativeTimeNanos() {
+            return relativeNanos.get();
+        }
+
+        void advance(Duration duration) {
+            absoluteMillis.addAndGet(duration.toMillis());
+            relativeNanos.addAndGet(duration.toNanos());
+        }
+
+        /** Steps the wall clock only; relative time is unaffected, like a real NTP step. */
+        void jumpWallClock(Duration duration) {
+            absoluteMillis.addAndGet(duration.toMillis());
+        }
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/security/token/DefaultDelegationTokenManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/security/token/DefaultDelegationTokenManagerTest.java
@@ -391,6 +391,25 @@ public class DefaultDelegationTokenManagerTest {
     }
 
     @Test
+    public void registerJobFailureWithLinkageErrorMustRollBackProviders() {
+        DefaultDelegationTokenManager delegationTokenManager =
+                new DefaultDelegationTokenManager(new Configuration(), null, null, null);
+
+        // A LinkageError from provider plugin code must get the same treatment as an exception:
+        // roll back on all providers and rethrow.
+        ExceptionThrowingDelegationTokenProvider.throwErrorInRegister.set(true);
+        JobID jobId = JobID.generate();
+
+        assertThrows(
+                NoClassDefFoundError.class,
+                () -> delegationTokenManager.registerJob(jobId, new Configuration()));
+        assertTrue(
+                ExceptionThrowingDelegationTokenProvider.registeredJobs.get().isEmpty(),
+                "A registration that failed with a LinkageError must be rolled back on all"
+                        + " providers");
+    }
+
+    @Test
     public void unregisterJobShouldSwallowProviderFailure() throws Exception {
         Configuration configuration = new Configuration();
         DefaultDelegationTokenManager delegationTokenManager =
@@ -401,6 +420,20 @@ public class DefaultDelegationTokenManagerTest {
 
         // A provider that throws during unregistration must not prevent cleanup from completing.
         ExceptionThrowingDelegationTokenProvider.throwInUnregister.set(true);
+        assertDoesNotThrow(() -> delegationTokenManager.unregisterJob(jobId));
+    }
+
+    @Test
+    public void unregisterJobShouldSwallowProviderLinkageError() throws Exception {
+        DefaultDelegationTokenManager delegationTokenManager =
+                new DefaultDelegationTokenManager(new Configuration(), null, null, null);
+
+        JobID jobId = JobID.generate();
+        delegationTokenManager.registerJob(jobId, new Configuration());
+
+        // A LinkageError during unregistration must be swallowed like an exception, so it does
+        // not abort the cleanup of the remaining providers.
+        ExceptionThrowingDelegationTokenProvider.throwErrorInUnregister.set(true);
         assertDoesNotThrow(() -> delegationTokenManager.unregisterJob(jobId));
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/security/token/DefaultDelegationTokenManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/security/token/DefaultDelegationTokenManagerTest.java
@@ -550,7 +550,8 @@ public class DefaultDelegationTokenManagerTest {
 
     @Test
     public void reobtainShouldBeIgnoredWhenNotStarted() {
-        // Constructed with null executors -> not started; a re-obtain request must be a safe no-op.
+        // Constructed with null executors, so never started. A re-obtain request must be a safe
+        // no-op.
         DefaultDelegationTokenManager delegationTokenManager =
                 new DefaultDelegationTokenManager(new Configuration(), null, null, null);
 
@@ -624,7 +625,7 @@ public class DefaultDelegationTokenManagerTest {
 
     /**
      * Configuration for cooldown-scheduling tests: sets the cooldown and disables all providers
-     * that could fail the obtain cycle (hadoopfs/hbase need a real Hadoop setup; the throw
+     * that could fail the obtain cycle (hadoopfs/hbase need a real Hadoop setup, and the throw
      * provider fails on demand). A failed cycle schedules a jittered retry, and the bring-forward
      * clamp would coalesce the on-demand request into that retry instead of deferring by the
      * cooldown, making delay assertions nondeterministic.

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/security/token/DefaultDelegationTokenManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/security/token/DefaultDelegationTokenManagerTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.security.token;
 
+import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.security.token.DelegationTokenProvider;
 import org.apache.flink.core.security.token.DelegationTokenReceiver;
@@ -31,11 +32,22 @@ import org.junit.jupiter.api.Test;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.ZoneId;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.BrokenBarrierException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static java.time.Instant.ofEpochMilli;
@@ -43,7 +55,9 @@ import static org.apache.flink.configuration.ConfigurationUtils.getBooleanConfig
 import static org.apache.flink.configuration.SecurityOptions.DELEGATION_TOKENS_RENEWAL_RETRY_INITIAL_BACKOFF;
 import static org.apache.flink.configuration.SecurityOptions.DELEGATION_TOKENS_RENEWAL_RETRY_MAX_BACKOFF;
 import static org.apache.flink.configuration.SecurityOptions.DELEGATION_TOKENS_RENEWAL_TIME_RATIO;
+import static org.apache.flink.configuration.SecurityOptions.DELEGATION_TOKENS_REOBTAIN_COOLDOWN;
 import static org.apache.flink.core.security.token.DelegationTokenProvider.CONFIG_PREFIX;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -299,5 +313,335 @@ public class DefaultDelegationTokenManagerTest {
         // Delay must not exceed the TTL cap (30 s / 3 = 10 s), with jitter the max is 10 s.
         assertTrue(delay <= Duration.ofSeconds(10).toMillis());
         assertTrue(delay >= 0);
+    }
+
+    @Test
+    public void registerJobShouldTriggerImmediateRenewalAndTrackJob() throws Exception {
+        final ManuallyTriggeredScheduledExecutor scheduledExecutor =
+                new ManuallyTriggeredScheduledExecutor();
+        final ManuallyTriggeredScheduledExecutorService scheduler =
+                new ManuallyTriggeredScheduledExecutorService();
+
+        Configuration configuration = new Configuration();
+        configuration.set(getBooleanConfigOption(CONFIG_PREFIX + ".throw.enabled"), true);
+        AtomicInteger startTokensUpdateCallCount = new AtomicInteger(0);
+        DefaultDelegationTokenManager delegationTokenManager =
+                new DefaultDelegationTokenManager(
+                        configuration, null, scheduledExecutor, scheduler) {
+                    @Override
+                    void startTokensUpdate() {
+                        startTokensUpdateCallCount.incrementAndGet();
+                        super.startTokensUpdate();
+                    }
+                };
+        // Ask the provider to request an immediate refresh when the job is registered.
+        ExceptionThrowingDelegationTokenProvider.shouldReobtainOnRegister.set(true);
+
+        JobID jobId = JobID.generate();
+        delegationTokenManager.registerJob(jobId, new Configuration());
+        scheduledExecutor.triggerScheduledTasks();
+        scheduler.triggerAll();
+
+        assertEquals(1, startTokensUpdateCallCount.get());
+        assertEquals(1, ExceptionThrowingDelegationTokenProvider.registeredJobs.get().size());
+
+        delegationTokenManager.unregisterJob(jobId);
+        assertEquals(0, ExceptionThrowingDelegationTokenProvider.registeredJobs.get().size());
+    }
+
+    @Test
+    public void stopShouldStopProviders() {
+        Configuration configuration = new Configuration();
+        DefaultDelegationTokenManager delegationTokenManager =
+                new DefaultDelegationTokenManager(configuration, null, null, null);
+
+        delegationTokenManager.stop();
+
+        assertTrue(ExceptionThrowingDelegationTokenProvider.stopped.get());
+    }
+
+    @Test
+    public void registerJobShouldRollBackAndRethrowWhenProviderThrows() throws Exception {
+        Configuration configuration = new Configuration();
+        DefaultDelegationTokenManager delegationTokenManager =
+                new DefaultDelegationTokenManager(configuration, null, null, null);
+
+        JobID jobId = JobID.generate();
+        delegationTokenManager.registerJob(jobId, new Configuration());
+        assertEquals(1, ExceptionThrowingDelegationTokenProvider.registeredJobs.get().size());
+
+        // A provider that throws during registration must cause the job to be unregistered from
+        // all providers and the exception to be rethrown.
+        ExceptionThrowingDelegationTokenProvider.throwInRegister.set(true);
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> delegationTokenManager.registerJob(jobId, new Configuration()));
+        assertEquals(0, ExceptionThrowingDelegationTokenProvider.registeredJobs.get().size());
+    }
+
+    @Test
+    public void unregisterJobShouldSwallowProviderFailure() throws Exception {
+        Configuration configuration = new Configuration();
+        DefaultDelegationTokenManager delegationTokenManager =
+                new DefaultDelegationTokenManager(configuration, null, null, null);
+
+        JobID jobId = JobID.generate();
+        delegationTokenManager.registerJob(jobId, new Configuration());
+
+        // A provider that throws during unregistration must not prevent cleanup from completing.
+        ExceptionThrowingDelegationTokenProvider.throwInUnregister.set(true);
+        assertDoesNotThrow(() -> delegationTokenManager.unregisterJob(jobId));
+    }
+
+    @Test
+    public void reobtainShouldCoalesceConcurrentRequests() {
+        final ManuallyTriggeredScheduledExecutor scheduledExecutor =
+                new ManuallyTriggeredScheduledExecutor();
+        final ManuallyTriggeredScheduledExecutorService scheduler =
+                new ManuallyTriggeredScheduledExecutorService();
+
+        AtomicInteger startTokensUpdateCallCount = new AtomicInteger(0);
+        DefaultDelegationTokenManager delegationTokenManager =
+                new DefaultDelegationTokenManager(
+                        new Configuration(), null, scheduledExecutor, scheduler) {
+                    @Override
+                    void startTokensUpdate() {
+                        startTokensUpdateCallCount.incrementAndGet();
+                        super.startTokensUpdate();
+                    }
+                };
+
+        // Two requests before the cycle runs must be coalesced into a single scheduled obtain.
+        delegationTokenManager.reobtainDelegationTokens();
+        delegationTokenManager.reobtainDelegationTokens();
+        assertEquals(1, scheduledExecutor.getActiveScheduledTasks().size());
+        // The second request must be a true no-op: it must not cancel and reschedule a new future
+        // (which would also leave a single *active* task). getAllScheduledTasks() includes
+        // cancelled futures, so it stays 1 only if the second request was genuinely coalesced.
+        assertEquals(1, scheduledExecutor.getAllScheduledTasks().size());
+
+        scheduledExecutor.triggerScheduledTasks();
+        scheduler.triggerAll();
+        assertEquals(1, startTokensUpdateCallCount.get());
+    }
+
+    @Test
+    public void periodicRenewalMustNotCancelPendingOnDemandReobtain() {
+        final ManuallyTriggeredScheduledExecutor scheduledExecutor =
+                new ManuallyTriggeredScheduledExecutor();
+        final ManuallyTriggeredScheduledExecutorService scheduler =
+                new ManuallyTriggeredScheduledExecutorService();
+
+        DefaultDelegationTokenManager delegationTokenManager =
+                new DefaultDelegationTokenManager(
+                        new Configuration(), null, scheduledExecutor, scheduler);
+
+        // An on-demand re-obtain is scheduled (e.g. a freshly registered job).
+        delegationTokenManager.reobtainDelegationTokens();
+        assertEquals(1, scheduledExecutor.getAllScheduledTasks().size());
+        assertEquals(0L, onlyScheduledDelayMillis(scheduledExecutor));
+
+        // A periodic obtain cycle that was already running completes and tries to install its own
+        // renewal. It must NOT cancel the pending on-demand re-obtain (regression test for the
+        // lost-reobtain race that also latched the dedupe flag).
+        delegationTokenManager.maybeScheduleRenewal(999_999L);
+
+        // No cancel+reschedule happened (still a single schedule call) and the pending future is
+        // still the immediate on-demand one, not the 999_999ms periodic renewal.
+        assertEquals(1, scheduledExecutor.getAllScheduledTasks().size());
+        assertEquals(0L, onlyScheduledDelayMillis(scheduledExecutor));
+
+        // Once the on-demand cycle has run and cleared the dedupe flag, a periodic renewal can be
+        // scheduled normally again.
+        scheduledExecutor.triggerScheduledTasks();
+        scheduler.triggerAll();
+        delegationTokenManager.maybeScheduleRenewal(123L);
+        assertEquals(123L, onlyScheduledDelayMillis(scheduledExecutor));
+    }
+
+    @Test
+    public void reobtainShouldRunImmediatelyAfterCooldownWindowElapses() {
+        final ManuallyTriggeredScheduledExecutor scheduledExecutor =
+                new ManuallyTriggeredScheduledExecutor();
+        final ManuallyTriggeredScheduledExecutorService scheduler =
+                new ManuallyTriggeredScheduledExecutorService();
+
+        Configuration configuration = hermeticCooldownConfig(Duration.ofMillis(60_000));
+        DefaultDelegationTokenManager delegationTokenManager =
+                new DefaultDelegationTokenManager(
+                        configuration, null, scheduledExecutor, scheduler);
+
+        long t0 = 1_000_000L;
+        delegationTokenManager.setClock(Clock.fixed(ofEpochMilli(t0), ZoneId.systemDefault()));
+        delegationTokenManager.reobtainDelegationTokens();
+        assertEquals(0L, onlyScheduledDelayMillis(scheduledExecutor));
+        scheduledExecutor.triggerScheduledTasks();
+        scheduler.triggerAll();
+
+        // A request arriving after the full cooldown window has elapsed runs immediately again.
+        delegationTokenManager.setClock(
+                Clock.fixed(ofEpochMilli(t0 + 70_000L), ZoneId.systemDefault()));
+        delegationTokenManager.reobtainDelegationTokens();
+        assertEquals(0L, onlyScheduledDelayMillis(scheduledExecutor));
+    }
+
+    @Test
+    public void stopShouldResetCooldownForSubsequentStart() throws Exception {
+        final ManuallyTriggeredScheduledExecutor scheduledExecutor =
+                new ManuallyTriggeredScheduledExecutor();
+        final ManuallyTriggeredScheduledExecutorService scheduler =
+                new ManuallyTriggeredScheduledExecutorService();
+
+        Configuration configuration = hermeticCooldownConfig(Duration.ofMillis(60_000));
+        DefaultDelegationTokenManager delegationTokenManager =
+                new DefaultDelegationTokenManager(
+                        configuration, null, scheduledExecutor, scheduler);
+
+        long t0 = 1_000_000L;
+        delegationTokenManager.setClock(Clock.fixed(ofEpochMilli(t0), ZoneId.systemDefault()));
+        delegationTokenManager.reobtainDelegationTokens();
+        assertEquals(0L, onlyScheduledDelayMillis(scheduledExecutor));
+        scheduledExecutor.triggerScheduledTasks();
+        scheduler.triggerAll();
+
+        // 10s later a re-obtain is deferred by the cooldown.
+        delegationTokenManager.setClock(
+                Clock.fixed(ofEpochMilli(t0 + 10_000L), ZoneId.systemDefault()));
+        delegationTokenManager.reobtainDelegationTokens();
+        assertEquals(50_000L, onlyScheduledDelayMillis(scheduledExecutor));
+
+        // stop() clears the cooldown anchor (and the dedupe/stopped state). After a restart, the
+        // next re-obtain runs immediately instead of inheriting the stale cooldown.
+        delegationTokenManager.stop();
+        delegationTokenManager.start(tokens -> {});
+        delegationTokenManager.setClock(
+                Clock.fixed(ofEpochMilli(t0 + 15_000L), ZoneId.systemDefault()));
+        delegationTokenManager.reobtainDelegationTokens();
+        assertEquals(0L, onlyScheduledDelayMillis(scheduledExecutor));
+    }
+
+    @Test
+    public void reobtainShouldRespectCooldown() {
+        final ManuallyTriggeredScheduledExecutor scheduledExecutor =
+                new ManuallyTriggeredScheduledExecutor();
+        final ManuallyTriggeredScheduledExecutorService scheduler =
+                new ManuallyTriggeredScheduledExecutorService();
+
+        Configuration configuration = hermeticCooldownConfig(Duration.ofMillis(60_000));
+        DefaultDelegationTokenManager delegationTokenManager =
+                new DefaultDelegationTokenManager(
+                        configuration, null, scheduledExecutor, scheduler);
+
+        long t0 = 1_000_000L;
+        delegationTokenManager.setClock(Clock.fixed(ofEpochMilli(t0), ZoneId.systemDefault()));
+
+        // First re-obtain after a quiet period runs immediately (no cooldown applies).
+        delegationTokenManager.reobtainDelegationTokens();
+        assertEquals(0L, onlyScheduledDelayMillis(scheduledExecutor));
+        scheduledExecutor.triggerScheduledTasks();
+        scheduler.triggerAll();
+
+        // A second re-obtain 10s later must be deferred until the 60s cooldown elapses.
+        delegationTokenManager.setClock(
+                Clock.fixed(ofEpochMilli(t0 + 10_000L), ZoneId.systemDefault()));
+        delegationTokenManager.reobtainDelegationTokens();
+        assertEquals(50_000L, onlyScheduledDelayMillis(scheduledExecutor));
+    }
+
+    @Test
+    public void reobtainShouldBeIgnoredWhenNotStarted() {
+        // Constructed with null executors -> not started; a re-obtain request must be a safe no-op.
+        DefaultDelegationTokenManager delegationTokenManager =
+                new DefaultDelegationTokenManager(new Configuration(), null, null, null);
+
+        assertDoesNotThrow(delegationTokenManager::reobtainDelegationTokens);
+    }
+
+    @Test
+    public void registerJobShouldBeIdempotent() throws Exception {
+        DefaultDelegationTokenManager delegationTokenManager =
+                new DefaultDelegationTokenManager(new Configuration(), null, null, null);
+
+        // Re-registering the same job (e.g. on JobManager/ResourceManager failover) must not
+        // accumulate duplicate per-job state in the providers.
+        JobID jobId = JobID.generate();
+        delegationTokenManager.registerJob(jobId, new Configuration());
+        delegationTokenManager.registerJob(jobId, new Configuration());
+
+        assertEquals(1, ExceptionThrowingDelegationTokenProvider.registeredJobs.get().size());
+    }
+
+    @Test
+    public void obtainLockSerializesConcurrentObtainCycles() throws Exception {
+        final ManuallyTriggeredScheduledExecutor scheduledExecutor =
+                new ManuallyTriggeredScheduledExecutor();
+        final ExecutorService ioExecutor = Executors.newFixedThreadPool(2);
+        try {
+            // The barrier trips only if two obtain cycles are inside the obtain/broadcast
+            // section at the same time. obtainLock must serialize them, so each should time out.
+            final CyclicBarrier barrier = new CyclicBarrier(2);
+            final AtomicBoolean concurrentObtainDetected = new AtomicBoolean(false);
+            final CountDownLatch done = new CountDownLatch(2);
+
+            DefaultDelegationTokenManager delegationTokenManager =
+                    new DefaultDelegationTokenManager(
+                            new Configuration(), null, scheduledExecutor, ioExecutor) {
+                        @Override
+                        protected Optional<Long> obtainDelegationTokensAndGetNextRenewal(
+                                DelegationTokenContainer container) {
+                            try {
+                                barrier.await(200, TimeUnit.MILLISECONDS);
+                                // Reached only if both cycles met here concurrently.
+                                concurrentObtainDetected.set(true);
+                            } catch (TimeoutException | BrokenBarrierException serialized) {
+                                // Expected: the other cycle never entered within the window.
+                            } catch (InterruptedException e) {
+                                Thread.currentThread().interrupt();
+                            }
+                            return Optional.empty();
+                        }
+                    };
+
+            ioExecutor.execute(
+                    () -> {
+                        delegationTokenManager.startTokensUpdate();
+                        done.countDown();
+                    });
+            ioExecutor.execute(
+                    () -> {
+                        delegationTokenManager.startTokensUpdate();
+                        done.countDown();
+                    });
+
+            assertTrue(done.await(10, TimeUnit.SECONDS));
+            assertFalse(
+                    concurrentObtainDetected.get(),
+                    "obtainLock must prevent two obtain cycles from running concurrently");
+        } finally {
+            ioExecutor.shutdownNow();
+        }
+    }
+
+    /**
+     * Configuration for cooldown-scheduling tests: sets the cooldown and disables all providers
+     * that could fail the obtain cycle (hadoopfs/hbase need a real Hadoop setup; the throw
+     * provider fails on demand). A failed cycle schedules a jittered retry, and the bring-forward
+     * clamp would coalesce the on-demand request into that retry instead of deferring by the
+     * cooldown, making delay assertions nondeterministic.
+     */
+    private static Configuration hermeticCooldownConfig(Duration cooldown) {
+        Configuration configuration = new Configuration();
+        configuration.set(DELEGATION_TOKENS_REOBTAIN_COOLDOWN, cooldown);
+        configuration.set(getBooleanConfigOption(CONFIG_PREFIX + ".throw.enabled"), false);
+        configuration.set(getBooleanConfigOption(CONFIG_PREFIX + ".hadoopfs.enabled"), false);
+        configuration.set(getBooleanConfigOption(CONFIG_PREFIX + ".hbase.enabled"), false);
+        return configuration;
+    }
+
+    private static long onlyScheduledDelayMillis(
+            ManuallyTriggeredScheduledExecutor scheduledExecutor) {
+        Collection<ScheduledFuture<?>> tasks = scheduledExecutor.getActiveScheduledTasks();
+        assertEquals(1, tasks.size());
+        return tasks.iterator().next().getDelay(TimeUnit.MILLISECONDS);
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/security/token/DefaultDelegationTokenManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/security/token/DefaultDelegationTokenManagerTest.java
@@ -362,14 +362,53 @@ public class DefaultDelegationTokenManagerTest {
     }
 
     @Test
-    public void stopShouldStopProviders() {
-        Configuration configuration = new Configuration();
+    public void closeShouldStopProvidersExactlyOnce() {
         DefaultDelegationTokenManager delegationTokenManager =
-                new DefaultDelegationTokenManager(configuration, null, null, null);
+                new DefaultDelegationTokenManager(new Configuration(), null, null, null);
 
-        delegationTokenManager.stop();
+        // close() is the terminal teardown: it stops the providers, and a repeated close() must
+        // not stop them again (the SPI promises stop() is called at most once).
+        delegationTokenManager.close();
+        delegationTokenManager.close();
 
         assertTrue(ExceptionThrowingDelegationTokenProvider.stopped.get());
+        assertEquals(1, (int) ExceptionThrowingDelegationTokenProvider.stopCallCount.get());
+    }
+
+    @Test
+    public void closeShouldEndSessionAndUnregisterJobs() throws Exception {
+        DefaultDelegationTokenManager delegationTokenManager =
+                new DefaultDelegationTokenManager(new Configuration(), null, null, null);
+
+        JobID jobId = JobID.generate();
+        delegationTokenManager.registerJob(jobId, new Configuration());
+
+        // close() ends the session first, so the jobs are unregistered while the providers are
+        // still usable, and only then are the providers stopped.
+        delegationTokenManager.close();
+
+        assertEquals(0, ExceptionThrowingDelegationTokenProvider.registeredJobs.get().size());
+        assertTrue(ExceptionThrowingDelegationTokenProvider.stopped.get());
+    }
+
+    @Test
+    public void startAfterCloseMustFail() {
+        final ManuallyTriggeredScheduledExecutor scheduledExecutor =
+                new ManuallyTriggeredScheduledExecutor();
+        final ManuallyTriggeredScheduledExecutorService scheduler =
+                new ManuallyTriggeredScheduledExecutorService();
+
+        DefaultDelegationTokenManager delegationTokenManager =
+                new DefaultDelegationTokenManager(
+                        hermeticCooldownConfig(Duration.ofMillis(60_000)),
+                        null,
+                        scheduledExecutor,
+                        scheduler);
+        delegationTokenManager.close();
+
+        // A closed manager's providers are stopped for good: starting it would run obtain
+        // cycles against dead providers, so it must fail fast.
+        assertThrows(IllegalStateException.class, () -> delegationTokenManager.start(tokens -> {}));
     }
 
     @Test
@@ -711,6 +750,33 @@ public class DefaultDelegationTokenManagerTest {
                 1,
                 delegate.getActiveScheduledTasks().size(),
                 "A re-obtain after a scheduler failure must schedule a fresh obtain cycle");
+    }
+
+    @Test
+    public void stopShouldKeepProvidersUsableForSubsequentStart() throws Exception {
+        final ManuallyTriggeredScheduledExecutor scheduledExecutor =
+                new ManuallyTriggeredScheduledExecutor();
+        final ManuallyTriggeredScheduledExecutorService scheduler =
+                new ManuallyTriggeredScheduledExecutorService();
+
+        DefaultDelegationTokenManager delegationTokenManager =
+                new DefaultDelegationTokenManager(
+                        new Configuration(), null, scheduledExecutor, scheduler);
+
+        // The manager is a process-lifetime singleton reused across ResourceManager leadership
+        // sessions: stop() runs on every leadership revoke and start() on the next grant, with
+        // the same provider instances. Providers are init()-ed exactly once, in the manager
+        // constructor, and the SPI has no re-init hook, so a provider closed by stop() stays
+        // broken for every following term. Providers must therefore only be closed at genuine
+        // process shutdown, not by the per-session stop().
+        delegationTokenManager.start(tokens -> {});
+        delegationTokenManager.stop();
+        delegationTokenManager.start(tokens -> {});
+
+        assertFalse(
+                ExceptionThrowingDelegationTokenProvider.stopped.get(),
+                "A leadership-session stop() must not close the providers, the next start()"
+                        + " re-uses them");
     }
 
     @Test

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/security/token/DefaultDelegationTokenManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/security/token/DefaultDelegationTokenManagerTest.java
@@ -23,6 +23,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.security.token.DelegationTokenProvider;
 import org.apache.flink.core.security.token.DelegationTokenReceiver;
 import org.apache.flink.core.testutils.ManuallyTriggeredScheduledExecutorService;
+import org.apache.flink.util.clock.ManualClock;
 import org.apache.flink.util.concurrent.ManuallyTriggeredScheduledExecutor;
 import org.apache.flink.util.concurrent.ScheduledExecutor;
 
@@ -30,9 +31,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.time.Clock;
 import java.time.Duration;
-import java.time.ZoneId;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -52,7 +51,6 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static java.time.Instant.ofEpochMilli;
 import static org.apache.flink.configuration.ConfigurationUtils.getBooleanConfigOption;
 import static org.apache.flink.configuration.SecurityOptions.DELEGATION_TOKENS_RENEWAL_RETRY_INITIAL_BACKOFF;
 import static org.apache.flink.configuration.SecurityOptions.DELEGATION_TOKENS_RENEWAL_RETRY_MAX_BACKOFF;
@@ -251,7 +249,7 @@ public class DefaultDelegationTokenManagerTest {
         DefaultDelegationTokenManager delegationTokenManager =
                 new DefaultDelegationTokenManager(configuration, null, null, null);
 
-        Clock constantClock = Clock.fixed(ofEpochMilli(100), ZoneId.systemDefault());
+        ManualClock constantClock = new ManualClock(100 * 1_000_000L);
         assertEquals(50, delegationTokenManager.calculateRenewalDelay(constantClock, 200));
     }
 
@@ -265,7 +263,7 @@ public class DefaultDelegationTokenManagerTest {
         DefaultDelegationTokenManager manager =
                 new DefaultDelegationTokenManager(configuration, null, null, null);
 
-        Clock clock = Clock.fixed(ofEpochMilli(0), ZoneId.systemDefault());
+        ManualClock clock = new ManualClock(0);
         long delay1 = manager.calculateRetryDelay(clock);
         long delay2 = manager.calculateRetryDelay(clock);
         long delay3 = manager.calculateRetryDelay(clock);
@@ -289,7 +287,7 @@ public class DefaultDelegationTokenManagerTest {
                 new DefaultDelegationTokenManager(configuration, null, null, null);
 
         // Ramp up the backoff via two failures.
-        Clock clock = Clock.fixed(ofEpochMilli(0), ZoneId.systemDefault());
+        ManualClock clock = new ManualClock(0);
         manager.calculateRetryDelay(clock);
         manager.calculateRetryDelay(clock);
         // Simulate success: reset currentRetryBackoff (as startTokensUpdate() would).
@@ -311,7 +309,7 @@ public class DefaultDelegationTokenManagerTest {
 
         // Simulate a failure close to token expiry (30 s remaining). The delay must be capped
         // so that the retry happens while the token is still valid (at most 30 s / 3 = 10 s).
-        Clock clock = Clock.fixed(ofEpochMilli(0), ZoneId.systemDefault());
+        ManualClock clock = new ManualClock(0);
         manager.lastKnownNextRenewal = Duration.ofSeconds(30).toMillis();
 
         long delay = manager.calculateRetryDelay(clock);
@@ -567,12 +565,12 @@ public class DefaultDelegationTokenManagerTest {
                 new ManuallyTriggeredScheduledExecutorService();
 
         Configuration configuration = hermeticCooldownConfig(Duration.ofMillis(60_000));
+        long t0 = 1_000_000L;
+        ManualClock clock = new ManualClock(t0 * 1_000_000L);
         DefaultDelegationTokenManager delegationTokenManager =
                 new DefaultDelegationTokenManager(
-                        configuration, null, scheduledExecutor, scheduler);
+                        configuration, null, scheduledExecutor, scheduler, clock);
 
-        long t0 = 1_000_000L;
-        delegationTokenManager.setClock(Clock.fixed(ofEpochMilli(t0), ZoneId.systemDefault()));
         delegationTokenManager.start(tokens -> {});
         delegationTokenManager.reobtainDelegationTokens();
         assertEquals(0L, onlyScheduledDelayMillis(scheduledExecutor));
@@ -580,8 +578,7 @@ public class DefaultDelegationTokenManagerTest {
         scheduler.triggerAll();
 
         // A request arriving after the full cooldown window has elapsed runs immediately again.
-        delegationTokenManager.setClock(
-                Clock.fixed(ofEpochMilli(t0 + 70_000L), ZoneId.systemDefault()));
+        clock.advanceTime(Duration.ofMillis(70_000L));
         delegationTokenManager.reobtainDelegationTokens();
         assertEquals(0L, onlyScheduledDelayMillis(scheduledExecutor));
     }
@@ -594,12 +591,12 @@ public class DefaultDelegationTokenManagerTest {
                 new ManuallyTriggeredScheduledExecutorService();
 
         Configuration configuration = hermeticCooldownConfig(Duration.ofMillis(60_000));
+        long t0 = 1_000_000L;
+        ManualClock clock = new ManualClock(t0 * 1_000_000L);
         DefaultDelegationTokenManager delegationTokenManager =
                 new DefaultDelegationTokenManager(
-                        configuration, null, scheduledExecutor, scheduler);
+                        configuration, null, scheduledExecutor, scheduler, clock);
 
-        long t0 = 1_000_000L;
-        delegationTokenManager.setClock(Clock.fixed(ofEpochMilli(t0), ZoneId.systemDefault()));
         delegationTokenManager.start(tokens -> {});
         delegationTokenManager.reobtainDelegationTokens();
         assertEquals(0L, onlyScheduledDelayMillis(scheduledExecutor));
@@ -607,8 +604,7 @@ public class DefaultDelegationTokenManagerTest {
         scheduler.triggerAll();
 
         // 10s later a re-obtain is deferred by the cooldown.
-        delegationTokenManager.setClock(
-                Clock.fixed(ofEpochMilli(t0 + 10_000L), ZoneId.systemDefault()));
+        clock.advanceTime(Duration.ofMillis(10_000L));
         delegationTokenManager.reobtainDelegationTokens();
         assertEquals(50_000L, onlyScheduledDelayMillis(scheduledExecutor));
 
@@ -616,8 +612,7 @@ public class DefaultDelegationTokenManagerTest {
         // next re-obtain runs immediately instead of inheriting the stale cooldown.
         delegationTokenManager.stop();
         delegationTokenManager.start(tokens -> {});
-        delegationTokenManager.setClock(
-                Clock.fixed(ofEpochMilli(t0 + 15_000L), ZoneId.systemDefault()));
+        clock.advanceTime(Duration.ofMillis(5_000L));
         delegationTokenManager.reobtainDelegationTokens();
         assertEquals(0L, onlyScheduledDelayMillis(scheduledExecutor));
     }
@@ -630,12 +625,11 @@ public class DefaultDelegationTokenManagerTest {
                 new ManuallyTriggeredScheduledExecutorService();
 
         Configuration configuration = hermeticCooldownConfig(Duration.ofMillis(60_000));
+        long t0 = 1_000_000L;
+        ManualClock clock = new ManualClock(t0 * 1_000_000L);
         DefaultDelegationTokenManager delegationTokenManager =
                 new DefaultDelegationTokenManager(
-                        configuration, null, scheduledExecutor, scheduler);
-
-        long t0 = 1_000_000L;
-        delegationTokenManager.setClock(Clock.fixed(ofEpochMilli(t0), ZoneId.systemDefault()));
+                        configuration, null, scheduledExecutor, scheduler, clock);
 
         delegationTokenManager.start(tokens -> {});
 
@@ -646,8 +640,7 @@ public class DefaultDelegationTokenManagerTest {
         scheduler.triggerAll();
 
         // A second re-obtain 10s later must be deferred until the 60s cooldown elapses.
-        delegationTokenManager.setClock(
-                Clock.fixed(ofEpochMilli(t0 + 10_000L), ZoneId.systemDefault()));
+        clock.advanceTime(Duration.ofMillis(10_000L));
         delegationTokenManager.reobtainDelegationTokens();
         assertEquals(50_000L, onlyScheduledDelayMillis(scheduledExecutor));
     }
@@ -842,12 +835,12 @@ public class DefaultDelegationTokenManagerTest {
                 new ManuallyTriggeredScheduledExecutorService();
 
         Configuration configuration = hermeticCooldownConfig(Duration.ofMillis(60_000));
+        long t0 = 1_000_000L;
+        ManualClock clock = new ManualClock(t0 * 1_000_000L);
         DefaultDelegationTokenManager delegationTokenManager =
                 new DefaultDelegationTokenManager(
-                        configuration, null, scheduledExecutor, scheduler);
+                        configuration, null, scheduledExecutor, scheduler, clock);
 
-        long t0 = 1_000_000L;
-        delegationTokenManager.setClock(Clock.fixed(ofEpochMilli(t0), ZoneId.systemDefault()));
         delegationTokenManager.start(tokens -> {});
 
         delegationTokenManager.reobtainDelegationTokens();
@@ -855,8 +848,7 @@ public class DefaultDelegationTokenManagerTest {
         scheduler.triggerAll();
 
         // 10s later a second re-obtain is cooldown-deferred by 50s.
-        delegationTokenManager.setClock(
-                Clock.fixed(ofEpochMilli(t0 + 10_000L), ZoneId.systemDefault()));
+        clock.advanceTime(Duration.ofMillis(10_000L));
         delegationTokenManager.reobtainDelegationTokens();
         assertEquals(50_000L, onlyScheduledDelayMillis(scheduledExecutor));
 
@@ -1050,15 +1042,16 @@ public class DefaultDelegationTokenManagerTest {
         final ManuallyTriggeredScheduledExecutorService scheduler =
                 new ManuallyTriggeredScheduledExecutorService();
 
+        long t0 = 1_000_000L;
+        ManualClock clock = new ManualClock(t0 * 1_000_000L);
         DefaultDelegationTokenManager delegationTokenManager =
                 new DefaultDelegationTokenManager(
                         hermeticCooldownConfig(Duration.ofMillis(60_000)),
                         null,
                         scheduledExecutor,
-                        scheduler);
+                        scheduler,
+                        clock);
 
-        long t0 = 1_000_000L;
-        delegationTokenManager.setClock(Clock.fixed(ofEpochMilli(t0), ZoneId.systemDefault()));
         delegationTokenManager.start(tokens -> {});
 
         // The first request runs immediately.
@@ -1068,12 +1061,10 @@ public class DefaultDelegationTokenManagerTest {
         scheduler.triggerAll();
 
         // A request at t0+1s is deferred by 59s: its obtain cycle runs at t0+60s.
-        delegationTokenManager.setClock(
-                Clock.fixed(ofEpochMilli(t0 + 1_000L), ZoneId.systemDefault()));
+        clock.advanceTime(Duration.ofMillis(1_000L));
         delegationTokenManager.reobtainDelegationTokens();
         assertEquals(59_000L, onlyScheduledDelayMillis(scheduledExecutor));
-        delegationTokenManager.setClock(
-                Clock.fixed(ofEpochMilli(t0 + 60_000L), ZoneId.systemDefault()));
+        clock.advanceTime(Duration.ofMillis(59_000L));
         scheduledExecutor.triggerScheduledTasks();
         scheduler.triggerAll();
 
@@ -1081,8 +1072,7 @@ public class DefaultDelegationTokenManagerTest {
         // so a request arriving just after the deferred cycle ran must be deferred by a full
         // cooldown measured from that cycle's execution, not run (almost) immediately because
         // the previous REQUEST arrived one cooldown ago.
-        delegationTokenManager.setClock(
-                Clock.fixed(ofEpochMilli(t0 + 61_000L), ZoneId.systemDefault()));
+        clock.advanceTime(Duration.ofMillis(1_000L));
         delegationTokenManager.reobtainDelegationTokens();
         assertEquals(
                 59_000L,
@@ -1097,15 +1087,16 @@ public class DefaultDelegationTokenManagerTest {
         final ManuallyTriggeredScheduledExecutorService scheduler =
                 new ManuallyTriggeredScheduledExecutorService();
 
+        long t0 = 1_000_000L;
+        ManualClock clock = new ManualClock(t0 * 1_000_000L);
         DefaultDelegationTokenManager delegationTokenManager =
                 new DefaultDelegationTokenManager(
                         hermeticCooldownConfig(Duration.ofMillis(60_000)),
                         null,
                         scheduledExecutor,
-                        scheduler);
+                        scheduler,
+                        clock);
 
-        long t0 = 1_000_000L;
-        delegationTokenManager.setClock(Clock.fixed(ofEpochMilli(t0), ZoneId.systemDefault()));
         delegationTokenManager.start(tokens -> {});
 
         delegationTokenManager.reobtainDelegationTokens();
@@ -1113,8 +1104,7 @@ public class DefaultDelegationTokenManagerTest {
         scheduler.triggerAll();
 
         // 10s later a second request is cooldown-deferred by 50s (would run at t0+60s).
-        delegationTokenManager.setClock(
-                Clock.fixed(ofEpochMilli(t0 + 10_000L), ZoneId.systemDefault()));
+        clock.advanceTime(Duration.ofMillis(10_000L));
         delegationTokenManager.reobtainDelegationTokens();
         assertEquals(50_000L, onlyScheduledDelayMillis(scheduledExecutor));
 
@@ -1122,16 +1112,14 @@ public class DefaultDelegationTokenManagerTest {
         // forward to +5s, so the coalesced cycle actually executes at t0+15s.
         delegationTokenManager.maybeScheduleRenewal(5_000L);
         assertEquals(5_000L, onlyScheduledDelayMillis(scheduledExecutor));
-        delegationTokenManager.setClock(
-                Clock.fixed(ofEpochMilli(t0 + 15_000L), ZoneId.systemDefault()));
+        clock.advanceTime(Duration.ofMillis(5_000L));
         scheduledExecutor.triggerScheduledTasks();
         scheduler.triggerAll();
 
         // The next request must measure its cooldown from the brought-forward execution
         // (t0+15s), not from the originally scheduled t0+60s. Otherwise it would defer
         // beyond a full cooldown (104s here instead of 59s).
-        delegationTokenManager.setClock(
-                Clock.fixed(ofEpochMilli(t0 + 16_000L), ZoneId.systemDefault()));
+        clock.advanceTime(Duration.ofMillis(1_000L));
         delegationTokenManager.reobtainDelegationTokens();
         assertEquals(
                 59_000L,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/security/token/DefaultDelegationTokenManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/security/token/DefaultDelegationTokenManagerTest.java
@@ -239,7 +239,7 @@ public class DefaultDelegationTokenManagerTest {
         ExceptionThrowingDelegationTokenProvider.throwInUsage.set(false);
         scheduledExecutor.triggerScheduledTasks();
         scheduler.triggerAll();
-        delegationTokenManager.stopTokensUpdate();
+        delegationTokenManager.stop();
 
         assertEquals(3, startTokensUpdateCallCount.get());
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/security/token/DefaultDelegationTokenManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/security/token/DefaultDelegationTokenManagerTest.java
@@ -363,17 +363,17 @@ public class DefaultDelegationTokenManagerTest {
     }
 
     @Test
-    public void closeShouldStopProvidersExactlyOnce() {
+    public void closeShouldCloseProvidersExactlyOnce() {
         DefaultDelegationTokenManager delegationTokenManager =
                 new DefaultDelegationTokenManager(new Configuration(), null, null, null);
 
-        // close() is the terminal teardown: it stops the providers, and a repeated close() must
-        // not stop them again (the SPI promises stop() is called at most once).
+        // close() is the terminal teardown: it closes the providers, and a repeated close() must
+        // not close them again (the SPI promises close() is called at most once).
         delegationTokenManager.close();
         delegationTokenManager.close();
 
-        assertTrue(ExceptionThrowingDelegationTokenProvider.stopped.get());
-        assertEquals(1, (int) ExceptionThrowingDelegationTokenProvider.stopCallCount.get());
+        assertTrue(ExceptionThrowingDelegationTokenProvider.closed.get());
+        assertEquals(1, (int) ExceptionThrowingDelegationTokenProvider.closeCallCount.get());
     }
 
     @Test
@@ -385,11 +385,11 @@ public class DefaultDelegationTokenManagerTest {
         delegationTokenManager.registerJob(jobId, new Configuration());
 
         // close() ends the session first, so the jobs are unregistered while the providers are
-        // still usable, and only then are the providers stopped.
+        // still usable, and only then are the providers closed.
         delegationTokenManager.close();
 
         assertEquals(0, ExceptionThrowingDelegationTokenProvider.registeredJobs.get().size());
-        assertTrue(ExceptionThrowingDelegationTokenProvider.stopped.get());
+        assertTrue(ExceptionThrowingDelegationTokenProvider.closed.get());
     }
 
     @Test
@@ -407,7 +407,7 @@ public class DefaultDelegationTokenManagerTest {
                         scheduler);
         delegationTokenManager.close();
 
-        // A closed manager's providers are stopped for good: starting it would run obtain
+        // A closed manager's providers are closed for good: starting it would run obtain
         // cycles against dead providers, so it must fail fast.
         assertThrows(IllegalStateException.class, () -> delegationTokenManager.start(tokens -> {}));
     }
@@ -770,7 +770,7 @@ public class DefaultDelegationTokenManagerTest {
         delegationTokenManager.start(tokens -> {});
 
         assertFalse(
-                ExceptionThrowingDelegationTokenProvider.stopped.get(),
+                ExceptionThrowingDelegationTokenProvider.closed.get(),
                 "A leadership-session stop() must not close the providers, the next start()"
                         + " re-uses them");
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/security/token/DefaultDelegationTokenManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/security/token/DefaultDelegationTokenManagerTest.java
@@ -881,13 +881,14 @@ public class DefaultDelegationTokenManagerTest {
     }
 
     @Test
-    public void obtainLockSerializesConcurrentObtainCycles() throws Exception {
+    public void renewalCycleLockSerializesConcurrentObtainCycles() throws Exception {
         final ManuallyTriggeredScheduledExecutor scheduledExecutor =
                 new ManuallyTriggeredScheduledExecutor();
         final ExecutorService ioExecutor = Executors.newFixedThreadPool(2);
         try {
             // The barrier trips only if two obtain cycles are inside the obtain/broadcast
-            // section at the same time. obtainLock must serialize them, so each should time out.
+            // section at the same time. renewalCycleLock must serialize them, so each should
+            // time out.
             final CyclicBarrier barrier = new CyclicBarrier(2);
             final AtomicBoolean concurrentObtainDetected = new AtomicBoolean(false);
             final CountDownLatch done = new CountDownLatch(2);
@@ -934,7 +935,7 @@ public class DefaultDelegationTokenManagerTest {
             assertTrue(done.await(10, TimeUnit.SECONDS));
             assertFalse(
                     concurrentObtainDetected.get(),
-                    "obtainLock must prevent two obtain cycles from running concurrently");
+                    "renewalCycleLock must prevent two obtain cycles from running concurrently");
         } finally {
             ioExecutor.shutdownNow();
         }
@@ -1289,7 +1290,7 @@ public class DefaultDelegationTokenManagerTest {
 
         // Leadership changes while A's cycle is parked in the obtain: stop() ends session A and
         // the next session starts before the cycle resumes. start(B) publishes B's listener
-        // under tokensUpdateFutureLock and then blocks on obtainLock behind A's cycle, so the
+        // under schedulingLock and then blocks on renewalCycleLock behind A's cycle, so the
         // resuming cycle observes running == true and B's listener.
         delegationTokenManager.stop();
         AtomicInteger sessionBNotifications = new AtomicInteger(0);
@@ -1304,7 +1305,7 @@ public class DefaultDelegationTokenManagerTest {
                             }
                         });
         starterB.start();
-        // Wait until start(B) is parked on obtainLock behind A's cycle. B publishes its
+        // Wait until start(B) is parked on renewalCycleLock behind A's cycle. B publishes its
         // listener under the manager's lock strictly before it can block there, so a durable
         // BLOCKED state implies the listener is in place without reading the lock-guarded
         // field unsynchronized. This gates when to resume A's parked cycle, so A's re-check

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/security/token/ExceptionThrowingDelegationTokenProvider.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/security/token/ExceptionThrowingDelegationTokenProvider.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.security.token;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.ConfigurationUtils;
 import org.apache.flink.core.security.token.DelegationTokenManagerCallback;
 import org.apache.flink.core.security.token.DelegationTokenProvider;
 
@@ -31,6 +32,9 @@ import java.util.Set;
  * An example implementation of {@link DelegationTokenProvider} which throws exception when enabled.
  */
 public class ExceptionThrowingDelegationTokenProvider implements DelegationTokenProvider {
+
+    /** Key written into the job configuration when {@link #mutateJobConfiguration} is set. */
+    public static final String MUTATED_KEY = "test.mutated.by.provider";
 
     public static volatile ThreadLocal<Boolean> throwInInit =
             ThreadLocal.withInitial(() -> Boolean.FALSE);
@@ -52,6 +56,8 @@ public class ExceptionThrowingDelegationTokenProvider implements DelegationToken
             ThreadLocal.withInitial(() -> Boolean.FALSE);
     public static volatile ThreadLocal<Boolean> stopped =
             ThreadLocal.withInitial(() -> Boolean.FALSE);
+    public static volatile ThreadLocal<Boolean> mutateJobConfiguration =
+            ThreadLocal.withInitial(() -> Boolean.FALSE);
     public static volatile ThreadLocal<Set<JobID>> registeredJobs =
             ThreadLocal.withInitial(HashSet::new);
 
@@ -66,6 +72,7 @@ public class ExceptionThrowingDelegationTokenProvider implements DelegationToken
         throwInUnregister.set(false);
         throwErrorInUnregister.set(false);
         stopped.set(false);
+        mutateJobConfiguration.set(false);
         registeredJobs.get().clear();
     }
 
@@ -117,6 +124,9 @@ public class ExceptionThrowingDelegationTokenProvider implements DelegationToken
     public void registerJob(JobID jobId, Configuration jobConfiguration) {
         if (throwInRegister.get()) {
             throw new IllegalArgumentException();
+        }
+        if (mutateJobConfiguration.get()) {
+            jobConfiguration.set(ConfigurationUtils.getBooleanConfigOption(MUTATED_KEY), true);
         }
         registeredJobs.get().add(jobId);
         if (throwErrorInRegister.get()) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/security/token/ExceptionThrowingDelegationTokenProvider.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/security/token/ExceptionThrowingDelegationTokenProvider.java
@@ -18,10 +18,14 @@
 
 package org.apache.flink.runtime.security.token;
 
+import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.security.token.DelegationTokenManagerCallback;
 import org.apache.flink.core.security.token.DelegationTokenProvider;
 
+import java.util.HashSet;
 import java.util.Optional;
+import java.util.Set;
 
 /**
  * An example implementation of {@link DelegationTokenProvider} which throws exception when enabled.
@@ -36,13 +40,30 @@ public class ExceptionThrowingDelegationTokenProvider implements DelegationToken
             ThreadLocal.withInitial(() -> Boolean.FALSE);
     public static volatile ThreadLocal<Boolean> constructed =
             ThreadLocal.withInitial(() -> Boolean.FALSE);
+    public static volatile ThreadLocal<Boolean> shouldReobtainOnRegister =
+            ThreadLocal.withInitial(() -> Boolean.FALSE);
+    public static volatile ThreadLocal<Boolean> throwInRegister =
+            ThreadLocal.withInitial(() -> Boolean.FALSE);
+    public static volatile ThreadLocal<Boolean> throwInUnregister =
+            ThreadLocal.withInitial(() -> Boolean.FALSE);
+    public static volatile ThreadLocal<Boolean> stopped =
+            ThreadLocal.withInitial(() -> Boolean.FALSE);
+    public static volatile ThreadLocal<Set<JobID>> registeredJobs =
+            ThreadLocal.withInitial(HashSet::new);
 
     public static void reset() {
         throwInInit.set(false);
         throwInUsage.set(false);
         addToken.set(false);
         constructed.set(false);
+        shouldReobtainOnRegister.set(false);
+        throwInRegister.set(false);
+        throwInUnregister.set(false);
+        stopped.set(false);
+        registeredJobs.get().clear();
     }
+
+    private DelegationTokenManagerCallback callback;
 
     public ExceptionThrowingDelegationTokenProvider() {
         constructed.set(true);
@@ -58,6 +79,12 @@ public class ExceptionThrowingDelegationTokenProvider implements DelegationToken
         if (throwInInit.get()) {
             throw new IllegalArgumentException();
         }
+    }
+
+    @Override
+    public void init(Configuration configuration, DelegationTokenManagerCallback callback) {
+        this.callback = callback;
+        init(configuration);
     }
 
     @Override
@@ -78,5 +105,29 @@ public class ExceptionThrowingDelegationTokenProvider implements DelegationToken
         } else {
             return null;
         }
+    }
+
+    @Override
+    public void registerJob(JobID jobId, Configuration jobConfiguration) {
+        if (throwInRegister.get()) {
+            throw new IllegalArgumentException();
+        }
+        registeredJobs.get().add(jobId);
+        if (shouldReobtainOnRegister.get()) {
+            callback.reobtainDelegationTokens();
+        }
+    }
+
+    @Override
+    public void unregisterJob(JobID jobId) {
+        if (throwInUnregister.get()) {
+            throw new IllegalArgumentException();
+        }
+        registeredJobs.get().remove(jobId);
+    }
+
+    @Override
+    public void stop() {
+        stopped.set(true);
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/security/token/ExceptionThrowingDelegationTokenProvider.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/security/token/ExceptionThrowingDelegationTokenProvider.java
@@ -56,6 +56,7 @@ public class ExceptionThrowingDelegationTokenProvider implements DelegationToken
             ThreadLocal.withInitial(() -> Boolean.FALSE);
     public static volatile ThreadLocal<Boolean> stopped =
             ThreadLocal.withInitial(() -> Boolean.FALSE);
+    public static volatile ThreadLocal<Integer> stopCallCount = ThreadLocal.withInitial(() -> 0);
     public static volatile ThreadLocal<Boolean> mutateJobConfiguration =
             ThreadLocal.withInitial(() -> Boolean.FALSE);
     public static volatile ThreadLocal<Set<JobID>> registeredJobs =
@@ -72,6 +73,7 @@ public class ExceptionThrowingDelegationTokenProvider implements DelegationToken
         throwInUnregister.set(false);
         throwErrorInUnregister.set(false);
         stopped.set(false);
+        stopCallCount.set(0);
         mutateJobConfiguration.set(false);
         registeredJobs.get().clear();
     }
@@ -151,5 +153,6 @@ public class ExceptionThrowingDelegationTokenProvider implements DelegationToken
     @Override
     public void stop() {
         stopped.set(true);
+        stopCallCount.set(stopCallCount.get() + 1);
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/security/token/ExceptionThrowingDelegationTokenProvider.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/security/token/ExceptionThrowingDelegationTokenProvider.java
@@ -44,7 +44,11 @@ public class ExceptionThrowingDelegationTokenProvider implements DelegationToken
             ThreadLocal.withInitial(() -> Boolean.FALSE);
     public static volatile ThreadLocal<Boolean> throwInRegister =
             ThreadLocal.withInitial(() -> Boolean.FALSE);
+    public static volatile ThreadLocal<Boolean> throwErrorInRegister =
+            ThreadLocal.withInitial(() -> Boolean.FALSE);
     public static volatile ThreadLocal<Boolean> throwInUnregister =
+            ThreadLocal.withInitial(() -> Boolean.FALSE);
+    public static volatile ThreadLocal<Boolean> throwErrorInUnregister =
             ThreadLocal.withInitial(() -> Boolean.FALSE);
     public static volatile ThreadLocal<Boolean> stopped =
             ThreadLocal.withInitial(() -> Boolean.FALSE);
@@ -58,7 +62,9 @@ public class ExceptionThrowingDelegationTokenProvider implements DelegationToken
         constructed.set(false);
         shouldReobtainOnRegister.set(false);
         throwInRegister.set(false);
+        throwErrorInRegister.set(false);
         throwInUnregister.set(false);
+        throwErrorInUnregister.set(false);
         stopped.set(false);
         registeredJobs.get().clear();
     }
@@ -113,6 +119,9 @@ public class ExceptionThrowingDelegationTokenProvider implements DelegationToken
             throw new IllegalArgumentException();
         }
         registeredJobs.get().add(jobId);
+        if (throwErrorInRegister.get()) {
+            throw new NoClassDefFoundError("simulated classpath failure in provider registerJob");
+        }
         if (shouldReobtainOnRegister.get()) {
             callback.reobtainDelegationTokens();
         }
@@ -122,6 +131,9 @@ public class ExceptionThrowingDelegationTokenProvider implements DelegationToken
     public void unregisterJob(JobID jobId) {
         if (throwInUnregister.get()) {
             throw new IllegalArgumentException();
+        }
+        if (throwErrorInUnregister.get()) {
+            throw new NoClassDefFoundError("simulated classpath failure in provider unregisterJob");
         }
         registeredJobs.get().remove(jobId);
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/security/token/ExceptionThrowingDelegationTokenProvider.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/security/token/ExceptionThrowingDelegationTokenProvider.java
@@ -54,9 +54,9 @@ public class ExceptionThrowingDelegationTokenProvider implements DelegationToken
             ThreadLocal.withInitial(() -> Boolean.FALSE);
     public static volatile ThreadLocal<Boolean> throwErrorInUnregister =
             ThreadLocal.withInitial(() -> Boolean.FALSE);
-    public static volatile ThreadLocal<Boolean> stopped =
+    public static volatile ThreadLocal<Boolean> closed =
             ThreadLocal.withInitial(() -> Boolean.FALSE);
-    public static volatile ThreadLocal<Integer> stopCallCount = ThreadLocal.withInitial(() -> 0);
+    public static volatile ThreadLocal<Integer> closeCallCount = ThreadLocal.withInitial(() -> 0);
     public static volatile ThreadLocal<Boolean> mutateJobConfiguration =
             ThreadLocal.withInitial(() -> Boolean.FALSE);
     public static volatile ThreadLocal<Set<JobID>> registeredJobs =
@@ -72,8 +72,8 @@ public class ExceptionThrowingDelegationTokenProvider implements DelegationToken
         throwErrorInRegister.set(false);
         throwInUnregister.set(false);
         throwErrorInUnregister.set(false);
-        stopped.set(false);
-        stopCallCount.set(0);
+        closed.set(false);
+        closeCallCount.set(0);
         mutateJobConfiguration.set(false);
         registeredJobs.get().clear();
     }
@@ -151,8 +151,8 @@ public class ExceptionThrowingDelegationTokenProvider implements DelegationToken
     }
 
     @Override
-    public void stop() {
-        stopped.set(true);
-        stopCallCount.set(stopCallCount.get() + 1);
+    public void close() {
+        closed.set(true);
+        closeCallCount.set(closeCallCount.get() + 1);
     }
 }

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java
@@ -1344,7 +1344,12 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
             DelegationTokenManager delegationTokenManager =
                     new DefaultDelegationTokenManager(flinkConfiguration, null, null, null);
             DelegationTokenContainer container = new DelegationTokenContainer();
-            delegationTokenManager.obtainDelegationTokens(container);
+            try {
+                delegationTokenManager.obtainDelegationTokens(container);
+            } finally {
+                // One-shot, client-side use: release the providers' resources right away.
+                delegationTokenManager.close();
+            }
 
             // This is here for backward compatibility to make log aggregation work
             for (Map.Entry<String, byte[]> e : container.getTokens().entrySet()) {


### PR DESCRIPTION
## What is the purpose of the change

Flink's delegation token framework is cluster-scoped: a DelegationTokenProvider obtains one set of tokens for the whole cluster and has no notion of an individual job. This breaks multi-tenant setups where jobs running on a shared cluster (e.g. a session cluster) need to authenticate as different identities against the same external service. This PR implements [FLIP-588](https://cwiki.apache.org/confluence/spaces/FLINK/pages/430408507/FLIP-588+Support+per-job+delegation+tokens): it adds per-job awareness to the provider SPI plus the runtime wiring to invoke it. All new SPI methods are default, so existing providers keep working unchanged.

## Brief change log

- Manager lifecycle split into session scope and process scope: stop() (once per ResourceManager leadership session) stops scheduling, releases the listener and unregisters the session's jobs, while the new DelegationTokenManager.close() stops the providers exactly once at process shutdown (wired into ClusterEntrypoint, MiniCluster and YarnClusterDescriptor's one-shot obtain), so provider instances survive leadership changes
- DelegationTokenProvider gains default methods: an init(Configuration, DelegationTokenManagerCallback) overload, registerJob(JobID, Configuration), unregisterJob(JobID) and stop()
- New `@Experimental` interface DelegationTokenManagerCallback with a single reobtainDelegationTokens(), handed to providers at init time so they can request an on-demand obtain-and-broadcast cycle (e.g. right after a new job registers)
- DelegationTokenManager (`@Internal`) gains the corresponding methods as no-op defaults, so NoOpDelegationTokenManager and other implementations are unaffected
- DefaultDelegationTokenManager fans registerJob/unregisterJob out to all providers: a failed first registration is rolled back from all providers and rethrown, a failed re-registration keeps the previous registration so a running job's tokens are not dropped, and per-provider failures during unregistration are caught so one provider cannot abort the cleanup of the others. 
- On-demand re-obtains reuse the existing renewal machinery: concurrent requests are coalesced, throttled by the new security.delegation.tokens.reobtain.cooldown option (default 30s), and only ever bring the next cycle forward, never delaying a scheduled renewal
- ResourceManager calls registerJob when a JobMaster registers and rejects the registration if it throws, so a job never starts without the tokens it requires; unregisterJob is called when the job is removed
- ResourceManagerGateway#registerJobMaster is widened to carry the job Configuration (the JobMaster now sends executionPlan.getJobConfiguration(); a backward-compatible overload is kept)
- Generated configuration docs updated for the new option


## Verifying this change
This change added tests and can be verified as follows: 
- Extended DefaultDelegationTokenManagerTest (manually-triggered executors) covering: register/unregister fan-out with rollback on failure, coalescing of concurrent re-obtains, cooldown behavior (first request immediate, deferral within the window, reset on stop()); periodic-renewal vs. on-demand interplay, idempotent registration, and serialized obtain cycles 
- Added ResourceManagerJobMasterTest#testRegisterJobMasterRejectedWhenDelegationTokenRegistrationFails, which drives the widened RPC and asserts the JobMaster registration is rejected when the delegation token manager's registerJob throws 
- Existing delegation token provider implementations are untouched and their tests still pass (the new SPI methods are default, so existing providers compile and run unchanged) 
- Additionally verified end-to-end with a Kafka connector prototype (per-job OAuth tokens against a real SASL/OAUTHBEARER broker with per-principal ACLs); that connector work will be proposed separately to flink-connector-kafka

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: SecurityOptions (@PublicEvolving) gains the new `security.delegation.tokens.reobtain.cooldown` option, the extended/new SPI types (DelegationTokenProvider, DelegationTokenManagerCallback) are @Experimental
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: the JobMaster registration path in the ResourceManager: registration is rejected if registerJob throws, and registerJob is invoked again on JobMaster re-registration after failover (the SPI contract requires it to be idempotent)
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? docs / JavaDocs: the new config option is in the generated configuration reference, the SPI contracts (threading, idempotency, ordering) are documented in the JavaDocs, and the overall design is in [FLIP-588](https://cwiki.apache.org/confluence/spaces/FLINK/pages/430408507/FLIP-588+Support+per-job+delegation+tokens)

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change the checkbox below to `[X]` followed by the name of the tool, and uncomment the
"Generated-by" line. See the ASF Generative Tooling Guidance for details:
https://www.apache.org/legal/generative-tooling.html

You are responsible for the quality and correctness of every change in this PR
regardless of the tooling used. Low-effort AI-generated PRs will be closed. See
AGENTS.md for the full guidance.
-->

- [x] Yes (Claude Opus 4.8, via Claude Code)

<!--
Generated-by: Claude Opus 4.8 (1M context)
-->
