### PR TITLE
[BP-2.3][FLINK-39921][FLINK-39929][tests] Fix flaky scheduler tests under async TDD creation

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionVertexCancelTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionVertexCancelTest.java
@@ -19,8 +19,9 @@
 package org.apache.flink.runtime.executiongraph;
 
 import org.apache.flink.api.common.JobStatus;
-import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutorServiceAdapter;
+import org.apache.flink.runtime.concurrent.NoMainThreadCheckComponentMainThreadExecutor;
 import org.apache.flink.runtime.execution.ExecutionState;
+import org.apache.flink.runtime.executiongraph.utils.ExecutionUtils;
 import org.apache.flink.runtime.executiongraph.utils.SimpleAckingTaskManagerGateway;
 import org.apache.flink.runtime.jobgraph.JobGraphTestUtils;
 import org.apache.flink.runtime.jobmaster.LogicalSlot;
@@ -247,12 +248,14 @@ class ExecutionVertexCancelTest {
         final SchedulerBase scheduler =
                 SchedulerTestingUtils.createScheduler(
                         JobGraphTestUtils.streamingJobGraph(createNoOpVertex(10)),
-                        ComponentMainThreadExecutorServiceAdapter.forMainThread(),
+                        new NoMainThreadCheckComponentMainThreadExecutor(),
                         EXECUTOR_RESOURCE.getExecutor());
         final ExecutionGraph graph = scheduler.getExecutionGraph();
 
         scheduler.startScheduling();
-
+        for (ExecutionVertex ev : graph.getAllExecutionVertices()) {
+            ExecutionUtils.waitForTaskDeploymentDescriptorsCreation(ev);
+        }
         ExecutionGraphTestUtils.switchAllVerticesToRunning(graph);
         assertThat(graph.getState()).isEqualTo(JobStatus.RUNNING);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/slowtaskdetector/ExecutionTimeBasedSlowTaskDetectorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/slowtaskdetector/ExecutionTimeBasedSlowTaskDetectorTest.java
@@ -22,10 +22,12 @@ package org.apache.flink.runtime.scheduler.slowtaskdetector;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.SlowTaskDetectorOptions;
 import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutorServiceAdapter;
+import org.apache.flink.runtime.concurrent.NoMainThreadCheckComponentMainThreadExecutor;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.executiongraph.ExecutionGraph;
 import org.apache.flink.runtime.executiongraph.ExecutionGraphTestUtils;
 import org.apache.flink.runtime.executiongraph.ExecutionVertex;
+import org.apache.flink.runtime.executiongraph.utils.ExecutionUtils;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
 import org.apache.flink.runtime.jobgraph.DistributionPattern;
 import org.apache.flink.runtime.jobgraph.JobGraph;
@@ -91,7 +93,7 @@ class ExecutionTimeBasedSlowTaskDetectorTest {
         final ExecutionGraph executionGraph =
                 SchedulerTestingUtils.createScheduler(
                                 jobGraph,
-                                ComponentMainThreadExecutorServiceAdapter.forMainThread(),
+                                new NoMainThreadCheckComponentMainThreadExecutor(),
                                 EXECUTOR_RESOURCE.getExecutor())
                         .getExecutionGraph();
 
@@ -433,12 +435,15 @@ class ExecutionTimeBasedSlowTaskDetectorTest {
         final SchedulerBase scheduler =
                 SchedulerTestingUtils.createScheduler(
                         jobGraph,
-                        ComponentMainThreadExecutorServiceAdapter.forMainThread(),
+                        new NoMainThreadCheckComponentMainThreadExecutor(),
                         EXECUTOR_RESOURCE.getExecutor());
 
         final ExecutionGraph executionGraph = scheduler.getExecutionGraph();
 
         scheduler.startScheduling();
+        for (ExecutionVertex ev : executionGraph.getAllExecutionVertices()) {
+            ExecutionUtils.waitForTaskDeploymentDescriptorsCreation(ev);
+        }
         ExecutionGraphTestUtils.switchAllVerticesToRunning(executionGraph);
 
         return executionGraph;
@@ -450,13 +455,16 @@ class ExecutionTimeBasedSlowTaskDetectorTest {
         final SchedulerBase scheduler =
                 new DefaultSchedulerBuilder(
                                 jobGraph,
-                                ComponentMainThreadExecutorServiceAdapter.forMainThread(),
+                                new NoMainThreadCheckComponentMainThreadExecutor(),
                                 EXECUTOR_RESOURCE.getExecutor())
                         .buildAdaptiveBatchJobScheduler();
 
         final ExecutionGraph executionGraph = scheduler.getExecutionGraph();
 
         scheduler.startScheduling();
+        for (ExecutionVertex ev : executionGraph.getAllExecutionVertices()) {
+            ExecutionUtils.waitForTaskDeploymentDescriptorsCreation(ev);
+        }
         ExecutionGraphTestUtils.switchAllVerticesToRunning(executionGraph);
 
         return executionGraph;


### PR DESCRIPTION
## What is the purpose of the change

Backport of the FLINK-39921 and FLINK-39929 test-stability fixes from master to release-2.3.

`ExecutionVertexCancelTest.testSendCancelAndReceiveFail` and `ExecutionTimeBasedSlowTaskDetectorTest` flake on release-2.3 nightlies with `IllegalStateException: BUG: trying to schedule a region which is not in CREATED state` at `startScheduling` (e.g. [build 76729](https://dev.azure.com/apache-flink/apache-flink/_build/results?buildId=76729&view=results), where `ExecutionVertexCancelTest` failed in both the `test_ci core` and `test_cron_azure core` legs).

Root cause (same as on master): since FLINK-38114, TaskDeploymentDescriptor creation is offloaded to the I/O executor and the deploy continuations complete on background threads. The `ComponentMainThreadExecutorServiceAdapter.forMainThread()` test executor asserts the caller is the test main thread, so these completions trip the assertion and surface as scheduling-state errors. FLINK-38114 is on release-2.3, so the assertion relaxation applied by the master fixes is equally justified here. Test-only change; the production scheduler is not affected.

## Brief change log

Clean `git cherry-pick -x` of the merged master fixes (byte-identical, original authorship preserved):

  - FLINK-39921 (master a8d6a287ae2, #28449): use `NoMainThreadCheckComponentMainThreadExecutor` and wait for TDD creation via `ExecutionUtils.waitForTaskDeploymentDescriptorsCreation` in `ExecutionVertexCancelTest`.
  - FLINK-39929 (master 67eba458114, #28434): same treatment in `ExecutionTimeBasedSlowTaskDetectorTest`.

The sibling fixes of this family (FLINK-39387, FLINK-39914, FLINK-39922) are already present on release-2.3.

## Verifying this change

This change is already covered by existing tests: ran `ExecutionVertexCancelTest` and `ExecutionTimeBasedSlowTaskDetectorTest` 4x each on this branch, 20/20 tests green every run.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no (test-only)
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (Claude Code)

Generated-by: Claude Code (Claude Fable 5)
