### PR TITLE
[BP-2.2][FLINK-39387][FLINK-39914][FLINK-39922][FLINK-39921][FLINK-39929][tests] Fix flaky scheduler tests under async TDD creation

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/asyncprocessing/operators/AbstractAsyncRunnableStreamOperatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/asyncprocessing/operators/AbstractAsyncRunnableStreamOperatorTest.java
@@ -241,17 +241,20 @@ public class AbstractAsyncRunnableStreamOperatorTest {
                     (SimpleAsyncExecutionController)
                             ((AbstractAsyncRunnableStreamOperator) testHarness.getOperator())
                                     .getAsyncExecutionController();
+            CompletableFuture<Void> unblockAsyncRequest = new CompletableFuture<>();
             ((AbstractAsyncRunnableStreamOperator<String>) testHarness.getOperator())
                     .setAsyncKeyedContextElement(
                             new StreamRecord<>(Tuple2.of(5, "5")), new TestKeySelector());
             ((AbstractAsyncRunnableStreamOperator<String>) testHarness.getOperator())
                     .asyncProcess(
                             () -> {
+                                unblockAsyncRequest.get(10, TimeUnit.SECONDS);
                                 return null;
                             });
             ((AbstractAsyncRunnableStreamOperator<String>) testHarness.getOperator())
                     .postProcessElement();
             assertThat(asyncExecutionController.getInFlightRecordNum()).isEqualTo(1);
+            unblockAsyncRequest.complete(null);
             testHarness.drainAsyncRequests();
             assertThat(asyncExecutionController.getInFlightRecordNum()).isEqualTo(0);
         }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/concurrent/NoMainThreadCheckComponentMainThreadExecutor.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/concurrent/NoMainThreadCheckComponentMainThreadExecutor.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.concurrent;
+
+import org.apache.flink.runtime.testutils.DirectScheduledExecutorService;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * A synchronous {@link ComponentMainThreadExecutor} that executes tasks directly on the calling
+ * thread without performing strict thread identity checks.
+ *
+ * <p>Unlike {@link ComponentMainThreadExecutorServiceAdapter#forMainThread()}, this executor does
+ * not assert that the current thread is the main thread, avoiding flaky test failures when {@link
+ * java.util.concurrent.CompletableFuture} callbacks are dispatched from background threads.
+ */
+public class NoMainThreadCheckComponentMainThreadExecutor implements ComponentMainThreadExecutor {
+
+    private final DirectScheduledExecutorService executor = new DirectScheduledExecutorService();
+
+    @Override
+    public void assertRunningInMainThread() {
+        // No-op: Skip thread assertion to avoid flaky test failures
+    }
+
+    @Override
+    public void execute(Runnable command) {
+        executor.execute(command);
+    }
+
+    @Override
+    public ScheduledFuture<?> schedule(Runnable command, long delay, TimeUnit unit) {
+        return executor.schedule(command, delay, unit);
+    }
+
+    @Override
+    public <V> ScheduledFuture<V> schedule(Callable<V> callable, long delay, TimeUnit unit) {
+        return executor.schedule(callable, delay, unit);
+    }
+
+    @Override
+    public ScheduledFuture<?> scheduleAtFixedRate(
+            Runnable command, long initialDelay, long period, TimeUnit unit) {
+        return executor.scheduleAtFixedRate(command, initialDelay, period, unit);
+    }
+
+    @Override
+    public ScheduledFuture<?> scheduleWithFixedDelay(
+            Runnable command, long initialDelay, long delay, TimeUnit unit) {
+        return executor.scheduleWithFixedDelay(command, initialDelay, delay, unit);
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/deployment/TaskDeploymentDescriptorFactoryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/deployment/TaskDeploymentDescriptorFactoryTest.java
@@ -35,6 +35,7 @@ import org.apache.flink.runtime.executiongraph.ExecutionVertex;
 import org.apache.flink.runtime.executiongraph.IntermediateResult;
 import org.apache.flink.runtime.executiongraph.MarkPartitionFinishedStrategy;
 import org.apache.flink.runtime.executiongraph.TestingDefaultExecutionGraphBuilder;
+import org.apache.flink.runtime.executiongraph.utils.ExecutionUtils;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
 import org.apache.flink.runtime.jobgraph.DistributionPattern;
 import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
@@ -49,6 +50,7 @@ import org.apache.flink.runtime.scheduler.SchedulerBase;
 import org.apache.flink.runtime.shuffle.ShuffleDescriptor;
 import org.apache.flink.testutils.TestingUtils;
 import org.apache.flink.testutils.executor.TestExecutorExtension;
+import org.apache.flink.util.Preconditions;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -58,6 +60,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledExecutorService;
 
 import static org.apache.flink.configuration.JobManagerOptions.HybridPartitionDataConsumeConstraint.ONLY_FINISHED_PRODUCERS;
@@ -221,18 +224,25 @@ class TaskDeploymentDescriptorFactoryTest {
                 ResultPartitionType.HYBRID_FULL);
 
         JobGraph jobGraph = JobGraphTestUtils.batchJobGraph(producer, consumer);
+
         SchedulerBase scheduler =
                 new DefaultSchedulerBuilder(
                                 jobGraph,
-                                ComponentMainThreadExecutorServiceAdapter.forMainThread(),
+                                ComponentMainThreadExecutorServiceAdapter.forSingleThreadExecutor(
+                                        EXECUTOR_RESOURCE.getExecutor()),
                                 EXECUTOR_RESOURCE.getExecutor())
                         .setHybridPartitionDataConsumeConstraint(ONLY_FINISHED_PRODUCERS)
                         .buildAdaptiveBatchJobScheduler();
-        scheduler.startScheduling();
+        CompletableFuture.runAsync(scheduler::startScheduling, EXECUTOR_RESOURCE.getExecutor())
+                .join();
+        // Barrier: ensure the async vertex-initialization action queued inside startScheduling
+        // has completed before we access getTaskVertices().
+        CompletableFuture.runAsync(() -> {}, EXECUTOR_RESOURCE.getExecutor()).join();
         ExecutionGraph executionGraph = scheduler.getExecutionGraph();
-        return Tuple2.of(
-                executionGraph.getJobVertex(producer.getID()),
-                executionGraph.getJobVertex(consumer.getID()));
+        ExecutionJobVertex producerVertex =
+                Preconditions.checkNotNull(executionGraph.getJobVertex(producer.getID()));
+        ExecutionUtils.waitForTaskDeploymentDescriptorsCreation(producerVertex.getTaskVertices());
+        return Tuple2.of(producerVertex, executionGraph.getJobVertex(consumer.getID()));
     }
 
     // ============== Utils ==============

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionVertexCancelTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionVertexCancelTest.java
@@ -19,8 +19,9 @@
 package org.apache.flink.runtime.executiongraph;
 
 import org.apache.flink.api.common.JobStatus;
-import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutorServiceAdapter;
+import org.apache.flink.runtime.concurrent.NoMainThreadCheckComponentMainThreadExecutor;
 import org.apache.flink.runtime.execution.ExecutionState;
+import org.apache.flink.runtime.executiongraph.utils.ExecutionUtils;
 import org.apache.flink.runtime.executiongraph.utils.SimpleAckingTaskManagerGateway;
 import org.apache.flink.runtime.jobgraph.JobGraphTestUtils;
 import org.apache.flink.runtime.jobmaster.LogicalSlot;
@@ -247,12 +248,14 @@ class ExecutionVertexCancelTest {
         final SchedulerBase scheduler =
                 SchedulerTestingUtils.createScheduler(
                         JobGraphTestUtils.streamingJobGraph(createNoOpVertex(10)),
-                        ComponentMainThreadExecutorServiceAdapter.forMainThread(),
+                        new NoMainThreadCheckComponentMainThreadExecutor(),
                         EXECUTOR_RESOURCE.getExecutor());
         final ExecutionGraph graph = scheduler.getExecutionGraph();
 
         scheduler.startScheduling();
-
+        for (ExecutionVertex ev : graph.getAllExecutionVertices()) {
+            ExecutionUtils.waitForTaskDeploymentDescriptorsCreation(ev);
+        }
         ExecutionGraphTestUtils.switchAllVerticesToRunning(graph);
         assertThat(graph.getState()).isEqualTo(JobStatus.RUNNING);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/EventReceivingTasks.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/EventReceivingTasks.java
@@ -18,18 +18,13 @@
 
 package org.apache.flink.runtime.operators.coordination;
 
-import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
+import org.apache.flink.runtime.concurrent.NoMainThreadCheckComponentMainThreadExecutor;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.messages.Acknowledge;
 import org.apache.flink.runtime.operators.coordination.util.IncompleteFuturesTracker;
-import org.apache.flink.runtime.testutils.DirectScheduledExecutorService;
 import org.apache.flink.util.SerializedValue;
 import org.apache.flink.util.concurrent.FutureUtils;
-import org.apache.flink.util.concurrent.ScheduledExecutor;
-import org.apache.flink.util.concurrent.ScheduledExecutorServiceAdapter;
-
-import javax.annotation.Nonnull;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -39,8 +34,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ScheduledFuture;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import static org.apache.flink.runtime.executiongraph.ExecutionGraphTestUtils.createExecutionAttemptId;
@@ -240,50 +233,6 @@ public class EventReceivingTasks implements SubtaskAccess.SubtaskAccessFactory {
 
         public List<Throwable> getTaskFailoverReasons() {
             return taskFailoverReasons;
-        }
-    }
-
-    /**
-     * An implementation of {@link ComponentMainThreadExecutor} that executes Runnables with a
-     * wrapped {@link ScheduledExecutor} and disables {@link #assertRunningInMainThread()} checks.
-     */
-    private static class NoMainThreadCheckComponentMainThreadExecutor
-            implements ComponentMainThreadExecutor {
-        private final ScheduledExecutor scheduledExecutor;
-
-        private NoMainThreadCheckComponentMainThreadExecutor() {
-            this.scheduledExecutor =
-                    new ScheduledExecutorServiceAdapter(new DirectScheduledExecutorService());
-        }
-
-        @Override
-        public ScheduledFuture<?> schedule(Runnable command, long delay, TimeUnit unit) {
-            return scheduledExecutor.schedule(command, delay, unit);
-        }
-
-        @Override
-        public <V> ScheduledFuture<V> schedule(Callable<V> callable, long delay, TimeUnit unit) {
-            return scheduledExecutor.schedule(callable, delay, unit);
-        }
-
-        @Override
-        public ScheduledFuture<?> scheduleAtFixedRate(
-                Runnable command, long initialDelay, long period, TimeUnit unit) {
-            return scheduledExecutor.scheduleAtFixedRate(command, initialDelay, period, unit);
-        }
-
-        @Override
-        public ScheduledFuture<?> scheduleWithFixedDelay(
-                Runnable command, long initialDelay, long delay, TimeUnit unit) {
-            return scheduledExecutor.scheduleAtFixedRate(command, initialDelay, delay, unit);
-        }
-
-        @Override
-        public void assertRunningInMainThread() {}
-
-        @Override
-        public void execute(@Nonnull Runnable command) {
-            scheduledExecutor.execute(command);
         }
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/SchedulerBenchmarkUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/SchedulerBenchmarkUtils.java
@@ -21,7 +21,7 @@ package org.apache.flink.runtime.scheduler.benchmark;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.runtime.JobException;
 import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
-import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutorServiceAdapter;
+import org.apache.flink.runtime.concurrent.NoMainThreadCheckComponentMainThreadExecutor;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.executiongraph.AccessExecutionJobVertex;
 import org.apache.flink.runtime.executiongraph.Execution;
@@ -111,7 +111,7 @@ public class SchedulerBenchmarkUtils {
         final JobGraph jobGraph = createJobGraph(jobVertices, jobConfiguration);
 
         final ComponentMainThreadExecutor mainThreadExecutor =
-                ComponentMainThreadExecutorServiceAdapter.forMainThread();
+                new NoMainThreadCheckComponentMainThreadExecutor();
 
         DefaultSchedulerBuilder schedulerBuilder =
                 new DefaultSchedulerBuilder(jobGraph, mainThreadExecutor, scheduledExecutorService)

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/slowtaskdetector/ExecutionTimeBasedSlowTaskDetectorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/slowtaskdetector/ExecutionTimeBasedSlowTaskDetectorTest.java
@@ -22,10 +22,12 @@ package org.apache.flink.runtime.scheduler.slowtaskdetector;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.SlowTaskDetectorOptions;
 import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutorServiceAdapter;
+import org.apache.flink.runtime.concurrent.NoMainThreadCheckComponentMainThreadExecutor;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.executiongraph.ExecutionGraph;
 import org.apache.flink.runtime.executiongraph.ExecutionGraphTestUtils;
 import org.apache.flink.runtime.executiongraph.ExecutionVertex;
+import org.apache.flink.runtime.executiongraph.utils.ExecutionUtils;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
 import org.apache.flink.runtime.jobgraph.DistributionPattern;
 import org.apache.flink.runtime.jobgraph.JobGraph;
@@ -91,7 +93,7 @@ class ExecutionTimeBasedSlowTaskDetectorTest {
         final ExecutionGraph executionGraph =
                 SchedulerTestingUtils.createScheduler(
                                 jobGraph,
-                                ComponentMainThreadExecutorServiceAdapter.forMainThread(),
+                                new NoMainThreadCheckComponentMainThreadExecutor(),
                                 EXECUTOR_RESOURCE.getExecutor())
                         .getExecutionGraph();
 
@@ -433,12 +435,15 @@ class ExecutionTimeBasedSlowTaskDetectorTest {
         final SchedulerBase scheduler =
                 SchedulerTestingUtils.createScheduler(
                         jobGraph,
-                        ComponentMainThreadExecutorServiceAdapter.forMainThread(),
+                        new NoMainThreadCheckComponentMainThreadExecutor(),
                         EXECUTOR_RESOURCE.getExecutor());
 
         final ExecutionGraph executionGraph = scheduler.getExecutionGraph();
 
         scheduler.startScheduling();
+        for (ExecutionVertex ev : executionGraph.getAllExecutionVertices()) {
+            ExecutionUtils.waitForTaskDeploymentDescriptorsCreation(ev);
+        }
         ExecutionGraphTestUtils.switchAllVerticesToRunning(executionGraph);
 
         return executionGraph;
@@ -450,13 +455,16 @@ class ExecutionTimeBasedSlowTaskDetectorTest {
         final SchedulerBase scheduler =
                 new DefaultSchedulerBuilder(
                                 jobGraph,
-                                ComponentMainThreadExecutorServiceAdapter.forMainThread(),
+                                new NoMainThreadCheckComponentMainThreadExecutor(),
                                 EXECUTOR_RESOURCE.getExecutor())
                         .buildAdaptiveBatchJobScheduler();
 
         final ExecutionGraph executionGraph = scheduler.getExecutionGraph();
 
         scheduler.startScheduling();
+        for (ExecutionVertex ev : executionGraph.getAllExecutionVertices()) {
+            ExecutionUtils.waitForTaskDeploymentDescriptorsCreation(ev);
+        }
         ExecutionGraphTestUtils.switchAllVerticesToRunning(executionGraph);
 
         return executionGraph;


### PR DESCRIPTION
## What is the purpose of the change

Backport of the async-TDD `ComponentMainThreadExecutor` test-stability fix family from master to release-2.2. This PR intentionally bundles five JIRAs because they form one coherent cluster with an internal dependency (the FLINK-39387 pick introduces `NoMainThreadCheckComponentMainThreadExecutor`, which the later picks need to compile); each is a separate clean `-x` cherry-pick, so individual reverts remain possible.

Observed on release-2.2 nightlies: `ExecutionVertexCancelTest.testSendCancelAndReceiveFail` and `ExecutionTimeBasedSlowTaskDetectorTest.testFinishedTaskNotExceedRatio` fail with `IllegalStateException: BUG: trying to schedule a region which is not in CREATED state` at `startScheduling` ([build 76677](https://dev.azure.com/apache-flink/apache-flink/_build/results?buildId=76677&view=results), `test_cron_jdk21 core` and `test_cron_azure core` legs).

Root cause (same as on master): since FLINK-38114, TaskDeploymentDescriptor creation is offloaded to the I/O executor and deploy continuations complete on background threads. The `ComponentMainThreadExecutorServiceAdapter.forMainThread()` test executor asserts the caller is the test main thread, so these completions trip the assertion. FLINK-38114 is on release-2.2, so the assertion relaxation applied by the master fixes is equally justified here. Test-only change; the production scheduler is not affected. The same fixes are already on release-2.3 (partly inherited, partly via the parallel backport PR).

## Brief change log

Clean `git cherry-pick -x` of the merged master fixes, in dependency order (byte-identical, original authorship preserved):

  - FLINK-39387 (master 106acbced18): prerequisite, introduces `NoMainThreadCheckComponentMainThreadExecutor` (absent on release-2.2).
  - FLINK-39914 (master 6d47db1d541, #28398): fix flaky `TaskDeploymentDescriptorFactoryTest#testHybridVertexFinish`.
  - FLINK-39922 (master 6d106cda908, #28425): fix flaky `AbstractAsyncRunnableStreamOperatorTest#testCheckpointDrain`.
  - FLINK-39921 (master a8d6a287ae2, #28449): fix flaky `ExecutionVertexCancelTest.testSendCancelAndReceiveFail`.
  - FLINK-39929 (master 67eba458114, #28434): fix flaky `ExecutionTimeBasedSlowTaskDetectorTest`.

## Verifying this change

This change is already covered by existing tests:

  - `ExecutionVertexCancelTest` + `ExecutionTimeBasedSlowTaskDetectorTest`: 4 runs, 20/20 green each run.
  - `TaskDeploymentDescriptorFactoryTest` + `AbstractAsyncRunnableStreamOperatorTest`: green (36/36 combined run).
  - `flink-runtime` test-compile verified at every individual commit boundary.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no (test-only)
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (Claude Code)

Generated-by: Claude Code (Claude Fable 5)
