### PR TITLE
[BP-2.2][FLINK-38441][FLINK-39182][tests] Fix flaky ExecutionGraph restart tests under async TDD creation

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphRestartTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphRestartTest.java
@@ -32,6 +32,7 @@ import org.apache.flink.runtime.jobgraph.JobGraphTestUtils;
 import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.jobmaster.JobMasterId;
 import org.apache.flink.runtime.jobmaster.slotpool.DeclarativeSlotPoolBridge;
+import org.apache.flink.runtime.jobmaster.slotpool.DeclarativeSlotPoolBridgeBuilder;
 import org.apache.flink.runtime.jobmaster.slotpool.LocationPreferenceSlotSelectionStrategy;
 import org.apache.flink.runtime.jobmaster.slotpool.PhysicalSlotProvider;
 import org.apache.flink.runtime.jobmaster.slotpool.PhysicalSlotProviderImpl;
@@ -40,7 +41,6 @@ import org.apache.flink.runtime.jobmaster.slotpool.SlotPoolUtils;
 import org.apache.flink.runtime.resourcemanager.ResourceManagerGateway;
 import org.apache.flink.runtime.resourcemanager.utils.TestingResourceManagerGateway;
 import org.apache.flink.runtime.scheduler.DefaultSchedulerBuilder;
-import org.apache.flink.runtime.scheduler.ExecutionSlotAllocatorFactory;
 import org.apache.flink.runtime.scheduler.SchedulerBase;
 import org.apache.flink.runtime.scheduler.SchedulerTestingUtils;
 import org.apache.flink.runtime.testtasks.NoOpInvokable;
@@ -49,6 +49,7 @@ import org.apache.flink.testutils.TestingUtils;
 import org.apache.flink.testutils.executor.TestExecutorExtension;
 import org.apache.flink.util.concurrent.ManuallyTriggeredScheduledExecutor;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -56,6 +57,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Iterator;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.Consumer;
 
@@ -67,17 +69,36 @@ class ExecutionGraphRestartTest {
     private static final int NUM_TASKS = 31;
 
     @RegisterExtension
-    static final TestExecutorExtension<ScheduledExecutorService> EXECUTOR_RESOURCE =
-            TestingUtils.defaultExecutorExtension();
+    static final TestExecutorExtension<ScheduledExecutorService> EXECUTOR_EXTENSION =
+            TestingUtils.jmAsyncThreadExecutorExtension();
 
-    private static final ComponentMainThreadExecutor mainThreadExecutor =
-            ComponentMainThreadExecutorServiceAdapter.forMainThread();
+    @RegisterExtension
+    static final TestExecutorExtension<ScheduledExecutorService> JM_MAIN_THREAD_EXECUTOR_EXTENSION =
+            TestingUtils.jmMainThreadExecutorExtension();
+
+    private ComponentMainThreadExecutor mainThreadExecutor;
 
     private ManuallyTriggeredScheduledExecutor taskRestartExecutor;
+
+    private DeclarativeSlotPoolBridge slotPool;
 
     @BeforeEach
     void setUp() {
         taskRestartExecutor = new ManuallyTriggeredScheduledExecutor();
+        mainThreadExecutor =
+                ComponentMainThreadExecutorServiceAdapter.forSingleThreadExecutor(
+                        JM_MAIN_THREAD_EXECUTOR_EXTENSION.getExecutor());
+        slotPool =
+                new DeclarativeSlotPoolBridgeBuilder()
+                        .setMainThreadExecutor(mainThreadExecutor)
+                        .build();
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (slotPool != null) {
+            runInMainThread(slotPool::close);
+        }
     }
 
     // ------------------------------------------------------------------------
@@ -95,179 +116,165 @@ class ExecutionGraphRestartTest {
 
     @Test
     void testCancelAllPendingRequestWhileCanceling() throws Exception {
-        try (DeclarativeSlotPoolBridge slotPool = SlotPoolUtils.createDeclarativeSlotPoolBridge()) {
+        final int numTasksExceedSlotPool = 50;
+        // create a graph with task count larger than slot pool
+        JobVertex sender =
+                ExecutionGraphTestUtils.createJobVertex(
+                        "Task", NUM_TASKS + numTasksExceedSlotPool, NoOpInvokable.class);
+        JobGraph graph = JobGraphTestUtils.streamingJobGraph(sender);
+        SchedulerBase scheduler = createSchedulerBuilder(graph).build();
 
-            final int numTasksExceedSlotPool = 50;
-            // create a graph with task count larger than slot pool
-            JobVertex sender =
-                    ExecutionGraphTestUtils.createJobVertex(
-                            "Task", NUM_TASKS + numTasksExceedSlotPool, NoOpInvokable.class);
-            JobGraph graph = JobGraphTestUtils.streamingJobGraph(sender);
-            SchedulerBase scheduler =
-                    new DefaultSchedulerBuilder(
-                                    graph, mainThreadExecutor, EXECUTOR_RESOURCE.getExecutor())
-                            .setExecutionSlotAllocatorFactory(
-                                    createExecutionSlotAllocatorFactory(slotPool))
-                            .build();
-            ExecutionGraph executionGraph = scheduler.getExecutionGraph();
+        runInMainThread(
+                () -> {
+                    ExecutionGraph executionGraph = scheduler.getExecutionGraph();
+                    startScheduling(scheduler);
+                    SlotPoolUtils.offerSlotsFromMainThread(
+                            slotPool, Collections.nCopies(NUM_TASKS, ResourceProfile.ANY));
 
-            startScheduling(scheduler);
-            offerSlots(slotPool, NUM_TASKS);
+                    assertThat(slotPool.getNumPendingRequests()).isEqualTo(numTasksExceedSlotPool);
 
-            assertThat(slotPool.getNumPendingRequests()).isEqualTo(numTasksExceedSlotPool);
-
-            scheduler.cancel();
-            assertThat(executionGraph.getState()).isEqualTo(JobStatus.CANCELLING);
-            assertThat(slotPool.getNumPendingRequests()).isZero();
-        }
+                    scheduler.cancel();
+                    assertThat(executionGraph.getState()).isEqualTo(JobStatus.CANCELLING);
+                    assertThat(slotPool.getNumPendingRequests()).isZero();
+                });
     }
 
     @Test
     void testCancelAllPendingRequestWhileFailing() throws Exception {
-        try (DeclarativeSlotPoolBridge slotPool = SlotPoolUtils.createDeclarativeSlotPoolBridge()) {
+        final int numTasksExceedSlotPool = 50;
+        // create a graph with task count larger than slot pool
+        JobVertex sender =
+                ExecutionGraphTestUtils.createJobVertex(
+                        "Task", NUM_TASKS + numTasksExceedSlotPool, NoOpInvokable.class);
+        JobGraph graph = JobGraphTestUtils.streamingJobGraph(sender);
+        SchedulerBase scheduler = createSchedulerBuilder(graph).build();
+        runInMainThread(
+                () -> {
+                    ExecutionGraph executionGraph = scheduler.getExecutionGraph();
 
-            final int numTasksExceedSlotPool = 50;
-            // create a graph with task count larger than slot pool
-            JobVertex sender =
-                    ExecutionGraphTestUtils.createJobVertex(
-                            "Task", NUM_TASKS + numTasksExceedSlotPool, NoOpInvokable.class);
-            JobGraph graph = JobGraphTestUtils.streamingJobGraph(sender);
-            SchedulerBase scheduler =
-                    new DefaultSchedulerBuilder(
-                                    graph, mainThreadExecutor, EXECUTOR_RESOURCE.getExecutor())
-                            .setExecutionSlotAllocatorFactory(
-                                    createExecutionSlotAllocatorFactory(slotPool))
-                            .build();
-            ExecutionGraph executionGraph = scheduler.getExecutionGraph();
+                    startScheduling(scheduler);
+                    SlotPoolUtils.offerSlotsFromMainThread(
+                            slotPool, Collections.nCopies(NUM_TASKS, ResourceProfile.ANY));
 
-            startScheduling(scheduler);
-            offerSlots(slotPool, NUM_TASKS);
+                    assertThat(slotPool.getNumPendingRequests()).isEqualTo(numTasksExceedSlotPool);
 
-            assertThat(slotPool.getNumPendingRequests()).isEqualTo(numTasksExceedSlotPool);
-
-            scheduler.handleGlobalFailure(new Exception("test"));
-            assertThat(executionGraph.getState()).isEqualTo(JobStatus.FAILING);
-            assertThat(slotPool.getNumPendingRequests()).isZero();
-        }
+                    scheduler.handleGlobalFailure(new Exception("test"));
+                    assertThat(executionGraph.getState()).isEqualTo(JobStatus.FAILING);
+                    assertThat(slotPool.getNumPendingRequests()).isZero();
+                });
     }
 
     @Test
     void testCancelWhileRestarting() throws Exception {
         // We want to manually control the restart and delay
-        try (SlotPool slotPool = SlotPoolUtils.createDeclarativeSlotPoolBridge()) {
-            SchedulerBase scheduler =
-                    new DefaultSchedulerBuilder(
-                                    createJobGraph(),
-                                    mainThreadExecutor,
-                                    EXECUTOR_RESOURCE.getExecutor())
-                            .setExecutionSlotAllocatorFactory(
-                                    createExecutionSlotAllocatorFactory(slotPool))
-                            .setRestartBackoffTimeStrategy(
-                                    new TestRestartBackoffTimeStrategy(true, Long.MAX_VALUE))
-                            .setDelayExecutor(taskRestartExecutor)
-                            .build();
-            ExecutionGraph executionGraph = scheduler.getExecutionGraph();
+        SchedulerBase scheduler =
+                createSchedulerBuilder(createJobGraph())
+                        .setRestartBackoffTimeStrategy(
+                                new TestRestartBackoffTimeStrategy(true, Long.MAX_VALUE))
+                        .setDelayExecutor(taskRestartExecutor)
+                        .build();
 
-            startScheduling(scheduler);
+        runInMainThread(
+                () -> {
+                    ExecutionGraph executionGraph = scheduler.getExecutionGraph();
 
-            final ResourceID taskManagerResourceId = offerSlots(slotPool, NUM_TASKS);
+                    startScheduling(scheduler);
 
-            // Release the TaskManager and wait for the job to restart
-            slotPool.releaseTaskManager(taskManagerResourceId, new Exception("Test Exception"));
-            assertThat(executionGraph.getState()).isEqualTo(JobStatus.RESTARTING);
+                    final ResourceID taskManagerResourceId =
+                            SlotPoolUtils.offerSlotsFromMainThread(
+                                    slotPool, Collections.nCopies(NUM_TASKS, ResourceProfile.ANY));
 
-            // Canceling needs to abort the restart
-            scheduler.cancel();
+                    // Release the TaskManager and wait for the job to restart
+                    slotPool.releaseTaskManager(
+                            taskManagerResourceId, new Exception("Test Exception"));
+                    assertThat(executionGraph.getState()).isEqualTo(JobStatus.RESTARTING);
 
-            assertThat(executionGraph.getState()).isEqualTo(JobStatus.CANCELED);
+                    // Canceling needs to abort the restart
+                    scheduler.cancel();
 
-            taskRestartExecutor.triggerScheduledTasks();
+                    assertThat(executionGraph.getState()).isEqualTo(JobStatus.CANCELED);
 
-            assertThat(executionGraph.getState()).isEqualTo(JobStatus.CANCELED);
-            for (ExecutionVertex vertex : executionGraph.getAllExecutionVertices()) {
-                assertThat(vertex.getExecutionState()).isEqualTo(ExecutionState.FAILED);
-            }
-        }
+                    taskRestartExecutor.triggerScheduledTasks();
+
+                    assertThat(executionGraph.getState()).isEqualTo(JobStatus.CANCELED);
+                    for (ExecutionVertex vertex : executionGraph.getAllExecutionVertices()) {
+                        assertThat(vertex.getExecutionState()).isEqualTo(ExecutionState.FAILED);
+                    }
+                });
     }
 
-    private static ResourceID offerSlots(SlotPool slotPool, int numSlots) {
-        return SlotPoolUtils.offerSlots(
-                slotPool, mainThreadExecutor, Collections.nCopies(numSlots, ResourceProfile.ANY));
+    private static void runInMainThread(final Runnable runnable) {
+        CompletableFuture.runAsync(runnable, JM_MAIN_THREAD_EXECUTOR_EXTENSION.getExecutor())
+                .join();
     }
 
     @Test
     void testCancelWhileFailing() throws Exception {
-        try (SlotPool slotPool = SlotPoolUtils.createDeclarativeSlotPoolBridge()) {
-            SchedulerBase scheduler =
-                    new DefaultSchedulerBuilder(
-                                    createJobGraph(),
-                                    mainThreadExecutor,
-                                    EXECUTOR_RESOURCE.getExecutor())
-                            .setExecutionSlotAllocatorFactory(
-                                    createExecutionSlotAllocatorFactory(slotPool))
-                            .setRestartBackoffTimeStrategy(
-                                    new TestRestartBackoffTimeStrategy(false, Long.MAX_VALUE))
-                            .build();
-            ExecutionGraph graph = scheduler.getExecutionGraph();
+        SchedulerBase scheduler =
+                createSchedulerBuilder(createJobGraph())
+                        .setRestartBackoffTimeStrategy(
+                                new TestRestartBackoffTimeStrategy(false, Long.MAX_VALUE))
+                        .build();
+        runInMainThread(
+                () -> {
+                    ExecutionGraph graph = scheduler.getExecutionGraph();
 
-            startScheduling(scheduler);
+                    startScheduling(scheduler);
 
-            offerSlots(slotPool, NUM_TASKS);
+                    SlotPoolUtils.offerSlotsFromMainThread(
+                            slotPool, Collections.nCopies(NUM_TASKS, ResourceProfile.ANY));
 
-            assertThat(graph.getState()).isEqualTo(JobStatus.RUNNING);
+                    assertThat(graph.getState()).isEqualTo(JobStatus.RUNNING);
 
-            switchAllTasksToRunning(graph);
+                    switchAllTasksToRunning(graph);
 
-            scheduler.handleGlobalFailure(new Exception("test"));
+                    scheduler.handleGlobalFailure(new Exception("test"));
 
-            assertThat(graph.getState()).isEqualTo(JobStatus.FAILING);
+                    assertThat(graph.getState()).isEqualTo(JobStatus.FAILING);
 
-            scheduler.cancel();
+                    scheduler.cancel();
 
-            assertThat(graph.getState()).isEqualTo(JobStatus.CANCELLING);
+                    assertThat(graph.getState()).isEqualTo(JobStatus.CANCELLING);
 
-            // let all tasks finish cancelling
-            completeCanceling(graph);
+                    // let all tasks finish cancelling
+                    completeCanceling(graph);
 
-            assertThat(graph.getState()).isEqualTo(JobStatus.CANCELED);
-        }
+                    assertThat(graph.getState()).isEqualTo(JobStatus.CANCELED);
+                });
     }
 
     @Test
     void testFailWhileCanceling() throws Exception {
-        try (SlotPool slotPool = SlotPoolUtils.createDeclarativeSlotPoolBridge()) {
-            SchedulerBase scheduler =
-                    new DefaultSchedulerBuilder(
-                                    createJobGraph(),
-                                    mainThreadExecutor,
-                                    EXECUTOR_RESOURCE.getExecutor())
-                            .setExecutionSlotAllocatorFactory(
-                                    createExecutionSlotAllocatorFactory(slotPool))
-                            .setRestartBackoffTimeStrategy(
-                                    new TestRestartBackoffTimeStrategy(false, Long.MAX_VALUE))
-                            .build();
-            ExecutionGraph graph = scheduler.getExecutionGraph();
+        SchedulerBase scheduler =
+                createSchedulerBuilder(createJobGraph())
+                        .setRestartBackoffTimeStrategy(
+                                new TestRestartBackoffTimeStrategy(false, Long.MAX_VALUE))
+                        .build();
+        runInMainThread(
+                () -> {
+                    ExecutionGraph graph = scheduler.getExecutionGraph();
 
-            startScheduling(scheduler);
+                    startScheduling(scheduler);
 
-            offerSlots(slotPool, NUM_TASKS);
+                    SlotPoolUtils.offerSlotsFromMainThread(
+                            slotPool, Collections.nCopies(NUM_TASKS, ResourceProfile.ANY));
 
-            assertThat(graph.getState()).isEqualTo(JobStatus.RUNNING);
-            switchAllTasksToRunning(graph);
+                    assertThat(graph.getState()).isEqualTo(JobStatus.RUNNING);
+                    switchAllTasksToRunning(graph);
 
-            scheduler.cancel();
+                    scheduler.cancel();
 
-            assertThat(graph.getState()).isEqualTo(JobStatus.CANCELLING);
+                    assertThat(graph.getState()).isEqualTo(JobStatus.CANCELLING);
 
-            scheduler.handleGlobalFailure(new Exception("test"));
+                    scheduler.handleGlobalFailure(new Exception("test"));
 
-            assertThat(graph.getState()).isEqualTo(JobStatus.FAILING);
+                    assertThat(graph.getState()).isEqualTo(JobStatus.FAILING);
 
-            // let all tasks finish cancelling
-            completeCanceling(graph);
+                    // let all tasks finish cancelling
+                    completeCanceling(graph);
 
-            assertThat(graph.getState()).isEqualTo(JobStatus.FAILED);
-        }
+                    assertThat(graph.getState()).isEqualTo(JobStatus.FAILED);
+                });
     }
 
     private void switchAllTasksToRunning(ExecutionGraph graph) {
@@ -286,55 +293,74 @@ class ExecutionGraphRestartTest {
                 ExecutionGraphTestUtils.createJobVertex("Task2", 1, NoOpInvokable.class);
         JobGraph jobGraph = JobGraphTestUtils.streamingJobGraph(sender, receiver);
 
-        try (SlotPool slotPool = SlotPoolUtils.createDeclarativeSlotPoolBridge()) {
-            SchedulerBase scheduler =
-                    new DefaultSchedulerBuilder(
-                                    jobGraph, mainThreadExecutor, EXECUTOR_RESOURCE.getExecutor())
-                            .setExecutionSlotAllocatorFactory(
-                                    createExecutionSlotAllocatorFactory(slotPool))
-                            .setRestartBackoffTimeStrategy(
-                                    new TestRestartBackoffTimeStrategy(true, Long.MAX_VALUE))
-                            .setDelayExecutor(taskRestartExecutor)
-                            .build();
-            ExecutionGraph eg = scheduler.getExecutionGraph();
+        SchedulerBase scheduler =
+                createSchedulerBuilder(jobGraph)
+                        .setRestartBackoffTimeStrategy(
+                                new TestRestartBackoffTimeStrategy(true, Long.MAX_VALUE))
+                        .setDelayExecutor(taskRestartExecutor)
+                        .build();
 
-            startScheduling(scheduler);
+        final ExecutionGraph eg = scheduler.getExecutionGraph();
+        // Hold the original finished execution reference across runInMainThread calls
+        final Execution[] savedExecution = new Execution[1];
 
-            offerSlots(slotPool, 2);
+        // Phase 1: Start, deploy, fail one task, and trigger restart.
+        // The restart callback (restartTasks) is queued on mainThreadExecutor via
+        // cancelFuture.thenRunAsync(..., mainThreadExecutor) and will execute after this
+        // runInMainThread call returns.
+        runInMainThread(
+                () -> {
+                    startScheduling(scheduler);
 
-            Iterator<ExecutionVertex> executionVertices = eg.getAllExecutionVertices().iterator();
+                    SlotPoolUtils.offerSlotsFromMainThread(
+                            slotPool, Collections.nCopies(2, ResourceProfile.ANY));
 
-            Execution finishedExecution = executionVertices.next().getCurrentExecutionAttempt();
-            Execution failedExecution = executionVertices.next().getCurrentExecutionAttempt();
+                    Iterator<ExecutionVertex> executionVertices =
+                            eg.getAllExecutionVertices().iterator();
 
-            finishedExecution.markFinished();
+                    Execution finishedExecution =
+                            executionVertices.next().getCurrentExecutionAttempt();
+                    Execution failedExecution =
+                            executionVertices.next().getCurrentExecutionAttempt();
 
-            failedExecution.fail(new Exception("Test Exception"));
-            failedExecution.completeCancelling();
+                    finishedExecution.markFinished();
 
-            taskRestartExecutor.triggerScheduledTasks();
+                    failedExecution.fail(new Exception("Test Exception"));
+                    failedExecution.completeCancelling();
 
-            assertThat(eg.getState()).isEqualTo(JobStatus.RUNNING);
+                    savedExecution[0] = finishedExecution;
 
-            // At this point all resources have been assigned
-            for (ExecutionVertex vertex : eg.getAllExecutionVertices()) {
-                assertThat(vertex.getCurrentAssignedResource()).isNotNull();
-                vertex.getCurrentExecutionAttempt().switchToInitializing();
-                vertex.getCurrentExecutionAttempt().switchToRunning();
-            }
+                    taskRestartExecutor.triggerScheduledTasks();
+                });
 
-            // fail old finished execution, this should not affect the execution
-            finishedExecution.fail(new Exception("This should have no effect"));
+        // Phase 2: The restart callback has now executed (it was queued ahead of this
+        // lambda). Verify the graph restarted and the old finished execution is unaffected.
+        runInMainThread(
+                () -> {
+                    Execution finishedExecution = savedExecution[0];
 
-            for (ExecutionVertex vertex : eg.getAllExecutionVertices()) {
-                vertex.getCurrentExecutionAttempt().markFinished();
-            }
+                    assertThat(eg.getState()).isEqualTo(JobStatus.RUNNING);
 
-            // the state of the finished execution should have not changed since it is terminal
-            assertThat(finishedExecution.getState()).isEqualTo(ExecutionState.FINISHED);
+                    // At this point all resources have been assigned
+                    for (ExecutionVertex vertex : eg.getAllExecutionVertices()) {
+                        assertThat(vertex.getCurrentAssignedResource()).isNotNull();
+                        vertex.getCurrentExecutionAttempt().switchToInitializing();
+                        vertex.getCurrentExecutionAttempt().switchToRunning();
+                    }
 
-            assertThat(eg.getState()).isEqualTo(JobStatus.FINISHED);
-        }
+                    // fail old finished execution, this should not affect the execution
+                    finishedExecution.fail(new Exception("This should have no effect"));
+
+                    for (ExecutionVertex vertex : eg.getAllExecutionVertices()) {
+                        vertex.getCurrentExecutionAttempt().markFinished();
+                    }
+
+                    // the state of the finished execution should have not changed since it
+                    // is terminal
+                    assertThat(finishedExecution.getState()).isEqualTo(ExecutionState.FINISHED);
+
+                    assertThat(eg.getState()).isEqualTo(JobStatus.FINISHED);
+                });
     }
 
     /**
@@ -344,41 +370,41 @@ class ExecutionGraphRestartTest {
      */
     @Test
     void testFailExecutionAfterCancel() throws Exception {
-        try (SlotPool slotPool = SlotPoolUtils.createDeclarativeSlotPoolBridge()) {
-            SchedulerBase scheduler =
-                    new DefaultSchedulerBuilder(
-                                    createJobGraphToCancel(),
-                                    mainThreadExecutor,
-                                    EXECUTOR_RESOURCE.getExecutor())
-                            .setExecutionSlotAllocatorFactory(
-                                    createExecutionSlotAllocatorFactory(slotPool))
-                            .setRestartBackoffTimeStrategy(
-                                    new TestRestartBackoffTimeStrategy(false, Long.MAX_VALUE))
-                            .setDelayExecutor(taskRestartExecutor)
-                            .build();
-            ExecutionGraph eg = scheduler.getExecutionGraph();
+        SchedulerBase scheduler =
+                createSchedulerBuilder(createJobGraphToCancel())
+                        .setRestartBackoffTimeStrategy(
+                                new TestRestartBackoffTimeStrategy(false, Long.MAX_VALUE))
+                        .setDelayExecutor(taskRestartExecutor)
+                        .build();
+        runInMainThread(
+                () -> {
+                    ExecutionGraph eg = scheduler.getExecutionGraph();
 
-            startScheduling(scheduler);
+                    startScheduling(scheduler);
 
-            offerSlots(slotPool, 1);
+                    SlotPoolUtils.offerSlotsFromMainThread(
+                            slotPool, Collections.singletonList(ResourceProfile.ANY));
 
-            // Fail right after cancel (for example with concurrent slot release)
-            scheduler.cancel();
+                    // Fail right after cancel (for example with concurrent slot release)
+                    scheduler.cancel();
 
-            for (ExecutionVertex v : eg.getAllExecutionVertices()) {
-                v.getCurrentExecutionAttempt().fail(new Exception("Test Exception"));
-            }
+                    for (ExecutionVertex v : eg.getAllExecutionVertices()) {
+                        v.getCurrentExecutionAttempt().fail(new Exception("Test Exception"));
+                    }
 
-            FlinkAssertions.assertThatFuture(eg.getTerminationFuture())
-                    .eventuallySucceeds()
-                    .isEqualTo(JobStatus.CANCELED);
+                    FlinkAssertions.assertThatFuture(eg.getTerminationFuture())
+                            .eventuallySucceeds()
+                            .isEqualTo(JobStatus.CANCELED);
 
-            Execution execution =
-                    eg.getAllExecutionVertices().iterator().next().getCurrentExecutionAttempt();
+                    Execution execution =
+                            eg.getAllExecutionVertices()
+                                    .iterator()
+                                    .next()
+                                    .getCurrentExecutionAttempt();
 
-            execution.completeCancelling();
-            assertThat(eg.getState()).isEqualTo(JobStatus.CANCELED);
-        }
+                    execution.completeCancelling();
+                    assertThat(eg.getState()).isEqualTo(JobStatus.CANCELED);
+                });
     }
 
     // ------------------------------------------------------------------------
@@ -391,14 +417,16 @@ class ExecutionGraphRestartTest {
         assertThat(scheduler.getExecutionGraph().getState()).isEqualTo(JobStatus.RUNNING);
     }
 
-    private static ExecutionSlotAllocatorFactory createExecutionSlotAllocatorFactory(
-            SlotPool slotPool) throws Exception {
+    private DefaultSchedulerBuilder createSchedulerBuilder(JobGraph jobGraph) throws Exception {
         setupSlotPool(slotPool);
         PhysicalSlotProvider physicalSlotProvider =
                 new PhysicalSlotProviderImpl(
                         LocationPreferenceSlotSelectionStrategy.createDefault(), slotPool);
-        return SchedulerTestingUtils.newSlotSharingExecutionSlotAllocatorFactory(
-                physicalSlotProvider);
+        return new DefaultSchedulerBuilder(
+                        jobGraph, mainThreadExecutor, EXECUTOR_EXTENSION.getExecutor())
+                .setExecutionSlotAllocatorFactory(
+                        SchedulerTestingUtils.newSlotSharingExecutionSlotAllocatorFactory(
+                                physicalSlotProvider));
     }
 
     private static void setupSlotPool(SlotPool slotPool) throws Exception {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolUtils.java
@@ -74,23 +74,24 @@ public class SlotPoolUtils {
             SlotPool slotPool,
             ComponentMainThreadExecutor mainThreadExecutor,
             List<ResourceProfile> resourceProfiles) {
-        return offerSlots(
-                slotPool,
-                mainThreadExecutor,
-                resourceProfiles,
-                new SimpleAckingTaskManagerGateway());
+        return CompletableFuture.supplyAsync(
+                        () -> offerSlotsFromMainThread(slotPool, resourceProfiles),
+                        mainThreadExecutor)
+                .join();
     }
 
     public static ResourceID tryOfferSlots(
             SlotPool slotPool,
             ComponentMainThreadExecutor mainThreadExecutor,
             List<ResourceProfile> resourceProfiles) {
-        return offerSlots(
-                slotPool,
-                mainThreadExecutor,
-                resourceProfiles,
-                new SimpleAckingTaskManagerGateway(),
-                false);
+        return CompletableFuture.supplyAsync(
+                        () ->
+                                tryOfferSlotsFromMainThread(
+                                        slotPool,
+                                        resourceProfiles,
+                                        new SimpleAckingTaskManagerGateway()),
+                        mainThreadExecutor)
+                .join();
     }
 
     public static ResourceID offerSlots(
@@ -98,40 +99,81 @@ public class SlotPoolUtils {
             ComponentMainThreadExecutor mainThreadExecutor,
             List<ResourceProfile> resourceProfiles,
             TaskManagerGateway taskManagerGateway) {
-        return offerSlots(slotPool, mainThreadExecutor, resourceProfiles, taskManagerGateway, true);
-    }
-
-    private static ResourceID offerSlots(
-            SlotPool slotPool,
-            ComponentMainThreadExecutor mainThreadExecutor,
-            List<ResourceProfile> resourceProfiles,
-            TaskManagerGateway taskManagerGateway,
-            boolean assertAllSlotsAreAccepted) {
-        final TaskManagerLocation taskManagerLocation = new LocalTaskManagerLocation();
-        CompletableFuture.runAsync(
-                        () -> {
-                            slotPool.registerTaskManager(taskManagerLocation.getResourceID());
-
-                            final Collection<SlotOffer> slotOffers =
-                                    IntStream.range(0, resourceProfiles.size())
-                                            .mapToObj(
-                                                    i ->
-                                                            new SlotOffer(
-                                                                    new AllocationID(),
-                                                                    i,
-                                                                    resourceProfiles.get(i)))
-                                            .collect(Collectors.toList());
-
-                            final Collection<SlotOffer> acceptedOffers =
-                                    slotPool.offerSlots(
-                                            taskManagerLocation, taskManagerGateway, slotOffers);
-
-                            if (assertAllSlotsAreAccepted) {
-                                assertThat(acceptedOffers).isEqualTo(slotOffers);
-                            }
-                        },
+        return CompletableFuture.supplyAsync(
+                        () ->
+                                offerSlotsFromMainThread(
+                                        slotPool, resourceProfiles, taskManagerGateway),
                         mainThreadExecutor)
                 .join();
+    }
+
+    /**
+     * Offers slots directly on the slot pool. Must be called from the main thread (e.g. inside a
+     * {@code runInMainThread} block). All offered slots are expected to be accepted.
+     *
+     * @param slotPool the slot pool to offer slots to
+     * @param resourceProfiles the resource profiles of the slots to offer
+     * @return the resource ID of the registered task manager
+     */
+    public static ResourceID offerSlotsFromMainThread(
+            SlotPool slotPool, List<ResourceProfile> resourceProfiles) {
+        return offerSlotsFromMainThread(
+                slotPool, resourceProfiles, new SimpleAckingTaskManagerGateway());
+    }
+
+    /**
+     * Offers slots directly on the slot pool. Must be called from the main thread (e.g. inside a
+     * {@code runInMainThread} block). All offered slots are expected to be accepted.
+     *
+     * @param slotPool the slot pool to offer slots to
+     * @param resourceProfiles the resource profiles of the slots to offer
+     * @param taskManagerGateway the task manager gateway to use
+     * @return the resource ID of the registered task manager
+     */
+    public static ResourceID offerSlotsFromMainThread(
+            SlotPool slotPool,
+            List<ResourceProfile> resourceProfiles,
+            TaskManagerGateway taskManagerGateway) {
+        final TaskManagerLocation taskManagerLocation = new LocalTaskManagerLocation();
+        slotPool.registerTaskManager(taskManagerLocation.getResourceID());
+
+        final Collection<SlotOffer> slotOffers =
+                IntStream.range(0, resourceProfiles.size())
+                        .mapToObj(
+                                i -> new SlotOffer(new AllocationID(), i, resourceProfiles.get(i)))
+                        .collect(Collectors.toList());
+
+        final Collection<SlotOffer> acceptedOffers =
+                slotPool.offerSlots(taskManagerLocation, taskManagerGateway, slotOffers);
+
+        assertThat(acceptedOffers).isEqualTo(slotOffers);
+
+        return taskManagerLocation.getResourceID();
+    }
+
+    /**
+     * Offers slots directly on the slot pool without asserting that all slots are accepted. Must be
+     * called from the main thread (e.g. inside a {@code runInMainThread} block).
+     *
+     * @param slotPool the slot pool to offer slots to
+     * @param resourceProfiles the resource profiles of the slots to offer
+     * @param taskManagerGateway the task manager gateway to use
+     * @return the resource ID of the registered task manager
+     */
+    public static ResourceID tryOfferSlotsFromMainThread(
+            SlotPool slotPool,
+            List<ResourceProfile> resourceProfiles,
+            TaskManagerGateway taskManagerGateway) {
+        final TaskManagerLocation taskManagerLocation = new LocalTaskManagerLocation();
+        slotPool.registerTaskManager(taskManagerLocation.getResourceID());
+
+        final Collection<SlotOffer> slotOffers =
+                IntStream.range(0, resourceProfiles.size())
+                        .mapToObj(
+                                i -> new SlotOffer(new AllocationID(), i, resourceProfiles.get(i)))
+                        .collect(Collectors.toList());
+
+        slotPool.offerSlots(taskManagerLocation, taskManagerGateway, slotOffers);
 
         return taskManagerLocation.getResourceID();
     }


### PR DESCRIPTION
## What is the purpose of the change

Backport of the FLINK-38441 and FLINK-39182 test-stability fixes from master to release-2.2 (both are already on release-2.3). The two JIRAs are bundled because they fix the same root cause in two sibling test classes; each is a separate clean `-x` cherry-pick, so individual reverts remain possible. This PR is independent of the parallel FLINK-39921/FLINK-39929 backport PR.

Observed on release-2.2 nightlies:

  - `ExecutionGraphRestartTest.testCancelWhileFailing` (expected RUNNING but was FAILING) and `testFailingExecutionAfterRestart` (expected FINISHED but was FAILED) in [build 76712](https://dev.azure.com/apache-flink/apache-flink/_build/results?buildId=76712&view=results), `test_ci core` leg.
  - `ExecutionGraphCoLocationRestartTest.testConstraintsAfterRestart` timing out in `waitForAllExecutionsPredicate` in [build 76611](https://dev.azure.com/apache-flink/apache-flink/_build/results?buildId=76611&view=results) and [build 76677](https://dev.azure.com/apache-flink/apache-flink/_build/results?buildId=76677&view=results), adaptive-scheduler core legs.

Root cause: since FLINK-38114, TaskDeploymentDescriptor creation is offloaded to the I/O executor and deploy continuations complete on background threads, tripping the thread-identity assertion of the `ComponentMainThreadExecutorServiceAdapter.forMainThread()` test executor. The assertion failure surfaces as a deployment failure (spurious FAILING/FAILED job state) or as executions never reaching DEPLOYING (predicate timeout). Both master fixes move the tests onto a real single-threaded main-thread executor instead. Test-only change (including the `SlotPoolUtils` test helper, whose public API is unchanged); the production scheduler is not affected.

## Brief change log

Clean `git cherry-pick -x` of the merged master fixes (byte-identical, original authorship preserved):

  - FLINK-38441 (master 94c65494b20, #27060): run `ExecutionGraphCoLocationRestartTest` via `TestingComponentMainThreadExecutor`.
  - FLINK-39182 (master 3fb0d04d225): run `ExecutionGraphRestartTest` via `ComponentMainThreadExecutorServiceAdapter.forSingleThreadExecutor`, adjusting the `SlotPoolUtils` test helper (public method signatures preserved; only a private overload removed).

## Verifying this change

This change is already covered by existing tests: ran `ExecutionGraphRestartTest` (7 tests) and `ExecutionGraphCoLocationRestartTest` (1 test) on this branch, 8/8 green (and 5 consecutive green runs of the same classes during preparation of the picks).

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no (test-only)
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (Claude Code)

Generated-by: Claude Code (Claude Fable 5)
