### PR TITLE
[FLINK-40073] [INFRA] Add delete and force push protection to default and release branches

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -13,6 +13,18 @@ github:
     - sql
   collaborators:
     - flinkbot
+  rulesets:
+    - name: "Default and Release Branch Protection"
+      type: branch
+      branches:
+        includes:
+          - "~DEFAULT_BRANCH"
+          - "release-*"
+        excludes: [ ]
+      bypass_teams:
+        - root
+      restrict_deletion: true
+      restrict_force_push: true
 notifications:
   commits:      commits@flink.apache.org
   issues:       issues@flink.apache.org


### PR DESCRIPTION
<!--

## Contribution Checklist
  

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Add delete and force push protections to default and release branches. Replacing bot PR https://github.com/apache/flink/pull/28171 with the wrong release branch pattern.


## Brief change log

- Added a ruleset in the .asf.yaml. file for the default and release branches.



## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): No
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: No
  - The serializers: No
  - The runtime per-record code paths (performance sensitive): No
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: No
  - The S3 file system connector: No

## Documentation

  - Does this pull request introduce a new feature? No
  - If yes, how is the feature documented? Not Applicable

---

##### Was generative AI tooling used to co-author this PR?

No


