### PR TITLE
[FLINK-39034][runtime] Preserve timestamps in SortPartitionOperator

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/streaming/api/operators/sortpartition/SortPartitionOperator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/api/operators/sortpartition/SortPartitionOperator.java
@@ -23,14 +23,16 @@ import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.InvalidProgramException;
 import org.apache.flink.api.common.operators.Keys;
 import org.apache.flink.api.common.operators.Order;
+import org.apache.flink.api.common.typeinfo.AtomicType;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
-import org.apache.flink.api.common.typeinfo.Types;
 import org.apache.flink.api.common.typeutils.CompositeType;
 import org.apache.flink.api.common.typeutils.TypeComparator;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.typeutils.TypeExtractor;
+import org.apache.flink.api.java.typeutils.runtime.TupleComparator;
+import org.apache.flink.api.java.typeutils.runtime.TupleSerializer;
 import org.apache.flink.configuration.AlgorithmOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.memory.ManagedMemoryUseCase;
@@ -44,10 +46,12 @@ import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
 import org.apache.flink.streaming.api.operators.OperatorAttributes;
 import org.apache.flink.streaming.api.operators.OperatorAttributesBuilder;
 import org.apache.flink.streaming.api.operators.Output;
-import org.apache.flink.streaming.api.operators.TimestampedCollector;
+import org.apache.flink.streaming.runtime.streamrecord.StreamElementSerializer;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.runtime.tasks.StreamTask;
 import org.apache.flink.util.MutableObjectIterator;
+
+import java.util.Arrays;
 
 /**
  * The {@link SortPartitionOperator} sorts records of a partition on non-keyed data stream. It
@@ -86,10 +90,10 @@ public class SortPartitionOperator<INPUT> extends AbstractStreamOperator<INPUT>
     private final int positionSortField;
 
     /** The sorter to sort record if the record is not sorted by {@link KeySelector}. */
-    private PushSorter<INPUT> recordSorter = null;
+    private PushSorter<StreamRecord<INPUT>> recordSorter = null;
 
     /** The sorter to sort record if the record is sorted by {@link KeySelector}. */
-    private PushSorter<Tuple2<?, INPUT>> recordSorterForKeySelector = null;
+    private PushSorter<Tuple2<?, StreamRecord<INPUT>>> recordSorterForKeySelector = null;
 
     public SortPartitionOperator(
             TypeInformation<INPUT> inputType, int positionSortField, Order sortOrder) {
@@ -131,30 +135,16 @@ public class SortPartitionOperator<INPUT> extends AbstractStreamOperator<INPUT>
         super.setup(containingTask, config, output);
         ExecutionConfig executionConfig = containingTask.getEnvironment().getExecutionConfig();
         if (sortFieldSelector != null) {
-            TypeInformation<Tuple2<?, INPUT>> sortTypeInfo =
-                    Types.TUPLE(
-                            TypeExtractor.getKeySelectorTypes(sortFieldSelector, inputType),
-                            inputType);
-            recordSorterForKeySelector =
-                    getSorter(
-                            sortTypeInfo.createSerializer(executionConfig.getSerializerConfig()),
-                            ((CompositeType<Tuple2<?, INPUT>>) sortTypeInfo)
-                                    .createComparator(
-                                            getSortFieldIndex(),
-                                            getSortOrderIndicator(),
-                                            0,
-                                            executionConfig),
-                            containingTask);
+            setupRecordSorterForKeySelector(executionConfig, containingTask);
         } else {
+            TypeSerializer<StreamRecord<INPUT>> streamRecordSerializer =
+                    createStreamRecordSerializer(
+                            inputType.createSerializer(executionConfig.getSerializerConfig()));
             recordSorter =
                     getSorter(
-                            inputType.createSerializer(executionConfig.getSerializerConfig()),
-                            ((CompositeType<INPUT>) inputType)
-                                    .createComparator(
-                                            getSortFieldIndex(),
-                                            getSortOrderIndicator(),
-                                            0,
-                                            executionConfig),
+                            streamRecordSerializer,
+                            new StreamRecordComparator<>(
+                                    createInputComparator(executionConfig), streamRecordSerializer),
                             containingTask);
         }
     }
@@ -163,31 +153,30 @@ public class SortPartitionOperator<INPUT> extends AbstractStreamOperator<INPUT>
     public void processElement(StreamRecord<INPUT> element) throws Exception {
         if (sortFieldSelector != null) {
             recordSorterForKeySelector.writeRecord(
-                    Tuple2.of(sortFieldSelector.getKey(element.getValue()), element.getValue()));
+                    Tuple2.of(sortFieldSelector.getKey(element.getValue()), element));
         } else {
-            recordSorter.writeRecord(element.getValue());
+            recordSorter.writeRecord(element);
         }
     }
 
     @Override
     public void endInput() throws Exception {
-        TimestampedCollector<INPUT> outputCollector = new TimestampedCollector<>(output);
         if (sortFieldSelector != null) {
             recordSorterForKeySelector.finishReading();
-            MutableObjectIterator<Tuple2<?, INPUT>> dataIterator =
+            MutableObjectIterator<Tuple2<?, StreamRecord<INPUT>>> dataIterator =
                     recordSorterForKeySelector.getIterator();
-            Tuple2<?, INPUT> record = dataIterator.next();
+            Tuple2<?, StreamRecord<INPUT>> record = dataIterator.next();
             while (record != null) {
-                outputCollector.collect(record.f1);
+                output.collect(record.f1);
                 record = dataIterator.next();
             }
             recordSorterForKeySelector.close();
         } else {
             recordSorter.finishReading();
-            MutableObjectIterator<INPUT> dataIterator = recordSorter.getIterator();
-            INPUT record = dataIterator.next();
+            MutableObjectIterator<StreamRecord<INPUT>> dataIterator = recordSorter.getIterator();
+            StreamRecord<INPUT> record = dataIterator.next();
             while (record != null) {
-                outputCollector.collect(record);
+                output.collect(record);
                 record = dataIterator.next();
             }
             recordSorter.close();
@@ -197,6 +186,73 @@ public class SortPartitionOperator<INPUT> extends AbstractStreamOperator<INPUT>
     @Override
     public OperatorAttributes getOperatorAttributes() {
         return new OperatorAttributesBuilder().setOutputOnlyAfterEndOfStream(true).build();
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private <K> void setupRecordSorterForKeySelector(
+            ExecutionConfig executionConfig, StreamTask<?, ?> containingTask) {
+        KeySelector<INPUT, K> typedSortFieldSelector = (KeySelector<INPUT, K>) sortFieldSelector;
+        TypeInformation<K> keyType =
+                TypeExtractor.getKeySelectorTypes(typedSortFieldSelector, inputType);
+        TypeSerializer<K> keySerializer =
+                keyType.createSerializer(executionConfig.getSerializerConfig());
+        TypeSerializer<StreamRecord<INPUT>> streamRecordSerializer =
+                createStreamRecordSerializer(
+                        inputType.createSerializer(executionConfig.getSerializerConfig()));
+        TupleSerializer<Tuple2<K, StreamRecord<INPUT>>> tupleSerializer =
+                new TupleSerializer<>(
+                        (Class<Tuple2<K, StreamRecord<INPUT>>>) (Class<?>) Tuple2.class,
+                        new TypeSerializer<?>[] {keySerializer, streamRecordSerializer});
+        TupleComparator<Tuple2<K, StreamRecord<INPUT>>> tupleComparator =
+                new TupleComparator<>(
+                        new int[] {0},
+                        new TypeComparator<?>[] {
+                            createKeyComparator(keyType, typedSortFieldSelector, executionConfig)
+                        },
+                        new TypeSerializer<?>[] {keySerializer, streamRecordSerializer});
+        recordSorterForKeySelector =
+                (PushSorter) getSorter(tupleSerializer, tupleComparator, containingTask);
+    }
+
+    @SuppressWarnings("unchecked")
+    private TypeComparator<INPUT> createInputComparator(ExecutionConfig executionConfig) {
+        if (inputType instanceof CompositeType) {
+            return ((CompositeType<INPUT>) inputType)
+                    .createComparator(
+                            getSortFieldIndex(), getSortOrderIndicator(), 0, executionConfig);
+        } else if (inputType instanceof AtomicType) {
+            return ((AtomicType<INPUT>) inputType)
+                    .createComparator(sortOrder == Order.ASCENDING, executionConfig);
+        }
+        throw new UnsupportedOperationException(
+                "Partition sorting does not support type " + inputType + " yet.");
+    }
+
+    @SuppressWarnings("unchecked")
+    private <K> TypeComparator<K> createKeyComparator(
+            TypeInformation<K> keyType,
+            KeySelector<INPUT, K> keySelector,
+            ExecutionConfig executionConfig) {
+        boolean ascending = sortOrder == Order.ASCENDING;
+        if (keyType instanceof CompositeType) {
+            Keys.SelectorFunctionKeys<INPUT, K> sortKey =
+                    new Keys.SelectorFunctionKeys<>(keySelector, inputType, keyType);
+            int[] sortFieldIndex = sortKey.computeLogicalKeyPositions();
+            boolean[] sortOrderIndicator = new boolean[sortFieldIndex.length];
+            Arrays.fill(sortOrderIndicator, ascending);
+            return ((CompositeType<K>) keyType)
+                    .createComparator(sortFieldIndex, sortOrderIndicator, 0, executionConfig);
+        } else if (keyType instanceof AtomicType) {
+            return ((AtomicType<K>) keyType).createComparator(ascending, executionConfig);
+        }
+        throw new UnsupportedOperationException(
+                "Partition sorting does not support key type " + keyType + " yet.");
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private static <T> TypeSerializer<StreamRecord<T>> createStreamRecordSerializer(
+            TypeSerializer<T> valueSerializer) {
+        return (TypeSerializer) new StreamElementSerializer<>(valueSerializer);
     }
 
     /**

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/api/operators/sortpartition/StreamRecordComparator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/api/operators/sortpartition/StreamRecordComparator.java
@@ -1,0 +1,148 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.operators.sortpartition;
+
+import org.apache.flink.api.common.typeutils.TypeComparator;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.core.memory.DataOutputView;
+import org.apache.flink.core.memory.MemorySegment;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+
+import java.io.IOException;
+
+/** Comparator that delegates sorting to the wrapped StreamRecord value comparator. */
+final class StreamRecordComparator<T> extends TypeComparator<StreamRecord<T>> {
+
+    private static final long serialVersionUID = 1L;
+
+    private final TypeComparator<T> valueComparator;
+    private final TypeSerializer<StreamRecord<T>> streamRecordSerializer;
+
+    StreamRecordComparator(
+            TypeComparator<T> valueComparator,
+            TypeSerializer<StreamRecord<T>> streamRecordSerializer) {
+        this.valueComparator = valueComparator;
+        this.streamRecordSerializer = streamRecordSerializer;
+    }
+
+    @Override
+    public int hash(StreamRecord<T> record) {
+        return valueComparator.hash(record.getValue());
+    }
+
+    @Override
+    public void setReference(StreamRecord<T> toCompare) {
+        valueComparator.setReference(toCompare.getValue());
+    }
+
+    @Override
+    public boolean equalToReference(StreamRecord<T> candidate) {
+        return valueComparator.equalToReference(candidate.getValue());
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public int compareToReference(TypeComparator<StreamRecord<T>> referencedComparator) {
+        return valueComparator.compareToReference(
+                ((StreamRecordComparator<T>) referencedComparator).valueComparator);
+    }
+
+    @Override
+    public boolean supportsCompareAgainstReference() {
+        return valueComparator.supportsCompareAgainstReference();
+    }
+
+    @SuppressWarnings("rawtypes")
+    @Override
+    public int compareAgainstReference(Comparable[] keys) {
+        return valueComparator.compareAgainstReference(keys);
+    }
+
+    @Override
+    public int compare(StreamRecord<T> first, StreamRecord<T> second) {
+        return valueComparator.compare(first.getValue(), second.getValue());
+    }
+
+    @Override
+    public int compareSerialized(DataInputView firstSource, DataInputView secondSource)
+            throws IOException {
+        StreamRecord<T> firstRecord = streamRecordSerializer.deserialize(firstSource);
+        StreamRecord<T> secondRecord = streamRecordSerializer.deserialize(secondSource);
+        return compare(firstRecord, secondRecord);
+    }
+
+    @Override
+    public boolean supportsNormalizedKey() {
+        return valueComparator.supportsNormalizedKey();
+    }
+
+    @Override
+    public boolean supportsSerializationWithKeyNormalization() {
+        return false;
+    }
+
+    @Override
+    public int getNormalizeKeyLen() {
+        return valueComparator.getNormalizeKeyLen();
+    }
+
+    @Override
+    public boolean isNormalizedKeyPrefixOnly(int keyBytes) {
+        return valueComparator.isNormalizedKeyPrefixOnly(keyBytes);
+    }
+
+    @Override
+    public void putNormalizedKey(
+            StreamRecord<T> record, MemorySegment target, int offset, int numBytes) {
+        valueComparator.putNormalizedKey(record.getValue(), target, offset, numBytes);
+    }
+
+    @Override
+    public void writeWithKeyNormalization(StreamRecord<T> record, DataOutputView target) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public StreamRecord<T> readWithKeyDenormalization(StreamRecord<T> reuse, DataInputView source) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean invertNormalizedKey() {
+        return valueComparator.invertNormalizedKey();
+    }
+
+    @Override
+    public TypeComparator<StreamRecord<T>> duplicate() {
+        return new StreamRecordComparator<>(
+                valueComparator.duplicate(), streamRecordSerializer.duplicate());
+    }
+
+    @Override
+    public int extractKeys(Object record, Object[] target, int index) {
+        return valueComparator.extractKeys(((StreamRecord<?>) record).getValue(), target, index);
+    }
+
+    @SuppressWarnings("rawtypes")
+    @Override
+    public TypeComparator[] getFlatComparators() {
+        return valueComparator.getFlatComparators();
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/streaming/api/operators/sortpartition/SortPartitionOperatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/streaming/api/operators/sortpartition/SortPartitionOperatorTest.java
@@ -47,12 +47,14 @@ class SortPartitionOperatorTest {
                 testHarness1 = new OneInputStreamOperatorTestHarness<>(operator1);
         Queue<Object> expectedOutput1 = new LinkedList<>();
         testHarness1.setup();
-        testHarness1.processElement(new StreamRecord<>(Tuple2.of(3, "3")));
-        testHarness1.processElement(new StreamRecord<>(Tuple2.of(1, "1")));
+        long earlierTimestamp = 1L;
+        long laterTimestamp = 3L;
+        testHarness1.processElement(new StreamRecord<>(Tuple2.of(3, "3"), earlierTimestamp));
+        testHarness1.processElement(new StreamRecord<>(Tuple2.of(1, "1"), laterTimestamp));
         testHarness1.endInput();
         testHarness1.close();
-        expectedOutput1.add(new StreamRecord<>(Tuple2.of(1, "1")));
-        expectedOutput1.add(new StreamRecord<>(Tuple2.of(3, "3")));
+        expectedOutput1.add(new StreamRecord<>(Tuple2.of(1, "1"), laterTimestamp));
+        expectedOutput1.add(new StreamRecord<>(Tuple2.of(3, "3"), earlierTimestamp));
         TestHarnessUtil.assertOutputEquals(
                 "The sort partition result is not correct.",
                 expectedOutput1,
@@ -63,12 +65,12 @@ class SortPartitionOperatorTest {
                 new OneInputStreamOperatorTestHarness<>(operator2);
         Queue<Object> expectedOutput2 = new LinkedList<>();
         testHarness2.setup();
-        testHarness2.processElement(new StreamRecord<>(new TestPojo("3", 3)));
-        testHarness2.processElement(new StreamRecord<>(new TestPojo("1", 1)));
+        testHarness2.processElement(new StreamRecord<>(new TestPojo("3", 3), earlierTimestamp));
+        testHarness2.processElement(new StreamRecord<>(new TestPojo("1", 1), laterTimestamp));
         testHarness2.endInput();
         testHarness2.close();
-        expectedOutput2.add(new StreamRecord<>(new TestPojo("1", 1)));
-        expectedOutput2.add(new StreamRecord<>(new TestPojo("3", 3)));
+        expectedOutput2.add(new StreamRecord<>(new TestPojo("1", 1), laterTimestamp));
+        expectedOutput2.add(new StreamRecord<>(new TestPojo("3", 3), earlierTimestamp));
         TestHarnessUtil.assertOutputEquals(
                 "The sort partition result is not correct.",
                 expectedOutput2,
@@ -79,12 +81,12 @@ class SortPartitionOperatorTest {
                 new OneInputStreamOperatorTestHarness<>(operator3);
         Queue<Object> expectedOutput3 = new LinkedList<>();
         testHarness3.setup();
-        testHarness3.processElement(new StreamRecord<>(new TestPojo("3", 3)));
-        testHarness3.processElement(new StreamRecord<>(new TestPojo("1", 1)));
+        testHarness3.processElement(new StreamRecord<>(new TestPojo("3", 3), earlierTimestamp));
+        testHarness3.processElement(new StreamRecord<>(new TestPojo("1", 1), laterTimestamp));
         testHarness3.endInput();
         testHarness3.close();
-        expectedOutput3.add(new StreamRecord<>(new TestPojo("1", 1)));
-        expectedOutput3.add(new StreamRecord<>(new TestPojo("3", 3)));
+        expectedOutput3.add(new StreamRecord<>(new TestPojo("1", 1), laterTimestamp));
+        expectedOutput3.add(new StreamRecord<>(new TestPojo("3", 3), earlierTimestamp));
         TestHarnessUtil.assertOutputEquals(
                 "The sort partition result is not correct.",
                 expectedOutput3,
@@ -102,6 +104,7 @@ class SortPartitionOperatorTest {
         testHarness.endInput();
         testHarness.close();
         assertThat(testHarness.getOutput()).isNotEmpty();
+        assertThat(((StreamRecord<?>) testHarness.getOutput().poll()).hasTimestamp()).isFalse();
     }
 
     private SortPartitionOperator<Tuple2<Integer, String>>


### PR DESCRIPTION
## What is the purpose of the change

`SortPartitionOperator` currently writes only record values into the external sorter for non-key-selector sorting. When records are emitted after sorting, this recreates output records without preserving the original `StreamRecord` timestamp state.

This change stores `StreamRecord` instances in the sorter and compares their wrapped values through a `StreamRecordComparator`, so sorted output preserves whether the input record had a timestamp and, when present, the original timestamp.

## Brief change log

- Store `StreamRecord<INPUT>` in the non-key-selector sorter path.
- Add `StreamRecordComparator` to compare records by their wrapped values while preserving stream record metadata.
- Extend `SortPartitionOperatorTest` to verify sorted output keeps timestamps and no-timestamp records remain timestamp-less.

## Verifying this change

This change is covered by existing and extended tests.

Verified locally with:

`./mvnw -pl flink-runtime -am -Dtest=SortPartitionOperatorTest -Dsurefire.failIfNoSpecifiedTests=false test`

The target test passed with 2 tests, 0 failures, 0 errors, and 0 skipped.

## Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): no
- The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
- The serializers: yes
- The runtime per-record code paths (performance sensitive): yes
- Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
- The S3 file system connector: no

## Documentation

- Does this pull request introduce a new feature? no
- If yes, how is the feature documented? not applicable

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: OpenAI GPT-5.5, reviewd by human
I'm responsible for the quality and correctness of every change in this PR regardless of the tooling used.