### PR TITLE
[FLINK-40077][table-planner] Fix lost NoMoreSplitsEvent masking failure cause in CommonExecSinkITCase

### DIFF
--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecSinkITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecSinkITCase.java
@@ -626,13 +626,21 @@ class CommonExecSinkITCase {
 
                                 @Override
                                 public void notifyNoMoreSplits() {
-                                    // Gates completion for every reader, including the split
-                                    // holder, so pollNext only finishes once this signal arrives.
+                                    // Signals that all coordinator events have been delivered,
+                                    // gating both emission and completion in pollNext below.
                                     noMoreSplits = true;
                                 }
 
                                 @Override
                                 public InputStatus pollNext(ReaderOutput<RowData> out) {
+                                    // Wait for the NoMoreSplitsEvent before emitting. Otherwise a
+                                    // downstream failure (e.g. the NOT NULL enforcer) can fail the
+                                    // task while that event is still in flight, so it reaches an
+                                    // already-FAILED task as a lost OperatorEvent whose failover
+                                    // masks the real cause under NoRestartBackoffTimeStrategy.
+                                    if (!noMoreSplits) {
+                                        return InputStatus.NOTHING_AVAILABLE;
+                                    }
                                     if (hasSplit && !emitted) {
                                         rows.forEach(
                                                 r ->
@@ -640,15 +648,7 @@ class CommonExecSinkITCase {
                                                                 (RowData) converter.toInternal(r)));
                                         emitted = true;
                                     }
-                                    // Finish only after the NoMoreSplitsEvent has arrived.
-                                    // Returning END_OF_INPUT earlier lets the task reach FINISHED
-                                    // before the coordinator delivers that event, which surfaces as
-                                    // a lost OperatorEvent and fails the job under
-                                    // NoRestartBackoffTimeStrategy.
-                                    if (noMoreSplits) {
-                                        return InputStatus.END_OF_INPUT;
-                                    }
-                                    return InputStatus.NOTHING_AVAILABLE;
+                                    return InputStatus.END_OF_INPUT;
                                 }
                             };
                         }


### PR DESCRIPTION
## What is the purpose of the change

`CommonExecSinkITCase.testNullEnforcer` is flaky on CI (observed on the AdaptiveScheduler nightly leg, Azure build [76751](https://dev.azure.com/apache-flink/apache-flink/_build/results?buildId=76751&view=results)). The test asserts that the job failure cause chain contains the NOT NULL enforcer message, but intermittently the reported terminal cause is instead `FlinkException: An OperatorEvent ... was lost ... Event: '[NoMoreSplitEvent]'`.

Root cause: the Source V2 test source emits all rows on the first `pollNext`, before the coordinator's `NoMoreSplitsEvent` is delivered. The NOT NULL enforcer then fails the chained `Source -> ConstraintEnforcer -> Writer` task; the still-in-flight `NoMoreSplitsEvent` reaches an already-FAILED task and, since it is not loss-tolerant, escalates to a lost-OperatorEvent failover. Under `NoRestartBackoffTimeStrategy` that failover wins as the reported cause and masks the enforcer error. This race is distinct from FLINK-40011 (which addressed the reader reaching FINISHED before the event arrived); it occurs on the FAILED-task path, which gating `END_OF_INPUT` alone cannot cover.

The underlying runtime behavior (a lost, non-loss-tolerant coordinator event to an already-failing task superseding the real application failure cause) is a pre-existing general issue tracked separately as [FLINK-40078](https://issues.apache.org/jira/browse/FLINK-40078); this PR only removes the race from the test scaffolding.

## Brief change log

- Gate record emission in the test source's `pollNext` on `noMoreSplits`, so both coordinator events are delivered before any record is emitted (and thus before the enforcer can fail the task), leaving no coordinator event in flight at failure time. This extends the `noMoreSplits` gating added in FLINK-40011 from completion to emission.

## Verifying this change

This change is a test-stability fix, covered by the existing `CommonExecSinkITCase` tests.

- Ran `CommonExecSinkITCase#testNullEnforcer` 30 times under `-Penable-adaptive-scheduler` (the failing profile): all green.
- The other tests in the class that reuse the same source (`testStreamRecordTimestampInserter*`, `testUnifiedSinksAreUsableWithDataStreamSinkProvider`, `testCharLengthEnforcer`, `testBinaryLengthEnforcer`) still pass, since the enumerator always signals no-more-splits and the rows are still emitted.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: Claude Code (Opus 4.8)