### PR TITLE
[FLINK-39520] Preparatory refactoring for channel state recovery (no behavior change)

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/RecoveredChannelStateHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/RecoveredChannelStateHandler.java
@@ -73,28 +73,156 @@ interface RecoveredChannelStateHandler<Info, Context> extends AutoCloseable {
             throws IOException, InterruptedException;
 }
 
-class InputChannelRecoveredStateHandler
+/**
+ * Abstract base for all input-channel recovery handlers. Holds the channel mapping logic shared by
+ * both variants (no-filtering, filtering).
+ *
+ * <p>Subclasses implement {@link #recover} according to their specific recovery mode and override
+ * {@link #closeInternal()} to release mode-specific resources.
+ *
+ * <p>Use the static {@link #create} factory to obtain the correct concrete subclass.
+ */
+abstract class AbstractInputChannelRecoveredStateHandler
         implements RecoveredChannelStateHandler<InputChannelInfo, Buffer> {
-    private final InputGate[] inputGates;
 
-    private final InflightDataRescalingDescriptor channelMapping;
+    final InputGate[] inputGates;
+    final InflightDataRescalingDescriptor channelMapping;
+    final Map<InputChannelInfo, RecoveredInputChannel> rescaledChannels = new HashMap<>();
+    final Map<Integer, RescaleMappings> oldToNewMappings = new HashMap<>();
 
-    private final Map<InputChannelInfo, RecoveredInputChannel> rescaledChannels = new HashMap<>();
-    private final Map<Integer, RescaleMappings> oldToNewMappings = new HashMap<>();
+    AbstractInputChannelRecoveredStateHandler(
+            InputGate[] inputGates, InflightDataRescalingDescriptor channelMapping) {
+        this.inputGates = inputGates;
+        this.channelMapping = channelMapping;
+    }
 
     /**
-     * Optional filtering handler for filtering recovered buffers. When non-null, filtering is
-     * performed during recovery in the channel-state-unspilling thread.
+     * Factory that selects the correct subclass based on {@code checkpointingDuringRecoveryEnabled}
+     * and whether a {@code filteringHandler} is present.
+     *
+     * <ul>
+     *   <li>{@code false} → {@link NoSpillingHandler}
+     *   <li>{@code true} and {@code filteringHandler == null} → {@link NoSpillingHandler}
+     *   <li>{@code true} and {@code filteringHandler != null} → {@link FilteringHandler}
+     * </ul>
      */
-    @Nullable private final ChannelStateFilteringHandler filteringHandler;
+    static AbstractInputChannelRecoveredStateHandler create(
+            InputGate[] inputGates,
+            InflightDataRescalingDescriptor channelMapping,
+            boolean checkpointingDuringRecoveryEnabled,
+            @Nullable ChannelStateFilteringHandler filteringHandler,
+            int memorySegmentSize) {
+        if (!checkpointingDuringRecoveryEnabled) {
+            return new NoSpillingHandler(inputGates, channelMapping);
+        }
+        // FLINK-38544 transitional: the flag-on path still uses the in-memory handlers until the
+        // spilling backend lands.
+        if (filteringHandler == null) {
+            return new NoSpillingHandler(inputGates, channelMapping);
+        }
+        return new FilteringHandler(
+                inputGates, channelMapping, filteringHandler, memorySegmentSize);
+    }
+
+    /** Default buffer allocation from the network buffer pool, used by non-filtering modes. */
+    @Override
+    public BufferWithContext<Buffer> getBuffer(InputChannelInfo channelInfo)
+            throws IOException, InterruptedException {
+        RecoveredInputChannel channel = getMappedChannels(channelInfo);
+        Buffer buffer = channel.requestBufferBlocking();
+        return new BufferWithContext<>(wrap(buffer), buffer);
+    }
+
+    @Override
+    public void close() throws IOException {
+        // note that we need to finish all RecoveredInputChannels, not just those with state
+        for (final InputGate inputGate : inputGates) {
+            inputGate.finishReadRecoveredState();
+        }
+        closeInternal();
+    }
+
+    /** Hook for subclasses to release their own resources. Called by {@link #close()}. */
+    void closeInternal() throws IOException {}
+
+    RecoveredInputChannel getMappedChannels(InputChannelInfo channelInfo) {
+        return rescaledChannels.computeIfAbsent(channelInfo, this::calculateMapping);
+    }
+
+    @Nonnull
+    private RecoveredInputChannel calculateMapping(InputChannelInfo info) {
+        final RescaleMappings oldToNewMapping =
+                oldToNewMappings.computeIfAbsent(
+                        info.getGateIdx(), idx -> channelMapping.getChannelMapping(idx).invert());
+        int[] mappedIndexes = oldToNewMapping.getMappedIndexes(info.getInputChannelIdx());
+        checkState(
+                mappedIndexes.length == 1,
+                "One buffer is only distributed to one target InputChannel since "
+                        + "one buffer is expected to be processed once by the same task.");
+        return getChannel(info.getGateIdx(), mappedIndexes[0]);
+    }
+
+    private RecoveredInputChannel getChannel(int gateIndex, int subPartitionIndex) {
+        final InputChannel inputChannel = inputGates[gateIndex].getChannel(subPartitionIndex);
+        if (!(inputChannel instanceof RecoveredInputChannel)) {
+            throw new IllegalStateException(
+                    "Cannot restore state to a non-recovered input channel: " + inputChannel);
+        }
+        return (RecoveredInputChannel) inputChannel;
+    }
+}
+
+/**
+ * Recovery handler for the case where checkpointing during recovery is disabled. Delivers recovered
+ * buffers directly into the input channel via {@code onRecoveredStateBuffer}, with no spill file.
+ */
+class NoSpillingHandler extends AbstractInputChannelRecoveredStateHandler {
+
+    NoSpillingHandler(InputGate[] inputGates, InflightDataRescalingDescriptor channelMapping) {
+        super(inputGates, channelMapping);
+    }
+
+    @Override
+    public void recover(
+            InputChannelInfo channelInfo,
+            int oldSubtaskIndex,
+            BufferWithContext<Buffer> bufferWithContext)
+            throws IOException, InterruptedException {
+        Buffer buffer = bufferWithContext.context;
+        try {
+            if (buffer.readableBytes() > 0) {
+                RecoveredInputChannel channel = getMappedChannels(channelInfo);
+                channel.onRecoveredStateBuffer(
+                        EventSerializer.toBuffer(
+                                new SubtaskConnectionDescriptor(
+                                        oldSubtaskIndex, channelInfo.getInputChannelIdx()),
+                                false));
+                channel.onRecoveredStateBuffer(buffer.retainBuffer());
+            }
+        } finally {
+            buffer.recycleBuffer();
+        }
+    }
+}
+
+/**
+ * Recovery handler for the case where checkpointing during recovery is enabled and a filtering
+ * handler is present. Uses a reusable heap-backed pre-filter buffer (isolated from the Network
+ * Buffer Pool), filters recovered buffers through {@link
+ * ChannelStateFilteringHandler#filterAndRewrite}, and delivers the filtered buffers directly into
+ * the input channel via {@code onRecoveredStateBuffer}.
+ */
+class FilteringHandler extends AbstractInputChannelRecoveredStateHandler {
+
+    private final ChannelStateFilteringHandler filteringHandler;
 
     /** Network buffer memory segment size in bytes. Used to size the reusable pre-filter buffer. */
     private final int memorySegmentSize;
 
     /**
      * Reusable heap memory segment backing the pre-filter buffer in filtering mode. Lazily
-     * allocated on the first {@link #getPreFilterBuffer} call, reused for every subsequent call,
-     * and freed in {@link #close()}.
+     * allocated on the first {@link #getBuffer} call, reused for every subsequent call, and freed
+     * in {@link #closeInternal()}.
      *
      * <p>Reuse is safe because at most one pre-filter buffer is in flight per task at any moment.
      * This invariant is enforced at runtime by {@link #preFilterBufferInUse}.
@@ -108,29 +236,16 @@ class InputChannelRecoveredStateHandler
      */
     private boolean preFilterBufferInUse;
 
-    InputChannelRecoveredStateHandler(
+    FilteringHandler(
             InputGate[] inputGates,
             InflightDataRescalingDescriptor channelMapping,
-            @Nullable ChannelStateFilteringHandler filteringHandler,
+            ChannelStateFilteringHandler filteringHandler,
             int memorySegmentSize) {
-        this.inputGates = inputGates;
-        this.channelMapping = channelMapping;
+        super(inputGates, channelMapping);
         this.filteringHandler = filteringHandler;
         checkArgument(
                 memorySegmentSize > 0, "memorySegmentSize must be positive: %s", memorySegmentSize);
         this.memorySegmentSize = memorySegmentSize;
-    }
-
-    @Override
-    public BufferWithContext<Buffer> getBuffer(InputChannelInfo channelInfo)
-            throws IOException, InterruptedException {
-        if (filteringHandler != null) {
-            return getPreFilterBuffer();
-        }
-        // Non-filtering mode: use existing network buffer pool allocation.
-        RecoveredInputChannel channel = getMappedChannels(channelInfo);
-        Buffer buffer = channel.requestBufferBlocking();
-        return new BufferWithContext<>(wrap(buffer), buffer);
     }
 
     /**
@@ -139,8 +254,8 @@ class InputChannelRecoveredStateHandler
      *
      * <p>Memory management: a single {@link MemorySegment} per task is lazily allocated on first
      * invocation and reused across every subsequent call. The custom {@link BufferRecycler} does
-     * not free the segment — it only flips {@link #preFilterBufferInUse} back to {@code false} so
-     * the next call can reuse it. The segment itself is freed in {@link #close()}.
+     * not free the segment; it only flips {@link #preFilterBufferInUse} back to {@code false} so
+     * the next call can reuse it. The segment itself is freed in {@link #closeInternal()}.
      *
      * <p>Runtime invariant check: the one-at-a-time invariant on pre-filter buffers is guaranteed
      * by Flink's serial recovery loop and the deserializer's ownership contract. This method
@@ -148,7 +263,8 @@ class InputChannelRecoveredStateHandler
      * recycled, it throws {@link IllegalStateException} so any future regression fails loudly
      * instead of silently corrupting memory.
      */
-    private BufferWithContext<Buffer> getPreFilterBuffer() {
+    @Override
+    public BufferWithContext<Buffer> getBuffer(InputChannelInfo channelInfo) {
         checkState(
                 !preFilterBufferInUse,
                 "Previous pre-filter buffer has not been recycled. This violates the "
@@ -165,17 +281,6 @@ class InputChannelRecoveredStateHandler
         return new BufferWithContext<>(wrap(buffer), buffer);
     }
 
-    @VisibleForTesting
-    boolean isPreFilterBufferInUse() {
-        return preFilterBufferInUse;
-    }
-
-    @VisibleForTesting
-    @Nullable
-    MemorySegment getPreFilterSegmentForTesting() {
-        return preFilterSegment;
-    }
-
     @Override
     public void recover(
             InputChannelInfo channelInfo,
@@ -186,18 +291,7 @@ class InputChannelRecoveredStateHandler
         try {
             if (buffer.readableBytes() > 0) {
                 RecoveredInputChannel channel = getMappedChannels(channelInfo);
-
-                if (filteringHandler != null) {
-                    recoverWithFiltering(
-                            channel, channelInfo, oldSubtaskIndex, buffer.retainBuffer());
-                } else {
-                    channel.onRecoveredStateBuffer(
-                            EventSerializer.toBuffer(
-                                    new SubtaskConnectionDescriptor(
-                                            oldSubtaskIndex, channelInfo.getInputChannelIdx()),
-                                    false));
-                    channel.onRecoveredStateBuffer(buffer.retainBuffer());
-                }
+                recoverWithFiltering(channel, channelInfo, oldSubtaskIndex, buffer.retainBuffer());
             }
         } finally {
             buffer.recycleBuffer();
@@ -232,43 +326,24 @@ class InputChannelRecoveredStateHandler
         }
     }
 
+    @VisibleForTesting
+    boolean isPreFilterBufferInUse() {
+        return preFilterBufferInUse;
+    }
+
+    @VisibleForTesting
+    @Nullable
+    MemorySegment getPreFilterSegmentForTesting() {
+        return preFilterSegment;
+    }
+
     @Override
-    public void close() throws IOException {
-        // note that we need to finish all RecoveredInputChannels, not just those with state
-        for (final InputGate inputGate : inputGates) {
-            inputGate.finishReadRecoveredState();
-        }
+    void closeInternal() throws IOException {
         if (preFilterSegment != null) {
             preFilterSegment.free();
             preFilterSegment = null;
             preFilterBufferInUse = false;
         }
-    }
-
-    private RecoveredInputChannel getChannel(int gateIndex, int subPartitionIndex) {
-        final InputChannel inputChannel = inputGates[gateIndex].getChannel(subPartitionIndex);
-        if (!(inputChannel instanceof RecoveredInputChannel)) {
-            throw new IllegalStateException(
-                    "Cannot restore state to a non-recovered input channel: " + inputChannel);
-        }
-        return (RecoveredInputChannel) inputChannel;
-    }
-
-    private RecoveredInputChannel getMappedChannels(InputChannelInfo channelInfo) {
-        return rescaledChannels.computeIfAbsent(channelInfo, this::calculateMapping);
-    }
-
-    @Nonnull
-    private RecoveredInputChannel calculateMapping(InputChannelInfo info) {
-        final RescaleMappings oldToNewMapping =
-                oldToNewMappings.computeIfAbsent(
-                        info.getGateIdx(), idx -> channelMapping.getChannelMapping(idx).invert());
-        int[] mappedIndexes = oldToNewMapping.getMappedIndexes(info.getInputChannelIdx());
-        checkState(
-                mappedIndexes.length == 1,
-                "One buffer is only distributed to one target InputChannel since "
-                        + "one buffer is expected to be processed once by the same task.");
-        return getChannel(info.getGateIdx(), mappedIndexes[0]);
     }
 }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/SequentialChannelStateReaderImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/SequentialChannelStateReaderImpl.java
@@ -70,10 +70,11 @@ public class SequentialChannelStateReaderImpl implements SequentialChannelStateR
                         : null;
 
         try (ChannelStateFilteringHandler ignored = filteringHandler;
-                InputChannelRecoveredStateHandler stateHandler =
-                        new InputChannelRecoveredStateHandler(
+                AbstractInputChannelRecoveredStateHandler stateHandler =
+                        AbstractInputChannelRecoveredStateHandler.create(
                                 inputGates,
                                 taskStateSnapshot.getInputRescalingDescriptor(),
+                                filterContext.isCheckpointingDuringRecoveryEnabled(),
                                 filteringHandler,
                                 filterContext.getMemorySegmentSize())) {
             read(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/logger/NetworkActionsLogger.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/logger/NetworkActionsLogger.java
@@ -98,13 +98,13 @@ public class NetworkActionsLogger {
 
     public static void tracePersist(
             String action, Buffer buffer, Object channelInfo, long checkpointId) {
+        tracePersist(action, buffer.toDebugString(INCLUDE_HASH), channelInfo, checkpointId);
+    }
+
+    public static void tracePersist(
+            String action, Object persisted, Object channelInfo, long checkpointId) {
         if (LOG.isTraceEnabled()) {
-            LOG.trace(
-                    "{} {}, checkpoint {} @ {}",
-                    action,
-                    buffer.toDebugString(INCLUDE_HASH),
-                    checkpointId,
-                    channelInfo);
+            LOG.trace("{} {}, checkpoint {} @ {}", action, persisted, checkpointId, channelInfo);
         }
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/InputGate.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/InputGate.java
@@ -141,6 +141,14 @@ public abstract class InputGate
     /** Returns the channel of this gate. */
     public abstract InputChannel getChannel(int channelIndex);
 
+    /**
+     * Returns the channel identified by {@code channelInfo}. Unlike {@link #getChannel(int)}, whose
+     * index is gate-global, this resolves through the full {@code (gateIdx, inputChannelIdx)} pair,
+     * so it stays correct for {@link UnionInputGate} where the global index differs from a member
+     * gate's local channel index.
+     */
+    public abstract InputChannel getChannel(InputChannelInfo channelInfo);
+
     /** Returns the channel infos of this gate. */
     public List<InputChannelInfo> getChannelInfos() {
         return IntStream.range(0, getNumberOfInputChannels())

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannel.java
@@ -81,8 +81,15 @@ public class LocalInputChannel extends InputChannel implements BufferAvailabilit
     private final Deque<BufferAndBacklog> toBeConsumedBuffers = new ArrayDeque<>();
 
     /**
+     * Buffers migrated from {@code RecoveredInputChannel}, kept separately from {@link
+     * #toBeConsumedBuffers} so that recovery semantics (priority event interleaving, checkpoint
+     * inflight persistence) do not leak into the FullyFilledBuffer split path.
+     */
+    private final Deque<BufferAndBacklog> recoveredBuffers = new ArrayDeque<>();
+
+    /**
      * Flag indicating whether there is a pending priority event (e.g., checkpoint barrier) in the
-     * subpartitionView that should be consumed before toBeConsumedBuffers. This is set by {@link
+     * subpartitionView that should be consumed before recoveredBuffers. This is set by {@link
      * #notifyPriorityEvent} and checked in {@link #getNextBuffer()}.
      */
     private volatile boolean hasPendingPriorityEvent = false;
@@ -131,13 +138,13 @@ public class LocalInputChannel extends InputChannel implements BufferAvailabilit
                 // buffersInBacklog is set to 0 as these are recovered buffers
                 BufferAndBacklog bufferAndBacklog =
                         new BufferAndBacklog(buffer, 0, nextDataType, seqNum++);
-                toBeConsumedBuffers.add(bufferAndBacklog);
+                recoveredBuffers.add(bufferAndBacklog);
             }
             checkState(
-                    toBeConsumedBuffers.size() == expectedCount,
+                    recoveredBuffers.size() == expectedCount,
                     "Buffer migration failed: expected %s buffers but got %s",
                     expectedCount,
-                    toBeConsumedBuffers.size());
+                    recoveredBuffers.size());
         }
     }
 
@@ -146,10 +153,11 @@ public class LocalInputChannel extends InputChannel implements BufferAvailabilit
     // ------------------------------------------------------------------------
 
     public void checkpointStarted(CheckpointBarrier barrier) throws CheckpointException {
-        // Collect inflight buffers from toBeConsumedBuffers to be persisted.
-        // These are buffers that have not been consumed yet when the checkpoint barrier arrives.
+        // Collect inflight buffers from recoveredBuffers to be persisted.
+        // These are recovered buffers that have not been consumed yet when the checkpoint
+        // barrier arrives.
         List<Buffer> inflightBuffers = new ArrayList<>();
-        for (BufferAndBacklog bufferAndBacklog : toBeConsumedBuffers) {
+        for (BufferAndBacklog bufferAndBacklog : recoveredBuffers) {
             if (bufferAndBacklog.buffer().isBuffer()) {
                 inflightBuffers.add(bufferAndBacklog.buffer().retainBuffer());
             }
@@ -163,6 +171,8 @@ public class LocalInputChannel extends InputChannel implements BufferAvailabilit
 
     @Override
     protected void requestSubpartitions() throws IOException {
+        checkState(toBeConsumedBuffers.isEmpty());
+
         boolean retriggerRequest = false;
         boolean notifyDataAvailable = false;
 
@@ -272,8 +282,12 @@ public class LocalInputChannel extends InputChannel implements BufferAvailabilit
     public Optional<BufferAndAvailability> getNextBuffer() throws IOException {
         checkError();
 
-        if (!toBeConsumedBuffers.isEmpty()) {
+        if (!recoveredBuffers.isEmpty()) {
             return getNextRecoveredBuffer();
+        }
+
+        if (!toBeConsumedBuffers.isEmpty()) {
+            return Optional.of(getBufferAndAvailability(toBeConsumedBuffers.removeFirst()));
         }
 
         ResultSubpartitionView subpartitionView = this.subpartitionView;
@@ -339,12 +353,12 @@ public class LocalInputChannel extends InputChannel implements BufferAvailabilit
     }
 
     /**
-     * Consumes the next buffer from toBeConsumedBuffers (recovered buffers), handling pending
-     * priority events and dynamic availability detection for the last recovered buffer.
+     * Consumes the next buffer from recoveredBuffers, handling pending priority events and dynamic
+     * availability detection for the last recovered buffer.
      */
     private Optional<BufferAndAvailability> getNextRecoveredBuffer() throws IOException {
         // If there is a pending priority event (e.g., unaligned checkpoint barrier), fetch it
-        // from subpartitionView first, skipping toBeConsumedBuffers. This ensures priority
+        // from subpartitionView first, skipping recoveredBuffers. This ensures priority
         // events are processed immediately even when there are pending recovered buffers.
         if (hasPendingPriorityEvent) {
             checkState(subpartitionView != null, "No subpartition view available");
@@ -362,10 +376,10 @@ public class LocalInputChannel extends InputChannel implements BufferAvailabilit
             if (!expectedNextDataType.hasPriority()) {
                 // Reset hasPendingPriorityEvent to false if no more priority event
                 hasPendingPriorityEvent = false;
-                if (!toBeConsumedBuffers.isEmpty()) {
-                    // Correct nextDataType: if toBeConsumedBuffers is not empty, the actual next
-                    // element to consume is from toBeConsumedBuffers, not from subpartitionView
-                    expectedNextDataType = toBeConsumedBuffers.peek().buffer().getDataType();
+                if (!recoveredBuffers.isEmpty()) {
+                    // Correct nextDataType: if recoveredBuffers is not empty, the actual next
+                    // element to consume is from recoveredBuffers, not from subpartitionView
+                    expectedNextDataType = recoveredBuffers.peek().buffer().getDataType();
                 }
             }
 
@@ -378,13 +392,13 @@ public class LocalInputChannel extends InputChannel implements BufferAvailabilit
                                     next.getSequenceNumber())));
         }
 
-        BufferAndBacklog next = toBeConsumedBuffers.removeFirst();
+        BufferAndBacklog next = recoveredBuffers.removeFirst();
 
         // If this is the last recovered buffer and nextDataType is NONE,
         // dynamically check if subpartitionView has data available.
         // The last buffer's nextDataType was preset to NONE during construction,
         // but subpartitionView may already have data available.
-        if (toBeConsumedBuffers.isEmpty()
+        if (recoveredBuffers.isEmpty()
                 && next.getNextDataType() == Buffer.DataType.NONE
                 && subpartitionView != null) {
             ResultSubpartitionView.AvailabilityWithBacklog availability =
@@ -510,8 +524,13 @@ public class LocalInputChannel extends InputChannel implements BufferAvailabilit
                 subpartitionView = null;
             }
 
-            // Release any remaining buffers in toBeConsumedBuffers to avoid memory leak.
-            // These may be recovered buffers or partial buffers from FullyFilledBuffer.
+            // Release any remaining buffers in recoveredBuffers (migrated recovered buffers
+            // not yet consumed) and toBeConsumedBuffers (FullyFilledBuffer partial splits)
+            // to avoid memory leak.
+            for (BufferAndBacklog bufferAndBacklog : recoveredBuffers) {
+                bufferAndBacklog.buffer().recycleBuffer();
+            }
+            recoveredBuffers.clear();
             for (BufferAndBacklog bufferAndBacklog : toBeConsumedBuffers) {
                 bufferAndBacklog.buffer().recycleBuffer();
             }
@@ -532,14 +551,16 @@ public class LocalInputChannel extends InputChannel implements BufferAvailabilit
     @Override
     int getBuffersInUseCount() {
         ResultSubpartitionView view = this.subpartitionView;
-        return toBeConsumedBuffers.size() + (view == null ? 0 : view.getNumberOfQueuedBuffers());
+        return recoveredBuffers.size()
+                + toBeConsumedBuffers.size()
+                + (view == null ? 0 : view.getNumberOfQueuedBuffers());
     }
 
     @Override
     public int unsynchronizedGetNumberOfQueuedBuffers() {
         ResultSubpartitionView view = subpartitionView;
 
-        int count = toBeConsumedBuffers.size();
+        int count = recoveredBuffers.size() + toBeConsumedBuffers.size();
         if (view != null) {
             count += view.unsynchronizedGetNumberOfQueuedBuffers();
         }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RecoveredInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RecoveredInputChannel.java
@@ -304,7 +304,7 @@ public abstract class RecoveredInputChannel extends InputChannel implements Chan
         }
     }
 
-    void releaseAllResources() throws IOException {
+    public void releaseAllResources() throws IOException {
         ArrayDeque<Buffer> releasedBuffers = new ArrayDeque<>();
         boolean shouldRelease = false;
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RecoveredInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RecoveredInputChannel.java
@@ -166,10 +166,7 @@ public abstract class RecoveredInputChannel extends InputChannel implements Chan
     public void onRecoveredStateBuffer(Buffer buffer) {
         boolean recycleBuffer = true;
         NetworkActionsLogger.traceRecover(
-                "InputChannelRecoveredStateHandler#recover",
-                buffer,
-                inputGate.getOwningTaskName(),
-                channelInfo);
+                "NoSpillingHandler#recover", buffer, inputGate.getOwningTaskName(), channelInfo);
         try {
             final boolean wasEmpty;
             synchronized (receivedBuffers) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGate.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGate.java
@@ -595,6 +595,11 @@ public class SingleInputGate extends IndexedInputGate {
         return channels[channelIndex];
     }
 
+    @Override
+    public InputChannel getChannel(InputChannelInfo channelInfo) {
+        return channels[channelInfo.getInputChannelIdx()];
+    }
+
     // ------------------------------------------------------------------------
     // Setup/Life-cycle
     // ------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/UnionInputGate.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/UnionInputGate.java
@@ -177,6 +177,13 @@ public class UnionInputGate extends InputGate {
     }
 
     @Override
+    public InputChannel getChannel(InputChannelInfo channelInfo) {
+        // The member gate's local channel index is carried directly in channelInfo, so resolve
+        // through the owning gate instead of the gate-global getChannel(int) addressing.
+        return inputGatesByGateIndex.get(channelInfo.getGateIdx()).getChannel(channelInfo);
+    }
+
+    @Override
     public boolean isFinished() {
         return inputGatesWithRemainingData.isEmpty();
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/InputGateWithMetrics.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/InputGateWithMetrics.java
@@ -81,6 +81,11 @@ public class InputGateWithMetrics extends IndexedInputGate {
     }
 
     @Override
+    public InputChannel getChannel(InputChannelInfo channelInfo) {
+        return inputGate.getChannel(channelInfo);
+    }
+
+    @Override
     public int getGateIndex() {
         return inputGate.getGateIndex();
     }

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/io/AbstractStreamTaskNetworkInput.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/io/AbstractStreamTaskNetworkInput.java
@@ -326,8 +326,7 @@ public abstract class AbstractStreamTaskNetworkInput<
         // terminate the TM
         Exception err = null;
         for (InputChannelInfo channelInfo : new ArrayList<>(recordDeserializers.keySet())) {
-            final boolean hadError =
-                    checkpointedInputGate.getChannel(channelInfo.getInputChannelIdx()).hasError();
+            final boolean hadError = checkpointedInputGate.getChannel(channelInfo).hasError();
             try {
                 releaseDeserializer(channelInfo);
             } catch (Exception e) {

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/io/StreamMultipleInputProcessor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/io/StreamMultipleInputProcessor.java
@@ -79,7 +79,17 @@ public final class StreamMultipleInputProcessor implements StreamInputProcessor 
             readingInputIndex = selectFirstReadingInputIndex();
         }
         if (readingInputIndex == InputSelection.NONE_AVAILABLE) {
-            return DataInputStatus.NOTHING_AVAILABLE;
+            // If all inputs are already finished, there is nothing left to read: report
+            // END_OF_INPUT rather than NOTHING_AVAILABLE. Otherwise, because getAvailableFuture()
+            // returns AVAILABLE once all inputs are finished, the mailbox loop would never block
+            // and
+            // would spin on processInput. This matters when processInput is invoked again after the
+            // operator already finished -- e.g. a task that reached END_OF_INPUT during recovery
+            // and
+            // is resumed once recovery completes (see StreamTask#processInput).
+            return inputSelectionHandler.areAllInputsFinished()
+                    ? DataInputStatus.END_OF_INPUT
+                    : DataInputStatus.NOTHING_AVAILABLE;
         }
 
         lastReadInputIndex = readingInputIndex;

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/io/checkpointing/CheckpointedInputGate.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/io/checkpointing/CheckpointedInputGate.java
@@ -296,6 +296,10 @@ public class CheckpointedInputGate implements PullingAsyncDataInput<BufferOrEven
         return inputGate.getChannel(channelIndex);
     }
 
+    public InputChannel getChannel(InputChannelInfo channelInfo) {
+        return inputGate.getChannel(channelInfo);
+    }
+
     public List<InputChannelInfo> getChannelInfos() {
         return inputGate.getChannelInfos();
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/InputChannelRecoveredStateHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/InputChannelRecoveredStateHandlerTest.java
@@ -40,12 +40,13 @@ import static org.apache.flink.runtime.checkpoint.InflightDataRescalingDescripto
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-/** Test of different implementation of {@link InputChannelRecoveredStateHandler}. */
+/** Test of different implementation of {@link AbstractInputChannelRecoveredStateHandler}. */
 class InputChannelRecoveredStateHandlerTest extends RecoveredChannelStateHandlerTest {
     private static final int preAllocatedSegments = 3;
     private NetworkBufferPool networkBufferPool;
     private SingleInputGate inputGate;
-    private InputChannelRecoveredStateHandler icsHandler;
+    // NoSpillingHandler: checkpointingDuringRecoveryEnabled=false, filteringHandler=null
+    private AbstractInputChannelRecoveredStateHandler icsHandler;
     private InputChannelInfo channelInfo;
 
     @BeforeEach
@@ -61,14 +62,14 @@ class InputChannelRecoveredStateHandlerTest extends RecoveredChannelStateHandler
                         .setSegmentProvider(networkBufferPool)
                         .build();
 
-        icsHandler = buildInputChannelStateHandler(inputGate);
+        icsHandler = buildNoSpillingHandler(inputGate);
 
         channelInfo = new InputChannelInfo(0, 0);
     }
 
-    private InputChannelRecoveredStateHandler buildInputChannelStateHandler(
+    private AbstractInputChannelRecoveredStateHandler buildNoSpillingHandler(
             SingleInputGate inputGate) {
-        return new InputChannelRecoveredStateHandler(
+        return AbstractInputChannelRecoveredStateHandler.create(
                 new InputGate[] {inputGate},
                 new InflightDataRescalingDescriptor(
                         new InflightDataRescalingDescriptor
@@ -82,11 +83,12 @@ class InputChannelRecoveredStateHandlerTest extends RecoveredChannelStateHandler
                                             .InflightDataGateOrPartitionRescalingDescriptor
                                             .MappingType.IDENTITY)
                         }),
+                false,
                 null,
                 MemoryManager.DEFAULT_PAGE_SIZE);
     }
 
-    private InputChannelRecoveredStateHandler buildMultiChannelHandler() {
+    private AbstractInputChannelRecoveredStateHandler buildMultiChannelHandler() {
         // Setup multi-channel scenario to trigger distribution constraint validation
         SingleInputGate multiChannelGate =
                 new SingleInputGateBuilder()
@@ -95,7 +97,7 @@ class InputChannelRecoveredStateHandlerTest extends RecoveredChannelStateHandler
                         .setSegmentProvider(networkBufferPool)
                         .build();
 
-        return new InputChannelRecoveredStateHandler(
+        return AbstractInputChannelRecoveredStateHandler.create(
                 new InputGate[] {multiChannelGate},
                 new InflightDataRescalingDescriptor(
                         new InflightDataRescalingDescriptor
@@ -110,39 +112,42 @@ class InputChannelRecoveredStateHandlerTest extends RecoveredChannelStateHandler
                                             .InflightDataGateOrPartitionRescalingDescriptor
                                             .MappingType.RESCALING)
                         }),
+                false,
                 null,
                 MemoryManager.DEFAULT_PAGE_SIZE);
     }
 
     /** Builds a handler in filtering mode (non-null filtering handler, no-op stub). */
-    private InputChannelRecoveredStateHandler buildFilteringInputChannelStateHandler() {
+    private FilteringHandler buildFilteringInputChannelStateHandler() {
         // Empty GateFilterHandler array: filtering is "enabled" structurally, but no gate-level
         // filter logic runs. Suitable for exercising getBuffer() routing only.
         ChannelStateFilteringHandler stubFilteringHandler =
                 new ChannelStateFilteringHandler(
                         new ChannelStateFilteringHandler.GateFilterHandler[0]);
-        return new InputChannelRecoveredStateHandler(
-                new InputGate[] {inputGate},
-                new InflightDataRescalingDescriptor(
-                        new InflightDataRescalingDescriptor
-                                        .InflightDataGateOrPartitionRescalingDescriptor[] {
-                            new InflightDataRescalingDescriptor
-                                    .InflightDataGateOrPartitionRescalingDescriptor(
-                                    new int[] {1},
-                                    RescaleMappings.identity(1, 1),
-                                    new HashSet<>(),
-                                    InflightDataRescalingDescriptor
-                                            .InflightDataGateOrPartitionRescalingDescriptor
-                                            .MappingType.IDENTITY)
-                        }),
-                stubFilteringHandler,
-                MemoryManager.DEFAULT_PAGE_SIZE);
+        return (FilteringHandler)
+                AbstractInputChannelRecoveredStateHandler.create(
+                        new InputGate[] {inputGate},
+                        new InflightDataRescalingDescriptor(
+                                new InflightDataRescalingDescriptor
+                                                .InflightDataGateOrPartitionRescalingDescriptor[] {
+                                    new InflightDataRescalingDescriptor
+                                            .InflightDataGateOrPartitionRescalingDescriptor(
+                                            new int[] {1},
+                                            RescaleMappings.identity(1, 1),
+                                            new HashSet<>(),
+                                            InflightDataRescalingDescriptor
+                                                    .InflightDataGateOrPartitionRescalingDescriptor
+                                                    .MappingType.IDENTITY)
+                                }),
+                        true,
+                        stubFilteringHandler,
+                        MemoryManager.DEFAULT_PAGE_SIZE);
     }
 
     @Test
     void testBufferDistributedToMultipleInputChannelsThrowsException() throws Exception {
         // Test constraint that prevents buffer distribution to multiple channels
-        try (InputChannelRecoveredStateHandler handler = buildMultiChannelHandler()) {
+        try (AbstractInputChannelRecoveredStateHandler handler = buildMultiChannelHandler()) {
             assertThatThrownBy(() -> handler.getBuffer(channelInfo))
                     .isInstanceOf(IllegalStateException.class)
                     .hasMessageContaining(
@@ -187,8 +192,7 @@ class InputChannelRecoveredStateHandlerTest extends RecoveredChannelStateHandler
 
     @Test
     void testPreFilterBufferIsolationFromNetworkBufferPool() throws Exception {
-        try (InputChannelRecoveredStateHandler filteringHandler =
-                buildFilteringInputChannelStateHandler()) {
+        try (FilteringHandler filteringHandler = buildFilteringInputChannelStateHandler()) {
             int availableBefore = networkBufferPool.getNumberOfAvailableMemorySegments();
 
             RecoveredChannelStateHandler.BufferWithContext<Buffer> bufferWithContext =
@@ -229,8 +233,7 @@ class InputChannelRecoveredStateHandlerTest extends RecoveredChannelStateHandler
 
     @Test
     void testPreFilterSegmentReusedAcrossCalls() throws Exception {
-        try (InputChannelRecoveredStateHandler filteringHandler =
-                buildFilteringInputChannelStateHandler()) {
+        try (FilteringHandler filteringHandler = buildFilteringInputChannelStateHandler()) {
             // First getBuffer() lazily allocates the segment.
             RecoveredChannelStateHandler.BufferWithContext<Buffer> first =
                     filteringHandler.getBuffer(channelInfo);
@@ -259,8 +262,7 @@ class InputChannelRecoveredStateHandlerTest extends RecoveredChannelStateHandler
 
     @Test
     void testGetBufferThrowsWhenPriorBufferNotRecycled() throws Exception {
-        try (InputChannelRecoveredStateHandler filteringHandler =
-                buildFilteringInputChannelStateHandler()) {
+        try (FilteringHandler filteringHandler = buildFilteringInputChannelStateHandler()) {
             RecoveredChannelStateHandler.BufferWithContext<Buffer> first =
                     filteringHandler.getBuffer(channelInfo);
             try {
@@ -283,8 +285,7 @@ class InputChannelRecoveredStateHandlerTest extends RecoveredChannelStateHandler
 
     @Test
     void testPreFilterSegmentFreedOnClose() throws Exception {
-        InputChannelRecoveredStateHandler filteringHandler =
-                buildFilteringInputChannelStateHandler();
+        FilteringHandler filteringHandler = buildFilteringInputChannelStateHandler();
         RecoveredChannelStateHandler.BufferWithContext<Buffer> bufferWithContext =
                 filteringHandler.getBuffer(channelInfo);
         bufferWithContext.context.recycleBuffer();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/RecoveredChannelStateHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/RecoveredChannelStateHandlerTest.java
@@ -22,7 +22,7 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Base class which contains all tests which should be implemented for every implementation of
- * {@link InputChannelRecoveredStateHandler}.
+ * {@link AbstractInputChannelRecoveredStateHandler}.
  */
 abstract class RecoveredChannelStateHandlerTest {
 

--- a/flink-runtime/src/test/java/org/apache/flink/streaming/runtime/io/MockIndexedInputGate.java
+++ b/flink-runtime/src/test/java/org/apache/flink/streaming/runtime/io/MockIndexedInputGate.java
@@ -87,6 +87,11 @@ public class MockIndexedInputGate extends IndexedInputGate {
     }
 
     @Override
+    public InputChannel getChannel(InputChannelInfo channelInfo) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public void setChannelStateWriter(ChannelStateWriter channelStateWriter) {}
 
     @Override

--- a/flink-runtime/src/test/java/org/apache/flink/streaming/runtime/io/MockInputGate.java
+++ b/flink-runtime/src/test/java/org/apache/flink/streaming/runtime/io/MockInputGate.java
@@ -102,6 +102,11 @@ public class MockInputGate extends IndexedInputGate {
     }
 
     @Override
+    public InputChannel getChannel(InputChannelInfo channelInfo) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public List<InputChannelInfo> getChannelInfos() {
         return IntStream.range(0, numberOfChannels)
                 .mapToObj(channelIndex -> new InputChannelInfo(0, channelIndex))

--- a/flink-runtime/src/test/java/org/apache/flink/streaming/runtime/io/checkpointing/AlignedCheckpointsMassiveRandomTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/streaming/runtime/io/checkpointing/AlignedCheckpointsMassiveRandomTest.java
@@ -179,6 +179,11 @@ class AlignedCheckpointsMassiveRandomTest {
         }
 
         @Override
+        public InputChannel getChannel(InputChannelInfo channelInfo) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
         public List<InputChannelInfo> getChannelInfos() {
             return IntStream.range(0, numberOfChannels)
                     .mapToObj(channelIndex -> new InputChannelInfo(0, channelIndex))


### PR DESCRIPTION
## What is the purpose of the change

[FLINK-39520] Preparatory refactoring for channel state recovery (no behavior change).

It's part 1 of FLINK-38544 (checkpointing during recovery of unaligned checkpoint state). This PR only refactors code in preparation for the reworked channel-state recovery; it also carries one standalone `[hotfix]` commit fixing a busy-spin in the multiple-input processor.

## Brief change log

- [hotfix] Report END_OF_INPUT from multiple-input processor when all inputs finished
- [FLINK-39520][network] Decouple LocalInputChannel recovery wiring from toBeConsumedBuffers
- [FLINK-39520][checkpoint] Extract AbstractInputChannelRecoveredStateHandler with concrete no-filtering/filtering handlers
- [FLINK-39520][network] Add InputGate#getChannel(InputChannelInfo)
- [FLINK-39520][network] Additive logging overload; widen releaseAllResources visibility

## Verifying this change

This change is a refactoring without behavior change; it is covered by existing tests (mechanical test adaptations only).

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
