### PR TITLE
[BP-1.20][FLINK-40074][tests] Avoid @TempDir cleanup race in SinkV2ITCase scaling test

### DIFF
--- a/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/SinkV2ITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/SinkV2ITCase.java
@@ -52,15 +52,16 @@ import org.apache.flink.streaming.util.FiniteTestSource;
 import org.apache.flink.test.junit5.InjectClusterClient;
 import org.apache.flink.test.junit5.InjectMiniCluster;
 import org.apache.flink.test.util.AbstractTestBase;
+import org.apache.flink.util.FileUtils;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
 import java.io.File;
 import java.io.Serializable;
+import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -227,29 +228,37 @@ public class SinkV2ITCase extends AbstractTestBase {
     public void writerAndCommitterExecuteInStreamingModeWithScaling(
             int initialParallelism,
             int scaledParallelism,
-            @TempDir File checkpointDir,
             @InjectMiniCluster MiniCluster miniCluster,
             @InjectClusterClient ClusterClient<?> clusterClient)
             throws Exception {
-        final DefaultCommitter committer =
-                new DefaultCommitter(
-                        (Supplier<Queue<Committer.CommitRequest<String>>> & Serializable)
-                                () -> COMMIT_QUEUE);
-        final Configuration config = createConfigForScalingTest(checkpointDir, initialParallelism);
+        // Managed explicitly so cleanup survives the shared MiniCluster's asynchronous checkpoint
+        // discard after job termination, which would otherwise race JUnit's @TempDir deletion.
+        final File checkpointDir = Files.createTempDirectory("SinkV2ITCase").toFile();
+        try {
+            final DefaultCommitter committer =
+                    new DefaultCommitter(
+                            (Supplier<Queue<Committer.CommitRequest<String>>> & Serializable)
+                                    () -> COMMIT_QUEUE);
+            final Configuration config =
+                    createConfigForScalingTest(checkpointDir, initialParallelism);
 
-        // first run
-        final JobID jobID = runStreamingWithScalingTest(config, true, committer, clusterClient);
+            // first run
+            final JobID jobID = runStreamingWithScalingTest(config, true, committer, clusterClient);
 
-        // second run
-        config.set(StateRecoveryOptions.SAVEPOINT_PATH, getCheckpointPath(miniCluster, jobID));
-        config.set(CoreOptions.DEFAULT_PARALLELISM, scaledParallelism);
-        runStreamingWithScalingTest(config, false, committer, clusterClient);
+            // second run
+            config.set(StateRecoveryOptions.SAVEPOINT_PATH, getCheckpointPath(miniCluster, jobID));
+            config.set(CoreOptions.DEFAULT_PARALLELISM, scaledParallelism);
+            runStreamingWithScalingTest(config, false, committer, clusterClient);
 
-        assertThat(
-                COMMIT_QUEUE.stream()
-                        .map(Committer.CommitRequest::getCommittable)
-                        .collect(Collectors.toList()),
-                containsInAnyOrder(duplicate(EXPECTED_COMMITTED_DATA_IN_STREAMING_MODE).toArray()));
+            assertThat(
+                    COMMIT_QUEUE.stream()
+                            .map(Committer.CommitRequest::getCommittable)
+                            .collect(Collectors.toList()),
+                    containsInAnyOrder(
+                            duplicate(EXPECTED_COMMITTED_DATA_IN_STREAMING_MODE).toArray()));
+        } finally {
+            FileUtils.deleteDirectoryQuietly(checkpointDir);
+        }
     }
 
     private static List<String> duplicate(List<String> values) {


### PR DESCRIPTION
## What is the purpose of the change

Backport of the master fix for FLINK-40074 (#28653). `SinkV2ITCase.writerAndCommitterExecuteInStreamingModeWithScaling` is the single largest cause of red release-1.20 nightlies (19 of the last 25 failed runs, 37 test errors, ~2026-06-08 to 2026-07-06, across all JDK/profile legs). The failure is a teardown race between JUnit's per-method `@TempDir` deletion of the checkpoint directory and the class-shared MiniCluster's asynchronous checkpoint discard, which continues after `requestJobResult().get()` returns; it surfaces as `IOException: Failed to delete temp directory` even though all assertions pass.

## Brief change log

- Same as the master PR: manage the checkpoint directory explicitly and clean it up in a `finally` block with `FileUtils.deleteDirectoryQuietly`.
- The Hamcrest assertion in the 1.20 version of the test was deliberately left as-is (not migrated to AssertJ) to keep the backport diff minimal and focused on the race.

## Verifying this change

This change is already covered by the existing test `SinkV2ITCase.writerAndCommitterExecuteInStreamingModeWithScaling`. Verified locally on release-1.20: the previously flaky method passes (3/3 parameterized cases) across repeated executions, the full `SinkV2ITCase` class passes (7/7), and `spotless:check` is clean. CI to watch after merge: the release-1.20 nightly `Test (module: tests)` legs.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no (test-only change)
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (Claude Fable 5)

Generated-by: Claude Fable 5
