### PR TITLE
[BP-2.3][FLINK-40074][tests] Avoid @TempDir cleanup race in SinkV2ITCase scaling test

### DIFF
--- a/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/SinkV2ITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/SinkV2ITCase.java
@@ -54,15 +54,16 @@ import org.apache.flink.test.junit5.InjectMiniCluster;
 import org.apache.flink.test.util.AbstractTestBase;
 import org.apache.flink.testutils.junit.SharedObjectsExtension;
 import org.apache.flink.testutils.junit.SharedReference;
+import org.apache.flink.util.FileUtils;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
-import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
 import java.io.File;
 import java.io.Serializable;
+import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -161,35 +162,47 @@ class SinkV2ITCase extends AbstractTestBase {
     void writerAndCommitterExecuteInStreamingModeWithScaling(
             int initialParallelism,
             int scaledParallelism,
-            @TempDir File checkpointDir,
             @InjectMiniCluster MiniCluster miniCluster,
             @InjectClusterClient ClusterClient<?> clusterClient)
             throws Exception {
-        SharedReference<Queue<Committer.CommitRequest<Record<Integer>>>> committed =
-                SHARED_OBJECTS.add(new ConcurrentLinkedQueue<>());
-        final TrackingCommitter trackingCommitter = new TrackingCommitter(committed);
-        final Configuration config = createConfigForScalingTest(checkpointDir, initialParallelism);
+        // Managed explicitly so cleanup survives the shared MiniCluster's asynchronous checkpoint
+        // discard after job termination, which would otherwise race JUnit's @TempDir deletion.
+        final File checkpointDir = Files.createTempDirectory("SinkV2ITCase").toFile();
+        try {
+            SharedReference<Queue<Committer.CommitRequest<Record<Integer>>>> committed =
+                    SHARED_OBJECTS.add(new ConcurrentLinkedQueue<>());
+            final TrackingCommitter trackingCommitter = new TrackingCommitter(committed);
+            final Configuration config =
+                    createConfigForScalingTest(checkpointDir, initialParallelism);
 
-        // first run
-        final JobID jobID =
-                runStreamingWithScalingTest(
-                        config,
-                        initialParallelism,
-                        trackingCommitter,
-                        true,
-                        miniCluster,
-                        clusterClient);
+            // first run
+            final JobID jobID =
+                    runStreamingWithScalingTest(
+                            config,
+                            initialParallelism,
+                            trackingCommitter,
+                            true,
+                            miniCluster,
+                            clusterClient);
 
-        // second run
-        config.set(StateRecoveryOptions.SAVEPOINT_PATH, getCheckpointPath(miniCluster, jobID));
-        config.set(CoreOptions.DEFAULT_PARALLELISM, scaledParallelism);
-        runStreamingWithScalingTest(
-                config, initialParallelism, trackingCommitter, false, miniCluster, clusterClient);
+            // second run
+            config.set(StateRecoveryOptions.SAVEPOINT_PATH, getCheckpointPath(miniCluster, jobID));
+            config.set(CoreOptions.DEFAULT_PARALLELISM, scaledParallelism);
+            runStreamingWithScalingTest(
+                    config,
+                    initialParallelism,
+                    trackingCommitter,
+                    false,
+                    miniCluster,
+                    clusterClient);
 
-        assertThat(committed.get())
-                .extracting(Committer.CommitRequest::getCommittable)
-                .containsExactlyInAnyOrderElementsOf(
-                        duplicate(EXPECTED_COMMITTED_DATA_IN_STREAMING_MODE));
+            assertThat(committed.get())
+                    .extracting(Committer.CommitRequest::getCommittable)
+                    .containsExactlyInAnyOrderElementsOf(
+                            duplicate(EXPECTED_COMMITTED_DATA_IN_STREAMING_MODE));
+        } finally {
+            FileUtils.deleteDirectoryQuietly(checkpointDir);
+        }
     }
 
     private static List<Record<Integer>> duplicate(List<Record<Integer>> values) {


### PR DESCRIPTION
## What is the purpose of the change

Backport of the master fix for FLINK-40074 (#28653), a clean cherry-pick of 6a99fec0750. `SinkV2ITCase.writerAndCommitterExecuteInStreamingModeWithScaling` carries a latent teardown race on this branch: the checkpoint directory is injected as a per-method JUnit `@TempDir`, but the class-shared MiniCluster keeps discarding checkpoint state asynchronously after `requestJobResult().get()` returns, so JUnit's temp-directory deletion can race with Flink's discard and fail with `IOException: Failed to delete temp directory`. The race currently manifests nightly on release-1.20 (19 of the last 25 failed nightly runs); the same ingredients exist here, only the timing differs.

## Brief change log

- Manage the scaling test's checkpoint directory explicitly (`Files.createTempDirectory`) instead of injecting it via `@TempDir`.
- Clean it up in a `finally` block with `FileUtils.deleteDirectoryQuietly`, which is safe against concurrent deletions and never lets a cleanup failure mask a real assertion failure.
- No change to the test's assertions or job logic.

## Verifying this change

This change is already covered by the existing test `SinkV2ITCase.writerAndCommitterExecuteInStreamingModeWithScaling`. Verified locally on this branch: the method passes (3/3 parameterized cases) and `spotless:check` is clean.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no (test-only change)
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (Claude Fable 5)

Generated-by: Claude Fable 5
