### PR TITLE
[FLINK-40015] Introduce getFunctionOutput in PTF Test Harness

### DIFF
--- a/docs/content.zh/docs/dev/table/functions/ptfs.md
+++ b/docs/content.zh/docs/dev/table/functions/ptfs.md
@@ -2120,7 +2120,7 @@ void testPassthrough() throws Exception {
     harness.processElement(Row.of(42));
     harness.processElement(Row.of(100));
 
-    List<Integer> output = harness.getOutput();
+    List<Integer> output = harness.getFunctionOutput();
     assertThat(output).containsExactly(42, 100);
   }
 }
@@ -2689,9 +2689,57 @@ void testPOJO() throws Exception {
 
     harness.processElement(Row.of(30, "Alice"));
 
-    List<Customer> output = harness.getOutput();
+    List<Customer> output = harness.getFunctionOutput();
     assertThat(output.get(0).name).isEqualTo("Alice");
     assertThat(output.get(0).age).isEqualTo(30);
+  }
+}
+```
+{{< /tab >}}
+{{< /tabs >}}
+
+{{< top >}}
+
+### Testing Pure Function Output with getFunctionOutput()
+
+`getOutput()` returns the full row the Flink runtime emits: partition keys and pass-through
+columns are prepended, the `rowtime` column is appended when `on_time` is configured, and
+non-`Row` output — an atomic value or a POJO — is wrapped or flattened into a `Row`. Use
+`getFunctionOutput()` to inspect exactly what the PTF itself collected, without those additional
+columns.
+
+{{< tabs "function-output" >}}
+{{< tab "Java" >}}
+```java
+// A non-row output PTF with set-semantic partitioning and an on-time column.
+public class PartitionedAtomicPTF extends ProcessTableFunction<Integer> {
+  public void eval(
+      @ArgumentHint({ArgumentTrait.SET_SEMANTIC_TABLE, ArgumentTrait.REQUIRE_ON_TIME})
+          Row input) {
+    int value = input.getFieldAs("value");
+    collect(value * 2);
+  }
+}
+
+@Test
+void testAtomicOutputFunctionOutput() throws Exception {
+  try (ProcessTableFunctionTestHarness<Integer> harness =
+      ProcessTableFunctionTestHarness.ofClass(PartitionedAtomicPTF.class)
+          .withTableArgument("input",
+              DataTypes.of("ROW<key STRING, value INT, ts TIMESTAMP(3)>"))
+          .withPartitionBy("input", "key")
+          .withOnTimeColumn("ts")
+          .build()) {
+
+    harness.processElement(Row.of("A", 21, LocalDateTime.of(2025, 1, 1, 0, 0, 1)));
+
+    // getFunctionOutput() returns the atomic value, unwrapped
+    assertThat(harness.getFunctionOutput()).containsExactly(42);
+
+    // getOutput() wraps the value into a single EXPR$0 column, prepends the
+    // partition key, and appends the rowtime column
+    assertThat(harness.getOutput())
+        .containsExactly(Row.of("A", 42, LocalDateTime.of(2025, 1, 1, 0, 0, 1)));
   }
 }
 ```

--- a/docs/content/docs/dev/table/functions/ptfs.md
+++ b/docs/content/docs/dev/table/functions/ptfs.md
@@ -2123,7 +2123,7 @@ void testPassthrough() throws Exception {
     harness.processElement(Row.of(42));
     harness.processElement(Row.of(100));
 
-    List<Integer> output = harness.getOutput();
+    List<Integer> output = harness.getFunctionOutput();
     assertThat(output).containsExactly(42, 100);
   }
 }
@@ -2692,9 +2692,57 @@ void testPOJO() throws Exception {
 
     harness.processElement(Row.of(30, "Alice"));
 
-    List<Customer> output = harness.getOutput();
+    List<Customer> output = harness.getFunctionOutput();
     assertThat(output.get(0).name).isEqualTo("Alice");
     assertThat(output.get(0).age).isEqualTo(30);
+  }
+}
+```
+{{< /tab >}}
+{{< /tabs >}}
+
+{{< top >}}
+
+### Testing Pure Function Output with getFunctionOutput()
+
+`getOutput()` returns the full row the Flink runtime emits: partition keys and pass-through
+columns are prepended, the `rowtime` column is appended when `on_time` is configured, and
+non-`Row` output — an atomic value or a POJO — is wrapped or flattened into a `Row`. Use
+`getFunctionOutput()` to inspect exactly what the PTF itself collected, without those additional
+columns.
+
+{{< tabs "function-output" >}}
+{{< tab "Java" >}}
+```java
+// A non-row output PTF with set-semantic partitioning and an on-time column.
+public class PartitionedAtomicPTF extends ProcessTableFunction<Integer> {
+  public void eval(
+      @ArgumentHint({ArgumentTrait.SET_SEMANTIC_TABLE, ArgumentTrait.REQUIRE_ON_TIME})
+          Row input) {
+    int value = input.getFieldAs("value");
+    collect(value * 2);
+  }
+}
+
+@Test
+void testAtomicOutputFunctionOutput() throws Exception {
+  try (ProcessTableFunctionTestHarness<Integer> harness =
+      ProcessTableFunctionTestHarness.ofClass(PartitionedAtomicPTF.class)
+          .withTableArgument("input",
+              DataTypes.of("ROW<key STRING, value INT, ts TIMESTAMP(3)>"))
+          .withPartitionBy("input", "key")
+          .withOnTimeColumn("ts")
+          .build()) {
+
+    harness.processElement(Row.of("A", 21, LocalDateTime.of(2025, 1, 1, 0, 0, 1)));
+
+    // getFunctionOutput() returns the atomic value, unwrapped
+    assertThat(harness.getFunctionOutput()).containsExactly(42);
+
+    // getOutput() wraps the value into a single EXPR$0 column, prepends the
+    // partition key, and appends the rowtime column
+    assertThat(harness.getOutput())
+        .containsExactly(Row.of("A", 42, LocalDateTime.of(2025, 1, 1, 0, 0, 1)));
   }
 }
 ```

--- a/flink-table/flink-table-test-utils/src/main/java/org/apache/flink/table/runtime/functions/ProcessTableFunctionTestHarness.java
+++ b/flink-table/flink-table-test-utils/src/main/java/org/apache/flink/table/runtime/functions/ProcessTableFunctionTestHarness.java
@@ -48,6 +48,7 @@ import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.MapType;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.logical.StructuredType;
+import org.apache.flink.table.types.logical.utils.LogicalTypeChecks;
 import org.apache.flink.table.types.utils.TypeConversions;
 import org.apache.flink.table.utils.DateTimeUtils;
 import org.apache.flink.types.Row;
@@ -100,6 +101,7 @@ import static org.apache.flink.util.Preconditions.checkState;
  * harness.processElement(Row.of(2, "Bob"));
  *
  * List<Row> output = harness.getOutput();
+ * List<Row> functionOutput = harness.getFunctionOutput();
  * }</pre>
  */
 @PublicEvolving
@@ -120,7 +122,8 @@ public class ProcessTableFunctionTestHarness<OUT> implements AutoCloseable {
 
     private final ProcessTableFunction<OUT> function;
     private final FunctionContext functionContext;
-    private final List<OUT> output;
+    private final List<OUT> functionOutput;
+    private final List<Row> output;
     private boolean isOpen;
     private final HarnessCollector collector;
     private final TestHarnessStateManager stateManager;
@@ -137,6 +140,10 @@ public class ProcessTableFunctionTestHarness<OUT> implements AutoCloseable {
     private final Map<String, TableArgumentConverters> argumentConverters;
     private final DataStructureConverter<Object, Object> harnessOutputConverter;
 
+    private final OutputKind outputKind;
+    @Nullable private final DataStructureConverter<Object, Object> compositeOutputToInternal;
+    @Nullable private final DataStructureConverter<Object, Object> compositeOutputToRow;
+
     private final TestHarnessTimerManager timerManager;
     @Nullable private final String onTimeColumnName;
 
@@ -152,6 +159,7 @@ public class ProcessTableFunctionTestHarness<OUT> implements AutoCloseable {
             List<ArgumentInfo> arguments,
             Map<String, TableArgumentConverters> argumentConverters,
             DataStructureConverter<Object, Object> harnessOutputConverter,
+            DataType ptfOutputType,
             TestHarnessStateManager stateManager,
             TestHarnessTimerManager timerManager,
             @Nullable String onTimeColumnName)
@@ -163,9 +171,32 @@ public class ProcessTableFunctionTestHarness<OUT> implements AutoCloseable {
         this.arguments = arguments;
         this.argumentConverters = argumentConverters;
         this.harnessOutputConverter = harnessOutputConverter;
+        if (!LogicalTypeChecks.isCompositeType(ptfOutputType.getLogicalType())) {
+            this.outputKind = OutputKind.ATOMIC;
+        } else if (ptfOutputType.getLogicalType() instanceof RowType) {
+            this.outputKind = OutputKind.ROW;
+        } else {
+            this.outputKind = OutputKind.STRUCTURED;
+        }
+        if (this.outputKind != OutputKind.ATOMIC) {
+            ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+            DataType rowOutputType =
+                    ptfOutputType.getLogicalType() instanceof StructuredType
+                            ? toRowDataType((StructuredType) ptfOutputType.getLogicalType())
+                            : ptfOutputType;
+            this.compositeOutputToInternal = DataStructureConverters.getConverter(ptfOutputType);
+            this.compositeOutputToRow = DataStructureConverters.getConverter(rowOutputType);
+
+            this.compositeOutputToInternal.open(classLoader);
+            this.compositeOutputToRow.open(classLoader);
+        } else {
+            this.compositeOutputToInternal = null;
+            this.compositeOutputToRow = null;
+        }
         this.stateManager = stateManager;
         this.timerManager = timerManager;
         this.onTimeColumnName = onTimeColumnName;
+        this.functionOutput = new ArrayList<>();
         this.output = new ArrayList<>();
         this.collector = new HarnessCollector();
         this.isOpen = false;
@@ -297,13 +328,27 @@ public class ProcessTableFunctionTestHarness<OUT> implements AutoCloseable {
         }
     }
 
-    /** Returns all collected output rows. */
-    public List<OUT> getOutput() {
+    /**
+     * Returns the collected output as full rows: atomic output wrapped into an {@code EXPR$0}
+     * column or structured output flattened into its attributes, with additional columns (partition
+     * keys, rowtime, etc.) prepended or appended as configured.
+     */
+    public List<Row> getOutput() {
         return List.copyOf(output);
+    }
+
+    /**
+     * Returns the collected output as values collected by the PTF, typed as its declared output.
+     * See {@link #getOutput()} for the full row the runtime would emit, including those additional
+     * columns.
+     */
+    public List<OUT> getFunctionOutput() {
+        return List.copyOf(functionOutput);
     }
 
     /** Clears all collected output. */
     public void clearOutput() {
+        functionOutput.clear();
         output.clear();
     }
 
@@ -815,19 +860,23 @@ public class ProcessTableFunctionTestHarness<OUT> implements AutoCloseable {
     private class HarnessCollector implements Collector<OUT> {
 
         @Override
+        @SuppressWarnings("unchecked")
         public void collect(OUT record) {
-            OUT finalRecord;
+            Row ptfRow = toPtfOutputRow(record);
 
+            functionOutput.add(outputKind == OutputKind.ROW ? (OUT) ptfRow : record);
+
+            Row finalRecord;
             OutputPrependStrategy strategy = resolvePrependStrategy();
             switch (strategy) {
                 case ALL_COLUMNS:
-                    finalRecord = prependAllColumns(record);
+                    finalRecord = prependAllColumns(ptfRow);
                     break;
                 case PARTITION_KEYS:
-                    finalRecord = prependPartitionKeys(record);
+                    finalRecord = prependPartitionKeys(ptfRow);
                     break;
                 case NONE:
-                    finalRecord = record;
+                    finalRecord = ptfRow;
                     break;
                 default:
                     throw new IllegalStateException("Unknown prepend strategy: " + strategy);
@@ -837,10 +886,17 @@ public class ProcessTableFunctionTestHarness<OUT> implements AutoCloseable {
                 finalRecord = appendRowtime(finalRecord);
             }
 
-            // After prepending, round-trip through converter to ensure output has proper
-            // field structure from derived output schema
-            OUT structuredRecord = applyOutputConverter(finalRecord);
-            output.add(structuredRecord);
+            // Round-trip through the converter so output carries the field structure of the
+            // derived output schema.
+            output.add(applyOutputConverter(finalRecord));
+        }
+
+        private Row toPtfOutputRow(Object record) {
+            if (outputKind == OutputKind.ATOMIC) {
+                return Row.of(record);
+            }
+            Object internal = compositeOutputToInternal.toInternalOrNull(record);
+            return (Row) compositeOutputToRow.toExternalOrNull(internal);
         }
 
         private OutputPrependStrategy resolvePrependStrategy() {
@@ -860,23 +916,13 @@ public class ProcessTableFunctionTestHarness<OUT> implements AutoCloseable {
             return OutputPrependStrategy.NONE;
         }
 
-        @SuppressWarnings("unchecked")
-        private OUT applyOutputConverter(OUT record) {
-            if (record instanceof Row) {
-                Object internal = harnessOutputConverter.toInternalOrNull(record);
-                Object external = harnessOutputConverter.toExternalOrNull(internal);
-                return (OUT) external;
-            }
-            return record;
+        private Row applyOutputConverter(Row record) {
+            Object internal = harnessOutputConverter.toInternalOrNull(record);
+            return (Row) harnessOutputConverter.toExternalOrNull(internal);
         }
 
-        @SuppressWarnings("unchecked")
-        private OUT appendRowtime(OUT ptfOutput) {
-            if (!(ptfOutput instanceof Row)) {
-                throw new IllegalStateException(
-                        "Cannot append rowtime to non-Row output type: " + ptfOutput.getClass());
-            }
-            return (OUT) appendField((Row) ptfOutput, resolveRowtimeValue());
+        private Row appendRowtime(Row ptfOutput) {
+            return appendField(ptfOutput, resolveRowtimeValue());
         }
 
         private Object resolveRowtimeValue() {
@@ -887,15 +933,7 @@ public class ProcessTableFunctionTestHarness<OUT> implements AutoCloseable {
             return ctx.row.getField(onTimeColumnName);
         }
 
-        @SuppressWarnings("unchecked")
-        private OUT prependPartitionKeys(OUT ptfOutput) {
-            if (!(ptfOutput instanceof Row)) {
-                throw new IllegalStateException(
-                        "Cannot prepend partition keys to non-Row output type: "
-                                + ptfOutput.getClass());
-            }
-
-            Row ptfRow = (Row) ptfOutput;
+        private Row prependPartitionKeys(Row ptfRow) {
             Row partitionKey = currentInvocation.partitionKey;
 
             int totalPartitionKeyCount = 0;
@@ -929,17 +967,10 @@ public class ProcessTableFunctionTestHarness<OUT> implements AutoCloseable {
                 result.setField(resultIndex++, ptfRow.getField(i));
             }
 
-            return (OUT) result;
+            return result;
         }
 
-        @SuppressWarnings("unchecked")
-        private OUT prependAllColumns(OUT ptfOutput) {
-            if (!(ptfOutput instanceof Row)) {
-                throw new IllegalStateException(
-                        "Cannot prepend columns to non-Row output type: " + ptfOutput.getClass());
-            }
-
-            Row ptfRow = (Row) ptfOutput;
+        private Row prependAllColumns(Row ptfRow) {
             Row inputRow = currentInvocation.row;
             int inputArity = inputRow.getArity();
             int ptfOutputArity = ptfRow.getArity();
@@ -955,7 +986,7 @@ public class ProcessTableFunctionTestHarness<OUT> implements AutoCloseable {
                 result.setField(inputArity + i, ptfRow.getField(i));
             }
 
-            return (OUT) result;
+            return result;
         }
 
         @Override
@@ -963,7 +994,7 @@ public class ProcessTableFunctionTestHarness<OUT> implements AutoCloseable {
     }
 
     private static Row appendField(Row row, Object value) {
-        Row result = new Row(row.getArity() + 1);
+        Row result = new Row(row.getKind(), row.getArity() + 1);
         for (int i = 0; i < row.getArity(); i++) {
             result.setField(i, row.getField(i));
         }
@@ -990,6 +1021,18 @@ public class ProcessTableFunctionTestHarness<OUT> implements AutoCloseable {
                         "Unsupported data type: %s. "
                                 + "Only Row and structured types are supported.",
                         dataType));
+    }
+
+    /**
+     * Builds a {@link RowType} {@link DataType} whose fields mirror a structured type's attributes.
+     */
+    private static DataType toRowDataType(StructuredType structuredType) {
+        List<RowType.RowField> rowFields =
+                structuredType.getAttributes().stream()
+                        .map(attr -> new RowType.RowField(attr.getName(), attr.getType()))
+                        .collect(Collectors.toList());
+        return TypeConversions.fromLogicalToDataType(
+                new RowType(structuredType.isNullable(), rowFields));
     }
 
     /**
@@ -1199,18 +1242,24 @@ public class ProcessTableFunctionTestHarness<OUT> implements AutoCloseable {
             // SystemTypeInference needs table semantics for pass-through column deduplication
             List<TableArgumentInfo> tableArgInfos = ArgumentInfo.filterTableArguments(arguments);
 
-            // Derive output schema using SystemTypeInference
+            // The system inference yields the full operator output row (partition keys,
+            // pass-through columns, and rowtime); harnessOutputConverter stamps those field names.
             DataType derivedOutputType =
-                    deriveOutputTypeFromSystemInference(
+                    deriveOutputType(
                             function,
                             dataTypeFactory,
                             systemTypeInference,
                             arguments,
                             tableArgInfos);
 
-            // Create output converter for PTF emissions
             DataStructureConverter<Object, Object> harnessOutputConverter =
                     createPTFOutputConverter(derivedOutputType);
+
+            // The base inference yields the PTF's own emit type, which decides how a collected
+            // value is materialized into a Row: atomic is wrapped, composite is flattened.
+            DataType ptfOutputType =
+                    deriveOutputType(
+                            function, dataTypeFactory, baseTypeInference, arguments, tableArgInfos);
 
             // Validate onTimeColumn configuration
             if (onTimeColumnName != null) {
@@ -1239,6 +1288,7 @@ public class ProcessTableFunctionTestHarness<OUT> implements AutoCloseable {
                     arguments,
                     argumentConverters,
                     harnessOutputConverter,
+                    ptfOutputType,
                     stateManager,
                     timerManager,
                     onTimeColumnName);
@@ -1286,13 +1336,7 @@ public class ProcessTableFunctionTestHarness<OUT> implements AutoCloseable {
                                         .isPresent();
 
                 if (isStructuredType) {
-                    StructuredType structuredType = (StructuredType) logicalType;
-                    List<RowType.RowField> rowFields = new ArrayList<>();
-                    for (StructuredType.StructuredAttribute attr : structuredType.getAttributes()) {
-                        rowFields.add(new RowType.RowField(attr.getName(), attr.getType()));
-                    }
-                    RowType rowType = new RowType(logicalType.isNullable(), rowFields);
-                    DataType rowDataType = TypeConversions.fromLogicalToDataType(rowType);
+                    DataType rowDataType = toRowDataType((StructuredType) logicalType);
 
                     DataStructureConverter<Object, Object> toNamedRow =
                             DataStructureConverters.getConverter(rowDataType);
@@ -1932,29 +1976,34 @@ public class ProcessTableFunctionTestHarness<OUT> implements AutoCloseable {
         }
 
         /**
-         * Derives the output schema using SystemTypeInference, including field name deduplication.
+         * Derives an output schema by invoking the given {@link TypeInference}'s output strategy.
          *
-         * <p>SystemTypeInference's staticArgs list includes both user-declared arguments and
-         * system-injected arguments (on_time, uid). The CallContext we build must mirror this full
-         * list positionally — each index maps to a staticArg. User args get their resolved
-         * DataType; system args get placeholder types (DESCRIPTOR for on_time, STRING for uid).
-         * Table semantics are attached at the positions of table arguments so SystemTypeInference
-         * can perform pass-through column deduplication.
+         * <p>Passing the {@link SystemTypeInference} yields the full operator output (prepended
+         * partition/pass-through columns, the wrapped or flattened function output, and the rowtime
+         * column). Passing the base inference yields the PTF's own declared output type.
+         *
+         * <p>The staticArgs list may include both user-declared arguments and system-injected
+         * arguments (on_time, uid). The CallContext we build mirrors this list positionally — each
+         * index maps to a staticArg. User args get their resolved DataType; system args get
+         * placeholder types (DESCRIPTOR for on_time, STRING for uid). Table semantics are attached
+         * at the positions of table arguments so SystemTypeInference can perform pass-through
+         * column deduplication. The base inference has no system args, so those branches are simply
+         * unused.
          */
-        private DataType deriveOutputTypeFromSystemInference(
+        private DataType deriveOutputType(
                 ProcessTableFunction<OUT> function,
                 DataTypeFactory dataTypeFactory,
-                TypeInference systemTypeInference,
+                TypeInference typeInference,
                 List<ArgumentInfo> allArguments,
                 List<TableArgumentInfo> tableArguments) {
 
             List<StaticArgument> staticArgs =
-                    systemTypeInference
+                    typeInference
                             .getStaticArguments()
                             .orElseThrow(
                                     () ->
                                             new IllegalStateException(
-                                                    "SystemTypeInference has no static arguments"));
+                                                    "TypeInference has no static arguments"));
 
             Map<String, TableArgumentInfo> tableArgsByName = new HashMap<>();
             for (TableArgumentInfo tableArg : tableArguments) {
@@ -2020,13 +2069,12 @@ public class ProcessTableFunctionTestHarness<OUT> implements AutoCloseable {
                                 Collections.singletonList(onTimeColumnName)));
             }
 
-            TypeStrategy outputStrategy = systemTypeInference.getOutputTypeStrategy();
+            TypeStrategy outputStrategy = typeInference.getOutputTypeStrategy();
             Optional<DataType> outputTypeOpt = outputStrategy.inferType(callContext);
 
             if (outputTypeOpt.isEmpty()) {
                 throw new IllegalStateException(
-                        "Failed to derive output type from SystemTypeInference for "
-                                + function.getClass().getSimpleName());
+                        "Failed to derive output type for " + function.getClass().getSimpleName());
             }
 
             return outputTypeOpt.get();
@@ -2037,6 +2085,12 @@ public class ProcessTableFunctionTestHarness<OUT> implements AutoCloseable {
         NONE,
         PARTITION_KEYS,
         ALL_COLUMNS
+    }
+
+    private enum OutputKind {
+        ATOMIC,
+        ROW,
+        STRUCTURED
     }
 
     private void handleEvalInvocationException(

--- a/flink-table/flink-table-test-utils/src/test/java/org/apache/flink/table/runtime/functions/ProcessTableFunctionTestHarnessTest.java
+++ b/flink-table/flink-table-test-utils/src/test/java/org/apache/flink/table/runtime/functions/ProcessTableFunctionTestHarnessTest.java
@@ -118,6 +118,14 @@ class ProcessTableFunctionTestHarnessTest {
         }
     }
 
+    /** PTF with a non-Row (atomic) output, for testing the EXPR$0 wrap in getOutput(). */
+    public static class AtomicOutputPTF extends ProcessTableFunction<Integer> {
+        public void eval(@ArgumentHint(ArgumentTrait.ROW_SEMANTIC_TABLE) Row input) {
+            int value = input.getFieldAs("value");
+            collect(value * 2);
+        }
+    }
+
     /**
      * PTF with PASS_COLUMNS_THROUGH for validating that all input columns are prepended to output.
      */
@@ -936,13 +944,16 @@ class ProcessTableFunctionTestHarnessTest {
 
             harness.processElement(Row.of("Alice", 25));
 
-            List<User> output = harness.getOutput();
+            List<User> output = harness.getFunctionOutput();
             assertThat(output).hasSize(1);
 
             User result = output.get(0);
             assertThat(result.getClass()).isEqualTo(User.class);
             assertThat(result.name).isEqualTo("Alice");
             assertThat(result.age).isEqualTo(26);
+
+            // getOutput() flattens the POJO into its attributes.
+            assertThat(harness.getOutput()).containsExactly(Row.of("Alice", 26));
         }
     }
 
@@ -1212,12 +1223,49 @@ class ProcessTableFunctionTestHarnessTest {
             harness.processElement(Row.of(10));
             harness.processElement(Row.of(20));
             assertThat(harness.getOutput()).hasSize(2);
+            assertThat(harness.getFunctionOutput()).hasSize(2);
 
             harness.clearOutput();
             assertThat(harness.getOutput()).isEmpty();
+            assertThat(harness.getFunctionOutput()).isEmpty();
 
             harness.processElement(Row.of(30));
             assertThat(harness.getOutput()).hasSize(1);
+            assertThat(harness.getFunctionOutput()).hasSize(1);
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Function Output Tests
+    // -------------------------------------------------------------------------
+
+    @Test
+    void testFunctionOutputReturnsUnwrappedAtomicValue() throws Exception {
+        try (ProcessTableFunctionTestHarness<Integer> harness =
+                ProcessTableFunctionTestHarness.ofClass(AtomicOutputPTF.class)
+                        .withTableArgument("input", DataTypes.of("ROW<value INT>"))
+                        .build()) {
+
+            harness.processElement(Row.of(21));
+
+            assertThat(harness.getFunctionOutput()).containsExactly(42);
+            assertThat(harness.getOutput()).containsExactly(Row.of(42));
+        }
+    }
+
+    @Test
+    void testFunctionOutputExcludesPrependedPartitionKey() throws Exception {
+        try (ProcessTableFunctionTestHarness<Row> harness =
+                ProcessTableFunctionTestHarness.ofClass(PartitionedPTF.class)
+                        .withTableArgument("input", DataTypes.of("ROW<key STRING, value INT>"))
+                        .withPartitionBy("input", "key")
+                        .build()) {
+
+            harness.processElement(Row.of("X", 10));
+            harness.processElement(Row.of("Y", 20));
+
+            assertThat(harness.getFunctionOutput()).containsExactly(Row.of(10), Row.of(20));
+            assertThat(harness.getOutput()).containsExactly(Row.of("X", 10), Row.of("Y", 20));
         }
     }
 


### PR DESCRIPTION
## What is the purpose of the change

When testing the PTF Test Harness against the `ProcessTableFunctionTestPrograms`, I found a bug that occurs when trying to use a PTF that emits a non-row type in a mode where the harness adds extra columns (`rowtime` with `on_time`, partition columns, etc). This exposed a bit of a behaviour gap which this PR hopes to fill.

This PR redfines `getOutput` so that it returns always a `Row` and contains the system-generated columns such as partition keys and rowtime. Pojos get flattened into the row via the attributes, and atomic values are given the `EXPR$0` column. 

This PR also introduces the `getFunctionOutput` that returns a list of the declared type output of the PTF, without the generated columns or flattening into a Row for non-Row types. The reason for this is so that a user who wants to test directly the collected output of their PTF function can do so.

## Brief change log

- Changed `getOutput` in `ProcessTableFunctionTestHarness` to return `Row`, with system generated columns as needed.
- Added `getFunctionOutput` in `ProcessTableFunctionTestHarness` to return the declared return type of the PTF, without any extra columns as a way of directly asserting on the function's collected output.

## Verifying this change

This change added tests and can be verified by running `ProcessTableFunctionTestHarnessTest`.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs / JavaDocs)

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change the checkbox below to `[X]` followed by the name of the tool, and uncomment the
"Generated-by" line. See the ASF Generative Tooling Guidance for details:
https://www.apache.org/legal/generative-tooling.html

You are responsible for the quality and correctness of every change in this PR
regardless of the tooling used. Low-effort AI-generated PRs will be closed. See
AGENTS.md for the full guidance.
-->

- [x] Yes (2.1.201 (Claude Code)
