### PR TITLE
[FLINK-39522] Rework StreamTask recovery: async future chain, consume only after filtering completes

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/RecoveredChannelStateHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/RecoveredChannelStateHandler.java
@@ -135,10 +135,6 @@ abstract class AbstractInputChannelRecoveredStateHandler
 
     @Override
     public void close() throws IOException {
-        // note that we need to finish all RecoveredInputChannels, not just those with state
-        for (final InputGate inputGate : inputGates) {
-            inputGate.finishReadRecoveredState();
-        }
         closeInternal();
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/RecoveredChannelStateHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/RecoveredChannelStateHandler.java
@@ -90,10 +90,20 @@ abstract class AbstractInputChannelRecoveredStateHandler
     final Map<InputChannelInfo, RecoveredInputChannel> rescaledChannels = new HashMap<>();
     final Map<Integer, RescaleMappings> oldToNewMappings = new HashMap<>();
 
+    /**
+     * FLINK-38544 transitional: removed when the spilling backend lands. Gates the unbounded
+     * heap-buffer fallback in {@link RecoveredInputChannel#requestBufferBlocking(boolean)}; read
+     * from the job configuration at the call site now that the gate-level recovery flags are gone.
+     */
+    final boolean checkpointingDuringRecoveryEnabled;
+
     AbstractInputChannelRecoveredStateHandler(
-            InputGate[] inputGates, InflightDataRescalingDescriptor channelMapping) {
+            InputGate[] inputGates,
+            InflightDataRescalingDescriptor channelMapping,
+            boolean checkpointingDuringRecoveryEnabled) {
         this.inputGates = inputGates;
         this.channelMapping = channelMapping;
+        this.checkpointingDuringRecoveryEnabled = checkpointingDuringRecoveryEnabled;
     }
 
     /**
@@ -113,12 +123,12 @@ abstract class AbstractInputChannelRecoveredStateHandler
             @Nullable ChannelStateFilteringHandler filteringHandler,
             int memorySegmentSize) {
         if (!checkpointingDuringRecoveryEnabled) {
-            return new NoSpillingHandler(inputGates, channelMapping);
+            return new NoSpillingHandler(inputGates, channelMapping, false);
         }
         // FLINK-38544 transitional: the flag-on path still uses the in-memory handlers until the
         // spilling backend lands.
         if (filteringHandler == null) {
-            return new NoSpillingHandler(inputGates, channelMapping);
+            return new NoSpillingHandler(inputGates, channelMapping, true);
         }
         return new FilteringHandler(
                 inputGates, channelMapping, filteringHandler, memorySegmentSize);
@@ -129,7 +139,7 @@ abstract class AbstractInputChannelRecoveredStateHandler
     public BufferWithContext<Buffer> getBuffer(InputChannelInfo channelInfo)
             throws IOException, InterruptedException {
         RecoveredInputChannel channel = getMappedChannels(channelInfo);
-        Buffer buffer = channel.requestBufferBlocking();
+        Buffer buffer = channel.requestBufferBlocking(checkpointingDuringRecoveryEnabled);
         return new BufferWithContext<>(wrap(buffer), buffer);
     }
 
@@ -174,8 +184,11 @@ abstract class AbstractInputChannelRecoveredStateHandler
  */
 class NoSpillingHandler extends AbstractInputChannelRecoveredStateHandler {
 
-    NoSpillingHandler(InputGate[] inputGates, InflightDataRescalingDescriptor channelMapping) {
-        super(inputGates, channelMapping);
+    NoSpillingHandler(
+            InputGate[] inputGates,
+            InflightDataRescalingDescriptor channelMapping,
+            boolean checkpointingDuringRecoveryEnabled) {
+        super(inputGates, channelMapping, checkpointingDuringRecoveryEnabled);
     }
 
     @Override
@@ -237,7 +250,7 @@ class FilteringHandler extends AbstractInputChannelRecoveredStateHandler {
             InflightDataRescalingDescriptor channelMapping,
             ChannelStateFilteringHandler filteringHandler,
             int memorySegmentSize) {
-        super(inputGates, channelMapping);
+        super(inputGates, channelMapping, true);
         this.filteringHandler = filteringHandler;
         checkArgument(
                 memorySegmentSize > 0, "memorySegmentSize must be positive: %s", memorySegmentSize);
@@ -307,7 +320,7 @@ class FilteringHandler extends AbstractInputChannelRecoveredStateHandler {
                         oldSubtaskIndex,
                         channelInfo.getInputChannelIdx(),
                         retainedBuffer,
-                        channel::requestBufferBlocking);
+                        () -> channel.requestBufferBlocking(checkpointingDuringRecoveryEnabled));
 
         int i = 0;
         try {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/IndexedInputGate.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/IndexedInputGate.java
@@ -74,10 +74,4 @@ public abstract class IndexedInputGate extends InputGate implements Checkpointab
     public abstract ResultPartitionType getConsumedPartitionType();
 
     public abstract void triggerDebloating();
-
-    /** Sets whether unaligned checkpointing during recovery is enabled. */
-    public abstract void setCheckpointingDuringRecoveryEnabled(boolean enabled);
-
-    /** Returns whether unaligned checkpointing during recovery is enabled. */
-    public abstract boolean isCheckpointingDuringRecoveryEnabled();
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/InputGate.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/InputGate.java
@@ -209,12 +209,5 @@ public abstract class InputGate
 
     public abstract CompletableFuture<Void> getStateConsumedFuture();
 
-    /**
-     * Returns a future that completes when buffer filtering is complete for all channels. This
-     * future completes before {@link #getStateConsumedFuture()}, enabling earlier RUNNING state
-     * transition when unaligned checkpoint during recovery is enabled.
-     */
-    public abstract CompletableFuture<Void> getBufferFilteringCompleteFuture();
-
     public abstract void finishReadRecoveredState() throws IOException;
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RecoveredInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RecoveredInputChannel.java
@@ -62,13 +62,6 @@ public abstract class RecoveredInputChannel extends InputChannel implements Chan
     private final CompletableFuture<Void> stateConsumedFuture = new CompletableFuture<>();
     protected final BufferManager bufferManager;
 
-    /**
-     * Future that completes when recovered buffers have been filtered for this channel. This
-     * completes before stateConsumedFuture, enabling earlier RUNNING state transition when
-     * unaligned checkpoint during recovery is enabled.
-     */
-    private final CompletableFuture<Void> bufferFilteringCompleteFuture = new CompletableFuture<>();
-
     @GuardedBy("receivedBuffers")
     private boolean isReleased;
 
@@ -178,14 +171,6 @@ public abstract class RecoveredInputChannel extends InputChannel implements Chan
     protected abstract InputChannel toInputChannelInternal(boolean needsRecovery)
             throws IOException;
 
-    /**
-     * Returns the future that completes when buffer filtering is complete. This future completes
-     * before stateConsumedFuture, at the point when finishReadRecoveredState() is called.
-     */
-    CompletableFuture<Void> getBufferFilteringCompleteFuture() {
-        return bufferFilteringCompleteFuture;
-    }
-
     @Override
     public CompletableFuture<Void> getStateConsumedFuture() {
         return stateConsumedFuture;
@@ -220,21 +205,9 @@ public abstract class RecoveredInputChannel extends InputChannel implements Chan
     }
 
     public void finishReadRecoveredState() throws IOException {
-        // Adding the event and completing the future must be atomic under receivedBuffers lock.
-        // Without this, either ordering has a race:
-        // - event first: task thread consumes EndOfInputChannelStateEvent, which completes
-        //   stateConsumedFuture. When checkpointing during recovery is disabled,
-        //   stateConsumedFuture triggers requestPartitions -> toInputChannel(), which
-        //   fails because bufferFilteringCompleteFuture is not yet done.
-        // - future first: toInputChannel() extracts buffers before the event is added,
-        //   losing the EndOfInputChannelStateEvent.
-        // Both toInputChannel() and getNextRecoveredStateBuffer() synchronize on
-        // receivedBuffers, so holding the same lock here guarantees
-        // bufferFilteringCompleteFuture is always done before stateConsumedFuture.
         synchronized (receivedBuffers) {
             onRecoveredStateBuffer(
                     EventSerializer.toBuffer(EndOfInputChannelStateEvent.INSTANCE, false));
-            bufferFilteringCompleteFuture.complete(null);
         }
         bufferManager.releaseFloatingBuffers();
         LOG.debug("{}/{} finished recovering input.", inputGate.getOwningTaskName(), channelInfo);
@@ -254,8 +227,6 @@ public abstract class RecoveredInputChannel extends InputChannel implements Chan
         if (next == null) {
             return null;
         } else if (isEndOfInputChannelStateEvent(next)) {
-            Preconditions.checkState(
-                    bufferFilteringCompleteFuture.isDone(), "buffer filtering is not complete");
             stateConsumedFuture.complete(null);
             return null;
         } else {
@@ -357,13 +328,22 @@ public abstract class RecoveredInputChannel extends InputChannel implements Chan
         }
     }
 
-    public Buffer requestBufferBlocking() throws InterruptedException, IOException {
+    /**
+     * Requests a buffer for reading recovered state. {@code checkpointingDuringRecoveryEnabled} is
+     * threaded from the job configuration by the caller now that the gate-level recovery flags are
+     * gone; when set, the allocation may fall back to unpooled heap buffers.
+     *
+     * <p>FLINK-38544 transitional: removed when the spilling backend lands (together with the heap
+     * fallback below, which disk spilling supersedes).
+     */
+    public Buffer requestBufferBlocking(boolean checkpointingDuringRecoveryEnabled)
+            throws InterruptedException, IOException {
         // not in setup to avoid assigning buffers unnecessarily if there is no state
         if (!exclusiveBuffersAssigned) {
             bufferManager.requestExclusiveBuffers(networkBuffersPerChannel);
             exclusiveBuffersAssigned = true;
         }
-        if (!inputGate.isCheckpointingDuringRecoveryEnabled()) {
+        if (!checkpointingDuringRecoveryEnabled) {
             // When checkpoint-during-recovery is not enabled, the original blocking allocation
             // is used as-is — no heap buffer fallback, no behavior change from the legacy path.
             return bufferManager.requestBufferBlocking();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGate.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGate.java
@@ -243,8 +243,6 @@ public class SingleInputGate extends IndexedInputGate {
      */
     private final int[] endOfPartitions;
 
-    private volatile boolean checkpointingDuringRecoveryEnabled = false;
-
     public SingleInputGate(
             String owningTaskName,
             int gateIndex,
@@ -324,31 +322,6 @@ public class SingleInputGate extends IndexedInputGate {
             List<CompletableFuture<?>> futures = new ArrayList<>(numberOfInputChannels);
             for (InputChannel inputChannel : inputChannels()) {
                 futures.add(inputChannel.getStateConsumedFuture());
-            }
-            return CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));
-        }
-    }
-
-    @Override
-    public void setCheckpointingDuringRecoveryEnabled(boolean enabled) {
-        this.checkpointingDuringRecoveryEnabled = enabled;
-    }
-
-    @Override
-    public boolean isCheckpointingDuringRecoveryEnabled() {
-        return checkpointingDuringRecoveryEnabled;
-    }
-
-    @Override
-    public CompletableFuture<Void> getBufferFilteringCompleteFuture() {
-        synchronized (requestLock) {
-            List<CompletableFuture<?>> futures = new ArrayList<>(numberOfInputChannels);
-            for (InputChannel inputChannel : inputChannels()) {
-                if (inputChannel instanceof RecoveredInputChannel) {
-                    futures.add(
-                            ((RecoveredInputChannel) inputChannel)
-                                    .getBufferFilteringCompleteFuture());
-                }
             }
             return CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));
         }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/UnionInputGate.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/UnionInputGate.java
@@ -358,15 +358,6 @@ public class UnionInputGate extends InputGate {
     }
 
     @Override
-    public CompletableFuture<Void> getBufferFilteringCompleteFuture() {
-        return CompletableFuture.allOf(
-                inputGatesByGateIndex.values().stream()
-                        .map(InputGate::getBufferFilteringCompleteFuture)
-                        .collect(Collectors.toList())
-                        .toArray(new CompletableFuture[] {}));
-    }
-
-    @Override
     public void requestPartitions() throws IOException {
         requestPartitions(false);
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/InputGateWithMetrics.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/InputGateWithMetrics.java
@@ -126,11 +126,6 @@ public class InputGateWithMetrics extends IndexedInputGate {
     }
 
     @Override
-    public CompletableFuture<Void> getBufferFilteringCompleteFuture() {
-        return inputGate.getBufferFilteringCompleteFuture();
-    }
-
-    @Override
     public void requestPartitions() throws IOException {
         inputGate.requestPartitions();
     }
@@ -173,16 +168,6 @@ public class InputGateWithMetrics extends IndexedInputGate {
     @Override
     public void finishReadRecoveredState() throws IOException {
         inputGate.finishReadRecoveredState();
-    }
-
-    @Override
-    public void setCheckpointingDuringRecoveryEnabled(boolean enabled) {
-        inputGate.setCheckpointingDuringRecoveryEnabled(enabled);
-    }
-
-    @Override
-    public boolean isCheckpointingDuringRecoveryEnabled() {
-        return inputGate.isCheckpointingDuringRecoveryEnabled();
     }
 
     private BufferOrEvent updateMetrics(BufferOrEvent bufferOrEvent) {

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -62,7 +62,9 @@ import org.apache.flink.runtime.io.network.api.writer.SingleRecordWriter;
 import org.apache.flink.runtime.io.network.partition.ChannelStateHolder;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
 import org.apache.flink.runtime.io.network.partition.consumer.IndexedInputGate;
+import org.apache.flink.runtime.io.network.partition.consumer.InputChannel;
 import org.apache.flink.runtime.io.network.partition.consumer.InputGate;
+import org.apache.flink.runtime.io.network.partition.consumer.RecoverableInputChannel;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.jobgraph.tasks.CheckpointableTask;
 import org.apache.flink.runtime.jobgraph.tasks.CoordinatedTask;
@@ -141,6 +143,7 @@ import java.util.OptionalLong;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
@@ -149,6 +152,7 @@ import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 import static org.apache.flink.configuration.TaskManagerOptions.BUFFER_DEBLOAT_PERIOD;
 import static org.apache.flink.runtime.metrics.MetricNames.GATE_RESTORE_DURATION;
@@ -159,6 +163,7 @@ import static org.apache.flink.streaming.runtime.tasks.SubtaskCheckpointCoordina
 import static org.apache.flink.util.ExceptionUtils.firstOrSuppressed;
 import static org.apache.flink.util.Preconditions.checkState;
 import static org.apache.flink.util.concurrent.FutureUtils.assertNoException;
+import static org.apache.flink.util.concurrent.FutureUtils.completeAll;
 
 /**
  * Base class for all streaming tasks. A task is the unit of local processing that is deployed and
@@ -842,6 +847,12 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
                     allGatesRecoveredFuture.isDone(),
                     "Mailbox loop interrupted before recovery was finished.");
 
+            try {
+                allGatesRecoveredFuture.get();
+            } catch (ExecutionException e) {
+                ExceptionUtils.rethrowException(e.getCause());
+            }
+
             // we recovered all the gates, we can close the channel IO executor as it is no longer
             // needed
             channelIOExecutor.shutdown();
@@ -881,58 +892,112 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
                 INITIALIZE_STATE_DURATION, initializeStateEndTs - readOutputDataTs);
         IndexedInputGate[] inputGates = getEnvironment().getAllInputGates();
 
-        boolean checkpointingDuringRecoveryEnabled =
-                CheckpointingOptions.isCheckpointingDuringRecoveryEnabled(getJobConfiguration());
+        CompletableFuture<Void> recoveryCompletionFuture =
+                CheckpointingOptions.isCheckpointingDuringRecoveryEnabled(getJobConfiguration())
+                        ? recoverChannelsWithCheckpointing(reader, inputGates)
+                        : recoverChannelsWithoutCheckpointing(reader, inputGates);
 
-        // Must set the flag on input gates BEFORE starting the async read task, because
-        // finishReadRecoveredState() checks this flag to complete bufferFilteringCompleteFuture.
-        for (IndexedInputGate inputGate : inputGates) {
-            inputGate.setCheckpointingDuringRecoveryEnabled(checkpointingDuringRecoveryEnabled);
+        recoveryCompletionFuture.whenComplete((ign, throwable) -> mailboxProcessor.suspend());
+        return recoveryCompletionFuture;
+    }
+
+    private CompletableFuture<Void> recoverChannelsWithCheckpointing(
+            SequentialChannelStateReader reader, IndexedInputGate[] inputGates) {
+        if (inputGates.length == 0) {
+            return FutureUtils.completedVoidFuture();
         }
+        // FLINK-38544 transitional: removed when the spilling backend lands. In-memory backend:
+        // readInputChannelState first filters the recovered state completely (the filter output
+        // accumulates in the recovered channels' in-memory queues), then conversion pushes it into
+        // the physical channels through the push interface (requestPartitions(true)). The final
+        // form instead fetches the filter output to disk and drains it incrementally from here.
+        return CompletableFuture.runAsync(
+                        () -> readInputChannelState(reader, inputGates), channelIOExecutor)
+                .thenCompose(ign -> requestPartitions(inputGates, true))
+                .thenCompose(
+                        ign ->
+                                completeAll(
+                                        Arrays.stream(inputGates)
+                                                .map(InputGate::getStateConsumedFuture)
+                                                .collect(Collectors.toList())));
+    }
 
-        channelIOExecutor.execute(
-                () -> {
-                    try {
-                        reader.readInputData(inputGates, createRecordFilterContext());
-                    } catch (Exception e) {
-                        asyncExceptionHandler.handleAsyncException(
-                                "Unable to read channel state", e);
-                    }
-                });
-
-        // We wait for all input channel state to recover before we go into RUNNING state, and thus
-        // start checkpointing. If we implement incremental checkpointing of input channel state
-        // we must make sure it supports CheckpointType#FULL_CHECKPOINT.
-        List<CompletableFuture<?>> recoveredFutures = new ArrayList<>(inputGates.length);
+    private CompletableFuture<Void> recoverChannelsWithoutCheckpointing(
+            SequentialChannelStateReader reader, IndexedInputGate[] inputGates) {
+        // Feed recovered channel state on the IO thread. This is intentionally NOT part of the
+        // completion gate below: a gate's stateConsumedFuture only completes once the consumer (the
+        // default action, running in the restore mailbox loop) has drained the end-of-state
+        // sentinel that readInputChannelState pushes, so gating on stateConsumedFuture already
+        // implies the read has finished. Including the read future in the gate would defer
+        // suspend() past the restore loop's first default action, letting input be processed before
+        // recovery completes -- causing record loss and "Mailbox loop interrupted before recovery
+        // was finished". Read failures are surfaced via asyncExceptionHandler inside
+        // readInputChannelState.
+        channelIOExecutor.execute(() -> readInputChannelState(reader, inputGates));
+        List<CompletableFuture<Void>> futures = new ArrayList<>();
         for (InputGate inputGate : inputGates) {
-            CompletableFuture<?> requestPartitionsTrigger =
-                    checkpointingDuringRecoveryEnabled
-                            ? inputGate.getBufferFilteringCompleteFuture()
-                            : inputGate.getStateConsumedFuture();
-
-            recoveredFutures.add(requestPartitionsTrigger);
-
-            requestPartitionsTrigger.thenRun(
+            CompletableFuture<Void> stateConsumed = inputGate.getStateConsumedFuture();
+            futures.add(stateConsumed);
+            // Convert and request partitions for each gate as soon as ITS OWN recovered state is
+            // drained, independent of the other gates. Deferring conversion until every gate has
+            // drained deadlocks selective-reading multi-input operators: such an operator only
+            // drains the selected input's end-of-state sentinel, so an unselected gate would never
+            // drain (it is read only after conversion) while conversion would wait for it to drain
+            // first. suspend() is still gated on completeAll(futures) below.
+            stateConsumed.thenRun(
                     () ->
                             mainMailboxExecutor.execute(
-                                    inputGate::requestPartitions, "Input gate request partitions"));
+                                    () -> inputGate.requestPartitions(false),
+                                    "Input gate request partitions"));
         }
+        return completeAll(futures);
+    }
 
-        // Return allOf future instead of thenRun future. thenRun() returns a NEW future that
-        // completes only after the callback finishes. CompletableFuture executes thenRun callbacks
-        // synchronously on the thread that calls complete(). When recoveredFutures contains
-        // bufferFilteringCompleteFuture (checkpointingDuringRecovery enabled), complete() is called
-        // on channelIOExecutor (in finishReadRecoveredState), so thenRun(suspend) also runs on
-        // channelIOExecutor. suspend() sends a poison mail, and the mailbox thread can pick it up
-        // and exit runMailboxLoop() before the thenRun future completes — causing
-        // checkState(isDone) to fail. With stateConsumedFuture (the default), complete() runs on
-        // the mailbox thread itself, so thenRun(suspend) blocks the loop from processing the poison
-        // mail until the future completes — no race. Returning allOf future avoids the issue
-        // entirely.
-        CompletableFuture<Void> allRecoveredFuture =
-                CompletableFuture.allOf(recoveredFutures.toArray(new CompletableFuture[0]));
-        allRecoveredFuture.thenRun(mailboxProcessor::suspend);
-        return allRecoveredFuture;
+    private void readInputChannelState(
+            SequentialChannelStateReader reader, IndexedInputGate[] inputGates) {
+        try {
+            reader.readInputData(inputGates, createRecordFilterContext());
+
+            for (IndexedInputGate gate : inputGates) {
+                gate.finishReadRecoveredState();
+            }
+        } catch (Exception e) {
+            asyncExceptionHandler.handleAsyncException(
+                    "Unable to set up recovered channel state", e);
+        }
+    }
+
+    private CompletableFuture<List<RecoverableInputChannel>> requestPartitions(
+            IndexedInputGate[] inputGates, boolean needsRecovery) {
+        CompletableFuture<List<RecoverableInputChannel>> future = new CompletableFuture<>();
+        mainMailboxExecutor.execute(
+                () -> {
+                    try {
+                        for (InputGate inputGate : inputGates) {
+                            inputGate.requestPartitions(needsRecovery);
+                        }
+                        future.complete(collectPhysicalChannels(inputGates));
+                    } catch (Throwable t) {
+                        future.completeExceptionally(t);
+                        throw t;
+                    }
+                },
+                "Input gate request partitions");
+        return future;
+    }
+
+    private static List<RecoverableInputChannel> collectPhysicalChannels(InputGate[] inputGates) {
+        List<RecoverableInputChannel> channels = new ArrayList<>();
+        for (InputGate gate : inputGates) {
+            int numberOfInputChannels = gate.getNumberOfInputChannels();
+            for (int i = 0; i < numberOfInputChannels; i++) {
+                InputChannel channel = gate.getChannel(i);
+                if (channel instanceof RecoverableInputChannel) {
+                    channels.add((RecoverableInputChannel) channel);
+                }
+            }
+        }
+        return channels;
     }
 
     private void ensureNotCanceled() {

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -309,6 +309,14 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
     /** TODO it might be replaced by the global IO executor on TaskManager level future. */
     private final ExecutorService channelIOExecutor;
 
+    /**
+     * Completes when channel recovery has finished; set by {@link #restoreStateAndGates}. Used to
+     * defer the lifecycle finish of a task that reaches {@code END_OF_INPUT} during recovery (e.g.
+     * a bounded operator whose input is already fully available) so that it does not suspend the
+     * restore mailbox loop before recovery completes. Accessed only on the mailbox/task thread.
+     */
+    @Nullable private CompletableFuture<Void> recoveryCompletionFuture;
+
     // ========================================================
     //  Final  checkpoint / savepoint
     // ========================================================
@@ -677,6 +685,24 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
                 notifyEndOfData();
                 return;
             case END_OF_INPUT:
+                if (recoveryCompletionFuture != null && !recoveryCompletionFuture.isDone()) {
+                    // The task consumed all of its input during recovery (e.g. a bounded operator
+                    // whose input is already fully available, as with a blocking batch exchange).
+                    // Do NOT suspend the mailbox processor yet: recovery is still in progress and
+                    // relies on this restore loop to run its remaining mails. Suspending here would
+                    // end the restore loop early and trip "Mailbox loop interrupted before recovery
+                    // was finished" in restoreInternal. Instead suspend only the default action (to
+                    // avoid busy-spinning on repeated END_OF_INPUT) and resume it once recovery
+                    // completes; processInput then re-fires END_OF_INPUT from the main mailbox loop
+                    // and finishes through the normal path below.
+                    MailboxDefaultAction.Suspension suspension = controller.suspendDefaultAction();
+                    recoveryCompletionFuture.whenComplete(
+                            (ign, t) ->
+                                    mainMailboxExecutor.execute(
+                                            suspension::resume,
+                                            "resume default action after recovery"));
+                    return;
+                }
                 // Suspend the mailbox processor, it would be resumed in afterInvoke and finished
                 // after all records processed by the downstream tasks. We also suspend the default
                 // actions to avoid repeat executing the empty default operation (namely process
@@ -892,7 +918,7 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
                 INITIALIZE_STATE_DURATION, initializeStateEndTs - readOutputDataTs);
         IndexedInputGate[] inputGates = getEnvironment().getAllInputGates();
 
-        CompletableFuture<Void> recoveryCompletionFuture =
+        recoveryCompletionFuture =
                 CheckpointingOptions.isCheckpointingDuringRecoveryEnabled(getJobConfiguration())
                         ? recoverChannelsWithCheckpointing(reader, inputGates)
                         : recoverChannelsWithoutCheckpointing(reader, inputGates);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/SequentialChannelStateReaderImplTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/SequentialChannelStateReaderImplTest.java
@@ -145,6 +145,12 @@ public class SequentialChannelStateReaderImplTest {
         withInputGates(
                 gates -> {
                     reader.readInputData(gates, RecordFilterContext.disabled());
+                    // Mirror the production legacy path (StreamTask#readInputChannelState): the
+                    // EndOfInputChannelStateEvent sentinel that completes stateConsumedFuture is
+                    // enqueued by finishReadRecoveredState(), not by readInputData() itself.
+                    for (InputGate gate : gates) {
+                        gate.finishReadRecoveredState();
+                    }
                     assertBuffersEquals(inputChannelsData, collectBuffers(gates));
                     assertConsumed(gates);
                 });

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateBuilder.java
@@ -83,8 +83,6 @@ public class SingleInputGateBuilder {
 
     private TieredStorageConsumerClient tieredStorageConsumerClient = null;
 
-    private boolean isCheckpointingDuringRecoveryEnabled = false;
-
     public SingleInputGateBuilder setPartitionProducerStateProvider(
             PartitionProducerStateProvider partitionProducerStateProvider) {
 
@@ -169,11 +167,6 @@ public class SingleInputGateBuilder {
         return this;
     }
 
-    public SingleInputGateBuilder setCheckpointingDuringRecoveryEnabled(boolean enabled) {
-        this.isCheckpointingDuringRecoveryEnabled = enabled;
-        return this;
-    }
-
     public SingleInputGate build() {
         SingleInputGate gate =
                 new SingleInputGate(
@@ -202,7 +195,6 @@ public class SingleInputGateBuilder {
                             .toArray(InputChannel[]::new));
         }
         gate.setTieredStorageService(null, tieredStorageConsumerClient, null);
-        gate.setCheckpointingDuringRecoveryEnabled(isCheckpointingDuringRecoveryEnabled);
         return gate;
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateTest.java
@@ -142,36 +142,6 @@ class SingleInputGateTest extends InputGateTestBase {
                 .isInstanceOf(CheckpointException.class);
     }
 
-    @Test
-    void testBufferFilteringCompleteFutureAggregation() throws Exception {
-        final NettyShuffleEnvironment environment = createNettyShuffleEnvironment();
-        final SingleInputGate inputGate = createInputGate(environment);
-        try (Closer closer = Closer.create()) {
-            closer.register(environment::close);
-            closer.register(inputGate::close);
-
-            // Enable unaligned during recovery for this test so that
-            // bufferFilteringCompleteFuture is completed by finishReadRecoveredState()
-            inputGate.setCheckpointingDuringRecoveryEnabled(true);
-            inputGate.setup();
-
-            // Initially, the aggregated future should not be completed
-            assertThat(inputGate.getBufferFilteringCompleteFuture()).isNotDone();
-
-            // After finishing read recovered state, bufferFilteringCompleteFuture should be
-            // completed (only when config is enabled)
-            inputGate.finishReadRecoveredState();
-            assertThat(inputGate.getBufferFilteringCompleteFuture()).isDone();
-
-            // stateConsumedFuture should not be completed until data is consumed
-            assertThat(inputGate.getStateConsumedFuture()).isNotDone();
-
-            // Consuming the EndOfInputChannelStateEvent should complete stateConsumedFuture
-            inputGate.pollNext();
-            assertThat(inputGate.getStateConsumedFuture()).isDone();
-        }
-    }
-
     /**
      * Tests {@link InputGate#setup()} should create the respective {@link BufferPool} and assign
      * exclusive buffers for {@link RemoteInputChannel}s, but should not request partitions.

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/UnionInputGateTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/UnionInputGateTest.java
@@ -18,14 +18,12 @@
 
 package org.apache.flink.runtime.io.network.partition.consumer;
 
-import org.apache.flink.metrics.SimpleCounter;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.io.PullingAsyncDataInput;
 import org.apache.flink.runtime.io.network.api.StopMode;
 import org.apache.flink.runtime.io.network.buffer.BufferBuilderTestUtils;
 import org.apache.flink.runtime.io.network.partition.NoOpResultSubpartitionView;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
-import org.apache.flink.runtime.io.network.partition.ResultSubpartitionIndexSet;
 import org.apache.flink.runtime.io.network.partition.consumer.SingleInputGateTest.TestingResultPartitionManager;
 
 import org.junit.jupiter.api.Test;
@@ -275,60 +273,6 @@ class UnionInputGateTest extends InputGateTestBase {
         assertThat(unionInputGate.getChannel(0)).isEqualTo(inputChannel1);
         // Check that updated input channel is visible via UnionInputGate
         assertThat(unionInputGate.getChannel(1)).isEqualTo(inputChannel2);
-    }
-
-    @Test
-    void testBufferFilteringCompleteFutureAggregation() throws IOException {
-        // Create 2 SingleInputGates, each with 1 RecoveredInputChannel
-        SingleInputGate ig1 =
-                new SingleInputGateBuilder().setCheckpointingDuringRecoveryEnabled(true).build();
-        RecoveredInputChannel channel1 = buildRecoveredChannel(ig1);
-        ig1.setInputChannels(channel1);
-
-        SingleInputGate ig2 =
-                new SingleInputGateBuilder()
-                        .setSingleInputGateIndex(1)
-                        .setCheckpointingDuringRecoveryEnabled(true)
-                        .build();
-        RecoveredInputChannel channel2 = buildRecoveredChannel(ig2);
-        ig2.setInputChannels(channel2);
-
-        UnionInputGate union = new UnionInputGate(ig1, ig2);
-
-        // Initially, bufferFilteringCompleteFuture should not be done
-        assertThat(union.getBufferFilteringCompleteFuture()).isNotDone();
-        assertThat(union.getStateConsumedFuture()).isNotDone();
-
-        // Complete buffer filtering on first gate only
-        channel1.finishReadRecoveredState();
-        assertThat(ig1.getBufferFilteringCompleteFuture()).isDone();
-        assertThat(union.getBufferFilteringCompleteFuture()).isNotDone();
-
-        // Complete buffer filtering on second gate
-        channel2.finishReadRecoveredState();
-        assertThat(ig2.getBufferFilteringCompleteFuture()).isDone();
-        assertThat(union.getBufferFilteringCompleteFuture()).isDone();
-
-        // State consumed futures should still NOT be done (state not consumed yet)
-        assertThat(union.getStateConsumedFuture()).isNotDone();
-    }
-
-    private static RecoveredInputChannel buildRecoveredChannel(SingleInputGate inputGate) {
-        return new RecoveredInputChannel(
-                inputGate,
-                0,
-                new ResultPartitionID(),
-                new ResultSubpartitionIndexSet(0),
-                0,
-                0,
-                new SimpleCounter(),
-                new SimpleCounter(),
-                10) {
-            @Override
-            protected InputChannel toInputChannelInternal(boolean needsRecovery) {
-                throw new UnsupportedOperationException();
-            }
-        };
     }
 
     @Test

--- a/flink-runtime/src/test/java/org/apache/flink/streaming/runtime/io/MockIndexedInputGate.java
+++ b/flink-runtime/src/test/java/org/apache/flink/streaming/runtime/io/MockIndexedInputGate.java
@@ -58,11 +58,6 @@ public class MockIndexedInputGate extends IndexedInputGate {
     }
 
     @Override
-    public CompletableFuture<Void> getBufferFilteringCompleteFuture() {
-        return CompletableFuture.completedFuture(null);
-    }
-
-    @Override
     public void finishReadRecoveredState() {}
 
     @Override
@@ -147,12 +142,4 @@ public class MockIndexedInputGate extends IndexedInputGate {
 
     @Override
     public void triggerDebloating() {}
-
-    @Override
-    public void setCheckpointingDuringRecoveryEnabled(boolean enabled) {}
-
-    @Override
-    public boolean isCheckpointingDuringRecoveryEnabled() {
-        return false;
-    }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/streaming/runtime/io/MockInputGate.java
+++ b/flink-runtime/src/test/java/org/apache/flink/streaming/runtime/io/MockInputGate.java
@@ -81,11 +81,6 @@ public class MockInputGate extends IndexedInputGate {
     }
 
     @Override
-    public CompletableFuture<Void> getBufferFilteringCompleteFuture() {
-        return CompletableFuture.completedFuture(null);
-    }
-
-    @Override
     public void finishReadRecoveredState() {}
 
     @Override
@@ -208,13 +203,5 @@ public class MockInputGate extends IndexedInputGate {
     @Override
     public List<InputChannelInfo> getUnfinishedChannels() {
         return Collections.emptyList();
-    }
-
-    @Override
-    public void setCheckpointingDuringRecoveryEnabled(boolean enabled) {}
-
-    @Override
-    public boolean isCheckpointingDuringRecoveryEnabled() {
-        return false;
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/streaming/runtime/io/checkpointing/AlignedCheckpointsMassiveRandomTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/streaming/runtime/io/checkpointing/AlignedCheckpointsMassiveRandomTest.java
@@ -269,11 +269,6 @@ class AlignedCheckpointsMassiveRandomTest {
         }
 
         @Override
-        public CompletableFuture<Void> getBufferFilteringCompleteFuture() {
-            return CompletableFuture.completedFuture(null);
-        }
-
-        @Override
         public void finishReadRecoveredState() {}
 
         @Override
@@ -290,14 +285,6 @@ class AlignedCheckpointsMassiveRandomTest {
         @Override
         public List<InputChannelInfo> getUnfinishedChannels() {
             return Collections.emptyList();
-        }
-
-        @Override
-        public void setCheckpointingDuringRecoveryEnabled(boolean enabled) {}
-
-        @Override
-        public boolean isCheckpointingDuringRecoveryEnabled() {
-            return false;
         }
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/streaming/runtime/tasks/TaskCheckpointingBehaviourTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/streaming/runtime/tasks/TaskCheckpointingBehaviourTest.java
@@ -94,6 +94,7 @@ import org.apache.flink.util.SerializedValue;
 import org.apache.flink.util.concurrent.Executors;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -112,6 +113,7 @@ import static org.mockito.Mockito.mock;
  * checks correct working of different policies how tasks deal with checkpoint failures (fail task,
  * decline checkpoint and continue).
  */
+@Timeout(120)
 class TaskCheckpointingBehaviourTest {
 
     private static final OneShotLatch IN_CHECKPOINT_LATCH = new OneShotLatch();


### PR DESCRIPTION
This PR depends on https://github.com/apache/flink/pull/28651 and https://github.com/apache/flink/pull/28652

Please only review the last 3 commits (prefixed [FLINK-39522]).

## What is the purpose of the change

[FLINK-39522] Rework StreamTask recovery: async future chain, consume only after filtering completes.

It's part 3 of FLINK-38544 (checkpointing during recovery of unaligned checkpoint state). StreamTask channel-state recovery is restructured into an asynchronous future chain on the channelIOExecutor, and recovery completion is unified on the gates' state-consumed futures. With checkpointing-during-recovery enabled, the task now consumes recovered state only after rescale filtering has fully completed (previously consumption overlapped with filtering); the filtered buffers are held in the recovered channels' memory queues and handed to the physical channels through the push interface at conversion. The now-unused filtering-progress gate API is removed. Non-CDR observable behavior is preserved; the defer-finish commit fixes an existing race where a finite task could finish before recovery completed. Checkpoints during recovery are declined at this stage.

## Brief change log

- [FLINK-39522] Restructure StreamTask channel-state recovery into an async future chain
- [FLINK-39522][network] Remove recovery flags and the filtering-complete future from the gate API
- [FLINK-39522] Defer task finish until recovery completes

## Verifying this change

- Existing and adapted tests: TaskCheckpointingBehaviourTest, StreamTaskTest, MultipleInputStreamTaskTest, SingleInputGateTest, UnionInputGateTest, RecoveredInputChannelTest, SequentialChannelStateReaderImplTest

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
