### PR TITLE
[FLINK-39524][checkpoint] Fetched channel state: spill files, filtered write, reader

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/core/fs/OffsetAwareOutputStream.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/OffsetAwareOutputStream.java
@@ -35,7 +35,7 @@ public final class OffsetAwareOutputStream implements Closeable {
 
     private long position;
 
-    OffsetAwareOutputStream(OutputStream currentOut, long position) {
+    public OffsetAwareOutputStream(OutputStream currentOut, long position) {
         this.currentOut = checkNotNull(currentOut);
         this.position = position;
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/ChannelStateFilteringHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/ChannelStateFilteringHandler.java
@@ -101,7 +101,43 @@ public class ChannelStateFilteringHandler implements Closeable {
     }
 
     /**
-     * Filters a recovered buffer from the specified virtual channel, returning new buffers
+     * Filters {@code sourceBuffer} through the virtual channel identified by {@code gateIndex} /
+     * {@code oldChannelIndex}, appending each surviving record (length-prefixed) into {@code
+     * outputSerializer}. One call may emit 0..N records depending on the filter result and whether
+     * records spanning previous buffers complete here. The caller owns the segment boundary.
+     */
+    public void filterAndRewrite(
+            int gateIndex,
+            int oldSubtaskIndex,
+            int oldChannelIndex,
+            Buffer sourceBuffer,
+            DataOutputSerializer outputSerializer)
+            throws IOException {
+
+        if (gateIndex < 0 || gateIndex >= gateHandlers.length) {
+            throw new IllegalStateException(
+                    "Invalid gateIndex: "
+                            + gateIndex
+                            + ", number of gates: "
+                            + gateHandlers.length);
+        }
+
+        GateFilterHandler<?> gateHandler = gateHandlers[gateIndex];
+        if (gateHandler == null) {
+            throw new IllegalStateException(
+                    "No handler for gateIndex "
+                            + gateIndex
+                            + ". This gate is not a network input and should not have recovered buffers.");
+        }
+        gateHandler.filterAndRewrite(
+                oldSubtaskIndex, oldChannelIndex, sourceBuffer, outputSerializer);
+    }
+
+    /**
+     * FLINK-38544 transitional: removed when the spilling backend lands (dies together with the
+     * in-memory {@code FilteringHandler}, its only caller).
+     *
+     * <p>Filters a recovered buffer from the specified virtual channel, returning new buffers
      * containing only the records that belong to the current subtask.
      *
      * <p>One source buffer may produce 0 to N result buffers: 0 if all records are filtered out,
@@ -215,7 +251,8 @@ public class ChannelStateFilteringHandler implements Closeable {
                                 : VirtualChannelRecordFilterFactory.createPassThroughFilter();
 
                 RecordDeserializer<DeserializationDelegate<StreamElement>> deserializer =
-                        createDeserializer(filterContext.getTmpDirectories());
+                        new SpillingAdaptiveSpanningRecordDeserializer<>(
+                                filterContext.getTmpDirectories());
 
                 VirtualChannel<T> vc = new VirtualChannel<>(deserializer, recordFilter);
                 gateVirtualChannels.put(key, vc);
@@ -246,21 +283,14 @@ public class ChannelStateFilteringHandler implements Closeable {
         return oldIndexes.stream().mapToInt(Integer::intValue).toArray();
     }
 
-    private static RecordDeserializer<DeserializationDelegate<StreamElement>> createDeserializer(
-            String[] tmpDirectories) {
-        if (tmpDirectories != null && tmpDirectories.length > 0) {
-            return new SpillingAdaptiveSpanningRecordDeserializer<>(tmpDirectories);
-        } else {
-            String[] defaultDirs = new String[] {System.getProperty("java.io.tmpdir")};
-            return new SpillingAdaptiveSpanningRecordDeserializer<>(defaultDirs);
-        }
-    }
-
     // -------------------------------------------------------------------------------------------
     // Inner classes
     // -------------------------------------------------------------------------------------------
 
-    /** Provides buffers for re-serializing filtered records. Implementations may block. */
+    /**
+     * FLINK-38544 transitional: removed when the spilling backend lands. Provides buffers for
+     * re-serializing filtered records on the in-memory delivery path. Implementations may block.
+     */
     @FunctionalInterface
     public interface BufferSupplier {
         Buffer requestBufferBlocking() throws IOException, InterruptedException;
@@ -275,6 +305,9 @@ public class ChannelStateFilteringHandler implements Closeable {
         private final Map<SubtaskConnectionDescriptor, VirtualChannel<T>> virtualChannels;
         private final StreamElementSerializer<T> serializer;
         private final DeserializationDelegate<StreamElement> deserializationDelegate;
+
+        // FLINK-38544 transitional: removed when the spilling backend lands (used only by the
+        // in-memory buffer-delivering filterAndRewrite overload below).
         private final DataOutputSerializer outputSerializer;
         private final byte[] lengthBuffer = new byte[4];
 
@@ -286,6 +319,72 @@ public class ChannelStateFilteringHandler implements Closeable {
             this.deserializationDelegate = new NonReusingDeserializationDelegate<>(serializer);
             this.outputSerializer = new DataOutputSerializer(128);
         }
+
+        /**
+         * Deserializes records from {@code sourceBuffer}, applies the virtual channel's record
+         * filter, and re-serializes each surviving record into {@code outputSerializer}. No
+         * intermediate network buffer is used; the caller owns the segment boundary.
+         */
+        void filterAndRewrite(
+                int oldSubtaskIndex,
+                int oldChannelIndex,
+                Buffer sourceBuffer,
+                DataOutputSerializer outputSerializer)
+                throws IOException {
+
+            boolean sourceBufferOwnershipTransferred = false;
+            try {
+                SubtaskConnectionDescriptor key =
+                        new SubtaskConnectionDescriptor(oldSubtaskIndex, oldChannelIndex);
+                VirtualChannel<T> vc = virtualChannels.get(key);
+                if (vc == null) {
+                    throw new IllegalStateException(
+                            "No VirtualChannel found for key: "
+                                    + key
+                                    + "; known channels are "
+                                    + virtualChannels.keySet());
+                }
+
+                vc.setNextBuffer(sourceBuffer);
+                sourceBufferOwnershipTransferred = true;
+
+                while (true) {
+                    DeserializationResult result = vc.getNextRecord(deserializationDelegate);
+                    if (result.isFullRecord()) {
+                        serializeElement(deserializationDelegate.getInstance(), outputSerializer);
+                    }
+                    if (result.isBufferConsumed()) {
+                        break;
+                    }
+                }
+            } catch (Throwable t) {
+                if (!sourceBufferOwnershipTransferred) {
+                    sourceBuffer.recycleBuffer();
+                }
+                throw t;
+            }
+        }
+
+        /**
+         * Appends one stream element as a length-prefixed record. Reserves the 4B prefix,
+         * serializes the element, then backfills the length, because {@code outputSerializer}
+         * already holds the segment header and earlier records, so the prefix cannot be written
+         * from a fixed offset.
+         */
+        private void serializeElement(StreamElement element, DataOutputSerializer outputSerializer)
+                throws IOException {
+            int startPos = outputSerializer.length();
+            outputSerializer.writeInt(0); // length placeholder
+            serializer.serialize(element, outputSerializer);
+            int recordLength = outputSerializer.length() - startPos - Integer.BYTES;
+            outputSerializer.writeIntUnsafe(recordLength, startPos);
+        }
+
+        // -----------------------------------------------------------------------------------
+        // FLINK-38544 transitional: everything below until hasPartialData() is the in-memory
+        // buffer-delivering filter path, kept alive for the v1 FilteringHandler; removed when
+        // the spilling backend lands.
+        // -----------------------------------------------------------------------------------
 
         /**
          * Deserializes records from {@code sourceBuffer}, applies the virtual channel's record
@@ -446,6 +545,8 @@ public class ChannelStateFilteringHandler implements Closeable {
             }
             return currentBuffer;
         }
+
+        // ------------------------ end of FLINK-38544 transitional block -----------------------
 
         boolean hasPartialData() {
             return virtualChannels.values().stream().anyMatch(VirtualChannel::hasPartialData);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/FetchedChannelState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/FetchedChannelState.java
@@ -74,6 +74,16 @@ public final class FetchedChannelState implements Closeable {
     // Read-phase API (called by the reader after the writer is sealed)
     // -------------------------------------------------------------------------------------------
 
+    /**
+     * Opens a root reader covering all segments from the beginning. The returned reader holds one
+     * lifecycle grant and must be closed when done.
+     */
+    public FetchedChannelStateReader reader() {
+        return new FetchedChannelStateSnapshot(
+                        this, FetchedChannelStateReaderImpl.Position.atStart())
+                .reader();
+    }
+
     /** Returns the ordered list of spill file paths. Read-only view. */
     public List<Path> files() {
         return Collections.unmodifiableList(files);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/FetchedChannelState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/FetchedChannelState.java
@@ -22,42 +22,114 @@ import org.apache.flink.annotation.VisibleForTesting;
 
 import java.io.Closeable;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
- * Sealed container for fetched recovered channel-state data.
+ * Sealed container for recovered channel-state data written to spill files.
  *
- * <p>FLINK-38544 transitional in-memory placeholder: the in-memory recovery backend keeps all
- * recovered buffers inside the physical channels' own queues (pushed in one shot at conversion
- * time), so there is no spill file and nothing to hand out or clean up here. This container carries
- * only the "there is state to recover" signal that {@link
- * SequentialChannelStateReader#readInputData} returns to the {@code StreamTask} recovery link; the
- * lifecycle and file APIs are no-ops until the spilling backend lands and replaces this with a
- * real, file-backed container.
+ * <p>Holds a list of file paths (in write order). Segment boundaries are self-described in disk
+ * segment headers ([4B gateIdx][4B channelIdx][4B bufferLength]), so no in-memory segment locator
+ * table is maintained. The reader scans files sequentially, reading each 12-byte header to obtain
+ * the channel info and body length.
+ *
+ * <p>The file list grows as the writer rotates to new files (one rotation per 64 MB soft limit),
+ * and is sealed on writer close.
+ *
+ * <p>File lifecycle is managed by {@link #acquire()} / {@link #release()} reference counting. Files
+ * are deleted only when the last lifecycle grant is released (i.e. when both the drain reader and
+ * all snapshot readers have finished).
+ *
+ * <p>Mutations (file list appends) are single-writer and intentionally unsynchronized; callers must
+ * serialize them via the channel IO executor.
  */
 @Internal
 public final class FetchedChannelState implements Closeable {
 
+    /** Ordered list of spill file paths, one entry per physical file. Sealed at construction. */
+    private final List<Path> files;
+
+    // close() and release() may be called from different threads; volatile ensures visibility.
     private volatile boolean closed = false;
 
-    FetchedChannelState() {}
+    private final AtomicInteger refCount = new AtomicInteger(0);
 
-    /** Returns the ordered list of spill file paths; empty for the in-memory backend. */
-    public List<Path> files() {
-        return Collections.emptyList();
+    private final AtomicBoolean cleanedUp = new AtomicBoolean(false);
+
+    /**
+     * Wraps an already-written, ordered list of spill files. The list is sealed; it never grows.
+     */
+    FetchedChannelState(List<Path> files) {
+        this.files = new ArrayList<>(checkNotNull(files));
     }
 
-    /** Acquires a lifecycle grant; no-op for the in-memory backend (no files to keep alive). */
-    public void acquire() {}
+    // -------------------------------------------------------------------------------------------
+    // Read-phase API (called by the reader after the writer is sealed)
+    // -------------------------------------------------------------------------------------------
 
-    /** Releases a lifecycle grant; no-op for the in-memory backend (no files to delete). */
-    public void release() throws IOException {}
+    /** Returns the ordered list of spill file paths. Read-only view. */
+    public List<Path> files() {
+        return Collections.unmodifiableList(files);
+    }
 
+    // -------------------------------------------------------------------------------------------
+    // Lifecycle
+    // -------------------------------------------------------------------------------------------
+
+    /** Acquires a lifecycle grant for a reader or handoff owner. */
+    public void acquire() {
+        refCount.incrementAndGet();
+    }
+
+    /**
+     * Releases a lifecycle grant. When the last grant is released (refCount reaches zero), all
+     * spill files are deleted. This preserves the invariant that files exist for the lifetime of
+     * all readers (drain + snapshot) and are cleaned up exactly once when the last reader finishes.
+     */
+    public void release() throws IOException {
+        if (refCount.decrementAndGet() == 0) {
+            if (cleanedUp.compareAndSet(false, true)) {
+                closed = true;
+                deleteAllFiles();
+            }
+        }
+    }
+
+    /** Forces cleanup even when lifecycle grants are still outstanding. */
     @Override
     public void close() throws IOException {
+        if (closed) {
+            return;
+        }
         closed = true;
+        if (cleanedUp.compareAndSet(false, true)) {
+            deleteAllFiles();
+        }
+    }
+
+    private void deleteAllFiles() throws IOException {
+        IOException firstError = null;
+        for (Path file : files) {
+            try {
+                Files.deleteIfExists(file);
+            } catch (IOException e) {
+                if (firstError == null) {
+                    firstError = e;
+                } else {
+                    firstError.addSuppressed(e);
+                }
+            }
+        }
+        if (firstError != null) {
+            throw firstError;
+        }
     }
 
     @VisibleForTesting

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/FetchedChannelState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/FetchedChannelState.java
@@ -22,42 +22,114 @@ import org.apache.flink.annotation.VisibleForTesting;
 
 import java.io.Closeable;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
- * Sealed container for fetched recovered channel-state data.
+ * Sealed container for recovered channel-state data written to spill files.
  *
- * <p>FLINK-38544 transitional in-memory placeholder: the in-memory recovery backend keeps all
- * recovered buffers inside the physical channels' own queues (pushed in one shot at conversion
- * time), so there is no spill file and nothing to hand out or clean up here. This container carries
- * only the "there is state to recover" signal that {@link
- * SequentialChannelStateReader#readInputData} returns to the {@code StreamTask} recovery link; the
- * lifecycle and file APIs are no-ops until the spilling backend lands and replaces this with a
- * real, file-backed container.
+ * <p>Holds a list of file paths (in write order). Segment boundaries are self-described in disk
+ * segment headers ([4B gateIdx][4B channelIdx][4B bufferLength]), so no in-memory segment locator
+ * table is maintained. The reader scans files sequentially, reading each 12-byte header to obtain
+ * the channel info and body length.
+ *
+ * <p>The file list grows as the writer rotates to new files (one rotation per 64 MB soft limit),
+ * and is sealed on writer close.
+ *
+ * <p>File lifecycle is managed by {@link #acquire()} / {@link #release()} reference counting. Files
+ * are deleted only when the last lifecycle grant is released (i.e. when both the main reader and
+ * all snapshot readers have finished).
+ *
+ * <p>Mutations (file list appends) are single-writer and intentionally unsynchronized; callers must
+ * serialize them via the channel IO executor.
  */
 @Internal
 public final class FetchedChannelState implements Closeable {
 
+    /** Ordered list of spill file paths, one entry per physical file. Sealed at construction. */
+    private final List<Path> files;
+
+    // close() and release() may be called from different threads; volatile ensures visibility.
     private volatile boolean closed = false;
 
-    FetchedChannelState() {}
+    private final AtomicInteger refCount = new AtomicInteger(0);
 
-    /** Returns the ordered list of spill file paths; empty for the in-memory backend. */
-    public List<Path> files() {
-        return Collections.emptyList();
+    private final AtomicBoolean cleanedUp = new AtomicBoolean(false);
+
+    /**
+     * Wraps an already-written, ordered list of spill files. The list is sealed; it never grows.
+     */
+    FetchedChannelState(List<Path> files) {
+        this.files = new ArrayList<>(checkNotNull(files));
     }
 
-    /** Acquires a lifecycle grant; no-op for the in-memory backend (no files to keep alive). */
-    public void acquire() {}
+    // -------------------------------------------------------------------------------------------
+    // Read-phase API (called by the reader after the writer is sealed)
+    // -------------------------------------------------------------------------------------------
 
-    /** Releases a lifecycle grant; no-op for the in-memory backend (no files to delete). */
-    public void release() throws IOException {}
+    /** Returns the ordered list of spill file paths. Read-only view. */
+    public List<Path> files() {
+        return Collections.unmodifiableList(files);
+    }
 
+    // -------------------------------------------------------------------------------------------
+    // Lifecycle
+    // -------------------------------------------------------------------------------------------
+
+    /** Acquires a lifecycle grant for a reader or handoff owner. */
+    public void acquire() {
+        refCount.incrementAndGet();
+    }
+
+    /**
+     * Releases a lifecycle grant. When the last grant is released (refCount reaches zero), all
+     * spill files are deleted. This preserves the invariant that files exist for the lifetime of
+     * all readers (drain + snapshot) and are cleaned up exactly once when the last reader finishes.
+     */
+    public void release() throws IOException {
+        if (refCount.decrementAndGet() == 0) {
+            if (cleanedUp.compareAndSet(false, true)) {
+                closed = true;
+                deleteAllFiles();
+            }
+        }
+    }
+
+    /** Forces cleanup even when lifecycle grants are still outstanding. */
     @Override
     public void close() throws IOException {
+        if (closed) {
+            return;
+        }
         closed = true;
+        if (cleanedUp.compareAndSet(false, true)) {
+            deleteAllFiles();
+        }
+    }
+
+    private void deleteAllFiles() throws IOException {
+        IOException firstError = null;
+        for (Path file : files) {
+            try {
+                Files.deleteIfExists(file);
+            } catch (IOException e) {
+                if (firstError == null) {
+                    firstError = e;
+                } else {
+                    firstError.addSuppressed(e);
+                }
+            }
+        }
+        if (firstError != null) {
+            throw firstError;
+        }
     }
 
     @VisibleForTesting

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/FetchedChannelState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/FetchedChannelState.java
@@ -40,15 +40,12 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * table is maintained. The reader scans files sequentially, reading each 12-byte header to obtain
  * the channel info and body length.
  *
- * <p>The file list grows as the writer rotates to new files (one rotation per 64 MB soft limit),
- * and is sealed on writer close.
+ * <p>The file list is fixed at construction: rotation to new files (one per 64 MB soft limit)
+ * happens earlier, in the writer, which builds this container from the final list on close.
  *
  * <p>File lifecycle is managed by {@link #acquire()} / {@link #release()} reference counting. Files
  * are deleted only when the last lifecycle grant is released (i.e. when both the main reader and
  * all snapshot readers have finished).
- *
- * <p>Mutations (file list appends) are single-writer and intentionally unsynchronized; callers must
- * serialize them via the channel IO executor.
  */
 @Internal
 public final class FetchedChannelState implements Closeable {
@@ -73,6 +70,24 @@ public final class FetchedChannelState implements Closeable {
     // -------------------------------------------------------------------------------------------
     // Read-phase API (called by the reader after the writer is sealed)
     // -------------------------------------------------------------------------------------------
+
+    /**
+     * Opens the main reader covering all segments from the beginning. The returned reader holds one
+     * lifecycle grant and must be closed when done.
+     */
+    public FetchedChannelStateReader reader() {
+        return snapshotAtStart().reader();
+    }
+
+    /** A snapshot covering all segments from the beginning. */
+    public FetchedChannelStateSnapshot snapshotAtStart() {
+        return new FetchedChannelStateSnapshot(this, 0, 0L, null, 0);
+    }
+
+    /** A snapshot over no spill files: its reader yields no segments. */
+    public static FetchedChannelStateSnapshot emptySnapshot() {
+        return new FetchedChannelState(Collections.emptyList()).snapshotAtStart();
+    }
 
     /** Returns the ordered list of spill file paths. Read-only view. */
     public List<Path> files() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/FetchedChannelStateDrainer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/FetchedChannelStateDrainer.java
@@ -71,10 +71,14 @@ public final class FetchedChannelStateDrainer implements RecoveryCheckpointTrigg
      * must persist is already inside the channels' queues, so the snapshot is inherently empty.
      */
     @Override
-    public void snapshotAndInsertBarriers(long checkpointId) throws IOException {
+    public FetchedChannelStateReader snapshotAndInsertBarriers(long checkpointId)
+            throws IOException {
         for (RecoverableInputChannel channel : channels) {
             channel.insertRecoveryCheckpointBarrierIfInRecovery(checkpointId);
         }
+        // No snapshot side for the in-memory backend: everything a checkpoint must persist is
+        // already inside the channels' queues, so the returned reader is empty.
+        return FetchedChannelStateReader.emptyReader();
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/FetchedChannelStateDrainer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/FetchedChannelStateDrainer.java
@@ -71,10 +71,14 @@ public final class FetchedChannelStateDrainer implements RecoveryCheckpointTrigg
      * must persist is already inside the channels' queues, so the snapshot is inherently empty.
      */
     @Override
-    public void snapshotAndInsertBarriers(long checkpointId) throws IOException {
+    public FetchedChannelStateSnapshot snapshotAndInsertBarriers(long checkpointId)
+            throws IOException {
         for (RecoverableInputChannel channel : channels) {
             channel.insertRecoveryCheckpointBarrierIfInRecovery(checkpointId);
         }
+        // No snapshot side for the in-memory backend: everything a checkpoint must persist is
+        // already inside the channels' queues, so the returned snapshot is empty.
+        return FetchedChannelState.emptySnapshot();
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/FetchedChannelStateReader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/FetchedChannelStateReader.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.checkpoint.channel;
+
+import org.apache.flink.annotation.Internal;
+
+import java.io.Closeable;
+import java.io.InputStream;
+import java.util.Collections;
+import java.util.Optional;
+
+/**
+ * Forward reader over a {@link FetchedChannelState}'s spill files. This is our own segment reader,
+ * on purpose <em>not</em> a Java {@link java.util.Iterator}: our access pattern ("a body must be
+ * fully read before the next segment", "body ownership is handed to the consumer", "consume and
+ * commit are separate steps") does not fit the {@code hasNext/next} contract.
+ *
+ * <p>This interface is the contract callers depend on; {@link FetchedChannelStateReaderImpl} holds
+ * the implementation (the live file stream, the two progress positions, the bounded body view).
+ *
+ * <p>Reading is strictly sequential: a reader is positioned once (offset 0 for the root reader, or
+ * the committed position for a {@link #snapshot()}), then consumes forward only via {@link
+ * #nextSegment()}. It never seeks backward and never re-positions mid-iteration.
+ *
+ * <p>The drain thread reads the root reader front to back and commits via {@link
+ * SpillSegment#commit()}; each checkpoint derives a fresh {@link #snapshot()} that resumes from the
+ * committed position. {@link #snapshot()} and {@link SpillSegment#commit()} must be called under
+ * the drainer lock; disk reads happen outside it.
+ */
+@Internal
+public interface FetchedChannelStateReader extends Closeable {
+
+    /**
+     * Advances to the next segment and returns it, or {@link Optional#empty()} when no segment
+     * remains. Advancing and probing are one step; there is no separate {@code hasNext}.
+     *
+     * <p>Entry rule (the first call is exempt): the previous segment's body must be fully read,
+     * otherwise this is a contract violation and fails loud (no skip-ahead).
+     */
+    Optional<SpillSegment> nextSegment();
+
+    /**
+     * Derives an independent resume point starting from the committed position. The snapshot holds
+     * its own {@link FetchedChannelState} lifecycle grant; the caller must open a reader from it
+     * via {@link FetchedChannelStateSnapshot#reader()} and close that reader when done.
+     *
+     * <p>Must be called under the drainer lock so that the copied position reflects the latest
+     * committed state.
+     *
+     * @return a snapshot capturing the current committed position; caller must open and close a
+     *     reader from it
+     */
+    FetchedChannelStateSnapshot snapshot();
+
+    /**
+     * Returns a reader with no segments — its first {@link #nextSegment()} is empty. Each call
+     * hands out a fresh instance: readers have independent lifecycle and {@link #close()} is
+     * single-use, so a shared instance would let one consumer's close break later consumers. Used
+     * wherever there is nothing to snapshot (e.g. after drain finished, or the no-op recovery
+     * trigger).
+     */
+    static FetchedChannelStateReader emptyReader() {
+        return new FetchedChannelState(Collections.emptyList()).reader();
+    }
+
+    /**
+     * One per-channel segment produced by {@link #nextSegment()}.
+     *
+     * <p>The segment body bytes are opaque to the reader; record framing is handled by the
+     * consumer's deserializer. A consumer reads {@link #bodyStream()} to EOF (after {@link
+     * #length()} bytes), and the drain consumer additionally calls {@link #commit()} under the
+     * drainer lock after each delivery so that a later {@link FetchedChannelStateReader#snapshot()}
+     * resumes from the delivered boundary.
+     *
+     * <p>Ownership of {@link #bodyStream()} passes to the consumer: the reader no longer tracks how
+     * far it has been read. The "previous body must be fully read" rule (no skip-ahead) is enforced
+     * at the next {@link FetchedChannelStateReader#nextSegment()} call, not here.
+     *
+     * <p>A segment is valid only until the next {@code nextSegment()} call on the parent reader.
+     */
+    interface SpillSegment {
+
+        /** The channel whose data this segment contains. */
+        InputChannelInfo channelInfo();
+
+        /**
+         * Returns an {@link InputStream} bounded to this segment's body. Reading returns {@code -1}
+         * (EOF) after {@link #length()} bytes; it never reads into the next segment or the next
+         * file.
+         *
+         * <p>The stream is single-use, not thread-safe, and must be fully consumed before the next
+         * {@link FetchedChannelStateReader#nextSegment()}.
+         */
+        InputStream bodyStream();
+
+        /**
+         * Number of body bytes this segment hands out before EOF. For the snapshot path this is the
+         * not-yet-delivered remainder used as the length prefix when writing to the checkpoint
+         * stream. Bounded by the spill file size limit, so it always fits in an {@code int}.
+         */
+        int length();
+
+        /**
+         * Advances the reader's committed position to match how many body bytes have been read from
+         * {@link #bodyStream()} so far. Must be called under the drainer lock after each buffer
+         * delivery so that a subsequent {@link FetchedChannelStateReader#snapshot()} sees the
+         * correct delivered boundary. Only the drain (root) reader commits; the snapshot reader
+         * never does.
+         */
+        void commit();
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/FetchedChannelStateReader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/FetchedChannelStateReader.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.checkpoint.channel;
+
+import org.apache.flink.annotation.Internal;
+
+import java.io.Closeable;
+import java.io.InputStream;
+import java.util.Optional;
+
+/**
+ * Forward-only, strictly sequential reader over a {@link FetchedChannelState}'s spill files.
+ * Deliberately not a Java {@link java.util.Iterator}: a body must be fully read before advancing,
+ * body ownership is handed to the consumer, and consume/commit are separate steps.
+ *
+ * <p>The main reader (opened via {@link FetchedChannelState#reader()}, starting at offset 0)
+ * records the delivered boundary — the "committed position" — via {@link SpillSegment#commit()};
+ * before anything is committed it equals the reader's start position. Each checkpoint derives a
+ * {@link #snapshot()} that resumes from that boundary. {@link #snapshot()} and {@link
+ * SpillSegment#commit()} must be called under the drainer lock; disk reads happen outside it.
+ */
+@Internal
+public interface FetchedChannelStateReader extends Closeable {
+
+    /**
+     * Advances to the next segment and returns it, or {@link Optional#empty()} when no segment
+     * remains.
+     *
+     * <p>Entry rule (the first call is exempt): the previous segment's body must be fully read,
+     * otherwise this is a contract violation and fails loud (no skip-ahead).
+     */
+    Optional<SpillSegment> advanceAndGetNextSegment();
+
+    /**
+     * Derives an independent resume point starting from the committed position. The snapshot holds
+     * its own {@link FetchedChannelState} lifecycle grant; the caller must open a reader from it
+     * via {@link FetchedChannelStateSnapshot#reader()} and close that reader when done.
+     *
+     * <p>Must be called under the drainer lock so that the copied position reflects the latest
+     * committed state.
+     *
+     * @return a snapshot capturing the current committed position; caller must open and close a
+     *     reader from it
+     */
+    FetchedChannelStateSnapshot snapshot();
+
+    /**
+     * One per-channel segment produced by {@link #advanceAndGetNextSegment()}.
+     *
+     * <p>The segment body bytes are opaque to the reader; record framing is handled by the
+     * consumer's deserializer. A consumer reads {@link #bodyStream()} to EOF (after {@link
+     * #length()} bytes), and the drain consumer additionally calls {@link #commit()}.
+     *
+     * <p>Ownership of {@link #bodyStream()} passes to the consumer: the reader no longer tracks how
+     * far it has been read. The "previous body must be fully read" rule (no skip-ahead) is enforced
+     * at the next {@link FetchedChannelStateReader#advanceAndGetNextSegment()} call, not here.
+     *
+     * <p>A segment is valid only until the next {@code advanceAndGetNextSegment()} call on the
+     * parent reader.
+     */
+    interface SpillSegment {
+
+        /** The channel whose data this segment contains. */
+        InputChannelInfo channelInfo();
+
+        /**
+         * Returns an {@link InputStream} bounded to this segment's body. Reading returns {@code -1}
+         * (EOF) after {@link #length()} bytes; it never reads into the next segment or the next
+         * file.
+         *
+         * <p>The stream is single-use, not thread-safe, and must be fully consumed before the next
+         * {@link FetchedChannelStateReader#advanceAndGetNextSegment()}.
+         */
+        InputStream bodyStream();
+
+        /**
+         * Number of body bytes this segment hands out before EOF. For the snapshot path this is the
+         * not-yet-delivered remainder used as the length prefix when writing to the checkpoint
+         * stream. Bounded by the spill file size limit, so it always fits in an {@code int}.
+         */
+        int length();
+
+        /**
+         * Records the body bytes read from {@link #bodyStream()} so far as delivered.
+         *
+         * <p>Called once per delivered buffer by the drainer's drain loop, under the same lock as
+         * {@link FetchedChannelStateReader#snapshot()}, so a snapshot always resumes on a buffer
+         * boundary. Only the main reader commits.
+         */
+        void commit();
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/FetchedChannelStateReaderImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/FetchedChannelStateReaderImpl.java
@@ -1,0 +1,533 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.checkpoint.channel;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.runtime.checkpoint.channel.FetchedChannelStateReader.SpillSegment;
+
+import javax.annotation.Nullable;
+
+import java.io.ByteArrayInputStream;
+import java.io.DataInputStream;
+import java.io.EOFException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Optional;
+
+import static org.apache.flink.runtime.checkpoint.channel.AbstractSpillingHandler.SEGMENT_HEADER_BYTES;
+import static org.apache.flink.util.Preconditions.checkState;
+
+/**
+ * The single {@link FetchedChannelStateReader} implementation over a {@link FetchedChannelState}'s
+ * spill files.
+ *
+ * <p>Reading is strictly sequential and never seeks mid-iteration. There is exactly one place that
+ * skips bytes: the very first {@link #nextSegment()} call, where a snapshot reader started mid-body
+ * discards the already-delivered prefix to land on the not-yet-delivered remainder. Every later
+ * call does no skipping at all — the previous body was read to its end, so the stream already sits
+ * on the next segment's header. This "skip only on first positioning" rule is what keeps the
+ * steady-state path free of any seek/skip.
+ *
+ * <p>The reader holds <b>two</b> {@link Position}s and nothing else duplicates them:
+ *
+ * <ul>
+ *   <li>{@code current} — the live read position; its {@code readOffset} is exactly where the open
+ *       file stream sits, advancing as the header and the consumer's body reads consume bytes (the
+ *       latter outside the drainer lock).
+ *   <li>{@code committed} — the delivered boundary; {@link SpillSegment#commit()} advances it from
+ *       {@code current} (under the drainer lock). {@link #snapshot()} derives a new reader from it.
+ * </ul>
+ *
+ * <p>The "previous body fully read before advancing" rule is checked at the {@link #nextSegment()}
+ * entry (the first call is exempt — there is no previous segment). Body ownership is handed to the
+ * consumer, so the reader does not track body progress except through {@code current}.
+ */
+@Internal
+final class FetchedChannelStateReaderImpl implements FetchedChannelStateReader {
+
+    private final FetchedChannelStateSnapshot snapshot;
+    private final FetchedChannelState channelState;
+    private final List<Path> files;
+
+    /** Live read position; {@code readOffset} is where the open stream physically sits. */
+    private final Position current;
+
+    /** Delivered boundary; {@link SpillSegment#commit()} advances it from {@link #current}. */
+    private final Position committed;
+
+    /** Open stream over {@code current.fileIndex}, or {@code null} before the first read. */
+    @Nullable private InputStream fileStream;
+
+    /** Size of the file currently open. */
+    private long currentFileSize;
+
+    /** Body view of the segment returned by the last {@link #nextSegment()}, or {@code null}. */
+    @Nullable private BoundedSegmentStream currentBody;
+
+    private boolean positioned;
+    private boolean closed;
+
+    FetchedChannelStateReaderImpl(FetchedChannelStateSnapshot snapshot) {
+        this.snapshot = snapshot;
+        this.channelState = snapshot.channelState();
+        this.files = channelState.files();
+        // Must copy the position so that this reader's commits do not mutate the snapshot's state.
+        this.committed = snapshot.position().copy();
+        this.current = committed.copy();
+    }
+
+    @Override
+    public Optional<SpillSegment> nextSegment() {
+        checkState(!closed, "FetchedChannelStateReader is closed");
+        checkState(
+                currentBody == null || currentBody.remaining() == 0,
+                "Previous segment body not fully consumed before advancing: %s bytes left",
+                currentBody == null ? 0 : currentBody.remaining());
+        try {
+            if (!positioned) {
+                positioned = true;
+                return firstSegment();
+            }
+            return followingSegment();
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to read segment", e);
+        }
+    }
+
+    /**
+     * First positioning — the only path that may skip bytes. Opens the file at the committed header
+     * offset and reads the header. A snapshot may resume in the middle of a segment: the committed
+     * {@code readOffset} says how many body bytes were already delivered, and that prefix is
+     * skipped so the returned body starts at the not-yet-delivered remainder. If the segment was
+     * already fully delivered (prefix == whole body), it is exhausted here and we move on to the
+     * next one.
+     */
+    private Optional<SpillSegment> firstSegment() throws IOException {
+        // The committed read offset may sit mid-body (after a partial commit), but the header lives
+        // at segmentStartOffset. Capture how much was already delivered, then rewind the live read
+        // offset to the header so we open the file there and read the header, not mid-body.
+        int deliveredPrefix = (int) current.deliveredBodyBytes();
+        current.rewindToSegmentStart();
+
+        if (!openCurrentFile()) {
+            return Optional.empty();
+        }
+        SegmentHeader header = readHeaderAtCurrent();
+        checkState(
+                deliveredPrefix <= header.bufferLength,
+                "Delivered offset %s exceeds segment length %s",
+                deliveredPrefix,
+                header.bufferLength);
+
+        if (deliveredPrefix == header.bufferLength) {
+            // This segment was already fully delivered before the snapshot; nothing remains in it.
+            // Skip its whole body to reach the next segment's header, then take the steady path.
+            skipBody(header.bufferLength);
+            return followingSegment();
+        }
+
+        // Discard the already-delivered prefix (the one and only skip in this class), then hand out
+        // the remainder. alreadyDelivered is carried so commit() records the boundary from the
+        // head.
+        skipBody(deliveredPrefix);
+        currentBody =
+                new BoundedSegmentStream(header.bufferLength - deliveredPrefix, deliveredPrefix);
+        return Optional.of(new Segment(header.channelInfo, currentBody));
+    }
+
+    /**
+     * Steady-state path — no skipping. The previous body was read to its end, so the stream sits
+     * exactly on this segment's header (or at the current file's end, in which case we roll to the
+     * next file). Reads the header and returns the whole-body view.
+     */
+    private Optional<SpillSegment> followingSegment() throws IOException {
+        if (!openCurrentFile()) {
+            return Optional.empty();
+        }
+        SegmentHeader header = readHeaderAtCurrent();
+        currentBody = new BoundedSegmentStream(header.bufferLength);
+        return Optional.of(new Segment(header.channelInfo, currentBody));
+    }
+
+    @Override
+    public FetchedChannelStateSnapshot snapshot() {
+        checkState(!closed, "FetchedChannelStateReader is closed");
+        return new FetchedChannelStateSnapshot(channelState, committed.copy());
+    }
+
+    @Override
+    public void close() throws IOException {
+        if (closed) {
+            return;
+        }
+        closed = true;
+        try {
+            closeFileStream();
+        } finally {
+            snapshot.release();
+        }
+    }
+
+    // -------------------------------------------------------------------------------------------
+    // Sequential IO over the spill files; all of it advances current.readOffset / current.fileIndex
+    // -------------------------------------------------------------------------------------------
+
+    /**
+     * Ensures a file is open with the stream positioned at {@code current}'s read offset, ready to
+     * read this segment's header. Rolls to the next file when the current one is exhausted. Returns
+     * false when no segment remains.
+     *
+     * <p>{@code current.segmentStartOffset} is set to where the header begins, so a later {@link
+     * SpillSegment#commit()} records the right segment for the snapshot to resume from.
+     */
+    private boolean openCurrentFile() throws IOException {
+        if (current.fileIndex >= files.size()) {
+            return false;
+        }
+        openFileAndSeek();
+        if (current.readOffset < currentFileSize) {
+            current.startSegmentHere();
+            return true;
+        }
+        // Current file fully read: move to the next file's first segment.
+        closeFileStream();
+        current.rollToNextFile();
+        if (current.fileIndex >= files.size()) {
+            return false;
+        }
+        openFileAndSeek();
+        if (current.readOffset < currentFileSize) {
+            current.startSegmentHere();
+            return true;
+        }
+        return false;
+    }
+
+    /** Reads the 12-byte header at the current read offset; advances past it. */
+    private SegmentHeader readHeaderAtCurrent() throws IOException {
+        byte[] headerBytes = new byte[SEGMENT_HEADER_BYTES];
+        readFully(headerBytes);
+        DataInputStream h = new DataInputStream(new ByteArrayInputStream(headerBytes));
+        int gateIdx = h.readInt();
+        int channelIdx = h.readInt();
+        int bufferLength = h.readInt();
+        checkState(bufferLength >= 0, "negative segment length: %s", bufferLength);
+        return new SegmentHeader(new InputChannelInfo(gateIdx, channelIdx), bufferLength);
+    }
+
+    /**
+     * Ensures the file at {@code current.fileIndex} is open with the stream positioned at {@code
+     * current.readOffset}. If a stream is already open it is left as-is: sequential reading
+     * guarantees it is already there.
+     */
+    private void openFileAndSeek() throws IOException {
+        if (fileStream != null) {
+            return;
+        }
+        Path path = files.get(current.fileIndex);
+        currentFileSize = Files.size(path);
+        InputStream in = Files.newInputStream(path);
+        try {
+            skipOnStream(in, current.readOffset, path);
+        } catch (IOException e) {
+            in.close();
+            throw e;
+        }
+        fileStream = in;
+    }
+
+    /** Skips {@code count} body bytes on the open stream, advancing the read offset. */
+    private void skipBody(long count) throws IOException {
+        if (count > 0) {
+            skipOnStream(fileStream, count, files.get(current.fileIndex));
+            current.advanceReadOffset(count);
+        }
+    }
+
+    /** Skips exactly {@code count} bytes on {@code in}, failing loud if the file ends early. */
+    private void skipOnStream(InputStream in, long count, Path path) throws IOException {
+        long skipped = 0;
+        while (skipped < count) {
+            long s = in.skip(count - skipped);
+            if (s <= 0) {
+                // skip can return 0 near EOF; read-and-discard as a fallback.
+                if (in.read() < 0) {
+                    throw new EOFException(
+                            "Cannot position to offset " + count + " in spill file " + path);
+                }
+                skipped++;
+            } else {
+                skipped += s;
+            }
+        }
+    }
+
+    private void readFully(byte[] buf) throws IOException {
+        int read = 0;
+        while (read < buf.length) {
+            int n = fileStream.read(buf, read, buf.length - read);
+            if (n < 0) {
+                throw new EOFException(
+                        "Truncated segment header in file "
+                                + files.get(current.fileIndex)
+                                + " at offset "
+                                + current.readOffset
+                                + ": expected "
+                                + buf.length
+                                + " bytes, got "
+                                + read);
+            }
+            read += n;
+            current.advanceReadOffset(n);
+        }
+    }
+
+    /** Reads up to {@code len} body bytes from the current file; called only by the body view. */
+    private int readBody(byte[] buf, int off, int len) throws IOException {
+        int n = fileStream.read(buf, off, len);
+        if (n > 0) {
+            current.advanceReadOffset(n);
+        }
+        return n;
+    }
+
+    private void closeFileStream() throws IOException {
+        if (fileStream != null) {
+            fileStream.close();
+            fileStream = null;
+        }
+    }
+
+    // -------------------------------------------------------------------------------------------
+    // Position: the three progress values locating where a snapshot resumes
+    // -------------------------------------------------------------------------------------------
+
+    /**
+     * One progress point, expressed with the three values that fully locate where a snapshot
+     * resumes. The reader holds two of these: {@code current} (live read position) and {@code
+     * committed} (delivered boundary). They are the same shape but different in meaning; neither
+     * keeps a shadow copy of the other.
+     *
+     * <ul>
+     *   <li>{@code fileIndex} — file holding the current segment.
+     *   <li>{@code segmentStartOffset} — byte offset of the current segment's header. A snapshot
+     *       reads the segment metadata (channel, full body length) from here, because the segment
+     *       may already be partially delivered yet the snapshot still needs the whole-segment
+     *       header.
+     *   <li>{@code readOffset} — for {@code current}, exactly where the open stream sits (the live
+     *       read offset); for {@code committed}, the delivered boundary. For a brand-new segment
+     *       {@code readOffset == segmentStartOffset} (header not yet passed); after the header and
+     *       n body bytes it is {@code segmentStartOffset + SEGMENT_HEADER_BYTES + n}.
+     * </ul>
+     */
+    static final class Position {
+        private int fileIndex;
+        private long segmentStartOffset;
+        private long readOffset;
+
+        Position(int fileIndex, long segmentStartOffset, long readOffset) {
+            this.fileIndex = fileIndex;
+            this.segmentStartOffset = segmentStartOffset;
+            this.readOffset = readOffset;
+        }
+
+        static Position atStart() {
+            return new Position(0, 0L, 0L);
+        }
+
+        Position copy() {
+            return new Position(fileIndex, segmentStartOffset, readOffset);
+        }
+
+        /**
+         * Already-delivered body bytes of the current segment, clamped to 0 before the header is
+         * crossed (where {@code readOffset <= segmentStartOffset}). Only the first-positioning path
+         * uses it, to size the prefix a snapshot must discard.
+         */
+        long deliveredBodyBytes() {
+            return Math.max(0L, readOffset - segmentStartOffset - SEGMENT_HEADER_BYTES);
+        }
+
+        /** Advances the live read offset by {@code delta} bytes just read/skipped. */
+        void advanceReadOffset(long delta) {
+            readOffset += delta;
+        }
+
+        /**
+         * Rewinds the live read offset back to the current segment's header. Used only on first
+         * positioning: a snapshot's committed offset may sit mid-body, but the header must be read
+         * first, so the read offset returns to {@code segmentStartOffset} before opening the file.
+         */
+        void rewindToSegmentStart() {
+            readOffset = segmentStartOffset;
+        }
+
+        /**
+         * Marks the current read offset as the start of the segment about to be read (its header
+         * begins here). Called right before reading a header.
+         */
+        void startSegmentHere() {
+            segmentStartOffset = readOffset;
+        }
+
+        /** Rolls to the start of the next file once the current one is exhausted. */
+        void rollToNextFile() {
+            fileIndex++;
+            segmentStartOffset = 0L;
+            readOffset = 0L;
+        }
+
+        /**
+         * Copies this position into {@code target} but pins {@code target}'s read offset to {@code
+         * deliveredBody} body bytes of the current segment — i.e. {@code commit} records "delivered
+         * up to here", not "physically read up to here".
+         */
+        void copyAsDelivered(Position target, long deliveredBody) {
+            target.fileIndex = fileIndex;
+            target.segmentStartOffset = segmentStartOffset;
+            target.readOffset = segmentStartOffset + SEGMENT_HEADER_BYTES + deliveredBody;
+        }
+    }
+
+    /** Parsed segment header: channel and full body length. */
+    private static final class SegmentHeader {
+        private final InputChannelInfo channelInfo;
+        private final int bufferLength;
+
+        private SegmentHeader(InputChannelInfo channelInfo, int bufferLength) {
+            this.channelInfo = channelInfo;
+            this.bufferLength = bufferLength;
+        }
+    }
+
+    /**
+     * The single {@link SpillSegment} implementation. Exposes one segment's channel, body, and
+     * length; {@link #commit()} advances the reader's {@code committed} position to however many
+     * body bytes have been read. Reading the body and committing are separate steps so the consumer
+     * can read outside the drainer lock and commit inside it.
+     *
+     * <p>Only the root (drain) reader commits.
+     */
+    private final class Segment implements SpillSegment {
+        private final InputChannelInfo channelInfo;
+        private final BoundedSegmentStream body;
+
+        private Segment(InputChannelInfo channelInfo, BoundedSegmentStream body) {
+            this.channelInfo = channelInfo;
+            this.body = body;
+        }
+
+        @Override
+        public InputChannelInfo channelInfo() {
+            return channelInfo;
+        }
+
+        @Override
+        public InputStream bodyStream() {
+            return body;
+        }
+
+        @Override
+        public int length() {
+            return body.deliverableLength();
+        }
+
+        @Override
+        public void commit() {
+            current.copyAsDelivered(committed, body.deliveredFromSegmentHead());
+        }
+    }
+
+    /**
+     * A forward-only, bounded view over one segment's not-yet-delivered body remainder. It hands
+     * out {@code remainingLength} bytes and reaches EOF after them; it never reads into the next
+     * segment or file. The underlying stream is already positioned at the first byte this view
+     * hands out (the prefix, if any, was skipped before construction). If the file ends before the
+     * segment end, an {@link EOFException} is thrown (fail-loud). Closing this view does not close
+     * the underlying file; the reader owns it.
+     */
+    private final class BoundedSegmentStream extends InputStream {
+
+        /** Body bytes already delivered before this view (the skipped prefix); 0 for the root. */
+        private final int alreadyDelivered;
+
+        private final int remainingLength;
+        private int read;
+
+        private BoundedSegmentStream(int remainingLength) {
+            this(remainingLength, 0);
+        }
+
+        private BoundedSegmentStream(int remainingLength, int alreadyDelivered) {
+            this.remainingLength = remainingLength;
+            this.alreadyDelivered = alreadyDelivered;
+        }
+
+        /** Body bytes not yet handed out (between the read position and the segment end). */
+        int remaining() {
+            return remainingLength - read;
+        }
+
+        /** Number of body bytes this view will hand out: the not-yet-delivered remainder. */
+        int deliverableLength() {
+            return remainingLength;
+        }
+
+        /**
+         * Total delivered body bytes measured from the segment head: the skipped prefix plus what
+         * has been read through this view. This is what {@link Segment#commit()} records.
+         */
+        int deliveredFromSegmentHead() {
+            return alreadyDelivered + read;
+        }
+
+        @Override
+        public int read() throws IOException {
+            byte[] one = new byte[1];
+            int n = read(one, 0, 1);
+            return n < 0 ? -1 : (one[0] & 0xFF);
+        }
+
+        @Override
+        public int read(byte[] buf, int off, int len) throws IOException {
+            if (read >= remainingLength) {
+                return -1;
+            }
+            int toRead = Math.min(len, remainingLength - read);
+            int n = readBody(buf, off, toRead);
+            if (n < 0) {
+                throw new EOFException(
+                        "Unexpected EOF in segment body after "
+                                + read
+                                + "/"
+                                + remainingLength
+                                + " bytes");
+            }
+            read += n;
+            return n;
+        }
+
+        @Override
+        public void close() {
+            // Do not close the underlying file; it is owned by the reader.
+        }
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/FetchedChannelStateReaderImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/FetchedChannelStateReaderImpl.java
@@ -1,0 +1,444 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.checkpoint.channel;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.runtime.checkpoint.channel.FetchedChannelStateReader.SpillSegment;
+import org.apache.flink.util.IOUtils;
+
+import javax.annotation.Nullable;
+
+import java.io.BufferedInputStream;
+import java.io.ByteArrayInputStream;
+import java.io.DataInputStream;
+import java.io.EOFException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.channels.Channels;
+import java.nio.channels.SeekableByteChannel;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.List;
+import java.util.Optional;
+
+import static org.apache.flink.runtime.checkpoint.channel.AbstractSpillingHandler.SEGMENT_HEADER_BYTES;
+import static org.apache.flink.util.Preconditions.checkState;
+
+/**
+ * The single {@link FetchedChannelStateReader} implementation over a {@link FetchedChannelState}'s
+ * spill files.
+ *
+ * <p>Reading is strictly sequential: the stream is positioned once when a file is opened and then
+ * only moves forward. A snapshot that resumes inside a segment body starts right at the boundary —
+ * the segment's channel and remaining length come from the snapshot itself, so no header is re-read
+ * and no prefix is skipped.
+ *
+ * <p>The reader tracks two {@link Position}s of the same shape — the values a {@link
+ * FetchedChannelStateSnapshot} is made of: {@code current}, the live read position, and {@code
+ * committed}, the delivered boundary that {@link SpillSegment#commit()} publishes from it under the
+ * drainer lock.
+ *
+ * <p>The "previous body fully read before advancing" rule is checked at the {@link
+ * #advanceAndGetNextSegment()} entry. Body ownership is handed to the consumer, so the reader does
+ * not track body progress except through {@code current}.
+ */
+@Internal
+final class FetchedChannelStateReaderImpl implements FetchedChannelStateReader {
+
+    private final FetchedChannelStateSnapshot snapshot;
+
+    /**
+     * The live read position: the file being read and the exact byte offset within it. It runs
+     * ahead of the committed boundary by what the drainer has read from disk but not yet handed to
+     * a channel (at most one recovery buffer) — reads happen outside the drainer lock, delivery and
+     * commit inside it. A checkpoint therefore cuts at the committed boundary: what is already in
+     * the channel queue is persisted from the channel side, everything after it is re-read from the
+     * spill files.
+     */
+    private final Position current;
+
+    private final Position committed;
+
+    /** Open stream over {@code current.fileIndex}, or {@code null} before the first read. */
+    @Nullable private InputStream currentFileStream;
+
+    /** Size of the file currently open. */
+    private long currentFileSize;
+
+    /**
+     * The segment handed out by the last {@link #advanceAndGetNextSegment()}. A segment is only
+     * valid until the next one is handed out; reading or committing an older one fails loud.
+     */
+    @Nullable private Segment currentSegment;
+
+    private boolean positioned;
+    private boolean closed;
+
+    FetchedChannelStateReaderImpl(FetchedChannelStateSnapshot snapshot) {
+        this.snapshot = snapshot;
+        this.current =
+                new Position(
+                        snapshot.fileIndex(),
+                        snapshot.readOffset(),
+                        snapshot.channel(),
+                        snapshot.remaining());
+        this.committed = current.copy();
+    }
+
+    @Override
+    public Optional<SpillSegment> advanceAndGetNextSegment() {
+        checkState(!closed, "FetchedChannelStateReader is closed");
+        checkState(
+                !positioned || current.remaining == 0,
+                "Previous segment body not fully consumed before advancing: %s bytes left",
+                current.remaining);
+        try {
+            if (!positioned) {
+                positioned = true;
+                if (current.channel != null) {
+                    return resumedSegment();
+                }
+            }
+            return nextSegmentAtHeader();
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to read segment", e);
+        }
+    }
+
+    /**
+     * Resume path, taken once by a snapshot reader whose start offset sits inside a body: the
+     * channel and the remaining length come from the snapshot, so nothing is re-read or skipped.
+     */
+    private Optional<SpillSegment> resumedSegment() throws IOException {
+        openFileAndSeek();
+        currentSegment =
+                new Segment(
+                        this,
+                        current.channel,
+                        new BoundedSegmentStream(currentFileStream, current, current.remaining));
+        return Optional.of(currentSegment);
+    }
+
+    /** Steady path: the stream sits on a segment header; read it and hand out the whole body. */
+    private Optional<SpillSegment> nextSegmentAtHeader() throws IOException {
+        if (!openCurrentFile()) {
+            return Optional.empty();
+        }
+        SegmentHeader header = readHeaderAtCurrent();
+        current.startSegment(header.channelInfo, header.bufferLength);
+        if (currentSegment != null) {
+            currentSegment.body.invalidate();
+        }
+        currentSegment =
+                new Segment(
+                        this,
+                        header.channelInfo,
+                        new BoundedSegmentStream(currentFileStream, current, header.bufferLength));
+        return Optional.of(currentSegment);
+    }
+
+    @Override
+    public FetchedChannelStateSnapshot snapshot() {
+        checkState(!closed, "FetchedChannelStateReader is closed");
+        return new FetchedChannelStateSnapshot(
+                snapshot.channelState(),
+                committed.fileIndex,
+                committed.readOffset,
+                committed.channel,
+                committed.remaining);
+    }
+
+    @Override
+    public void close() throws IOException {
+        if (closed) {
+            return;
+        }
+        closed = true;
+        try {
+            closeFileStream();
+        } finally {
+            snapshot.release();
+        }
+    }
+
+    // -------------------------------------------------------------------------------------------
+    // Sequential IO over the spill files; all of it advances current.readOffset / current.fileIndex
+    // -------------------------------------------------------------------------------------------
+
+    /** The spill files in write order; the reader never mutates the list. */
+    private List<Path> files() {
+        return snapshot.channelState().files();
+    }
+
+    /**
+     * Ensures a file is open with the stream positioned at {@code current}'s read offset, ready to
+     * read this segment's header. Rolls to the next file when the current one is exhausted. Returns
+     * false when no segment remains.
+     */
+    private boolean openCurrentFile() throws IOException {
+        boolean rolled = false;
+        while (current.fileIndex < files().size()) {
+            openFileAndSeek();
+            if (current.readOffset < currentFileSize) {
+                return true;
+            }
+            // Current file fully read: move to the next file's first segment. The writer never
+            // produces an empty file, so one roll always lands on data.
+            checkState(!rolled, "Rolled past more than one empty file");
+            closeFileStream();
+            current.rollToNextFile();
+            rolled = true;
+        }
+        return false;
+    }
+
+    /** Reads the 12-byte header at the current read offset; advances past it. */
+    private SegmentHeader readHeaderAtCurrent() throws IOException {
+        byte[] headerBytes = new byte[SEGMENT_HEADER_BYTES];
+        readFully(headerBytes);
+        DataInputStream h = new DataInputStream(new ByteArrayInputStream(headerBytes));
+        int gateIdx = h.readInt();
+        int channelIdx = h.readInt();
+        int bufferLength = h.readInt();
+        checkState(bufferLength >= 0, "negative segment length: %s", bufferLength);
+        checkState(
+                gateIdx >= 0 && channelIdx >= 0,
+                "negative channel info in segment header: %s/%s",
+                gateIdx,
+                channelIdx);
+        return new SegmentHeader(new InputChannelInfo(gateIdx, channelIdx), bufferLength);
+    }
+
+    /**
+     * Ensures the file at {@code current.fileIndex} is open with the stream positioned at {@code
+     * current.readOffset}. If a stream is already open it is left as-is: sequential reading
+     * guarantees it is already there.
+     */
+    private void openFileAndSeek() throws IOException {
+        if (currentFileStream != null) {
+            return;
+        }
+        SeekableByteChannel channel =
+                Files.newByteChannel(files().get(current.fileIndex), StandardOpenOption.READ);
+        try {
+            currentFileSize = channel.size();
+            channel.position(current.readOffset);
+        } catch (IOException e) {
+            channel.close();
+            throw e;
+        }
+        currentFileStream = new BufferedInputStream(Channels.newInputStream(channel));
+    }
+
+    private void readFully(byte[] buf) throws IOException {
+        IOUtils.readFully(currentFileStream, buf, 0, buf.length);
+        current.advanceReadOffset(buf.length);
+    }
+
+    private void closeFileStream() throws IOException {
+        if (currentFileStream != null) {
+            currentFileStream.close();
+            currentFileStream = null;
+        }
+    }
+
+    // -------------------------------------------------------------------------------------------
+    // Position: where the open stream sits
+    // -------------------------------------------------------------------------------------------
+
+    /**
+     * A point in the spill files, in the four values a {@link FetchedChannelStateSnapshot} is made
+     * of: {@code channel} is null exactly when {@code readOffset} sits on a segment header, and
+     * non-null while a body is in flight, {@code remaining} being what is left of it.
+     */
+    static final class Position {
+        private int fileIndex;
+        private long readOffset;
+        @Nullable private InputChannelInfo channel;
+        private int remaining;
+
+        Position(
+                int fileIndex, long readOffset, @Nullable InputChannelInfo channel, int remaining) {
+            this.fileIndex = fileIndex;
+            this.readOffset = readOffset;
+            this.channel = channel;
+            this.remaining = remaining;
+        }
+
+        Position copy() {
+            return new Position(fileIndex, readOffset, channel, remaining);
+        }
+
+        /** Publishes {@code other} into this position (used by commit). */
+        void copyFrom(Position other) {
+            fileIndex = other.fileIndex;
+            readOffset = other.readOffset;
+            channel = other.channel;
+            remaining = other.remaining;
+        }
+
+        /** Advances past the {@code delta} header bytes just read; no body is in flight. */
+        void advanceReadOffset(long delta) {
+            readOffset += delta;
+        }
+
+        /** Enters the body of a freshly read segment header. */
+        void startSegment(InputChannelInfo segmentChannel, int bodyLength) {
+            channel = segmentChannel;
+            remaining = bodyLength;
+        }
+
+        /** Accounts for {@code n} body bytes handed to the consumer. */
+        void advanceBody(int n) {
+            readOffset += n;
+            remaining -= n;
+            if (remaining == 0) {
+                channel = null;
+            }
+        }
+
+        /** Rolls to the start of the next file once the current one is exhausted. */
+        void rollToNextFile() {
+            fileIndex++;
+            readOffset = 0L;
+        }
+    }
+
+    /** Parsed segment header: channel and full body length. */
+    private static final class SegmentHeader {
+        private final InputChannelInfo channelInfo;
+        private final int bufferLength;
+
+        private SegmentHeader(InputChannelInfo channelInfo, int bufferLength) {
+            this.channelInfo = channelInfo;
+            this.bufferLength = bufferLength;
+        }
+    }
+
+    /**
+     * The single {@link SpillSegment} implementation. Exposes one segment's channel, body, and
+     * length; {@link #commit()} advances the reader's {@code committed} position to however many
+     * body bytes have been read. Reading the body and committing are separate steps so the consumer
+     * can read outside the drainer lock and commit inside it.
+     *
+     * <p>Only the main reader commits.
+     */
+    private static final class Segment implements SpillSegment {
+        private final FetchedChannelStateReaderImpl reader;
+        private final InputChannelInfo channelInfo;
+        private final BoundedSegmentStream body;
+
+        private Segment(
+                FetchedChannelStateReaderImpl reader,
+                InputChannelInfo channelInfo,
+                BoundedSegmentStream body) {
+            this.reader = reader;
+            this.channelInfo = channelInfo;
+            this.body = body;
+        }
+
+        @Override
+        public InputChannelInfo channelInfo() {
+            return channelInfo;
+        }
+
+        @Override
+        public InputStream bodyStream() {
+            return body;
+        }
+
+        @Override
+        public int length() {
+            return body.deliverableLength();
+        }
+
+        @Override
+        public void commit() {
+            checkState(
+                    reader.currentSegment == this,
+                    "Committing a segment that is no longer the current one");
+            reader.committed.copyFrom(reader.current);
+        }
+    }
+
+    /**
+     * A forward-only, bounded view over the body bytes this reader still has to hand out for one
+     * segment. The bound is {@code current.remaining}, so the view keeps no counter of its own; it
+     * reaches EOF there and never reads into the next segment or file. If the file ends first, an
+     * {@link EOFException} is thrown (fail-loud). Closing this view does not close the underlying
+     * file; the reader owns it.
+     */
+    private static final class BoundedSegmentStream extends InputStream {
+        private final InputStream fileStream;
+        private final Position current;
+        private final int length;
+
+        /** Set when the reader hands out the next segment; this view must not be read after. */
+        private boolean stale;
+
+        private BoundedSegmentStream(InputStream fileStream, Position current, int length) {
+            this.fileStream = fileStream;
+            this.current = current;
+            this.length = length;
+        }
+
+        private void invalidate() {
+            stale = true;
+        }
+
+        /** Number of body bytes this view will hand out. */
+        int deliverableLength() {
+            return length;
+        }
+
+        @Override
+        public int read() throws IOException {
+            byte[] one = new byte[1];
+            int n = read(one, 0, 1);
+            return n < 0 ? -1 : (one[0] & 0xFF);
+        }
+
+        @Override
+        public int read(byte[] buf, int off, int len) throws IOException {
+            checkState(!stale, "Reading a segment that is no longer the current one");
+            if (current.remaining == 0) {
+                return -1;
+            }
+            int toRead = Math.min(len, current.remaining);
+            int n = fileStream.read(buf, off, toRead);
+            if (n > 0) {
+                current.advanceBody(n);
+            }
+            if (n < 0) {
+                throw new EOFException(
+                        "Unexpected EOF in segment body after "
+                                + (length - current.remaining)
+                                + "/"
+                                + length
+                                + " bytes");
+            }
+            return n;
+        }
+
+        @Override
+        public void close() {
+            // Do not close the underlying file; it is owned by the reader.
+        }
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/FetchedChannelStateSnapshot.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/FetchedChannelStateSnapshot.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.checkpoint.channel;
+
+import java.io.IOException;
+
+import static org.apache.flink.util.Preconditions.checkState;
+
+/**
+ * An immutable resume point for a {@link FetchedChannelState} reader. It captures the {@link
+ * FetchedChannelStateReaderImpl.Position} at which reading should start and holds one lifecycle
+ * grant on the underlying {@link FetchedChannelState} (acquired in the constructor).
+ *
+ * <p>A snapshot is a one-shot, single-reader handle:
+ *
+ * <ul>
+ *   <li>Exactly one {@link FetchedChannelStateReader} may be opened from it via {@link #reader()}.
+ *   <li>When that reader is closed, it releases the lifecycle grant via {@link #release()}.
+ * </ul>
+ *
+ * <p>The 1:1 reader constraint is enforced fail-loud: calling {@link #reader()} a second time
+ * throws {@link IllegalStateException} immediately.
+ */
+final class FetchedChannelStateSnapshot {
+
+    private final FetchedChannelState channelState;
+    private final FetchedChannelStateReaderImpl.Position position;
+
+    /** True once {@link #reader()} has been called; prevents opening a second reader. */
+    private boolean readerOpened;
+
+    /**
+     * Creates a snapshot at {@code position} within {@code channelState}. Acquires one lifecycle
+     * grant on {@code channelState}; the grant is released when the reader returned by {@link
+     * #reader()} is closed.
+     */
+    FetchedChannelStateSnapshot(
+            FetchedChannelState channelState, FetchedChannelStateReaderImpl.Position position) {
+        this.channelState = channelState;
+        this.position = position;
+        channelState.acquire();
+    }
+
+    /**
+     * Opens the reader for this snapshot. May be called at most once; a second call fails loud to
+     * enforce the 1:1 snapshot-to-reader invariant.
+     *
+     * @return a new reader starting from this snapshot's position; caller must close it when done
+     */
+    FetchedChannelStateReader reader() {
+        checkState(!readerOpened, "A reader has already been opened from this snapshot");
+        readerOpened = true;
+        return new FetchedChannelStateReaderImpl(this);
+    }
+
+    /**
+     * Releases the lifecycle grant held by this snapshot. Called by the reader on close; must not
+     * be called directly by any other party.
+     */
+    void release() throws IOException {
+        channelState.release();
+    }
+
+    /** Returns the underlying channel state (package-private; used by the reader). */
+    FetchedChannelState channelState() {
+        return channelState;
+    }
+
+    /**
+     * Returns the start position (package-private; used by the reader, which copies it
+     * immediately).
+     */
+    FetchedChannelStateReaderImpl.Position position() {
+        return position;
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/FetchedChannelStateSnapshot.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/FetchedChannelStateSnapshot.java
@@ -1,0 +1,156 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.checkpoint.channel;
+
+import org.apache.flink.annotation.Internal;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkState;
+
+/**
+ * An immutable resume point for a {@link FetchedChannelState} reader: where to start reading, plus
+ * the metadata of a half-delivered segment when the boundary falls inside one. It holds one
+ * lifecycle grant on the underlying {@link FetchedChannelState} (acquired in the constructor).
+ *
+ * <p>{@code channel} decides how the resume point is read. It is {@code null} when {@code
+ * readOffset} points at a segment header, and non-null when it points into a segment body, in which
+ * case {@code remaining} is that segment's not-yet-delivered byte count. The three cases that occur
+ * in practice:
+ *
+ * <pre>
+ * (0, 0,   null, 0)   nothing delivered yet — read everything from the first header
+ * (2, 840, null, 0)   boundary landed exactly on a header — read that header, then continue
+ * (2, 851, c3,   57)  boundary landed inside c3's body — hand out its last 57 bytes, no header read
+ * </pre>
+ *
+ * <p>A snapshot is a one-shot, single-reader handle: exactly one {@link FetchedChannelStateReader}
+ * may be opened from it via {@link #reader()}, and opening one transfers the grant to that reader,
+ * which returns it on close. A second {@link #reader()} call fails loud.
+ *
+ * <p>Owners must {@link #close()} the snapshot. Closing releases the grant when no reader was
+ * opened; once one was, the reader owns it and closing here is a no-op — so closing early never
+ * deletes files out from under a live reader.
+ */
+@Internal
+public final class FetchedChannelStateSnapshot implements AutoCloseable {
+
+    private final FetchedChannelState channelState;
+
+    /** Spill file to resume in. */
+    private final int fileIndex;
+
+    /** Byte offset within that file to resume at. */
+    private final long readOffset;
+
+    /** Channel of the half-delivered segment, or {@code null} if {@code readOffset} is a header. */
+    @Nullable private final InputChannelInfo channel;
+
+    /** Not-yet-delivered body bytes of that segment; 0 iff {@code channel} is {@code null}. */
+    private final int remaining;
+
+    /** True once {@link #reader()} has been called; prevents opening a second reader. */
+    private boolean readerOpened;
+
+    private boolean closed;
+
+    /**
+     * Creates a snapshot resuming at {@code readOffset} in file {@code fileIndex}. Acquires one
+     * lifecycle grant on {@code channelState}; the grant is released when the reader returned by
+     * {@link #reader()} is closed.
+     */
+    FetchedChannelStateSnapshot(
+            FetchedChannelState channelState,
+            int fileIndex,
+            long readOffset,
+            @Nullable InputChannelInfo channel,
+            int remaining) {
+        checkArgument(
+                (channel == null) == (remaining == 0),
+                "channel and remaining must be set together: %s / %s",
+                channel,
+                remaining);
+        this.channelState = channelState;
+        this.fileIndex = fileIndex;
+        this.readOffset = readOffset;
+        this.channel = channel;
+        this.remaining = remaining;
+        channelState.acquire();
+    }
+
+    /**
+     * Opens the reader for this snapshot. May be called at most once; a second call fails loud to
+     * enforce the 1:1 snapshot-to-reader invariant.
+     *
+     * @return a new reader starting from this snapshot's position; caller must close it when done
+     */
+    public FetchedChannelStateReader reader() {
+        checkState(!closed, "Snapshot is closed");
+        checkState(!readerOpened, "A reader has already been opened from this snapshot");
+        readerOpened = true;
+        return new FetchedChannelStateReaderImpl(this);
+    }
+
+    /**
+     * Releases the lifecycle grant held by this snapshot. Called by the reader on close; must not
+     * be called directly by any other party.
+     */
+    void release() throws IOException {
+        channelState.release();
+    }
+
+    /**
+     * Releases the grant if no reader was opened; otherwise the reader owns it and this is a no-op.
+     * Idempotent.
+     */
+    @Override
+    public void close() throws IOException {
+        if (closed) {
+            return;
+        }
+        closed = true;
+        if (!readerOpened) {
+            channelState.release();
+        }
+    }
+
+    /** Returns the underlying channel state (package-private; used by the reader). */
+    FetchedChannelState channelState() {
+        return channelState;
+    }
+
+    int fileIndex() {
+        return fileIndex;
+    }
+
+    long readOffset() {
+        return readOffset;
+    }
+
+    @Nullable
+    InputChannelInfo channel() {
+        return channel;
+    }
+
+    int remaining() {
+        return remaining;
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/RecoveredChannelStateHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/RecoveredChannelStateHandler.java
@@ -18,6 +18,8 @@
 package org.apache.flink.runtime.checkpoint.channel;
 
 import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.core.fs.OffsetAwareOutputStream;
+import org.apache.flink.core.memory.DataOutputSerializer;
 import org.apache.flink.core.memory.MemorySegment;
 import org.apache.flink.core.memory.MemorySegmentFactory;
 import org.apache.flink.runtime.checkpoint.InflightDataRescalingDescriptor;
@@ -38,13 +40,21 @@ import org.apache.flink.runtime.io.network.partition.consumer.RecoveredInputChan
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+import java.io.BufferedOutputStream;
+import java.io.FileOutputStream;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 import static org.apache.flink.runtime.checkpoint.channel.ChannelStateByteBuffer.wrap;
 import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkNotNull;
 import static org.apache.flink.util.Preconditions.checkState;
 
 interface RecoveredChannelStateHandler<Info, Context> extends AutoCloseable {
@@ -75,7 +85,7 @@ interface RecoveredChannelStateHandler<Info, Context> extends AutoCloseable {
 
 /**
  * Abstract base for all input-channel recovery handlers. Holds the channel mapping logic shared by
- * both variants (no-filtering, filtering).
+ * all three variants (no-spilling, spilling-no-filtering, spilling-with-filtering).
  *
  * <p>Subclasses implement {@link #recover} according to their specific recovery mode and override
  * {@link #closeInternal()} to release mode-specific resources.
@@ -141,6 +151,15 @@ abstract class AbstractInputChannelRecoveredStateHandler
         RecoveredInputChannel channel = getMappedChannels(channelInfo);
         Buffer buffer = channel.requestBufferBlocking(checkpointingDuringRecoveryEnabled);
         return new BufferWithContext<>(wrap(buffer), buffer);
+    }
+
+    /**
+     * Returns the {@link FetchedChannelState} produced during spilling, or {@code null} if spilling
+     * was not active (i.e., {@link NoSpillingHandler}).
+     */
+    @Nullable
+    FetchedChannelState getProducedChannelState() {
+        return null;
     }
 
     @Override
@@ -211,6 +230,240 @@ class NoSpillingHandler extends AbstractInputChannelRecoveredStateHandler {
         } finally {
             buffer.recycleBuffer();
         }
+    }
+}
+
+/**
+ * Intermediate abstract base for the two spilling variants. Owns the on-disk spill format end to
+ * end: a single reusable {@link DataOutputSerializer} accumulates one channel's segment, the
+ * segment header is backfilled with the body length at seal time, and sealed segments are flushed
+ * to the current file stream with 64 MB-bounded rotation.
+ *
+ * <h3>Disk format</h3>
+ *
+ * <pre>
+ * [ 4B BE int: gate idx      ]   segment header: written once per channel segment
+ * [ 4B BE int: channel idx   ]
+ * [ 4B BE int: buffer length ]   segment body byte count (backfilled at segment seal)
+ *   [ 4B BE int: record length ]  repeated for every record in this segment
+ *   [ N bytes: serialized record ]
+ * [ 4B BE int: gate idx      ]   next segment header (channel switch or post-rotation)
+ * ...
+ * </pre>
+ *
+ * <p>The body byte count is only known after the whole segment is written, so each segment is first
+ * accumulated in {@link #segmentSerializer} (header written at open with a zero placeholder) and
+ * {@link DataOutputSerializer#writeIntUnsafe} backfills the length at seal. A segment is one
+ * uninterrupted run of records for a single channel; file rotation happens only after a segment is
+ * fully sealed, so a segment never crosses a file boundary.
+ */
+abstract class AbstractSpillingHandler extends AbstractInputChannelRecoveredStateHandler {
+
+    /** Byte offset of the {@code bufferLength} field within a segment's header. */
+    static final int BUFFER_LENGTH_HEADER_OFFSET = 2 * Integer.BYTES;
+
+    /** Total size of the segment header in bytes: gateIdx + channelIdx + bufferLength. */
+    static final int SEGMENT_HEADER_BYTES = 3 * Integer.BYTES;
+
+    final String[] spillTmpDirectories;
+
+    public static final long DEFAULT_SPILL_FILE_SIZE_BYTES = 64L * 1024 * 1024;
+
+    /** Soft per-file size bound that triggers rotation between segments. */
+    private final long maxFileSizeBytes;
+
+    /**
+     * Accumulates the current segment: the header followed by the body, which is either
+     * length-prefixed filtered records or verbatim pass-through bytes, depending on the subclass.
+     * Reused across segments via {@code clear()}.
+     */
+    private final DataOutputSerializer segmentSerializer = new DataOutputSerializer(256);
+
+    /**
+     * Spill files written so far, in order. The {@link FetchedChannelState} handoff is built from
+     * this list once writing is sealed; an empty list means the handler never spilled any bytes, so
+     * it produces no state.
+     */
+    private final List<Path> files = new ArrayList<>();
+
+    /**
+     * Unique directory for this handler's spill files; created lazily when the first file opens.
+     */
+    private final Path baseDir;
+
+    /**
+     * Output stream to the current spill file; tracks the bytes written so far via {@link
+     * OffsetAwareOutputStream#getLength()} to decide when to rotate. Null before the first segment
+     * is flushed.
+     */
+    @Nullable private OffsetAwareOutputStream currentStream;
+
+    /** Channel whose segment is currently open; null when no segment is in progress. */
+    @Nullable private InputChannelInfo currentChannel;
+
+    @Nullable private FetchedChannelState producedChannelState;
+
+    AbstractSpillingHandler(
+            InputGate[] inputGates,
+            InflightDataRescalingDescriptor channelMapping,
+            String[] spillTmpDirectories,
+            long maxFileSizeBytes) {
+        // FLINK-38544 transitional: the base's third ctor arg is removed when the spilling backend
+        // lands (spilling always implies checkpointing-during-recovery enabled).
+        super(inputGates, channelMapping, true);
+        checkArgument(
+                checkNotNull(spillTmpDirectories).length > 0,
+                "spillTmpDirectories must not be empty");
+        checkArgument(
+                maxFileSizeBytes > 0, "maxFileSizeBytes must be positive: %s", maxFileSizeBytes);
+        this.spillTmpDirectories = spillTmpDirectories;
+        this.maxFileSizeBytes = maxFileSizeBytes;
+        this.baseDir =
+                Paths.get(spillTmpDirectories[0], "flink-channel-spill-" + UUID.randomUUID());
+    }
+
+    /**
+     * Opens (or switches to) the segment for {@code channelInfo} and returns its buffer for the
+     * caller to append the body into. The caller must not seal the segment.
+     */
+    DataOutputSerializer segmentSerializerFor(InputChannelInfo channelInfo) throws IOException {
+        switchChannelIfNeeded(channelInfo);
+        return segmentSerializer;
+    }
+
+    private void switchChannelIfNeeded(InputChannelInfo channelInfo) throws IOException {
+        if (channelInfo.equals(currentChannel)) {
+            return;
+        }
+        if (currentChannel != null) {
+            sealCurrentSegment();
+        }
+        segmentSerializer.clear();
+        segmentSerializer.writeInt(channelInfo.getGateIdx());
+        segmentSerializer.writeInt(channelInfo.getInputChannelIdx());
+        segmentSerializer.writeInt(0); // bufferLength placeholder
+        currentChannel = channelInfo;
+    }
+
+    /**
+     * Backfills the body length into the segment header and flushes the whole segment to the file
+     * stream. Empty segments (filtered out entirely, or a zero-byte pass-through) are dropped
+     * without opening a file, so no empty file is created.
+     */
+    private void sealCurrentSegment() throws IOException {
+        if (currentChannel == null) {
+            return;
+        }
+        currentChannel = null;
+        int totalBytes = segmentSerializer.length();
+        int bodyBytes = totalBytes - SEGMENT_HEADER_BYTES;
+        if (bodyBytes == 0) {
+            return;
+        }
+        // Math.toIntExact guards against the unlikely case of a single segment > 2 GB.
+        segmentSerializer.writeIntUnsafe(Math.toIntExact(bodyBytes), BUFFER_LENGTH_HEADER_OFFSET);
+        ensureFileOpen();
+        currentStream.write(segmentSerializer.getSharedBuffer(), 0, totalBytes);
+    }
+
+    /**
+     * Ensures an output stream is ready for the next segment, rotating to a fresh file first if the
+     * current one reached the size bound. Rotation happens here, between sealed segments, so a
+     * segment is never split across files.
+     */
+    private void ensureFileOpen() throws IOException {
+        if (currentStream != null && currentStream.getLength() >= maxFileSizeBytes) {
+            currentStream.flush();
+            currentStream.close();
+            currentStream = null;
+        }
+        if (currentStream != null) {
+            return;
+        }
+        // create the spill dir on the first file; no-op afterwards
+        Files.createDirectories(baseDir);
+        Path filePath = baseDir.resolve("spill-segment-" + files.size() + ".bin");
+        currentStream =
+                new OffsetAwareOutputStream(
+                        new BufferedOutputStream(new FileOutputStream(filePath.toFile())), 0L);
+        files.add(filePath);
+    }
+
+    @Override
+    @Nullable
+    FetchedChannelState getProducedChannelState() {
+        return producedChannelState;
+    }
+
+    /** Spill files written so far; empty if this handler never spilled any bytes. */
+    @VisibleForTesting
+    List<Path> peekSpillFilesForTesting() {
+        return files;
+    }
+
+    /**
+     * Seals the open segment and the file stream, then builds the {@link FetchedChannelState}
+     * handoff from the written files. Produces nothing if no bytes were ever spilled.
+     */
+    @Override
+    void closeInternal() throws IOException {
+        if (currentChannel != null) {
+            sealCurrentSegment();
+        }
+        if (currentStream != null) {
+            currentStream.flush();
+            currentStream.close(); // OffsetAwareOutputStream closes the wrapped stream quietly
+            currentStream = null;
+        }
+        if (files.isEmpty()) {
+            return;
+        }
+        producedChannelState = new FetchedChannelState(files);
+        // Keep the files alive between close() and drain-reader construction.
+        producedChannelState.acquire();
+    }
+}
+
+/**
+ * Recovery handler for the case where checkpointing during recovery is enabled but no filtering
+ * handler is present. Appends recovered buffer bytes verbatim into the current segment.
+ */
+class SpillingNoFilteringHandler extends AbstractSpillingHandler {
+
+    SpillingNoFilteringHandler(
+            InputGate[] inputGates,
+            InflightDataRescalingDescriptor channelMapping,
+            String[] spillTmpDirectories) {
+        super(inputGates, channelMapping, spillTmpDirectories, DEFAULT_SPILL_FILE_SIZE_BYTES);
+    }
+
+    @Override
+    public void recover(
+            InputChannelInfo channelInfo,
+            int oldSubtaskIndex,
+            BufferWithContext<Buffer> bufferWithContext)
+            throws IOException, InterruptedException {
+        Buffer buffer = bufferWithContext.context;
+        try {
+            if (buffer.readableBytes() > 0) {
+                recoverPassThroughToSpill(getMappedChannels(channelInfo).getChannelInfo(), buffer);
+            }
+        } finally {
+            buffer.recycleBuffer();
+        }
+    }
+
+    private void recoverPassThroughToSpill(InputChannelInfo channelInfo, Buffer source)
+            throws IOException {
+        // The recovered bytes are already a length-prefixed record sequence, so append them
+        // verbatim into the segment without re-framing. Writing straight from the backing
+        // MemorySegment lets it absorb the heap/off-heap distinction, avoiding both a branch on the
+        // NIO buffer kind and the intermediate copy a direct buffer would otherwise require.
+        segmentSerializerFor(channelInfo)
+                .write(
+                        source.getMemorySegment(),
+                        source.getMemorySegmentOffset() + source.getReaderIndex(),
+                        source.readableBytes());
     }
 }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/RecoveredChannelStateHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/RecoveredChannelStateHandler.java
@@ -131,12 +131,13 @@ abstract class AbstractInputChannelRecoveredStateHandler
             InflightDataRescalingDescriptor channelMapping,
             boolean checkpointingDuringRecoveryEnabled,
             @Nullable ChannelStateFilteringHandler filteringHandler,
-            int memorySegmentSize) {
+            int memorySegmentSize,
+            String[] spillTmpDirectories) {
         if (!checkpointingDuringRecoveryEnabled) {
             return new NoSpillingHandler(inputGates, channelMapping, false);
         }
         // FLINK-38544 transitional: the flag-on path still uses the in-memory handlers until the
-        // spilling backend lands.
+        // spilling backend lands; spillTmpDirectories is unused until then.
         if (filteringHandler == null) {
             return new NoSpillingHandler(inputGates, channelMapping, true);
         }
@@ -469,6 +470,131 @@ class SpillingNoFilteringHandler extends AbstractSpillingHandler {
 
 /**
  * Recovery handler for the case where checkpointing during recovery is enabled and a filtering
+ * handler is present. Uses a reusable heap-backed pre-filter buffer (isolated from the Network
+ * Buffer Pool) and writes filtered/rewritten output to the spill file via {@link
+ * ChannelStateFilteringHandler#filterAndRewrite}.
+ */
+class SpillingWithFilteringHandler extends AbstractSpillingHandler {
+
+    private final ChannelStateFilteringHandler filteringHandler;
+
+    /** Network buffer memory segment size in bytes. Used to size the reusable pre-filter buffer. */
+    private final int memorySegmentSize;
+
+    /**
+     * Reusable heap memory segment backing the pre-filter buffer in filtering mode. Lazily
+     * allocated on the first {@link #getBuffer} call, reused for every subsequent call, and freed
+     * in {@link #closeInternal()}.
+     *
+     * <p>Reuse is safe because at most one pre-filter buffer is in flight per task at any moment.
+     * This invariant is enforced at runtime by {@link #preFilterBufferInUse}.
+     */
+    @Nullable private MemorySegment preFilterSegment;
+
+    /**
+     * Tracks whether {@link #preFilterSegment} is currently wrapped by a live {@link Buffer} that
+     * has not yet been recycled. Flipped to {@code true} when a new buffer is issued, and flipped
+     * back to {@code false} by the custom {@link BufferRecycler} when the buffer is recycled.
+     */
+    private boolean preFilterBufferInUse;
+
+    SpillingWithFilteringHandler(
+            InputGate[] inputGates,
+            InflightDataRescalingDescriptor channelMapping,
+            ChannelStateFilteringHandler filteringHandler,
+            int memorySegmentSize,
+            String[] spillTmpDirectories) {
+        super(inputGates, channelMapping, spillTmpDirectories, DEFAULT_SPILL_FILE_SIZE_BYTES);
+        this.filteringHandler = filteringHandler;
+        checkArgument(
+                memorySegmentSize > 0, "memorySegmentSize must be positive: %s", memorySegmentSize);
+        this.memorySegmentSize = memorySegmentSize;
+    }
+
+    /**
+     * Allocates a pre-filter buffer from a reusable heap segment (isolated from the Network Buffer
+     * Pool) in filtering mode.
+     *
+     * <p>Memory management: a single {@link MemorySegment} per task is lazily allocated on first
+     * invocation and reused across every subsequent call. The custom {@link BufferRecycler} does
+     * not free the segment; it only flips {@link #preFilterBufferInUse} back to {@code false} so
+     * the next call can reuse it. The segment itself is freed in {@link #closeInternal()}.
+     *
+     * <p>Runtime invariant check: the one-at-a-time invariant on pre-filter buffers is guaranteed
+     * by Flink's serial recovery loop and the deserializer's ownership contract. This method
+     * asserts the invariant before issuing a buffer: if a previously issued buffer has not yet been
+     * recycled, it throws {@link IllegalStateException} so any future regression fails loudly
+     * instead of silently corrupting memory.
+     */
+    @Override
+    public BufferWithContext<Buffer> getBuffer(InputChannelInfo channelInfo) {
+        checkState(
+                !preFilterBufferInUse,
+                "Previous pre-filter buffer has not been recycled. This violates the "
+                        + "one-buffer-at-a-time invariant of pre-filter buffers.");
+
+        if (preFilterSegment == null) {
+            preFilterSegment = MemorySegmentFactory.allocateUnpooledSegment(memorySegmentSize);
+        }
+        preFilterBufferInUse = true;
+
+        // The recycler keeps the segment alive for reuse; only flips the in-use flag.
+        BufferRecycler recycler = segment -> preFilterBufferInUse = false;
+        Buffer buffer = new NetworkBuffer(preFilterSegment, recycler);
+        return new BufferWithContext<>(wrap(buffer), buffer);
+    }
+
+    @Override
+    public void recover(
+            InputChannelInfo channelInfo,
+            int oldSubtaskIndex,
+            BufferWithContext<Buffer> bufferWithContext)
+            throws IOException, InterruptedException {
+        Buffer buffer = bufferWithContext.context;
+        try {
+            if (buffer.readableBytes() > 0) {
+                filteringHandler.filterAndRewrite(
+                        channelInfo.getGateIdx(),
+                        oldSubtaskIndex,
+                        channelInfo.getInputChannelIdx(),
+                        buffer.retainBuffer(),
+                        segmentSerializerFor(getMappedChannels(channelInfo).getChannelInfo()));
+            }
+        } finally {
+            buffer.recycleBuffer();
+        }
+    }
+
+    @VisibleForTesting
+    boolean isPreFilterBufferInUse() {
+        return preFilterBufferInUse;
+    }
+
+    @VisibleForTesting
+    @Nullable
+    MemorySegment getPreFilterSegmentForTesting() {
+        return preFilterSegment;
+    }
+
+    @Override
+    void closeInternal() throws IOException {
+        try {
+            super.closeInternal();
+        } finally {
+            if (preFilterSegment != null) {
+                preFilterSegment.free();
+                preFilterSegment = null;
+                preFilterBufferInUse = false;
+            }
+        }
+    }
+}
+
+/**
+ * FLINK-38544 transitional: removed when the spilling backend lands (the factory then selects
+ * {@link SpillingWithFilteringHandler} instead).
+ *
+ * <p>Recovery handler for the case where checkpointing during recovery is enabled and a filtering
  * handler is present. Uses a reusable heap-backed pre-filter buffer (isolated from the Network
  * Buffer Pool), filters recovered buffers through {@link
  * ChannelStateFilteringHandler#filterAndRewrite}, and delivers the filtered buffers directly into

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/RecoveredChannelStateHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/RecoveredChannelStateHandler.java
@@ -18,6 +18,8 @@
 package org.apache.flink.runtime.checkpoint.channel;
 
 import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.core.fs.OffsetAwareOutputStream;
+import org.apache.flink.core.memory.DataOutputSerializer;
 import org.apache.flink.core.memory.MemorySegment;
 import org.apache.flink.core.memory.MemorySegmentFactory;
 import org.apache.flink.runtime.checkpoint.InflightDataRescalingDescriptor;
@@ -38,13 +40,21 @@ import org.apache.flink.runtime.io.network.partition.consumer.RecoveredInputChan
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+import java.io.BufferedOutputStream;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 import static org.apache.flink.runtime.checkpoint.channel.ChannelStateByteBuffer.wrap;
 import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkNotNull;
 import static org.apache.flink.util.Preconditions.checkState;
 
 interface RecoveredChannelStateHandler<Info, Context> extends AutoCloseable {
@@ -75,7 +85,7 @@ interface RecoveredChannelStateHandler<Info, Context> extends AutoCloseable {
 
 /**
  * Abstract base for all input-channel recovery handlers. Holds the channel mapping logic shared by
- * both variants (no-filtering, filtering).
+ * all three variants (no-spilling, spilling-no-filtering, spilling-with-filtering).
  *
  * <p>Subclasses implement {@link #recover} according to their specific recovery mode and override
  * {@link #closeInternal()} to release mode-specific resources.
@@ -141,6 +151,15 @@ abstract class AbstractInputChannelRecoveredStateHandler
         RecoveredInputChannel channel = getMappedChannels(channelInfo);
         Buffer buffer = channel.requestBufferBlocking(checkpointingDuringRecoveryEnabled);
         return new BufferWithContext<>(wrap(buffer), buffer);
+    }
+
+    /**
+     * Returns the {@link FetchedChannelState} produced during spilling, or {@code null} if spilling
+     * was not active (i.e., {@link NoSpillingHandler}).
+     */
+    @Nullable
+    FetchedChannelState getProducedChannelState() {
+        return null;
     }
 
     @Override
@@ -211,6 +230,266 @@ class NoSpillingHandler extends AbstractInputChannelRecoveredStateHandler {
         } finally {
             buffer.recycleBuffer();
         }
+    }
+}
+
+/**
+ * Intermediate abstract base for the two spilling variants. Owns the on-disk spill format end to
+ * end: a single reusable {@link DataOutputSerializer} accumulates one channel's segment, the
+ * segment header is backfilled with the body length at seal time, and sealed segments are flushed
+ * to the current file stream with 64 MB-bounded rotation.
+ *
+ * <h3>Disk format</h3>
+ *
+ * <pre>
+ * [ 4B BE int: gate idx      ]   segment header: written once per channel segment
+ * [ 4B BE int: channel idx   ]
+ * [ 4B BE int: buffer length ]   segment body byte count (backfilled at segment seal)
+ *   [ 4B BE int: record length ]  repeated for every record in this segment
+ *   [ N bytes: serialized record ]
+ * [ 4B BE int: gate idx      ]   next segment header (channel switch or post-rotation)
+ * ...
+ * </pre>
+ *
+ * <p>The body byte count is only known after the whole segment is written, so each segment is first
+ * accumulated in {@link #segmentSerializer} (header written at open with a zero placeholder) and
+ * {@link DataOutputSerializer#writeIntUnsafe} backfills the length at seal. A segment is one
+ * uninterrupted run of records for a single channel; file rotation happens only after a segment is
+ * fully sealed, so a segment never crosses a file boundary.
+ */
+abstract class AbstractSpillingHandler extends AbstractInputChannelRecoveredStateHandler {
+
+    /** Byte offset of the {@code bufferLength} field within a segment's header. */
+    static final int BUFFER_LENGTH_HEADER_OFFSET = 2 * Integer.BYTES;
+
+    /** Total size of the segment header in bytes: gateIdx + channelIdx + bufferLength. */
+    static final int SEGMENT_HEADER_BYTES = 3 * Integer.BYTES;
+
+    final String[] spillTmpDirectories;
+
+    public static final long DEFAULT_SPILL_FILE_SIZE_BYTES = 64L * 1024 * 1024;
+
+    public static final int DEFAULT_MAX_SEGMENT_SIZE_BYTES = 1024 * 1024;
+
+    /** Soft per-file size bound that triggers rotation between segments. */
+    private final long maxFileSizeBytes;
+
+    /** Soft per-segment size bound that triggers a seal, keeping heap use bounded. */
+    private final int maxSegmentSizeBytes;
+
+    /**
+     * Accumulates the current segment: the header followed by the body, which is either
+     * length-prefixed filtered records or verbatim pass-through bytes, depending on the subclass.
+     * Reused across segments via {@code clear()}.
+     */
+    private final DataOutputSerializer segmentSerializer = new DataOutputSerializer(256);
+
+    /**
+     * Spill files written so far, in order. The {@link FetchedChannelState} handoff is built from
+     * this list once writing is sealed; an empty list means the handler never spilled any bytes, so
+     * it produces no state.
+     */
+    private final List<Path> files = new ArrayList<>();
+
+    /**
+     * Unique directory for this handler's spill files; created lazily when the first file opens.
+     */
+    private final Path baseDir;
+
+    /**
+     * Output stream to the current spill file; tracks the bytes written so far via {@link
+     * OffsetAwareOutputStream#getLength()} to decide when to rotate. Null before the first segment
+     * is flushed.
+     */
+    @Nullable private OffsetAwareOutputStream currentStream;
+
+    /** Channel whose segment is currently open; null when no segment is in progress. */
+    @Nullable private InputChannelInfo currentChannel;
+
+    @Nullable private FetchedChannelState producedChannelState;
+
+    AbstractSpillingHandler(
+            InputGate[] inputGates,
+            InflightDataRescalingDescriptor channelMapping,
+            String[] spillTmpDirectories,
+            long maxFileSizeBytes,
+            int maxSegmentSizeBytes) {
+        // FLINK-38544 transitional: the base's third ctor arg is removed when the spilling backend
+        // lands (spilling always implies checkpointing-during-recovery enabled).
+        super(inputGates, channelMapping, true);
+        checkArgument(
+                checkNotNull(spillTmpDirectories).length > 0,
+                "spillTmpDirectories must not be empty");
+        checkArgument(
+                maxFileSizeBytes > 0, "maxFileSizeBytes must be positive: %s", maxFileSizeBytes);
+        checkArgument(
+                maxSegmentSizeBytes > 0,
+                "maxSegmentSizeBytes must be positive: %s",
+                maxSegmentSizeBytes);
+        this.spillTmpDirectories = spillTmpDirectories;
+        this.maxFileSizeBytes = maxFileSizeBytes;
+        this.maxSegmentSizeBytes = maxSegmentSizeBytes;
+        this.baseDir =
+                Paths.get(spillTmpDirectories[0], "flink-channel-spill-" + UUID.randomUUID());
+    }
+
+    /**
+     * Opens (or switches to) the segment for {@code channelInfo} and returns its buffer for the
+     * caller to append the body into. The caller must not seal the segment.
+     */
+    DataOutputSerializer segmentSerializerFor(InputChannelInfo channelInfo) throws IOException {
+        startNewSegmentIfNeeded(channelInfo);
+        return segmentSerializer;
+    }
+
+    private void startNewSegmentIfNeeded(InputChannelInfo channelInfo) throws IOException {
+        // A segment ends on a channel switch, or once it outgrew the heap bound; the disk format
+        // allows consecutive segments for one channel, so the reader is unaffected either way.
+        if (channelInfo.equals(currentChannel)
+                && segmentSerializer.length() <= maxSegmentSizeBytes) {
+            return;
+        }
+        if (currentChannel != null) {
+            sealCurrentSegment();
+        }
+        segmentSerializer.clear();
+        segmentSerializer.writeInt(channelInfo.getGateIdx());
+        segmentSerializer.writeInt(channelInfo.getInputChannelIdx());
+        segmentSerializer.writeInt(0); // bufferLength placeholder
+        currentChannel = channelInfo;
+    }
+
+    /**
+     * Backfills the body length into the segment header and flushes the whole segment to the file
+     * stream. Empty segments are dropped without opening a file, so no empty file is created.
+     */
+    private void sealCurrentSegment() throws IOException {
+        if (currentChannel == null) {
+            return;
+        }
+        currentChannel = null;
+        int totalBytes = segmentSerializer.length();
+        int bodyBytes = totalBytes - SEGMENT_HEADER_BYTES;
+        if (bodyBytes == 0) {
+            // The header is written before filtering runs, so a channel whose records are all
+            // filtered out ends up empty: drop it instead of writing a header-only segment.
+            return;
+        }
+        // Math.toIntExact guards against the unlikely case of a single segment > 2 GB.
+        segmentSerializer.writeIntUnsafe(Math.toIntExact(bodyBytes), BUFFER_LENGTH_HEADER_OFFSET);
+        ensureFileOpen();
+        currentStream.write(segmentSerializer.getSharedBuffer(), 0, totalBytes);
+    }
+
+    /**
+     * Ensures an output stream is ready for the next segment, rotating to a fresh file first if the
+     * current one reached the size bound. Rotation happens here, between sealed segments, so a
+     * segment is never split across files.
+     */
+    private void ensureFileOpen() throws IOException {
+        if (currentStream != null && currentStream.getLength() >= maxFileSizeBytes) {
+            currentStream.flush();
+            currentStream.close();
+            currentStream = null;
+        }
+        if (currentStream != null) {
+            return;
+        }
+        // create the spill dir on the first file; no-op afterwards
+        Files.createDirectories(baseDir);
+        Path filePath = baseDir.resolve("spill-segment-" + files.size() + ".bin");
+        // CREATE_NEW fails loud if the file already exists instead of silently overwriting it.
+        currentStream =
+                new OffsetAwareOutputStream(
+                        new BufferedOutputStream(
+                                Files.newOutputStream(
+                                        filePath,
+                                        StandardOpenOption.CREATE_NEW,
+                                        StandardOpenOption.WRITE)),
+                        0L);
+        files.add(filePath);
+    }
+
+    @Override
+    @Nullable
+    FetchedChannelState getProducedChannelState() {
+        return producedChannelState;
+    }
+
+    /** Spill files written so far; empty if this handler never spilled any bytes. */
+    @VisibleForTesting
+    List<Path> peekSpillFilesForTesting() {
+        return files;
+    }
+
+    /**
+     * Seals the open segment and the file stream, then builds the {@link FetchedChannelState}
+     * handoff from the written files. Produces nothing if no bytes were ever spilled.
+     */
+    @Override
+    void closeInternal() throws IOException {
+        if (currentChannel != null) {
+            sealCurrentSegment();
+        }
+        if (currentStream != null) {
+            currentStream.flush();
+            currentStream.close(); // OffsetAwareOutputStream closes the wrapped stream quietly
+            currentStream = null;
+        }
+        if (files.isEmpty()) {
+            return;
+        }
+        producedChannelState = new FetchedChannelState(files);
+        // Keep the files alive between close() and drain-reader construction.
+        producedChannelState.acquire();
+    }
+}
+
+/**
+ * Recovery handler for the case where checkpointing during recovery is enabled but no filtering
+ * handler is present. Appends recovered buffer bytes verbatim into the current segment.
+ */
+class SpillingNoFilteringHandler extends AbstractSpillingHandler {
+
+    SpillingNoFilteringHandler(
+            InputGate[] inputGates,
+            InflightDataRescalingDescriptor channelMapping,
+            String[] spillTmpDirectories) {
+        super(
+                inputGates,
+                channelMapping,
+                spillTmpDirectories,
+                DEFAULT_SPILL_FILE_SIZE_BYTES,
+                DEFAULT_MAX_SEGMENT_SIZE_BYTES);
+    }
+
+    @Override
+    public void recover(
+            InputChannelInfo channelInfo,
+            int oldSubtaskIndex,
+            BufferWithContext<Buffer> bufferWithContext)
+            throws IOException, InterruptedException {
+        Buffer buffer = bufferWithContext.context;
+        try {
+            if (buffer.readableBytes() > 0) {
+                recoverPassThroughToSpill(getMappedChannels(channelInfo).getChannelInfo(), buffer);
+            }
+        } finally {
+            buffer.recycleBuffer();
+        }
+    }
+
+    private void recoverPassThroughToSpill(InputChannelInfo channelInfo, Buffer source)
+            throws IOException {
+        // The recovered bytes are already a length-prefixed record sequence, so append them
+        // verbatim into the segment without re-framing. Writing straight from the backing
+        // MemorySegment lets it absorb the heap/off-heap distinction, avoiding both a branch on the
+        // NIO buffer kind and the intermediate copy a direct buffer would otherwise require.
+        segmentSerializerFor(channelInfo)
+                .write(
+                        source.getMemorySegment(),
+                        source.getMemorySegmentOffset() + source.getReaderIndex(),
+                        source.readableBytes());
     }
 }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/RecoveredChannelStateHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/RecoveredChannelStateHandler.java
@@ -131,12 +131,13 @@ abstract class AbstractInputChannelRecoveredStateHandler
             InflightDataRescalingDescriptor channelMapping,
             boolean checkpointingDuringRecoveryEnabled,
             @Nullable ChannelStateFilteringHandler filteringHandler,
-            int memorySegmentSize) {
+            int memorySegmentSize,
+            String[] spillTmpDirectories) {
         if (!checkpointingDuringRecoveryEnabled) {
             return new NoSpillingHandler(inputGates, channelMapping, false);
         }
         // FLINK-38544 transitional: the flag-on path still uses the in-memory handlers until the
-        // spilling backend lands.
+        // spilling backend lands; spillTmpDirectories is unused until then.
         if (filteringHandler == null) {
             return new NoSpillingHandler(inputGates, channelMapping, true);
         }
@@ -410,6 +411,8 @@ abstract class AbstractSpillingHandler extends AbstractInputChannelRecoveredStat
         files.add(filePath);
     }
 
+    // TODO: FLINK-38544 — wire this into SequentialChannelStateReaderImpl#readInputData when the
+    // handler factory starts selecting the Spilling* handlers; unused in production until then.
     @Override
     @Nullable
     FetchedChannelState getProducedChannelState() {
@@ -495,6 +498,136 @@ class SpillingNoFilteringHandler extends AbstractSpillingHandler {
 
 /**
  * Recovery handler for the case where checkpointing during recovery is enabled and a filtering
+ * handler is present. Uses a reusable heap-backed pre-filter buffer (isolated from the Network
+ * Buffer Pool) and writes filtered/rewritten output to the spill file via {@link
+ * ChannelStateFilteringHandler#filterAndRewrite}.
+ */
+class SpillingWithFilteringHandler extends AbstractSpillingHandler {
+
+    private final ChannelStateFilteringHandler filteringHandler;
+
+    /** Network buffer memory segment size in bytes. Used to size the reusable pre-filter buffer. */
+    private final int memorySegmentSize;
+
+    /**
+     * Reusable heap memory segment backing the pre-filter buffer in filtering mode. Lazily
+     * allocated on the first {@link #getBuffer} call, reused for every subsequent call, and freed
+     * in {@link #closeInternal()}.
+     *
+     * <p>Reuse is safe because at most one pre-filter buffer is in flight per task at any moment.
+     * This invariant is enforced at runtime by {@link #preFilterBufferInUse}.
+     */
+    @Nullable private MemorySegment preFilterSegment;
+
+    /**
+     * Tracks whether {@link #preFilterSegment} is currently wrapped by a live {@link Buffer} that
+     * has not yet been recycled. Flipped to {@code true} when a new buffer is issued, and flipped
+     * back to {@code false} by the custom {@link BufferRecycler} when the buffer is recycled.
+     */
+    private boolean preFilterBufferInUse;
+
+    SpillingWithFilteringHandler(
+            InputGate[] inputGates,
+            InflightDataRescalingDescriptor channelMapping,
+            ChannelStateFilteringHandler filteringHandler,
+            int memorySegmentSize,
+            String[] spillTmpDirectories) {
+        super(
+                inputGates,
+                channelMapping,
+                spillTmpDirectories,
+                DEFAULT_SPILL_FILE_SIZE_BYTES,
+                DEFAULT_MAX_SEGMENT_SIZE_BYTES);
+        this.filteringHandler = filteringHandler;
+        checkArgument(
+                memorySegmentSize > 0, "memorySegmentSize must be positive: %s", memorySegmentSize);
+        this.memorySegmentSize = memorySegmentSize;
+    }
+
+    /**
+     * Allocates a pre-filter buffer from a reusable heap segment (isolated from the Network Buffer
+     * Pool) in filtering mode.
+     *
+     * <p>Memory management: a single {@link MemorySegment} per task is lazily allocated on first
+     * invocation and reused across every subsequent call. The custom {@link BufferRecycler} does
+     * not free the segment; it only flips {@link #preFilterBufferInUse} back to {@code false} so
+     * the next call can reuse it. The segment itself is freed in {@link #closeInternal()}.
+     *
+     * <p>Runtime invariant check: the one-at-a-time invariant on pre-filter buffers is guaranteed
+     * by Flink's serial recovery loop and the deserializer's ownership contract. This method
+     * asserts the invariant before issuing a buffer: if a previously issued buffer has not yet been
+     * recycled, it throws {@link IllegalStateException} so any future regression fails loudly
+     * instead of silently corrupting memory.
+     */
+    @Override
+    public BufferWithContext<Buffer> getBuffer(InputChannelInfo channelInfo) {
+        checkState(
+                !preFilterBufferInUse,
+                "Previous pre-filter buffer has not been recycled. This violates the "
+                        + "one-buffer-at-a-time invariant of pre-filter buffers.");
+
+        if (preFilterSegment == null) {
+            preFilterSegment = MemorySegmentFactory.allocateUnpooledSegment(memorySegmentSize);
+        }
+        preFilterBufferInUse = true;
+
+        // The recycler keeps the segment alive for reuse; only flips the in-use flag.
+        BufferRecycler recycler = segment -> preFilterBufferInUse = false;
+        Buffer buffer = new NetworkBuffer(preFilterSegment, recycler);
+        return new BufferWithContext<>(wrap(buffer), buffer);
+    }
+
+    @Override
+    public void recover(
+            InputChannelInfo channelInfo,
+            int oldSubtaskIndex,
+            BufferWithContext<Buffer> bufferWithContext)
+            throws IOException, InterruptedException {
+        Buffer buffer = bufferWithContext.context;
+        try {
+            if (buffer.readableBytes() > 0) {
+                filteringHandler.filterAndRewrite(
+                        channelInfo.getGateIdx(),
+                        oldSubtaskIndex,
+                        channelInfo.getInputChannelIdx(),
+                        buffer.retainBuffer(),
+                        segmentSerializerFor(getMappedChannels(channelInfo).getChannelInfo()));
+            }
+        } finally {
+            buffer.recycleBuffer();
+        }
+    }
+
+    @VisibleForTesting
+    boolean isPreFilterBufferInUse() {
+        return preFilterBufferInUse;
+    }
+
+    @VisibleForTesting
+    @Nullable
+    MemorySegment getPreFilterSegmentForTesting() {
+        return preFilterSegment;
+    }
+
+    @Override
+    void closeInternal() throws IOException {
+        try {
+            super.closeInternal();
+        } finally {
+            if (preFilterSegment != null) {
+                preFilterSegment.free();
+                preFilterSegment = null;
+                preFilterBufferInUse = false;
+            }
+        }
+    }
+}
+
+/**
+ * FLINK-38544 transitional: removed when the spilling backend lands (the factory then selects
+ * {@link SpillingWithFilteringHandler} instead).
+ *
+ * <p>Recovery handler for the case where checkpointing during recovery is enabled and a filtering
  * handler is present. Uses a reusable heap-backed pre-filter buffer (isolated from the Network
  * Buffer Pool), filters recovered buffers through {@link
  * ChannelStateFilteringHandler#filterAndRewrite}, and delivers the filtered buffers directly into

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/RecoveryCheckpointTrigger.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/RecoveryCheckpointTrigger.java
@@ -27,18 +27,15 @@ import java.io.IOException;
 public interface RecoveryCheckpointTrigger {
 
     /**
-     * Atomically snapshots the undrained recovered state and inserts matching {@link
-     * RecoveryCheckpointBarrier}s into in-recovery channels.
-     *
-     * <p>FLINK-38544 transitional signature: once the spilling backend lands this returns an
-     * independent reader over the remaining (undrained) spill segments that the caller owns and
-     * must close. The in-memory backend hands all recovered buffers to the channels in one shot, so
-     * there is never an undrained residue and nothing to return yet.
+     * Atomically snapshots the undrained spill slice and inserts matching {@link
+     * RecoveryCheckpointBarrier}s into in-recovery channels. Returns an independent reader over the
+     * remaining segments; the caller owns and must close it.
      */
-    void snapshotAndInsertBarriers(long checkpointId) throws IOException, CheckpointException;
+    FetchedChannelStateReader snapshotAndInsertBarriers(long checkpointId)
+            throws IOException, CheckpointException;
 
-    /** Inserts no barriers (and there is no recovered state left to snapshot). */
-    RecoveryCheckpointTrigger NO_OP = checkpointId -> {};
+    /** Returns an empty reader (no spill files, so no segments) and inserts no barriers. */
+    RecoveryCheckpointTrigger NO_OP = checkpointId -> FetchedChannelStateReader.emptyReader();
 
     RecoveryCheckpointTrigger NOT_READY =
             ign -> {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/RecoveryCheckpointTrigger.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/RecoveryCheckpointTrigger.java
@@ -27,18 +27,15 @@ import java.io.IOException;
 public interface RecoveryCheckpointTrigger {
 
     /**
-     * Atomically snapshots the undrained recovered state and inserts matching {@link
-     * RecoveryCheckpointBarrier}s into in-recovery channels.
-     *
-     * <p>FLINK-38544 transitional signature: once the spilling backend lands this returns an
-     * independent reader over the remaining (undrained) spill segments that the caller owns and
-     * must close. The in-memory backend hands all recovered buffers to the channels in one shot, so
-     * there is never an undrained residue and nothing to return yet.
+     * Atomically snapshots the undrained spill slice and inserts matching {@link
+     * RecoveryCheckpointBarrier}s into in-recovery channels. Returns a snapshot over the remaining
+     * segments; the caller owns it, opens the reader it needs and must close the snapshot.
      */
-    void snapshotAndInsertBarriers(long checkpointId) throws IOException, CheckpointException;
+    FetchedChannelStateSnapshot snapshotAndInsertBarriers(long checkpointId)
+            throws IOException, CheckpointException;
 
-    /** Inserts no barriers (and there is no recovered state left to snapshot). */
-    RecoveryCheckpointTrigger NO_OP = checkpointId -> {};
+    /** Returns an empty snapshot (no spill files, so no segments) and inserts no barriers. */
+    RecoveryCheckpointTrigger NO_OP = checkpointId -> FetchedChannelState.emptySnapshot();
 
     RecoveryCheckpointTrigger NOT_READY =
             ign -> {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/SequentialChannelStateReaderImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/SequentialChannelStateReaderImpl.java
@@ -78,7 +78,8 @@ public class SequentialChannelStateReaderImpl implements SequentialChannelStateR
                                 taskStateSnapshot.getInputRescalingDescriptor(),
                                 filterContext.isCheckpointingDuringRecoveryEnabled(),
                                 filteringHandler,
-                                filterContext.getMemorySegmentSize())) {
+                                filterContext.getMemorySegmentSize(),
+                                filterContext.getTmpDirectories())) {
             boolean readAny =
                     read(
                             stateHandler,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/SequentialChannelStateReaderImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/SequentialChannelStateReaderImpl.java
@@ -110,7 +110,7 @@ public class SequentialChannelStateReaderImpl implements SequentialChannelStateR
             // only signals "there is state to recover". The spilling backend returns a real,
             // file-backed container here.
             return filterContext.isCheckpointingDuringRecoveryEnabled() && readAny
-                    ? Optional.of(new FetchedChannelState())
+                    ? Optional.of(new FetchedChannelState(java.util.Collections.emptyList()))
                     : Optional.empty();
         }
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/SequentialChannelStateReaderImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/SequentialChannelStateReaderImpl.java
@@ -33,6 +33,7 @@ import org.apache.flink.streaming.runtime.io.recovery.RecordFilterContext;
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -110,7 +111,7 @@ public class SequentialChannelStateReaderImpl implements SequentialChannelStateR
             // only signals "there is state to recover". The spilling backend returns a real,
             // file-backed container here.
             return filterContext.isCheckpointingDuringRecoveryEnabled() && readAny
-                    ? Optional.of(new FetchedChannelState())
+                    ? Optional.of(new FetchedChannelState(Collections.emptyList()))
                     : Optional.empty();
         }
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/SequentialChannelStateReaderImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/SequentialChannelStateReaderImpl.java
@@ -79,7 +79,8 @@ public class SequentialChannelStateReaderImpl implements SequentialChannelStateR
                                 taskStateSnapshot.getInputRescalingDescriptor(),
                                 filterContext.isCheckpointingDuringRecoveryEnabled(),
                                 filteringHandler,
-                                filterContext.getMemorySegmentSize())) {
+                                filterContext.getMemorySegmentSize(),
+                                filterContext.getTmpDirectories())) {
             boolean readAny =
                     read(
                             stateHandler,
@@ -98,18 +99,15 @@ public class SequentialChannelStateReaderImpl implements SequentialChannelStateR
                         !filteringHandler.hasPartialData(),
                         "Not all data has been fully consumed during filtering");
             }
-            // A recovered-state container is produced whenever the checkpointing-during-recovery
-            // path recovered any state, regardless of whether filtering was needed: on this path
-            // conversion must hand the recovered buffers to the physical channels in recovery mode
-            // (needsRecovery = state.isPresent()), so the signal must reflect "any recovered data
-            // was pushed", not "a filter ran". The no-checkpointing path pushes recovered buffers
-            // directly and produces nothing here, matching the caller's
-            // checkState(readInputData(...).isEmpty()).
+            // The container signals "any recovered data was pushed", not "a filter ran": the
+            // no-checkpointing path pushes recovered buffers directly and must produce nothing
+            // here, matching the caller's checkState(readInputData(...).isEmpty()).
             //
             // FLINK-38544 transitional in-memory backend: recovered buffers already live in the
-            // physical channels' queues, so the returned container is an empty placeholder that
-            // only signals "there is state to recover". The spilling backend returns a real,
-            // file-backed container here.
+            // physical channels' queues, so the returned container is an empty placeholder.
+            // TODO: FLINK-38544 — return stateHandler.getProducedChannelState() once the handler
+            // factory selects the Spilling* handlers; as-is their file-backed state would be
+            // silently dropped here.
             return filterContext.isCheckpointingDuringRecoveryEnabled() && readAny
                     ? Optional.of(new FetchedChannelState(Collections.emptyList()))
                     : Optional.empty();

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/io/checkpointing/ChannelState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/io/checkpointing/ChannelState.java
@@ -19,6 +19,7 @@
 package org.apache.flink.streaming.runtime.io.checkpointing;
 
 import org.apache.flink.runtime.checkpoint.CheckpointException;
+import org.apache.flink.runtime.checkpoint.channel.FetchedChannelStateSnapshot;
 import org.apache.flink.runtime.checkpoint.channel.InputChannelInfo;
 import org.apache.flink.runtime.checkpoint.channel.RecoveryCheckpointTrigger;
 import org.apache.flink.runtime.io.network.api.CheckpointBarrier;
@@ -114,15 +115,17 @@ final class ChannelState {
     /**
      * Dispatches checkpoint start: inserts recovery-checkpoint barriers into in-recovery channels
      * through the trigger, then notifies every input. (FLINK-38544 transitional: the spilling
-     * backend adds a third step handing the trigger's snapshot reader to the channel-state writer.)
+     * backend adds a third step handing a reader opened from the snapshot to the channel-state
+     * writer, instead of closing it here.)
      */
     public void onCheckpointStartedForAllInputs(CheckpointBarrier barrier)
             throws CheckpointException, IOException {
         long cpId = barrier.getId();
-        recoveryCheckpointTrigger.snapshotAndInsertBarriers(cpId);
-
-        for (CheckpointableInput input : inputs) {
-            input.checkpointStarted(barrier);
+        try (FetchedChannelStateSnapshot snapshot =
+                recoveryCheckpointTrigger.snapshotAndInsertBarriers(cpId)) {
+            for (CheckpointableInput input : inputs) {
+                input.checkpointStarted(barrier);
+            }
         }
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -1106,7 +1106,7 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
     public RecoveryCheckpointTrigger getRecoveryCheckpointTrigger() {
         return cpId -> {
             checkState(mailboxProcessor.isMailboxThread());
-            recoveryCheckpointTrigger.snapshotAndInsertBarriers(cpId);
+            return recoveryCheckpointTrigger.snapshotAndInsertBarriers(cpId);
         };
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -1119,7 +1119,7 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
     public RecoveryCheckpointTrigger getRecoveryCheckpointTrigger() {
         return cpId -> {
             checkState(mailboxProcessor.isMailboxThread());
-            recoveryCheckpointTrigger.snapshotAndInsertBarriers(cpId);
+            return recoveryCheckpointTrigger.snapshotAndInsertBarriers(cpId);
         };
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/AbstractSpillingHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/AbstractSpillingHandlerTest.java
@@ -1,0 +1,162 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.checkpoint.channel;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.DataInputStream;
+import java.io.FileInputStream;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests the on-disk spill format produced by {@link AbstractSpillingHandler}: the 12-byte segment
+ * header with backfilled buffer length, channel switching, file rotation, and empty-segment
+ * dropping. Records are appended through {@link TestSpillWriter}, mirroring how the filtering and
+ * pass-through subclasses feed the segment buffer.
+ */
+class AbstractSpillingHandlerTest {
+
+    @TempDir Path tempDir;
+
+    @Test
+    void testChannelSwitchProducesTwoSegmentsInOneFile() throws Exception {
+        try (TestSpillWriter writer = new TestSpillWriter(tempDir)) {
+            writer.writeRecord(new InputChannelInfo(0, 0), bytes(0xAA, 0xBB), 2);
+            writer.writeRecord(new InputChannelInfo(0, 1), bytes(0xCC, 0xDD, 0xEE), 3);
+            FetchedChannelState state = writer.getChannelState();
+
+            assertThat(state.files()).hasSize(1);
+            int seg0Body = Integer.BYTES + 2;
+            int seg1Body = Integer.BYTES + 3;
+            assertThat(state.files().get(0).toFile().length())
+                    .isEqualTo(
+                            (long) (AbstractSpillingHandler.SEGMENT_HEADER_BYTES + seg0Body)
+                                    + (AbstractSpillingHandler.SEGMENT_HEADER_BYTES + seg1Body));
+        }
+    }
+
+    @Test
+    void testSameChannelContinuousRecordsMergeIntoOneSegment() throws Exception {
+        InputChannelInfo ch = new InputChannelInfo(0, 0);
+        try (TestSpillWriter writer = new TestSpillWriter(tempDir)) {
+            writer.writeRecord(ch, bytes(1), 1);
+            writer.writeRecord(ch, bytes(2, 3), 2);
+            writer.writeRecord(ch, bytes(4, 5, 6), 3);
+            FetchedChannelState state = writer.getChannelState();
+
+            long expectedBody = 3L * Integer.BYTES + (1 + 2 + 3);
+            assertThat(state.files()).hasSize(1);
+            assertThat(state.files().get(0).toFile().length())
+                    .isEqualTo(AbstractSpillingHandler.SEGMENT_HEADER_BYTES + expectedBody);
+        }
+    }
+
+    @Test
+    void testPassThroughBytesAreWrittenVerbatim() throws Exception {
+        InputChannelInfo ch = new InputChannelInfo(1, 2);
+        byte[] data = bytes(0x01, 0x02, 0x03, 0x04, 0x05);
+        try (TestSpillWriter writer = new TestSpillWriter(tempDir)) {
+            writer.writePassThrough(ch, data, 0, data.length);
+            FetchedChannelState state = writer.getChannelState();
+
+            assertThat(state.files()).hasSize(1);
+            assertThat(state.files().get(0).toFile().length())
+                    .isEqualTo(AbstractSpillingHandler.SEGMENT_HEADER_BYTES + data.length);
+        }
+    }
+
+    // -------------------------------------------------------------------------------------------
+    // Empty segments: opening a segment without writing a body must not create a file
+    // -------------------------------------------------------------------------------------------
+
+    @Test
+    void testOpenSegmentWithoutBodyProducesNoFile() throws Exception {
+        try (TestSpillWriter writer = new TestSpillWriter(tempDir)) {
+            writer.openSegment(new InputChannelInfo(0, 0));
+            // No body was ever spilled, so no state (and therefore no file) is produced.
+            assertThat(writer.getChannelState()).isNull();
+        }
+    }
+
+    @Test
+    void testEmptySegmentsAroundANonEmptyOneProduceExactlyTheNonEmptyFile() throws Exception {
+        try (TestSpillWriter writer = new TestSpillWriter(tempDir)) {
+            writer.openSegment(new InputChannelInfo(0, 0));
+            writer.writeRecord(new InputChannelInfo(0, 1), bytes(7, 8, 9), 3);
+            writer.openSegment(new InputChannelInfo(0, 2));
+            FetchedChannelState state = writer.getChannelState();
+
+            assertThat(state.files()).hasSize(1);
+            assertThat(state.files().get(0).toFile().length())
+                    .isEqualTo(AbstractSpillingHandler.SEGMENT_HEADER_BYTES + Integer.BYTES + 3);
+        }
+    }
+
+    // -------------------------------------------------------------------------------------------
+    // File rotation
+    // -------------------------------------------------------------------------------------------
+
+    @Test
+    void testRotationProducesOneFilePerSegmentWhenBoundIsTiny() throws Exception {
+        try (TestSpillWriter writer = new TestSpillWriter(tempDir, 1L)) {
+            writer.writeRecord(new InputChannelInfo(0, 0), bytes(1), 1);
+            writer.writeRecord(new InputChannelInfo(0, 1), bytes(2, 3), 2);
+            writer.writeRecord(new InputChannelInfo(0, 2), bytes(4), 1);
+            FetchedChannelState state = writer.getChannelState();
+
+            assertThat(state.files()).hasSize(3);
+            for (Path file : state.files()) {
+                assertThat(file.toFile().length()).isGreaterThan(0);
+            }
+        }
+    }
+
+    // -------------------------------------------------------------------------------------------
+    // Disk-format verification
+    // -------------------------------------------------------------------------------------------
+
+    @Test
+    void testDiskFormatMatchesSpec() throws Exception {
+        try (TestSpillWriter writer = new TestSpillWriter(tempDir)) {
+            writer.writeRecord(new InputChannelInfo(7, 3), bytes(0xAB, 0xCD, 0xEF), 3);
+            Path file = writer.getChannelState().files().get(0);
+            try (DataInputStream in = new DataInputStream(new FileInputStream(file.toFile()))) {
+                assertThat(in.readInt()).isEqualTo(7); // gateIdx
+                assertThat(in.readInt()).isEqualTo(3); // channelIdx
+                assertThat(in.readInt()).isEqualTo(Integer.BYTES + 3); // bufferLength
+                assertThat(in.readInt()).isEqualTo(3); // record length prefix
+                assertThat(in.read()).isEqualTo(0xAB);
+                assertThat(in.read()).isEqualTo(0xCD);
+                assertThat(in.read()).isEqualTo(0xEF);
+                assertThat(in.read()).isEqualTo(-1); // EOF
+            }
+        }
+    }
+
+    private static byte[] bytes(int... values) {
+        byte[] out = new byte[values.length];
+        for (int i = 0; i < values.length; i++) {
+            out[i] = (byte) values[i];
+        }
+        return out;
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/AbstractSpillingHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/AbstractSpillingHandlerTest.java
@@ -1,0 +1,184 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.checkpoint.channel;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.DataInputStream;
+import java.io.FileInputStream;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests the on-disk spill format produced by {@link AbstractSpillingHandler}: the 12-byte segment
+ * header with backfilled buffer length, channel switching, file rotation, and empty-segment
+ * dropping. Records are appended through {@link TestSpillWriter}, mirroring how the filtering and
+ * pass-through subclasses feed the segment buffer.
+ */
+class AbstractSpillingHandlerTest {
+
+    @TempDir Path tempDir;
+
+    @Test
+    void testChannelSwitchProducesTwoSegmentsInOneFile() throws Exception {
+        try (TestSpillWriter writer = new TestSpillWriter(tempDir)) {
+            writer.writeRecord(new InputChannelInfo(0, 0), bytes(0xAA, 0xBB), 2);
+            writer.writeRecord(new InputChannelInfo(0, 1), bytes(0xCC, 0xDD, 0xEE), 3);
+            FetchedChannelState state = writer.getChannelState();
+
+            assertThat(state.files()).hasSize(1);
+            int seg0Body = Integer.BYTES + 2;
+            int seg1Body = Integer.BYTES + 3;
+            assertThat(state.files().get(0).toFile().length())
+                    .isEqualTo(
+                            (long) (AbstractSpillingHandler.SEGMENT_HEADER_BYTES + seg0Body)
+                                    + (AbstractSpillingHandler.SEGMENT_HEADER_BYTES + seg1Body));
+        }
+    }
+
+    @Test
+    void testSameChannelContinuousRecordsMergeIntoOneSegment() throws Exception {
+        InputChannelInfo ch = new InputChannelInfo(0, 0);
+        try (TestSpillWriter writer = new TestSpillWriter(tempDir)) {
+            writer.writeRecord(ch, bytes(1), 1);
+            writer.writeRecord(ch, bytes(2, 3), 2);
+            writer.writeRecord(ch, bytes(4, 5, 6), 3);
+            FetchedChannelState state = writer.getChannelState();
+
+            long expectedBody = 3L * Integer.BYTES + (1 + 2 + 3);
+            assertThat(state.files()).hasSize(1);
+            assertThat(state.files().get(0).toFile().length())
+                    .isEqualTo(AbstractSpillingHandler.SEGMENT_HEADER_BYTES + expectedBody);
+        }
+    }
+
+    @Test
+    void testSameChannelIsSplitIntoSegmentsWhenSizeBoundIsExceeded() throws Exception {
+        InputChannelInfo ch = new InputChannelInfo(0, 0);
+        // Segment bound of 8 bytes: every record outgrows it, so each write starts a new segment
+        // even though the channel never switches.
+        try (TestSpillWriter writer =
+                new TestSpillWriter(
+                        tempDir, AbstractSpillingHandler.DEFAULT_SPILL_FILE_SIZE_BYTES, 8)) {
+            writer.writeRecord(ch, bytes(1, 2, 3, 4, 5, 6, 7, 8), 8);
+            writer.writeRecord(ch, bytes(1, 2, 3, 4, 5, 6, 7, 8), 8);
+            writer.writeRecord(ch, bytes(1, 2, 3, 4, 5, 6, 7, 8), 8);
+            FetchedChannelState state = writer.getChannelState();
+
+            // Three headers instead of one: 3 * (header + 4B length prefix + 8B payload).
+            long segmentBytes = AbstractSpillingHandler.SEGMENT_HEADER_BYTES + Integer.BYTES + 8;
+            assertThat(state.files()).hasSize(1);
+            assertThat(state.files().get(0).toFile().length()).isEqualTo(3 * segmentBytes);
+        }
+    }
+
+    @Test
+    void testPassThroughBytesAreWrittenVerbatim() throws Exception {
+        InputChannelInfo ch = new InputChannelInfo(1, 2);
+        byte[] data = bytes(0x01, 0x02, 0x03, 0x04, 0x05);
+        try (TestSpillWriter writer = new TestSpillWriter(tempDir)) {
+            writer.writePassThrough(ch, data, 0, data.length);
+            FetchedChannelState state = writer.getChannelState();
+
+            assertThat(state.files()).hasSize(1);
+            assertThat(state.files().get(0).toFile().length())
+                    .isEqualTo(AbstractSpillingHandler.SEGMENT_HEADER_BYTES + data.length);
+        }
+    }
+
+    // -------------------------------------------------------------------------------------------
+    // Empty segments: opening a segment without writing a body must not create a file
+    // -------------------------------------------------------------------------------------------
+
+    @Test
+    void testOpenSegmentWithoutBodyProducesNoFile() throws Exception {
+        try (TestSpillWriter writer = new TestSpillWriter(tempDir)) {
+            writer.openSegment(new InputChannelInfo(0, 0));
+            // No body was ever spilled, so no state (and therefore no file) is produced.
+            assertThat(writer.getChannelState()).isNull();
+        }
+    }
+
+    @Test
+    void testEmptySegmentsAroundANonEmptyOneProduceExactlyTheNonEmptyFile() throws Exception {
+        try (TestSpillWriter writer = new TestSpillWriter(tempDir)) {
+            writer.openSegment(new InputChannelInfo(0, 0));
+            writer.writeRecord(new InputChannelInfo(0, 1), bytes(7, 8, 9), 3);
+            writer.openSegment(new InputChannelInfo(0, 2));
+            FetchedChannelState state = writer.getChannelState();
+
+            assertThat(state.files()).hasSize(1);
+            assertThat(state.files().get(0).toFile().length())
+                    .isEqualTo(AbstractSpillingHandler.SEGMENT_HEADER_BYTES + Integer.BYTES + 3);
+        }
+    }
+
+    // -------------------------------------------------------------------------------------------
+    // File rotation
+    // -------------------------------------------------------------------------------------------
+
+    @Test
+    void testRotationProducesOneFilePerSegmentWhenBoundIsTiny() throws Exception {
+        try (TestSpillWriter writer =
+                new TestSpillWriter(
+                        tempDir, 1L, AbstractSpillingHandler.DEFAULT_MAX_SEGMENT_SIZE_BYTES)) {
+            writer.writeRecord(new InputChannelInfo(0, 0), bytes(1), 1);
+            writer.writeRecord(new InputChannelInfo(0, 1), bytes(2, 3), 2);
+            writer.writeRecord(new InputChannelInfo(0, 2), bytes(4), 1);
+            FetchedChannelState state = writer.getChannelState();
+
+            assertThat(state.files()).hasSize(3);
+            for (Path file : state.files()) {
+                assertThat(file.toFile().length()).isGreaterThan(0);
+            }
+        }
+    }
+
+    // -------------------------------------------------------------------------------------------
+    // Disk-format verification
+    // -------------------------------------------------------------------------------------------
+
+    @Test
+    void testDiskFormatMatchesSpec() throws Exception {
+        try (TestSpillWriter writer = new TestSpillWriter(tempDir)) {
+            writer.writeRecord(new InputChannelInfo(7, 3), bytes(0xAB, 0xCD, 0xEF), 3);
+            Path file = writer.getChannelState().files().get(0);
+            try (DataInputStream in = new DataInputStream(new FileInputStream(file.toFile()))) {
+                assertThat(in.readInt()).isEqualTo(7); // gateIdx
+                assertThat(in.readInt()).isEqualTo(3); // channelIdx
+                assertThat(in.readInt()).isEqualTo(Integer.BYTES + 3); // bufferLength
+                assertThat(in.readInt()).isEqualTo(3); // record length prefix
+                assertThat(in.read()).isEqualTo(0xAB);
+                assertThat(in.read()).isEqualTo(0xCD);
+                assertThat(in.read()).isEqualTo(0xEF);
+                assertThat(in.read()).isEqualTo(-1); // EOF
+            }
+        }
+    }
+
+    private static byte[] bytes(int... values) {
+        byte[] out = new byte[values.length];
+        for (int i = 0; i < values.length; i++) {
+            out[i] = (byte) values[i];
+        }
+        return out;
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/ChannelStateFilteringHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/ChannelStateFilteringHandlerTest.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.checkpoint.channel;
+
+import org.apache.flink.api.common.typeutils.base.LongSerializer;
+import org.apache.flink.runtime.checkpoint.InflightDataRescalingDescriptor;
+import org.apache.flink.runtime.checkpoint.RescaleMappings;
+import org.apache.flink.runtime.io.network.partition.consumer.InputGate;
+import org.apache.flink.runtime.io.network.partition.consumer.SingleInputGateBuilder;
+import org.apache.flink.runtime.memory.MemoryManager;
+import org.apache.flink.streaming.runtime.io.recovery.RecordFilterContext;
+import org.apache.flink.streaming.runtime.partitioner.ForwardPartitioner;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.util.HashSet;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link ChannelStateFilteringHandler}. */
+class ChannelStateFilteringHandlerTest {
+
+    @TempDir Path tempDir;
+
+    @Test
+    void testCreateFromContextUsesProvidedSpillDirectories() {
+        InputGate inputGate = new SingleInputGateBuilder().setNumberOfChannels(1).build();
+        RecordFilterContext context = createRecordFilterContext(new String[] {tempDir.toString()});
+
+        ChannelStateFilteringHandler handler =
+                ChannelStateFilteringHandler.createFromContext(
+                        context, new InputGate[] {inputGate});
+
+        assertThat(handler).isNotNull();
+        handler.close();
+    }
+
+    private static RecordFilterContext createRecordFilterContext(String[] tmpDirectories) {
+        return new RecordFilterContext(
+                new RecordFilterContext.InputFilterConfig[] {
+                    new RecordFilterContext.InputFilterConfig(
+                            LongSerializer.INSTANCE, new ForwardPartitioner<>(), 1)
+                },
+                new InflightDataRescalingDescriptor(
+                        new InflightDataRescalingDescriptor
+                                        .InflightDataGateOrPartitionRescalingDescriptor[] {
+                            new InflightDataRescalingDescriptor
+                                    .InflightDataGateOrPartitionRescalingDescriptor(
+                                    new int[] {0},
+                                    RescaleMappings.identity(1, 1),
+                                    new HashSet<>(),
+                                    InflightDataRescalingDescriptor
+                                            .InflightDataGateOrPartitionRescalingDescriptor
+                                            .MappingType.IDENTITY)
+                        }),
+                0,
+                128,
+                tmpDirectories,
+                true,
+                MemoryManager.DEFAULT_PAGE_SIZE);
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/FetchedChannelStateReaderTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/FetchedChannelStateReaderTest.java
@@ -1,0 +1,531 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.checkpoint.channel;
+
+import org.apache.flink.runtime.checkpoint.channel.FetchedChannelStateReader.SpillSegment;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.EOFException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Unit tests for {@link FetchedChannelStateReader}: sequential segment scanning, body boundedness,
+ * cross-file transparency, snapshot derivation, and fail-loud on truncated segments.
+ *
+ * <p>Segment boundaries are self-described in disk headers; no in-memory segment locator table is
+ * used.
+ */
+class FetchedChannelStateReaderTest {
+
+    @TempDir Path tempDir;
+
+    // -------------------------------------------------------------------------------------------
+    // Segment iteration
+    // -------------------------------------------------------------------------------------------
+
+    @Test
+    void testIteratorEmptyWhenNoDataWritten() throws Exception {
+        // A writer that never spills produces no state; an empty state has no segments.
+        FetchedChannelState state = new FetchedChannelState(Collections.emptyList());
+        try (FetchedChannelStateReader reader = state.reader()) {
+            assertThat(reader.nextSegment()).isEmpty();
+        }
+    }
+
+    @Test
+    void testMultipleIteratorIteratedInOrder() throws Exception {
+        InputChannelInfo c0 = new InputChannelInfo(0, 0);
+        InputChannelInfo c1 = new InputChannelInfo(0, 1);
+
+        FetchedChannelState state;
+        try (TestSpillWriter writer = new TestSpillWriter(tempDir)) {
+            writer.writeRecord(c0, bytes(10), 1);
+            writer.writeRecord(c1, bytes(20), 1);
+            writer.writeRecord(c0, bytes(30), 1);
+            state = writer.getChannelState();
+        }
+
+        List<InputChannelInfo> channels = new ArrayList<>();
+        try (FetchedChannelStateReader reader = state.reader()) {
+            Optional<SpillSegment> next;
+            while ((next = reader.nextSegment()).isPresent()) {
+                SpillSegment seg = next.get();
+                channels.add(seg.channelInfo());
+                readAll(seg.bodyStream());
+            }
+        }
+
+        // Segments are produced at channel switches: c0, c1, c0
+        assertThat(channels).containsExactly(c0, c1, c0);
+    }
+
+    // -------------------------------------------------------------------------------------------
+    // Body boundedness: body() stops exactly at segment end
+    // -------------------------------------------------------------------------------------------
+
+    @Test
+    void testBodyReturnsMinus1AtSegmentEnd() throws Exception {
+        InputChannelInfo ch = new InputChannelInfo(0, 0);
+
+        FetchedChannelState state;
+        try (TestSpillWriter writer = new TestSpillWriter(tempDir)) {
+            writer.writeRecord(ch, bytes(1, 2), 2);
+            state = writer.getChannelState();
+        }
+
+        try (FetchedChannelStateReader reader = state.reader()) {
+            SpillSegment seg = reader.nextSegment().orElseThrow(AssertionError::new);
+            InputStream body = seg.bodyStream();
+            // Read exactly length bytes
+            byte[] data = new byte[seg.length()];
+            int totalRead = 0;
+            while (totalRead < data.length) {
+                int n = body.read(data, totalRead, data.length - totalRead);
+                assertThat(n).isGreaterThan(0);
+                totalRead += n;
+            }
+            // Next read must return EOF
+            assertThat(body.read()).isEqualTo(-1);
+        }
+    }
+
+    // -------------------------------------------------------------------------------------------
+    // Cross-file transparency
+    // -------------------------------------------------------------------------------------------
+
+    @Test
+    void testCrossFileTransparencyWhenRotationOccurs() throws Exception {
+        InputChannelInfo c0 = new InputChannelInfo(0, 0);
+        InputChannelInfo c1 = new InputChannelInfo(0, 1);
+
+        // Use tiny rotation threshold so first segment triggers a file rotation.
+        FetchedChannelState state;
+        try (TestSpillWriter writer = new TestSpillWriter(tempDir, 1L /* 1 byte threshold */)) {
+            writer.writeRecord(c0, bytes(10, 11, 12), 3);
+            writer.writeRecord(c1, bytes(20, 21), 2);
+            state = writer.getChannelState();
+        }
+
+        // Two segments in different files.
+        assertThat(state.files()).hasSize(2);
+
+        List<InputChannelInfo> channels = new ArrayList<>();
+        try (FetchedChannelStateReader reader = state.reader()) {
+            Optional<SpillSegment> next;
+            while ((next = reader.nextSegment()).isPresent()) {
+                SpillSegment seg = next.get();
+                channels.add(seg.channelInfo());
+                // Body read must not throw even if the segment is in a different file.
+                readAll(seg.bodyStream());
+            }
+        }
+
+        assertThat(channels).containsExactly(c0, c1);
+    }
+
+    // -------------------------------------------------------------------------------------------
+    // Snapshot: independent reader with correct start position
+    // -------------------------------------------------------------------------------------------
+
+    @Test
+    void testSnapshotCoversAllIteratorWhenNothingConsumed() throws Exception {
+        InputChannelInfo c0 = new InputChannelInfo(0, 0);
+        InputChannelInfo c1 = new InputChannelInfo(0, 1);
+
+        FetchedChannelState state;
+        try (TestSpillWriter writer = new TestSpillWriter(tempDir)) {
+            writer.writeRecord(c0, bytes(1), 1);
+            writer.writeRecord(c1, bytes(2), 1);
+            state = writer.getChannelState();
+        }
+
+        try (FetchedChannelStateReader root = state.reader()) {
+            // Snapshot before consuming anything
+            try (FetchedChannelStateReader snap = root.snapshot().reader()) {
+                List<InputChannelInfo> channels = new ArrayList<>();
+                Optional<SpillSegment> next;
+                while ((next = snap.nextSegment()).isPresent()) {
+                    SpillSegment seg = next.get();
+                    channels.add(seg.channelInfo());
+                    readAll(seg.bodyStream());
+                }
+                assertThat(channels).containsExactly(c0, c1);
+            }
+        }
+    }
+
+    @Test
+    void testSnapshotAfterFullSegmentConsumedSkipsThatSegment() throws Exception {
+        InputChannelInfo c0 = new InputChannelInfo(0, 0);
+        InputChannelInfo c1 = new InputChannelInfo(0, 1);
+
+        FetchedChannelState state;
+        try (TestSpillWriter writer = new TestSpillWriter(tempDir)) {
+            writer.writeRecord(c0, bytes(1), 1);
+            writer.writeRecord(c1, bytes(2), 1);
+            state = writer.getChannelState();
+        }
+
+        try (FetchedChannelStateReader root = state.reader()) {
+            // Consume and commit first segment
+            SpillSegment first = root.nextSegment().orElseThrow(AssertionError::new);
+            readAll(first.bodyStream());
+            first.commit();
+
+            // Snapshot must start from second segment
+            try (FetchedChannelStateReader snap = root.snapshot().reader()) {
+                List<InputChannelInfo> channels = new ArrayList<>();
+                Optional<SpillSegment> next;
+                while ((next = snap.nextSegment()).isPresent()) {
+                    SpillSegment seg = next.get();
+                    channels.add(seg.channelInfo());
+                    readAll(seg.bodyStream());
+                }
+                assertThat(channels).containsExactly(c1);
+            }
+        }
+    }
+
+    @Test
+    void testSnapshotFromMidSegmentStartsAtCommittedByteOffset() throws Exception {
+        InputChannelInfo ch = new InputChannelInfo(0, 0);
+
+        FetchedChannelState state;
+        try (TestSpillWriter writer = new TestSpillWriter(tempDir)) {
+            // Two records in the same channel -> one segment
+            writer.writeRecord(ch, bytes(10, 11), 2);
+            state = writer.getChannelState();
+        }
+        // Verify: one file with one segment
+        assertThat(state.files()).hasSize(1);
+
+        try (FetchedChannelStateReader root = state.reader()) {
+            SpillSegment seg = root.nextSegment().orElseThrow(AssertionError::new);
+            int fullLength = seg.length();
+            InputStream body = seg.bodyStream();
+
+            // Read only 1 byte without committing, then snapshot — snapshot should start from 0
+            // (no bytes committed yet).
+            body.read();
+
+            try (FetchedChannelStateReader snapBeforeCommit = root.snapshot().reader()) {
+                SpillSegment snapSeg =
+                        snapBeforeCommit.nextSegment().orElseThrow(AssertionError::new);
+                assertThat(snapSeg.length()).isEqualTo(fullLength);
+                readAll(snapSeg.bodyStream());
+            }
+
+            // Read rest of body and commit
+            readAll(body);
+            seg.commit();
+
+            // After commit the snapshot must be empty
+            try (FetchedChannelStateReader snapAfterCommit = root.snapshot().reader()) {
+                assertThat(snapAfterCommit.nextSegment()).isEmpty();
+            }
+        }
+    }
+
+    @Test
+    void testSnapshotAfterPartialCommitReadsRemainingBodyTail() throws Exception {
+        InputChannelInfo ch = new InputChannelInfo(0, 0);
+
+        FetchedChannelState state;
+        try (TestSpillWriter writer = new TestSpillWriter(tempDir)) {
+            // One segment whose body is a single pass-through blob of known bytes.
+            writer.writePassThrough(ch, bytes(1, 2, 3, 4, 5, 6, 7, 8), 0, 8);
+            state = writer.getChannelState();
+        }
+        assertThat(state.files()).hasSize(1);
+
+        try (FetchedChannelStateReader root = state.reader()) {
+            SpillSegment seg = root.nextSegment().orElseThrow(AssertionError::new);
+            int fullLength = seg.length();
+            InputStream body = seg.bodyStream();
+
+            // Read and commit only a 3-byte prefix.
+            byte[] prefix = new byte[3];
+            assertThat(body.read(prefix)).isEqualTo(3);
+            seg.commit();
+
+            // Snapshot must resume mid-segment and yield exactly the remaining tail bytes.
+            try (FetchedChannelStateReader snap = root.snapshot().reader()) {
+                SpillSegment snapSeg = snap.nextSegment().orElseThrow(AssertionError::new);
+                assertThat(snapSeg.channelInfo()).isEqualTo(ch);
+                assertThat(snapSeg.length()).isEqualTo(fullLength - 3);
+                byte[] tail = readAll(snapSeg.bodyStream());
+                assertThat(tail).isEqualTo(bytes(4, 5, 6, 7, 8));
+                assertThat(snap.nextSegment()).isEmpty();
+            }
+        }
+    }
+
+    @Test
+    void testSnapshotResumesPartialSegmentAcrossFileBoundary() throws Exception {
+        InputChannelInfo c0 = new InputChannelInfo(0, 0);
+        InputChannelInfo c1 = new InputChannelInfo(0, 1);
+
+        // Tiny rotation threshold so the two segments land in separate files.
+        FetchedChannelState state;
+        try (TestSpillWriter writer = new TestSpillWriter(tempDir, 1L)) {
+            writer.writePassThrough(c0, bytes(1, 2, 3, 4), 0, 4);
+            writer.writePassThrough(c1, bytes(5, 6, 7), 0, 3);
+            state = writer.getChannelState();
+        }
+        assertThat(state.files()).hasSize(2);
+
+        try (FetchedChannelStateReader root = state.reader()) {
+            SpillSegment first = root.nextSegment().orElseThrow(AssertionError::new);
+            // Commit a 1-byte prefix of the file-0 segment.
+            first.bodyStream().read(new byte[1]);
+            first.commit();
+
+            try (FetchedChannelStateReader snap = root.snapshot().reader()) {
+                SpillSegment resumed = snap.nextSegment().orElseThrow(AssertionError::new);
+                assertThat(resumed.channelInfo()).isEqualTo(c0);
+                assertThat(readAll(resumed.bodyStream())).isEqualTo(bytes(2, 3, 4));
+
+                // Crossing into file 1 must reset the skip to 0.
+                SpillSegment following = snap.nextSegment().orElseThrow(AssertionError::new);
+                assertThat(following.channelInfo()).isEqualTo(c1);
+                assertThat(readAll(following.bodyStream())).isEqualTo(bytes(5, 6, 7));
+
+                assertThat(snap.nextSegment()).isEmpty();
+            }
+        }
+    }
+
+    @Test
+    void testRootDrainViaRepeatedCommitsTerminatesAndFinalSnapshotEmpty() throws Exception {
+        InputChannelInfo c0 = new InputChannelInfo(0, 0);
+        InputChannelInfo c1 = new InputChannelInfo(0, 1);
+
+        FetchedChannelState state;
+        try (TestSpillWriter writer = new TestSpillWriter(tempDir)) {
+            writer.writePassThrough(c0, bytes(1, 2), 0, 2);
+            writer.writePassThrough(c1, bytes(3, 4, 5), 0, 3);
+            state = writer.getChannelState();
+        }
+
+        try (FetchedChannelStateReader root = state.reader()) {
+            int count = 0;
+            Optional<SpillSegment> next;
+            while ((next = root.nextSegment()).isPresent()) {
+                SpillSegment seg = next.get();
+                readAll(seg.bodyStream());
+                seg.commit();
+                count++;
+            }
+            assertThat(count).isEqualTo(2);
+
+            // After draining everything, a snapshot must have nothing left.
+            try (FetchedChannelStateReader snap = root.snapshot().reader()) {
+                assertThat(snap.nextSegment()).isEmpty();
+            }
+        }
+    }
+
+    // -------------------------------------------------------------------------------------------
+    // Fail-loud on truncated segment
+    // -------------------------------------------------------------------------------------------
+
+    @Test
+    void testBodyThrowsEOFExceptionOnTruncatedFile() throws Exception {
+        InputChannelInfo ch = new InputChannelInfo(0, 0);
+
+        FetchedChannelState state;
+        try (TestSpillWriter writer = new TestSpillWriter(tempDir)) {
+            writer.writeRecord(ch, bytes(1, 2, 3, 4, 5, 6, 7, 8), 8);
+            state = writer.getChannelState();
+        }
+
+        // Truncate the spill file to just the header (12 bytes) so the body is missing.
+        Path spill = state.files().get(0);
+        byte[] headerOnly = Files.readAllBytes(spill);
+        // Keep only the 12-byte header, discard body.
+        Files.write(
+                spill,
+                java.util.Arrays.copyOf(headerOnly, AbstractSpillingHandler.SEGMENT_HEADER_BYTES),
+                StandardOpenOption.TRUNCATE_EXISTING);
+
+        try (FetchedChannelStateReader reader = state.reader()) {
+            SpillSegment seg = reader.nextSegment().orElseThrow(AssertionError::new);
+            // bufferLength from header says > 0 bytes, but file has nothing after the header.
+            assertThatThrownBy(() -> readAll(seg.bodyStream())).isInstanceOf(EOFException.class);
+        }
+    }
+
+    // -------------------------------------------------------------------------------------------
+    // Reference counting: acquire/release via reader lifecycle
+    // -------------------------------------------------------------------------------------------
+
+    @Test
+    void testReaderAcquiresAndReleasesRefCount() throws Exception {
+        InputChannelInfo ch = new InputChannelInfo(0, 0);
+
+        FetchedChannelState state;
+        try (TestSpillWriter writer = new TestSpillWriter(tempDir)) {
+            writer.writeRecord(ch, bytes(1), 1);
+            state = writer.getChannelState();
+        }
+
+        Path spill = state.files().get(0);
+
+        FetchedChannelStateReader reader = state.reader();
+        // Drop the handoff grant so the reader's grant is the only one outstanding.
+        state.release();
+        assertThat(java.nio.file.Files.exists(spill)).isTrue();
+
+        reader.close();
+
+        // After closing the only reader, the file is cleaned up.
+        assertThat(java.nio.file.Files.exists(spill)).isFalse();
+    }
+
+    @Test
+    void testSnapshotKeepsFilesAliveUntilSnapshotClosed() throws Exception {
+        InputChannelInfo ch = new InputChannelInfo(0, 0);
+
+        FetchedChannelState state;
+        try (TestSpillWriter writer = new TestSpillWriter(tempDir)) {
+            writer.writeRecord(ch, bytes(1), 1);
+            state = writer.getChannelState();
+        }
+
+        Path spill = state.files().get(0);
+
+        FetchedChannelStateReader root = state.reader();
+        FetchedChannelStateReader snap = root.snapshot().reader();
+        // Drop the handoff grant so only the two reader grants remain outstanding.
+        state.release();
+
+        root.close(); // One grant released; file must still exist because snap holds another.
+        assertThat(java.nio.file.Files.exists(spill)).isTrue();
+
+        snap.close(); // Last grant released; file must be deleted.
+        assertThat(java.nio.file.Files.exists(spill)).isFalse();
+    }
+
+    // -------------------------------------------------------------------------------------------
+    // New behaviour: first-call exemption, fail-loud on body not consumed, empty reader
+    // -------------------------------------------------------------------------------------------
+
+    @Test
+    void testFirstNextSegmentCallDoesNotRequirePreviousBodyConsumed() throws Exception {
+        // The "previous body must be fully consumed" rule must not fire on the very first call
+        // because there is no previous segment.
+        FetchedChannelState state;
+        try (TestSpillWriter writer = new TestSpillWriter(tempDir)) {
+            writer.writeRecord(new InputChannelInfo(0, 0), bytes(1, 2), 2);
+            state = writer.getChannelState();
+        }
+
+        try (FetchedChannelStateReader reader = state.reader()) {
+            // Must not throw on the first call even though no body has been consumed before.
+            Optional<SpillSegment> seg = reader.nextSegment();
+            assertThat(seg).isPresent();
+        }
+    }
+
+    @Test
+    void testNextSegmentThrowsWhenPreviousBodyNotFullyConsumed() throws Exception {
+        InputChannelInfo ch = new InputChannelInfo(0, 0);
+        InputChannelInfo ch2 = new InputChannelInfo(0, 1);
+
+        FetchedChannelState state;
+        try (TestSpillWriter writer = new TestSpillWriter(tempDir)) {
+            writer.writeRecord(ch, bytes(1, 2, 3, 4), 4);
+            writer.writeRecord(ch2, bytes(5, 6), 2);
+            state = writer.getChannelState();
+        }
+
+        try (FetchedChannelStateReader reader = state.reader()) {
+            SpillSegment seg = reader.nextSegment().orElseThrow(AssertionError::new);
+            // Read only part of the body — do not exhaust it.
+            seg.bodyStream().read();
+
+            // Advancing to the next segment while the previous body is not fully consumed must fail
+            // loud.
+            assertThatThrownBy(reader::nextSegment)
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("Previous segment body not fully consumed");
+        }
+    }
+
+    @Test
+    void testEmptyReaderNextSegmentReturnsEmptyAndCloseIsClean() throws Exception {
+        FetchedChannelState state = new FetchedChannelState(Collections.emptyList());
+        try (FetchedChannelStateReader reader = state.reader()) {
+            // First call on an empty reader must return empty without throwing.
+            assertThat(reader.nextSegment()).isEmpty();
+            // Closing must not throw.
+        }
+    }
+
+    @Test
+    void testEmptyReaderHandsOutIndependentInstancesSoCloseDoesNotLeak() throws Exception {
+        // emptyReader() is obtained and closed once per checkpoint. close() is single-use (it flips
+        // the closed flag permanently), so each call must yield a fresh instance; otherwise the
+        // first consumer's close would make every later consumer's nextSegment() fail loud.
+        FetchedChannelStateReader first = FetchedChannelStateReader.emptyReader();
+        assertThat(first.nextSegment()).isEmpty();
+        first.close();
+
+        FetchedChannelStateReader second = FetchedChannelStateReader.emptyReader();
+        assertThat(second).isNotSameAs(first);
+        // Must still work after the previously obtained empty reader was closed.
+        assertThat(second.nextSegment()).isEmpty();
+        second.close();
+    }
+
+    // -------------------------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------------------------
+
+    private static byte[] readAll(InputStream in) throws IOException {
+        java.io.ByteArrayOutputStream out = new java.io.ByteArrayOutputStream();
+        byte[] buf = new byte[256];
+        int n;
+        while ((n = in.read(buf)) != -1) {
+            out.write(buf, 0, n);
+        }
+        return out.toByteArray();
+    }
+
+    private static byte[] bytes(int... values) {
+        byte[] arr = new byte[values.length];
+        for (int i = 0; i < values.length; i++) {
+            arr[i] = (byte) values[i];
+        }
+        return arr;
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/FetchedChannelStateReaderTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/FetchedChannelStateReaderTest.java
@@ -1,0 +1,637 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.checkpoint.channel;
+
+import org.apache.flink.runtime.checkpoint.channel.FetchedChannelStateReader.SpillSegment;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.EOFException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Unit tests for {@link FetchedChannelStateReader}: sequential segment scanning, body boundedness,
+ * cross-file transparency, snapshot derivation, and fail-loud on truncated segments.
+ *
+ * <p>Segment boundaries are self-described in disk headers; no in-memory segment locator table is
+ * used.
+ */
+class FetchedChannelStateReaderTest {
+
+    @TempDir Path tempDir;
+
+    // -------------------------------------------------------------------------------------------
+    // Segment iteration
+    // -------------------------------------------------------------------------------------------
+
+    @Test
+    void testIteratorEmptyWhenNoDataWritten() throws Exception {
+        // A writer that never spills produces no state; an empty state has no segments.
+        FetchedChannelState state = new FetchedChannelState(Collections.emptyList());
+        try (FetchedChannelStateReader reader = state.reader()) {
+            assertThat(reader.advanceAndGetNextSegment()).isEmpty();
+        }
+    }
+
+    @Test
+    void testMultipleIteratorIteratedInOrder() throws Exception {
+        InputChannelInfo c0 = new InputChannelInfo(0, 0);
+        InputChannelInfo c1 = new InputChannelInfo(0, 1);
+
+        FetchedChannelState state;
+        try (TestSpillWriter writer = new TestSpillWriter(tempDir)) {
+            writer.writeRecord(c0, bytes(10), 1);
+            writer.writeRecord(c1, bytes(20), 1);
+            writer.writeRecord(c0, bytes(30), 1);
+            state = writer.getChannelState();
+        }
+
+        List<InputChannelInfo> channels = new ArrayList<>();
+        try (FetchedChannelStateReader reader = state.reader()) {
+            Optional<SpillSegment> next;
+            while ((next = reader.advanceAndGetNextSegment()).isPresent()) {
+                SpillSegment seg = next.get();
+                channels.add(seg.channelInfo());
+                readAll(seg.bodyStream());
+            }
+        }
+
+        // Segments are produced at channel switches: c0, c1, c0
+        assertThat(channels).containsExactly(c0, c1, c0);
+    }
+
+    // -------------------------------------------------------------------------------------------
+    // Body boundedness: body() stops exactly at segment end
+    // -------------------------------------------------------------------------------------------
+
+    @Test
+    void testBodyReturnsMinus1AtSegmentEnd() throws Exception {
+        InputChannelInfo ch = new InputChannelInfo(0, 0);
+
+        FetchedChannelState state;
+        try (TestSpillWriter writer = new TestSpillWriter(tempDir)) {
+            writer.writeRecord(ch, bytes(1, 2), 2);
+            state = writer.getChannelState();
+        }
+
+        try (FetchedChannelStateReader reader = state.reader()) {
+            SpillSegment seg = reader.advanceAndGetNextSegment().orElseThrow(AssertionError::new);
+            InputStream body = seg.bodyStream();
+            // Read exactly length bytes
+            byte[] data = new byte[seg.length()];
+            int totalRead = 0;
+            while (totalRead < data.length) {
+                int n = body.read(data, totalRead, data.length - totalRead);
+                assertThat(n).isGreaterThan(0);
+                totalRead += n;
+            }
+            // Next read must return EOF
+            assertThat(body.read()).isEqualTo(-1);
+        }
+    }
+
+    // -------------------------------------------------------------------------------------------
+    // Cross-file transparency
+    // -------------------------------------------------------------------------------------------
+
+    @Test
+    void testCrossFileTransparencyWhenRotationOccurs() throws Exception {
+        InputChannelInfo c0 = new InputChannelInfo(0, 0);
+        InputChannelInfo c1 = new InputChannelInfo(0, 1);
+
+        // Use tiny rotation threshold so first segment triggers a file rotation.
+        FetchedChannelState state;
+        try (TestSpillWriter writer =
+                new TestSpillWriter(
+                        tempDir,
+                        1L /* 1 byte file bound */,
+                        AbstractSpillingHandler.DEFAULT_MAX_SEGMENT_SIZE_BYTES)) {
+            writer.writeRecord(c0, bytes(10, 11, 12), 3);
+            writer.writeRecord(c1, bytes(20, 21), 2);
+            state = writer.getChannelState();
+        }
+
+        // Two segments in different files.
+        assertThat(state.files()).hasSize(2);
+
+        List<InputChannelInfo> channels = new ArrayList<>();
+        try (FetchedChannelStateReader reader = state.reader()) {
+            Optional<SpillSegment> next;
+            while ((next = reader.advanceAndGetNextSegment()).isPresent()) {
+                SpillSegment seg = next.get();
+                channels.add(seg.channelInfo());
+                // Body read must not throw even if the segment is in a different file.
+                readAll(seg.bodyStream());
+            }
+        }
+
+        assertThat(channels).containsExactly(c0, c1);
+    }
+
+    // -------------------------------------------------------------------------------------------
+    // Snapshot: independent reader with correct start position
+    // -------------------------------------------------------------------------------------------
+
+    @Test
+    void testSnapshotCoversAllIteratorWhenNothingConsumed() throws Exception {
+        InputChannelInfo c0 = new InputChannelInfo(0, 0);
+        InputChannelInfo c1 = new InputChannelInfo(0, 1);
+
+        FetchedChannelState state;
+        try (TestSpillWriter writer = new TestSpillWriter(tempDir)) {
+            writer.writeRecord(c0, bytes(1), 1);
+            writer.writeRecord(c1, bytes(2), 1);
+            state = writer.getChannelState();
+        }
+
+        try (FetchedChannelStateReader root = state.reader()) {
+            // Snapshot before consuming anything
+            try (FetchedChannelStateReader snap = root.snapshot().reader()) {
+                List<InputChannelInfo> channels = new ArrayList<>();
+                Optional<SpillSegment> next;
+                while ((next = snap.advanceAndGetNextSegment()).isPresent()) {
+                    SpillSegment seg = next.get();
+                    channels.add(seg.channelInfo());
+                    readAll(seg.bodyStream());
+                }
+                assertThat(channels).containsExactly(c0, c1);
+            }
+        }
+    }
+
+    @Test
+    void testSnapshotAfterFullSegmentConsumedSkipsThatSegment() throws Exception {
+        InputChannelInfo c0 = new InputChannelInfo(0, 0);
+        InputChannelInfo c1 = new InputChannelInfo(0, 1);
+
+        FetchedChannelState state;
+        try (TestSpillWriter writer = new TestSpillWriter(tempDir)) {
+            writer.writeRecord(c0, bytes(1), 1);
+            writer.writeRecord(c1, bytes(2), 1);
+            state = writer.getChannelState();
+        }
+
+        try (FetchedChannelStateReader root = state.reader()) {
+            // Consume and commit first segment
+            SpillSegment first = root.advanceAndGetNextSegment().orElseThrow(AssertionError::new);
+            readAll(first.bodyStream());
+            first.commit();
+
+            // Snapshot must start from second segment
+            try (FetchedChannelStateReader snap = root.snapshot().reader()) {
+                List<InputChannelInfo> channels = new ArrayList<>();
+                Optional<SpillSegment> next;
+                while ((next = snap.advanceAndGetNextSegment()).isPresent()) {
+                    SpillSegment seg = next.get();
+                    channels.add(seg.channelInfo());
+                    readAll(seg.bodyStream());
+                }
+                assertThat(channels).containsExactly(c1);
+            }
+        }
+    }
+
+    @Test
+    void testSnapshotFromMidSegmentStartsAtCommittedByteOffset() throws Exception {
+        InputChannelInfo ch = new InputChannelInfo(0, 0);
+
+        FetchedChannelState state;
+        try (TestSpillWriter writer = new TestSpillWriter(tempDir)) {
+            // Two records in the same channel -> one segment
+            writer.writeRecord(ch, bytes(10, 11), 2);
+            state = writer.getChannelState();
+        }
+        // Verify: one file with one segment
+        assertThat(state.files()).hasSize(1);
+
+        try (FetchedChannelStateReader root = state.reader()) {
+            SpillSegment seg = root.advanceAndGetNextSegment().orElseThrow(AssertionError::new);
+            int fullLength = seg.length();
+            InputStream body = seg.bodyStream();
+
+            // Read only 1 byte without committing, then snapshot — snapshot should start from 0
+            // (no bytes committed yet).
+            body.read();
+
+            try (FetchedChannelStateReader snapBeforeCommit = root.snapshot().reader()) {
+                SpillSegment snapSeg =
+                        snapBeforeCommit
+                                .advanceAndGetNextSegment()
+                                .orElseThrow(AssertionError::new);
+                assertThat(snapSeg.length()).isEqualTo(fullLength);
+                readAll(snapSeg.bodyStream());
+            }
+
+            // Read rest of body and commit
+            readAll(body);
+            seg.commit();
+
+            // After commit the snapshot must be empty
+            try (FetchedChannelStateReader snapAfterCommit = root.snapshot().reader()) {
+                assertThat(snapAfterCommit.advanceAndGetNextSegment()).isEmpty();
+            }
+        }
+    }
+
+    @Test
+    void testSnapshotAfterPartialCommitReadsRemainingBodyTail() throws Exception {
+        InputChannelInfo ch = new InputChannelInfo(0, 0);
+
+        FetchedChannelState state;
+        try (TestSpillWriter writer = new TestSpillWriter(tempDir)) {
+            // One segment whose body is a single pass-through blob of known bytes.
+            writer.writePassThrough(ch, bytes(1, 2, 3, 4, 5, 6, 7, 8), 0, 8);
+            state = writer.getChannelState();
+        }
+        assertThat(state.files()).hasSize(1);
+
+        try (FetchedChannelStateReader root = state.reader()) {
+            SpillSegment seg = root.advanceAndGetNextSegment().orElseThrow(AssertionError::new);
+            int fullLength = seg.length();
+            InputStream body = seg.bodyStream();
+
+            // Read and commit only a 3-byte prefix.
+            byte[] prefix = new byte[3];
+            assertThat(body.read(prefix)).isEqualTo(3);
+            seg.commit();
+
+            // Snapshot must resume mid-segment and yield exactly the remaining tail bytes.
+            try (FetchedChannelStateReader snap = root.snapshot().reader()) {
+                SpillSegment snapSeg =
+                        snap.advanceAndGetNextSegment().orElseThrow(AssertionError::new);
+                assertThat(snapSeg.channelInfo()).isEqualTo(ch);
+                assertThat(snapSeg.length()).isEqualTo(fullLength - 3);
+                byte[] tail = readAll(snapSeg.bodyStream());
+                assertThat(tail).isEqualTo(bytes(4, 5, 6, 7, 8));
+                assertThat(snap.advanceAndGetNextSegment()).isEmpty();
+            }
+        }
+    }
+
+    @Test
+    void testSnapshotCarriesResumeSegmentOnlyWhenBoundaryIsMidBody() throws Exception {
+        InputChannelInfo ch = new InputChannelInfo(0, 0);
+
+        FetchedChannelState state;
+        try (TestSpillWriter writer = new TestSpillWriter(tempDir)) {
+            writer.writePassThrough(ch, bytes(1, 2, 3, 4, 5, 6, 7, 8), 0, 8);
+            state = writer.getChannelState();
+        }
+
+        try (FetchedChannelStateReader root = state.reader()) {
+            // Before anything is committed: start of the first file, no resume segment.
+            try (FetchedChannelStateSnapshot atStart = root.snapshot()) {
+                assertThat(atStart.fileIndex()).isZero();
+                assertThat(atStart.readOffset()).isZero();
+                assertThat(atStart.channel()).isNull();
+                assertThat(atStart.remaining()).isZero();
+            }
+
+            SpillSegment seg = root.advanceAndGetNextSegment().orElseThrow(AssertionError::new);
+            InputStream body = seg.bodyStream();
+            assertThat(body.read(new byte[3])).isEqualTo(3);
+            seg.commit();
+
+            // Boundary inside the body: the channel and its remainder travel with the snapshot.
+            try (FetchedChannelStateSnapshot midBody = root.snapshot()) {
+                assertThat(midBody.channel()).isEqualTo(ch);
+                assertThat(midBody.remaining()).isEqualTo(5);
+            }
+
+            readAll(body);
+            seg.commit();
+
+            // Boundary on a header (here: end of the last segment): no resume segment again.
+            try (FetchedChannelStateSnapshot atHeader = root.snapshot()) {
+                assertThat(atHeader.channel()).isNull();
+                assertThat(atHeader.remaining()).isZero();
+            }
+        }
+    }
+
+    @Test
+    void testSnapshotResumesPartialSegmentAcrossFileBoundary() throws Exception {
+        InputChannelInfo c0 = new InputChannelInfo(0, 0);
+        InputChannelInfo c1 = new InputChannelInfo(0, 1);
+
+        // Tiny rotation threshold so the two segments land in separate files.
+        FetchedChannelState state;
+        try (TestSpillWriter writer =
+                new TestSpillWriter(
+                        tempDir, 1L, AbstractSpillingHandler.DEFAULT_MAX_SEGMENT_SIZE_BYTES)) {
+            writer.writePassThrough(c0, bytes(1, 2, 3, 4), 0, 4);
+            writer.writePassThrough(c1, bytes(5, 6, 7), 0, 3);
+            state = writer.getChannelState();
+        }
+        assertThat(state.files()).hasSize(2);
+
+        try (FetchedChannelStateReader root = state.reader()) {
+            SpillSegment first = root.advanceAndGetNextSegment().orElseThrow(AssertionError::new);
+            // Commit a 1-byte prefix of the file-0 segment.
+            first.bodyStream().read(new byte[1]);
+            first.commit();
+
+            try (FetchedChannelStateReader snap = root.snapshot().reader()) {
+                SpillSegment resumed =
+                        snap.advanceAndGetNextSegment().orElseThrow(AssertionError::new);
+                assertThat(resumed.channelInfo()).isEqualTo(c0);
+                assertThat(readAll(resumed.bodyStream())).isEqualTo(bytes(2, 3, 4));
+
+                // Crossing into file 1 must reset the skip to 0.
+                SpillSegment following =
+                        snap.advanceAndGetNextSegment().orElseThrow(AssertionError::new);
+                assertThat(following.channelInfo()).isEqualTo(c1);
+                assertThat(readAll(following.bodyStream())).isEqualTo(bytes(5, 6, 7));
+
+                assertThat(snap.advanceAndGetNextSegment()).isEmpty();
+            }
+        }
+    }
+
+    @Test
+    void testRootDrainViaRepeatedCommitsTerminatesAndFinalSnapshotEmpty() throws Exception {
+        InputChannelInfo c0 = new InputChannelInfo(0, 0);
+        InputChannelInfo c1 = new InputChannelInfo(0, 1);
+
+        FetchedChannelState state;
+        try (TestSpillWriter writer = new TestSpillWriter(tempDir)) {
+            writer.writePassThrough(c0, bytes(1, 2), 0, 2);
+            writer.writePassThrough(c1, bytes(3, 4, 5), 0, 3);
+            state = writer.getChannelState();
+        }
+
+        try (FetchedChannelStateReader root = state.reader()) {
+            int count = 0;
+            Optional<SpillSegment> next;
+            while ((next = root.advanceAndGetNextSegment()).isPresent()) {
+                SpillSegment seg = next.get();
+                readAll(seg.bodyStream());
+                seg.commit();
+                count++;
+            }
+            assertThat(count).isEqualTo(2);
+
+            // After draining everything, a snapshot must have nothing left.
+            try (FetchedChannelStateReader snap = root.snapshot().reader()) {
+                assertThat(snap.advanceAndGetNextSegment()).isEmpty();
+            }
+        }
+    }
+
+    // -------------------------------------------------------------------------------------------
+    // Fail-loud on truncated segment
+    // -------------------------------------------------------------------------------------------
+
+    @Test
+    void testBodyThrowsEOFExceptionOnTruncatedFile() throws Exception {
+        InputChannelInfo ch = new InputChannelInfo(0, 0);
+
+        FetchedChannelState state;
+        try (TestSpillWriter writer = new TestSpillWriter(tempDir)) {
+            writer.writeRecord(ch, bytes(1, 2, 3, 4, 5, 6, 7, 8), 8);
+            state = writer.getChannelState();
+        }
+
+        // Truncate the spill file to just the header (12 bytes) so the body is missing.
+        Path spill = state.files().get(0);
+        byte[] headerOnly = Files.readAllBytes(spill);
+        // Keep only the 12-byte header, discard body.
+        Files.write(
+                spill,
+                java.util.Arrays.copyOf(headerOnly, AbstractSpillingHandler.SEGMENT_HEADER_BYTES),
+                StandardOpenOption.TRUNCATE_EXISTING);
+
+        try (FetchedChannelStateReader reader = state.reader()) {
+            SpillSegment seg = reader.advanceAndGetNextSegment().orElseThrow(AssertionError::new);
+            // bufferLength from header says > 0 bytes, but file has nothing after the header.
+            assertThatThrownBy(() -> readAll(seg.bodyStream())).isInstanceOf(EOFException.class);
+        }
+    }
+
+    // -------------------------------------------------------------------------------------------
+    // Reference counting: acquire/release via reader lifecycle
+    // -------------------------------------------------------------------------------------------
+
+    @Test
+    void testReaderAcquiresAndReleasesRefCount() throws Exception {
+        InputChannelInfo ch = new InputChannelInfo(0, 0);
+
+        FetchedChannelState state;
+        try (TestSpillWriter writer = new TestSpillWriter(tempDir)) {
+            writer.writeRecord(ch, bytes(1), 1);
+            state = writer.getChannelState();
+        }
+
+        Path spill = state.files().get(0);
+
+        FetchedChannelStateReader reader = state.reader();
+        // Drop the handoff grant so the reader's grant is the only one outstanding.
+        state.release();
+        assertThat(java.nio.file.Files.exists(spill)).isTrue();
+
+        reader.close();
+
+        // After closing the only reader, the file is cleaned up.
+        assertThat(java.nio.file.Files.exists(spill)).isFalse();
+    }
+
+    @Test
+    void testSnapshotClosedWithoutReaderReleasesItsGrant() throws Exception {
+        InputChannelInfo ch = new InputChannelInfo(0, 0);
+
+        FetchedChannelState state;
+        try (TestSpillWriter writer = new TestSpillWriter(tempDir)) {
+            writer.writeRecord(ch, bytes(1), 1);
+            state = writer.getChannelState();
+        }
+
+        Path spill = state.files().get(0);
+
+        FetchedChannelStateReader root = state.reader();
+        FetchedChannelStateSnapshot snapshot = root.snapshot();
+        // Drop the handoff grant so only the reader's and the snapshot's grants remain.
+        state.release();
+
+        root.close(); // The snapshot still holds a grant, so the file survives.
+        assertThat(Files.exists(spill)).isTrue();
+
+        snapshot.close(); // No reader was ever opened: closing returns the snapshot's own grant.
+        assertThat(Files.exists(spill)).isFalse();
+
+        snapshot.close(); // Idempotent: no second release, no exception.
+        assertThatThrownBy(snapshot::reader).isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void testClosingSnapshotAfterOpeningReaderDoesNotDeleteFilesEarly() throws Exception {
+        InputChannelInfo ch = new InputChannelInfo(0, 0);
+
+        FetchedChannelState state;
+        try (TestSpillWriter writer = new TestSpillWriter(tempDir)) {
+            writer.writeRecord(ch, bytes(1), 1);
+            state = writer.getChannelState();
+        }
+
+        Path spill = state.files().get(0);
+
+        FetchedChannelStateReader root = state.reader();
+        FetchedChannelStateSnapshot snapshot = root.snapshot();
+        FetchedChannelStateReader snapReader = snapshot.reader();
+        state.release();
+        root.close();
+
+        // The grant moved to the reader, so closing the snapshot must not drop it.
+        snapshot.close();
+        assertThat(Files.exists(spill)).isTrue();
+
+        snapReader.close();
+        assertThat(Files.exists(spill)).isFalse();
+    }
+
+    @Test
+    void testSnapshotKeepsFilesAliveUntilSnapshotClosed() throws Exception {
+        InputChannelInfo ch = new InputChannelInfo(0, 0);
+
+        FetchedChannelState state;
+        try (TestSpillWriter writer = new TestSpillWriter(tempDir)) {
+            writer.writeRecord(ch, bytes(1), 1);
+            state = writer.getChannelState();
+        }
+
+        Path spill = state.files().get(0);
+
+        FetchedChannelStateReader root = state.reader();
+        FetchedChannelStateReader snap = root.snapshot().reader();
+        // Drop the handoff grant so only the two reader grants remain outstanding.
+        state.release();
+
+        root.close(); // One grant released; file must still exist because snap holds another.
+        assertThat(java.nio.file.Files.exists(spill)).isTrue();
+
+        snap.close(); // Last grant released; file must be deleted.
+        assertThat(java.nio.file.Files.exists(spill)).isFalse();
+    }
+
+    // -------------------------------------------------------------------------------------------
+    // New behaviour: first-call exemption, fail-loud on body not consumed, empty reader
+    // -------------------------------------------------------------------------------------------
+
+    @Test
+    void testFirstNextSegmentCallDoesNotRequirePreviousBodyConsumed() throws Exception {
+        // The "previous body must be fully consumed" rule must not fire on the very first call
+        // because there is no previous segment.
+        FetchedChannelState state;
+        try (TestSpillWriter writer = new TestSpillWriter(tempDir)) {
+            writer.writeRecord(new InputChannelInfo(0, 0), bytes(1, 2), 2);
+            state = writer.getChannelState();
+        }
+
+        try (FetchedChannelStateReader reader = state.reader()) {
+            // Must not throw on the first call even though no body has been consumed before.
+            Optional<SpillSegment> seg = reader.advanceAndGetNextSegment();
+            assertThat(seg).isPresent();
+        }
+    }
+
+    @Test
+    void testNextSegmentThrowsWhenPreviousBodyNotFullyConsumed() throws Exception {
+        InputChannelInfo ch = new InputChannelInfo(0, 0);
+        InputChannelInfo ch2 = new InputChannelInfo(0, 1);
+
+        FetchedChannelState state;
+        try (TestSpillWriter writer = new TestSpillWriter(tempDir)) {
+            writer.writeRecord(ch, bytes(1, 2, 3, 4), 4);
+            writer.writeRecord(ch2, bytes(5, 6), 2);
+            state = writer.getChannelState();
+        }
+
+        try (FetchedChannelStateReader reader = state.reader()) {
+            SpillSegment seg = reader.advanceAndGetNextSegment().orElseThrow(AssertionError::new);
+            // Read only part of the body — do not exhaust it.
+            seg.bodyStream().read();
+
+            // Advancing to the next segment while the previous body is not fully consumed must fail
+            // loud.
+            assertThatThrownBy(reader::advanceAndGetNextSegment)
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("Previous segment body not fully consumed");
+        }
+    }
+
+    @Test
+    void testEmptyReaderNextSegmentReturnsEmptyAndCloseIsClean() throws Exception {
+        FetchedChannelState state = new FetchedChannelState(Collections.emptyList());
+        try (FetchedChannelStateReader reader = state.reader()) {
+            // First call on an empty reader must return empty without throwing.
+            assertThat(reader.advanceAndGetNextSegment()).isEmpty();
+            // Closing must not throw.
+        }
+    }
+
+    @Test
+    void testEmptySnapshotHandsOutIndependentReadersSoCloseDoesNotLeak() throws Exception {
+        // An empty snapshot is created and closed once per checkpoint. close() is single-use (it
+        // flips the closed flag permanently), so each call must yield a fresh instance; otherwise
+        // the first consumer's close would make every later consumer's advanceAndGetNextSegment()
+        // fail loud.
+        FetchedChannelStateReader first = FetchedChannelState.emptySnapshot().reader();
+        assertThat(first.advanceAndGetNextSegment()).isEmpty();
+        first.close();
+
+        FetchedChannelStateReader second = FetchedChannelState.emptySnapshot().reader();
+        assertThat(second).isNotSameAs(first);
+        // Must still work after the previously obtained empty reader was closed.
+        assertThat(second.advanceAndGetNextSegment()).isEmpty();
+        second.close();
+    }
+
+    // -------------------------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------------------------
+
+    private static byte[] readAll(InputStream in) throws IOException {
+        java.io.ByteArrayOutputStream out = new java.io.ByteArrayOutputStream();
+        byte[] buf = new byte[256];
+        int n;
+        while ((n = in.read(buf)) != -1) {
+            out.write(buf, 0, n);
+        }
+        return out.toByteArray();
+    }
+
+    private static byte[] bytes(int... values) {
+        byte[] arr = new byte[values.length];
+        for (int i = 0; i < values.length; i++) {
+            arr[i] = (byte) values[i];
+        }
+        return arr;
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/FetchedChannelStateTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/FetchedChannelStateTest.java
@@ -1,0 +1,189 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.checkpoint.channel;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Tests for {@link FetchedChannelState} lifecycle and file list management: reference counting
+ * (acquire/release pairing, zero-triggered file deletion, release-past-zero no-op), forced {@link
+ * FetchedChannelState#close()} cleanup, and the unmodifiable ordered file list.
+ */
+class FetchedChannelStateTest {
+
+    @TempDir Path tempDir;
+
+    @Test
+    void testInitialStateIsEmpty() {
+        FetchedChannelState state = new FetchedChannelState(Collections.emptyList());
+        assertThat(state.files()).isEmpty();
+        assertThat(state.isClosed()).isFalse();
+    }
+
+    @Test
+    void testFileListPreservesOrder() throws IOException {
+        Path file0 = tempDir.resolve("spill-0.bin");
+        Path file1 = tempDir.resolve("spill-1.bin");
+
+        try (FetchedChannelState state = new FetchedChannelState(Arrays.asList(file0, file1))) {
+            assertThat(state.files()).containsExactly(file0, file1);
+        }
+    }
+
+    @Test
+    void testFilesListIsUnmodifiable() throws IOException {
+        try (FetchedChannelState state =
+                new FetchedChannelState(Collections.singletonList(tempDir.resolve("f0.bin")))) {
+            assertThatThrownBy(() -> state.files().add(tempDir.resolve("f1.bin")))
+                    .isInstanceOf(UnsupportedOperationException.class);
+        }
+    }
+
+    @Test
+    void testAcquireReleaseDoesNotDeleteFilesBeforeLastRelease() throws IOException {
+        Path realFile = tempDir.resolve("spill-0.bin");
+        realFile.toFile().createNewFile();
+        FetchedChannelState state = new FetchedChannelState(Collections.singletonList(realFile));
+
+        state.acquire();
+        state.acquire();
+
+        state.release();
+        // File must still exist after first release.
+        assertThat(realFile.toFile()).exists();
+
+        state.release();
+        // Last release should delete the file.
+        assertThat(realFile.toFile()).doesNotExist();
+        assertThat(state.isClosed()).isTrue();
+    }
+
+    @Test
+    void testCloseDeletesAllFiles() throws IOException {
+        Path file0 = tempDir.resolve("f0.bin");
+        Path file1 = tempDir.resolve("f1.bin");
+        file0.toFile().createNewFile();
+        file1.toFile().createNewFile();
+
+        FetchedChannelState state = new FetchedChannelState(Arrays.asList(file0, file1));
+
+        state.close();
+
+        assertThat(file0.toFile()).doesNotExist();
+        assertThat(file1.toFile()).doesNotExist();
+        assertThat(state.isClosed()).isTrue();
+    }
+
+    @Test
+    void testCloseIsIdempotent() throws IOException {
+        FetchedChannelState state = new FetchedChannelState(Collections.emptyList());
+        state.close();
+        assertThat(state.isClosed()).isTrue();
+        // Second close must not throw.
+        state.close();
+        assertThat(state.isClosed()).isTrue();
+    }
+
+    @Test
+    void testCloseAfterReleaseIsIdempotent() throws IOException {
+        FetchedChannelState state = new FetchedChannelState(Collections.emptyList());
+        state.acquire();
+        state.release();
+        assertThat(state.isClosed()).isTrue();
+        // close() after last release must be a no-op (no double-delete attempt).
+        state.close();
+        assertThat(state.isClosed()).isTrue();
+    }
+
+    @Test
+    void testReleaseAfterZeroIsNoOp() throws IOException {
+        FetchedChannelState state = newStateWithData();
+        // Release the single handoff grant the produced state already holds.
+        state.release();
+        assertFilesDeleted(state);
+
+        // Extra releases past zero must be a no-op.
+        state.release();
+        state.release();
+        assertFilesDeleted(state);
+    }
+
+    @Test
+    void testBalancedAcquireReleaseDeletesOnlyOnLastRelease() throws IOException {
+        FetchedChannelState state = newStateWithData();
+
+        // The produced state already holds one handoff grant.
+        state.acquire();
+        state.acquire();
+
+        state.release();
+        state.release();
+        assertFilesExist(state);
+
+        state.release();
+        assertFilesDeleted(state);
+    }
+
+    @Test
+    void testForceCloseCleansFilesAndToleratesLateRelease() throws IOException {
+        FetchedChannelState state = newStateWithData();
+        // The produced state already holds one handoff grant.
+        state.acquire();
+        assertFilesExist(state);
+
+        state.close();
+        assertFilesDeleted(state);
+
+        // Double close must be a no-op.
+        state.close();
+
+        // Late release after close must not re-delete or throw.
+        state.release();
+        assertFilesDeleted(state);
+    }
+
+    private FetchedChannelState newStateWithData() throws IOException {
+        try (TestSpillWriter writer = new TestSpillWriter(tempDir)) {
+            writer.writeRecord(new InputChannelInfo(0, 0), new byte[] {1, 2, 3}, 3);
+            writer.writeRecord(new InputChannelInfo(0, 1), new byte[] {4, 5}, 2);
+            return writer.getChannelState();
+        }
+    }
+
+    private static void assertFilesExist(FetchedChannelState state) {
+        for (Path file : state.files()) {
+            assertThat(file.toFile()).exists();
+        }
+    }
+
+    private static void assertFilesDeleted(FetchedChannelState state) {
+        for (Path file : state.files()) {
+            assertThat(file.toFile()).doesNotExist();
+        }
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/GateFilterHandlerBufferOwnershipTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/GateFilterHandlerBufferOwnershipTest.java
@@ -38,16 +38,14 @@ import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Tests buffer ownership semantics of {@link ChannelStateFilteringHandler.GateFilterHandler}. Each
- * test verifies that buffers are properly recycled on both success and failure paths.
+ * test verifies that source buffers are properly recycled on both success and failure paths.
  */
 class GateFilterHandlerBufferOwnershipTest {
 
@@ -60,13 +58,9 @@ class GateFilterHandlerBufferOwnershipTest {
                 createHandler(RecordFilter.acceptAll());
 
         Buffer sourceBuffer = createBufferWithRecords(1L, 2L);
-        List<Buffer> result = handler.filterAndRewrite(0, 0, sourceBuffer, this::createEmptyBuffer);
+        handler.filterAndRewrite(0, 0, sourceBuffer, new DataOutputSerializer(BUFFER_SIZE));
 
-        // sourceBuffer should be recycled by the deserializer after consumption
         assertThat(sourceBuffer.isRecycled()).isTrue();
-
-        // Clean up result buffers
-        result.forEach(Buffer::recycleBuffer);
     }
 
     @Test
@@ -75,102 +69,60 @@ class GateFilterHandlerBufferOwnershipTest {
         ChannelStateFilteringHandler.GateFilterHandler<Long> handler = createHandler(rejectAll);
 
         Buffer sourceBuffer = createBufferWithRecords(1L, 2L);
-        List<Buffer> result = handler.filterAndRewrite(0, 0, sourceBuffer, this::createEmptyBuffer);
+        handler.filterAndRewrite(0, 0, sourceBuffer, new DataOutputSerializer(BUFFER_SIZE));
 
-        assertThat(result).isEmpty();
-        // sourceBuffer should still be recycled even though no output was produced
         assertThat(sourceBuffer.isRecycled()).isTrue();
     }
 
     @Test
     void testSourceBufferRecycledOnInvalidVirtualChannel() {
-        // Create handler with KEY=(0,0) but call with (1,1) to trigger IllegalStateException
+        // Create handler with KEY=(0,0) but call with (1,1) to trigger IllegalStateException.
         ChannelStateFilteringHandler.GateFilterHandler<Long> handler =
                 createHandler(RecordFilter.acceptAll());
 
         Buffer sourceBuffer = createBufferWithRecords(1L);
 
         assertThatThrownBy(
-                        () -> handler.filterAndRewrite(1, 1, sourceBuffer, this::createEmptyBuffer))
+                        () ->
+                                handler.filterAndRewrite(
+                                        1, 1, sourceBuffer, new DataOutputSerializer(BUFFER_SIZE)))
                 .isInstanceOf(IllegalStateException.class);
 
-        // sourceBuffer must be recycled even when lookup fails before setNextBuffer
-        assertThat(sourceBuffer.isRecycled()).isTrue();
-    }
-
-    @Test
-    void testResultBuffersAndCurrentBufferRecycledOnSerializationError() throws Exception {
-        // Use a small buffer so that records span multiple buffers. The supplier fails on the
-        // second request, after the first output buffer has been filled and added to resultBuffers.
-        AtomicInteger bufferRequestCount = new AtomicInteger(0);
-        ChannelStateFilteringHandler.BufferSupplier failingSupplier =
-                () -> {
-                    if (bufferRequestCount.incrementAndGet() > 1) {
-                        throw new IOException("Simulated buffer allocation failure");
-                    }
-                    return createEmptyBuffer(13);
-                };
-
-        ChannelStateFilteringHandler.GateFilterHandler<Long> handler =
-                createHandler(RecordFilter.acceptAll());
-
-        Buffer sourceBuffer = createBufferWithRecords(1L, 2L, 3L, 4L, 5L);
-
-        // The exception should propagate; no buffer leak (no IllegalReferenceCountException
-        // from double-recycle).
-        assertThatThrownBy(() -> handler.filterAndRewrite(0, 0, sourceBuffer, failingSupplier))
-                .isInstanceOf(IOException.class)
-                .hasMessage("Simulated buffer allocation failure");
-
-        // sourceBuffer ownership was transferred to the deserializer via setNextBuffer().
-        // The deserializer may still hold it if it hasn't fully consumed the buffer before the
-        // error. Calling clear() triggers the cleanup chain:
-        // GateFilterHandler#clear() -> VirtualChannel#clear() -> deserializer.clear()
-        handler.clear();
+        // sourceBuffer must be recycled even when lookup fails before setNextBuffer.
         assertThat(sourceBuffer.isRecycled()).isTrue();
     }
 
     /**
-     * Tests the production cleanup path: when filterAndRewrite throws mid-processing, the
-     * deserializer may still hold sourceBuffer. In production, ChannelStateFilteringHandler is used
-     * in a try-with-resources block (see {@code SequentialChannelStateReaderImpl#readInputData}),
-     * so its close() is guaranteed to be called, which triggers clear() on all GateFilterHandlers
-     * and their deserializers. This test simulates that exact pattern.
+     * When filterAndRewrite throws mid-processing, the deserializer may still hold sourceBuffer. In
+     * production, ChannelStateFilteringHandler is used in a try-with-resources block (see {@code
+     * SequentialChannelStateReaderImpl#readInputData}), so its close() is guaranteed to be called,
+     * which triggers clear() on all GateFilterHandlers and their deserializers. This test simulates
+     * that exact pattern.
      */
     @Test
     void testCloseRecyclesDeserializerHeldBufferAfterError() throws Exception {
-        AtomicInteger bufferRequestCount = new AtomicInteger(0);
-        ChannelStateFilteringHandler.BufferSupplier failingSupplier =
-                () -> {
-                    if (bufferRequestCount.incrementAndGet() > 1) {
-                        throw new IOException("Simulated buffer allocation failure");
-                    }
-                    return createEmptyBuffer(13);
-                };
-
         ChannelStateFilteringHandler.GateFilterHandler<Long> gateHandler =
                 createHandler(RecordFilter.acceptAll());
-        // Wrap in ChannelStateFilteringHandler, the production-level owner
         ChannelStateFilteringHandler filteringHandler =
                 new ChannelStateFilteringHandler(
                         new ChannelStateFilteringHandler.GateFilterHandler<?>[] {gateHandler});
 
+        // A serializer that throws while writing the second record's length prefix, triggering a
+        // mid-processing failure after the first record has already been emitted.
+        DataOutputSerializer failingSerializer = new FailingAfterFirstRecordSerializer();
         Buffer sourceBuffer = createBufferWithRecords(1L, 2L, 3L, 4L, 5L);
 
-        // Simulate the production try-with-resources pattern
         assertThatThrownBy(
                         () -> {
                             try (ChannelStateFilteringHandler ignored = filteringHandler) {
                                 filteringHandler.filterAndRewrite(
-                                        0, 0, 0, sourceBuffer, failingSupplier);
+                                        0, 0, 0, sourceBuffer, failingSerializer);
                             }
                         })
                 .isInstanceOf(IOException.class)
-                .hasMessage("Simulated buffer allocation failure");
+                .hasMessage("Simulated write failure");
 
-        // After close(), the entire cleanup chain has fired:
-        // ChannelStateFilteringHandler.close() -> GateFilterHandler.clear()
-        //   -> VirtualChannel.clear() -> deserializer.clear() -> sourceBuffer.recycleBuffer()
+        // After close(), the entire cleanup chain has fired.
         assertThat(sourceBuffer.isRecycled()).isTrue();
     }
 
@@ -219,12 +171,26 @@ class GateFilterHandlerBufferOwnershipTest {
         }
     }
 
-    private Buffer createEmptyBuffer() {
-        return createEmptyBuffer(BUFFER_SIZE);
-    }
+    /**
+     * A {@link DataOutputSerializer} that throws an IOException while writing the second record's
+     * length prefix, simulating a failure mid-stream to verify that the source buffer is still
+     * recycled via the filtering handler's close() cleanup chain. Each surviving record begins with
+     * a {@code writeInt} placeholder for its length, so the second {@code writeInt} marks the start
+     * of the second record.
+     */
+    private static final class FailingAfterFirstRecordSerializer extends DataOutputSerializer {
+        private int writeIntCount = 0;
 
-    private Buffer createEmptyBuffer(int size) {
-        MemorySegment segment = MemorySegmentFactory.allocateUnpooledSegment(size);
-        return new NetworkBuffer(segment, FreeingBufferRecycler.INSTANCE);
+        FailingAfterFirstRecordSerializer() {
+            super(BUFFER_SIZE);
+        }
+
+        @Override
+        public void writeInt(int v) throws IOException {
+            if (++writeIntCount > 1) {
+                throw new IOException("Simulated write failure");
+            }
+            super.writeInt(v);
+        }
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/GateFilterHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/GateFilterHandlerTest.java
@@ -57,10 +57,10 @@ class GateFilterHandlerTest {
                 createHandler(RecordFilter.acceptAll());
 
         Buffer sourceBuffer = createBufferWithRecords(1L, 2L, 3L);
-        List<Buffer> result = handler.filterAndRewrite(0, 0, sourceBuffer, this::createEmptyBuffer);
+        DataOutputSerializer output = new DataOutputSerializer(BUFFER_SIZE);
+        handler.filterAndRewrite(0, 0, sourceBuffer, output);
 
-        // deserializeBuffers consumes (recycles) each buffer via the deserializer
-        List<Long> values = deserializeBuffers(result);
+        List<Long> values = readRecordsFromSerializer(output);
         assertThat(values).containsExactly(1L, 2L, 3L);
     }
 
@@ -70,9 +70,11 @@ class GateFilterHandlerTest {
         ChannelStateFilteringHandler.GateFilterHandler<Long> handler = createHandler(rejectAll);
 
         Buffer sourceBuffer = createBufferWithRecords(1L, 2L, 3L);
-        List<Buffer> result = handler.filterAndRewrite(0, 0, sourceBuffer, this::createEmptyBuffer);
+        DataOutputSerializer output = new DataOutputSerializer(BUFFER_SIZE);
+        handler.filterAndRewrite(0, 0, sourceBuffer, output);
 
-        assertThat(result).isEmpty();
+        // No bytes should be written when all records are filtered out.
+        assertThat(output.length()).isZero();
     }
 
     @Test
@@ -81,29 +83,11 @@ class GateFilterHandlerTest {
         ChannelStateFilteringHandler.GateFilterHandler<Long> handler = createHandler(keepEven);
 
         Buffer sourceBuffer = createBufferWithRecords(1L, 2L, 3L, 4L, 5L);
-        List<Buffer> result = handler.filterAndRewrite(0, 0, sourceBuffer, this::createEmptyBuffer);
+        DataOutputSerializer output = new DataOutputSerializer(BUFFER_SIZE);
+        handler.filterAndRewrite(0, 0, sourceBuffer, output);
 
-        List<Long> values = deserializeBuffers(result);
+        List<Long> values = readRecordsFromSerializer(output);
         assertThat(values).containsExactly(2L, 4L);
-    }
-
-    @Test
-    void testSmallOutputBufferProducesMultipleBuffers() throws Exception {
-        // Use a very small output buffer size so records must span multiple buffers
-        int smallBufferSize = 8;
-        ChannelStateFilteringHandler.GateFilterHandler<Long> handler =
-                createHandler(RecordFilter.acceptAll());
-
-        Buffer sourceBuffer = createBufferWithRecords(1L, 2L, 3L);
-        List<Buffer> result =
-                handler.filterAndRewrite(
-                        0, 0, sourceBuffer, () -> createEmptyBuffer(smallBufferSize));
-
-        // Each Long record needs 4 bytes length + ~9 bytes data > 8-byte buffer
-        assertThat(result.size()).isGreaterThan(1);
-
-        List<Long> values = deserializeBuffers(result);
-        assertThat(values).containsExactly(1L, 2L, 3L);
     }
 
     @Test
@@ -114,9 +98,35 @@ class GateFilterHandlerTest {
         Buffer emptyBuffer = createEmptyBuffer();
         emptyBuffer.setSize(0);
 
-        List<Buffer> result = handler.filterAndRewrite(0, 0, emptyBuffer, this::createEmptyBuffer);
+        DataOutputSerializer output = new DataOutputSerializer(BUFFER_SIZE);
+        handler.filterAndRewrite(0, 0, emptyBuffer, output);
 
-        assertThat(result).isEmpty();
+        // No data written for an empty source buffer.
+        assertThat(output.length()).isZero();
+    }
+
+    @Test
+    void testSourceBufferRecycledOnSuccess() throws Exception {
+        ChannelStateFilteringHandler.GateFilterHandler<Long> handler =
+                createHandler(RecordFilter.acceptAll());
+
+        Buffer sourceBuffer = createBufferWithRecords(1L, 2L);
+        DataOutputSerializer output = new DataOutputSerializer(BUFFER_SIZE);
+        handler.filterAndRewrite(0, 0, sourceBuffer, output);
+
+        assertThat(sourceBuffer.isRecycled()).isTrue();
+    }
+
+    @Test
+    void testSourceBufferRecycledWhenAllRecordsFilteredOut() throws Exception {
+        RecordFilter<Long> rejectAll = record -> false;
+        ChannelStateFilteringHandler.GateFilterHandler<Long> handler = createHandler(rejectAll);
+
+        Buffer sourceBuffer = createBufferWithRecords(1L, 2L);
+        DataOutputSerializer output = new DataOutputSerializer(BUFFER_SIZE);
+        handler.filterAndRewrite(0, 0, sourceBuffer, output);
+
+        assertThat(sourceBuffer.isRecycled()).isTrue();
     }
 
     // -------------------------------------------------------------------------------------------
@@ -141,23 +151,13 @@ class GateFilterHandlerTest {
     private Buffer createBufferWithRecords(Long... values) throws IOException {
         StreamElementSerializer<Long> serializer =
                 new StreamElementSerializer<>(LongSerializer.INSTANCE);
-        return serializeRecordsToBuffer(serializer, values);
-    }
-
-    /** Serializes records into a buffer using Flink's length-prefixed format. */
-    private Buffer serializeRecordsToBuffer(
-            StreamElementSerializer<Long> serializer, Long... values) throws IOException {
         DataOutputSerializer output = new DataOutputSerializer(BUFFER_SIZE);
 
         for (Long value : values) {
-            // Serialize using the same length-prefixed format as Flink
             DataOutputSerializer recordOutput = new DataOutputSerializer(64);
             serializer.serialize(new StreamRecord<>(value), recordOutput);
             int recordLength = recordOutput.length();
-
-            // Write 4-byte big-endian length prefix
             output.writeInt(recordLength);
-            // Write record bytes
             output.write(recordOutput.getSharedBuffer(), 0, recordLength);
         }
 
@@ -171,43 +171,49 @@ class GateFilterHandlerTest {
     }
 
     private Buffer createEmptyBuffer() {
-        return createEmptyBuffer(BUFFER_SIZE);
-    }
-
-    private Buffer createEmptyBuffer(int size) {
-        MemorySegment segment = MemorySegmentFactory.allocateUnpooledSegment(size);
+        MemorySegment segment = MemorySegmentFactory.allocateUnpooledSegment(BUFFER_SIZE);
         return new NetworkBuffer(segment, FreeingBufferRecycler.INSTANCE);
     }
 
-    private List<Long> deserializeBuffers(List<Buffer> buffers) throws IOException {
+    /**
+     * Deserializes the records the handler appended into {@code output}. The body format is
+     * repeated (4B recordLen + N bytes of serialized StreamElement), which the deserializer reads
+     * directly.
+     */
+    private List<Long> readRecordsFromSerializer(DataOutputSerializer output) throws Exception {
+        List<Long> values = new ArrayList<>();
         StreamElementSerializer<Long> serializer =
                 new StreamElementSerializer<>(LongSerializer.INSTANCE);
+        DeserializationDelegate<StreamElement> delegate =
+                new NonReusingDeserializationDelegate<>(serializer);
+
+        byte[] bodyBytes = output.getCopyOfBuffer();
+        if (bodyBytes.length == 0) {
+            return values;
+        }
+        MemorySegment memSeg = MemorySegmentFactory.allocateUnpooledSegment(bodyBytes.length);
+        memSeg.put(0, bodyBytes);
+        NetworkBuffer buf = new NetworkBuffer(memSeg, FreeingBufferRecycler.INSTANCE);
+        buf.setSize(bodyBytes.length);
+
         SpillingAdaptiveSpanningRecordDeserializer<DeserializationDelegate<StreamElement>>
                 deserializer =
                         new SpillingAdaptiveSpanningRecordDeserializer<>(
                                 new String[] {System.getProperty("java.io.tmpdir")});
-        DeserializationDelegate<StreamElement> delegate =
-                new NonReusingDeserializationDelegate<>(serializer);
+        deserializer.setNextBuffer(buf);
 
-        List<Long> values = new ArrayList<>();
-        for (Buffer buffer : buffers) {
-            deserializer.setNextBuffer(buffer);
-            while (true) {
-                RecordDeserializer.DeserializationResult result =
-                        deserializer.getNextRecord(delegate);
-                if (result.isFullRecord()) {
-                    StreamElement element = delegate.getInstance();
-                    if (element.isRecord()) {
-                        @SuppressWarnings("unchecked")
-                        StreamRecord<Long> record = (StreamRecord<Long>) element;
-                        values.add(record.getValue());
-                    }
-                }
-                if (result.isBufferConsumed()) {
-                    break;
+        RecordDeserializer.DeserializationResult result;
+        do {
+            result = deserializer.getNextRecord(delegate);
+            if (result.isFullRecord()) {
+                StreamElement element = delegate.getInstance();
+                if (element.isRecord()) {
+                    @SuppressWarnings("unchecked")
+                    StreamRecord<Long> record = (StreamRecord<Long>) element;
+                    values.add(record.getValue());
                 }
             }
-        }
+        } while (!result.isBufferConsumed());
         return values;
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/InputChannelRecoveredStateHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/InputChannelRecoveredStateHandlerTest.java
@@ -32,7 +32,9 @@ import org.apache.flink.runtime.memory.MemoryManager;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
+import java.nio.file.Path;
 import java.util.HashSet;
 
 import static org.apache.flink.runtime.checkpoint.InflightDataRescalingDescriptorUtil.mappings;
@@ -42,6 +44,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Test of different implementation of {@link AbstractInputChannelRecoveredStateHandler}. */
 class InputChannelRecoveredStateHandlerTest extends RecoveredChannelStateHandlerTest {
+    @TempDir private Path tmpDir;
+
     private static final int preAllocatedSegments = 3;
     private NetworkBufferPool networkBufferPool;
     private SingleInputGate inputGate;
@@ -85,7 +89,8 @@ class InputChannelRecoveredStateHandlerTest extends RecoveredChannelStateHandler
                         }),
                 false,
                 null,
-                MemoryManager.DEFAULT_PAGE_SIZE);
+                MemoryManager.DEFAULT_PAGE_SIZE,
+                null);
     }
 
     private AbstractInputChannelRecoveredStateHandler buildMultiChannelHandler() {
@@ -114,34 +119,59 @@ class InputChannelRecoveredStateHandlerTest extends RecoveredChannelStateHandler
                         }),
                 false,
                 null,
-                MemoryManager.DEFAULT_PAGE_SIZE);
+                MemoryManager.DEFAULT_PAGE_SIZE,
+                null);
     }
 
     /** Builds a handler in filtering mode (non-null filtering handler, no-op stub). */
-    private FilteringHandler buildFilteringInputChannelStateHandler() {
+    private SpillingWithFilteringHandler buildFilteringInputChannelStateHandler() {
         // Empty GateFilterHandler array: filtering is "enabled" structurally, but no gate-level
         // filter logic runs. Suitable for exercising getBuffer() routing only.
         ChannelStateFilteringHandler stubFilteringHandler =
                 new ChannelStateFilteringHandler(
                         new ChannelStateFilteringHandler.GateFilterHandler[0]);
-        return (FilteringHandler)
-                AbstractInputChannelRecoveredStateHandler.create(
-                        new InputGate[] {inputGate},
-                        new InflightDataRescalingDescriptor(
-                                new InflightDataRescalingDescriptor
-                                                .InflightDataGateOrPartitionRescalingDescriptor[] {
-                                    new InflightDataRescalingDescriptor
-                                            .InflightDataGateOrPartitionRescalingDescriptor(
-                                            new int[] {1},
-                                            RescaleMappings.identity(1, 1),
-                                            new HashSet<>(),
-                                            InflightDataRescalingDescriptor
-                                                    .InflightDataGateOrPartitionRescalingDescriptor
-                                                    .MappingType.IDENTITY)
-                                }),
-                        true,
-                        stubFilteringHandler,
-                        MemoryManager.DEFAULT_PAGE_SIZE);
+        // FLINK-38544 transitional: constructed directly because the factory still routes the
+        // flag-on filtering case to the in-memory FilteringHandler; goes back through
+        // AbstractInputChannelRecoveredStateHandler.create(...) when the spilling backend lands.
+        return new SpillingWithFilteringHandler(
+                new InputGate[] {inputGate},
+                new InflightDataRescalingDescriptor(
+                        new InflightDataRescalingDescriptor
+                                        .InflightDataGateOrPartitionRescalingDescriptor[] {
+                            new InflightDataRescalingDescriptor
+                                    .InflightDataGateOrPartitionRescalingDescriptor(
+                                    new int[] {1},
+                                    RescaleMappings.identity(1, 1),
+                                    new HashSet<>(),
+                                    InflightDataRescalingDescriptor
+                                            .InflightDataGateOrPartitionRescalingDescriptor
+                                            .MappingType.IDENTITY)
+                        }),
+                stubFilteringHandler,
+                MemoryManager.DEFAULT_PAGE_SIZE,
+                new String[] {tmpDir.toAbsolutePath().toString()});
+    }
+
+    private AbstractInputChannelRecoveredStateHandler buildSpillingNoFilteringHandler(
+            String[] spillTmpDirectories) {
+        // FLINK-38544 transitional: constructed directly because the factory still routes the
+        // flag-on no-filtering case to the in-memory NoSpillingHandler; goes back through
+        // AbstractInputChannelRecoveredStateHandler.create(...) when the spilling backend lands.
+        return new SpillingNoFilteringHandler(
+                new InputGate[] {inputGate},
+                new InflightDataRescalingDescriptor(
+                        new InflightDataRescalingDescriptor
+                                        .InflightDataGateOrPartitionRescalingDescriptor[] {
+                            new InflightDataRescalingDescriptor
+                                    .InflightDataGateOrPartitionRescalingDescriptor(
+                                    new int[] {1},
+                                    RescaleMappings.identity(1, 1),
+                                    new HashSet<>(),
+                                    InflightDataRescalingDescriptor
+                                            .InflightDataGateOrPartitionRescalingDescriptor
+                                            .MappingType.IDENTITY)
+                        }),
+                spillTmpDirectories);
     }
 
     @Test
@@ -192,7 +222,8 @@ class InputChannelRecoveredStateHandlerTest extends RecoveredChannelStateHandler
 
     @Test
     void testPreFilterBufferIsolationFromNetworkBufferPool() throws Exception {
-        try (FilteringHandler filteringHandler = buildFilteringInputChannelStateHandler()) {
+        try (SpillingWithFilteringHandler filteringHandler =
+                buildFilteringInputChannelStateHandler()) {
             int availableBefore = networkBufferPool.getNumberOfAvailableMemorySegments();
 
             RecoveredChannelStateHandler.BufferWithContext<Buffer> bufferWithContext =
@@ -233,7 +264,8 @@ class InputChannelRecoveredStateHandlerTest extends RecoveredChannelStateHandler
 
     @Test
     void testPreFilterSegmentReusedAcrossCalls() throws Exception {
-        try (FilteringHandler filteringHandler = buildFilteringInputChannelStateHandler()) {
+        try (SpillingWithFilteringHandler filteringHandler =
+                buildFilteringInputChannelStateHandler()) {
             // First getBuffer() lazily allocates the segment.
             RecoveredChannelStateHandler.BufferWithContext<Buffer> first =
                     filteringHandler.getBuffer(channelInfo);
@@ -262,7 +294,8 @@ class InputChannelRecoveredStateHandlerTest extends RecoveredChannelStateHandler
 
     @Test
     void testGetBufferThrowsWhenPriorBufferNotRecycled() throws Exception {
-        try (FilteringHandler filteringHandler = buildFilteringInputChannelStateHandler()) {
+        try (SpillingWithFilteringHandler filteringHandler =
+                buildFilteringInputChannelStateHandler()) {
             RecoveredChannelStateHandler.BufferWithContext<Buffer> first =
                     filteringHandler.getBuffer(channelInfo);
             try {
@@ -285,7 +318,7 @@ class InputChannelRecoveredStateHandlerTest extends RecoveredChannelStateHandler
 
     @Test
     void testPreFilterSegmentFreedOnClose() throws Exception {
-        FilteringHandler filteringHandler = buildFilteringInputChannelStateHandler();
+        SpillingWithFilteringHandler filteringHandler = buildFilteringInputChannelStateHandler();
         RecoveredChannelStateHandler.BufferWithContext<Buffer> bufferWithContext =
                 filteringHandler.getBuffer(channelInfo);
         bufferWithContext.context.recycleBuffer();
@@ -298,5 +331,14 @@ class InputChannelRecoveredStateHandlerTest extends RecoveredChannelStateHandler
 
         assertThat(segment.isFreed()).isTrue();
         assertThat(filteringHandler.getPreFilterSegmentForTesting()).isNull();
+    }
+
+    @Test
+    void testSpillingHandlerRequiresSpillDirectories() {
+        assertThatThrownBy(() -> buildSpillingNoFilteringHandler(null))
+                .isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> buildSpillingNoFilteringHandler(new String[0]))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("spillTmpDirectories must not be empty");
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/InputChannelRecoveredStateHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/InputChannelRecoveredStateHandlerTest.java
@@ -33,7 +33,9 @@ import org.apache.flink.runtime.memory.MemoryManager;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
@@ -46,6 +48,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Test of different implementation of {@link AbstractInputChannelRecoveredStateHandler}. */
 class InputChannelRecoveredStateHandlerTest extends RecoveredChannelStateHandlerTest {
+    @TempDir private Path tmpDir;
+
     private static final int preAllocatedSegments = 3;
     private NetworkBufferPool networkBufferPool;
     private SingleInputGate inputGate;
@@ -89,7 +93,8 @@ class InputChannelRecoveredStateHandlerTest extends RecoveredChannelStateHandler
                         }),
                 false,
                 null,
-                MemoryManager.DEFAULT_PAGE_SIZE);
+                MemoryManager.DEFAULT_PAGE_SIZE,
+                null);
     }
 
     private AbstractInputChannelRecoveredStateHandler buildMultiChannelHandler() {
@@ -118,19 +123,43 @@ class InputChannelRecoveredStateHandlerTest extends RecoveredChannelStateHandler
                         }),
                 false,
                 null,
-                MemoryManager.DEFAULT_PAGE_SIZE);
+                MemoryManager.DEFAULT_PAGE_SIZE,
+                null);
     }
 
     /** Builds a handler in filtering mode (non-null filtering handler, no-op stub). */
-    private FilteringHandler buildFilteringInputChannelStateHandler() {
+    private SpillingWithFilteringHandler buildFilteringInputChannelStateHandler() {
         // Empty GateFilterHandler array: filtering is "enabled" structurally, but no gate-level
         // filter logic runs. Suitable for exercising getBuffer() routing only.
-        return buildFilteringInputChannelStateHandler(
-                inputGate,
+        ChannelStateFilteringHandler stubFilteringHandler =
                 new ChannelStateFilteringHandler(
-                        new ChannelStateFilteringHandler.GateFilterHandler[0]));
+                        new ChannelStateFilteringHandler.GateFilterHandler[0]);
+        // FLINK-38544 transitional: constructed directly because the factory still routes the
+        // flag-on filtering case to the in-memory FilteringHandler; goes back through
+        // AbstractInputChannelRecoveredStateHandler.create(...) when the spilling backend lands.
+        return new SpillingWithFilteringHandler(
+                new InputGate[] {inputGate},
+                new InflightDataRescalingDescriptor(
+                        new InflightDataRescalingDescriptor
+                                        .InflightDataGateOrPartitionRescalingDescriptor[] {
+                            new InflightDataRescalingDescriptor
+                                    .InflightDataGateOrPartitionRescalingDescriptor(
+                                    new int[] {1},
+                                    RescaleMappings.identity(1, 1),
+                                    new HashSet<>(),
+                                    InflightDataRescalingDescriptor
+                                            .InflightDataGateOrPartitionRescalingDescriptor
+                                            .MappingType.IDENTITY)
+                        }),
+                stubFilteringHandler,
+                MemoryManager.DEFAULT_PAGE_SIZE,
+                new String[] {tmpDir.toAbsolutePath().toString()});
     }
 
+    /**
+     * Builds the in-memory filtering handler through the factory: the flag-on filtering case still
+     * routes there until the spilling backend lands.
+     */
     private FilteringHandler buildFilteringInputChannelStateHandler(
             SingleInputGate inputGate, ChannelStateFilteringHandler stubFilteringHandler) {
         return (FilteringHandler)
@@ -150,7 +179,30 @@ class InputChannelRecoveredStateHandlerTest extends RecoveredChannelStateHandler
                                 }),
                         true,
                         stubFilteringHandler,
-                        MemoryManager.DEFAULT_PAGE_SIZE);
+                        MemoryManager.DEFAULT_PAGE_SIZE,
+                        null);
+    }
+
+    private AbstractInputChannelRecoveredStateHandler buildSpillingNoFilteringHandler(
+            String[] spillTmpDirectories) {
+        // FLINK-38544 transitional: constructed directly because the factory still routes the
+        // flag-on no-filtering case to the in-memory NoSpillingHandler; goes back through
+        // AbstractInputChannelRecoveredStateHandler.create(...) when the spilling backend lands.
+        return new SpillingNoFilteringHandler(
+                new InputGate[] {inputGate},
+                new InflightDataRescalingDescriptor(
+                        new InflightDataRescalingDescriptor
+                                        .InflightDataGateOrPartitionRescalingDescriptor[] {
+                            new InflightDataRescalingDescriptor
+                                    .InflightDataGateOrPartitionRescalingDescriptor(
+                                    new int[] {1},
+                                    RescaleMappings.identity(1, 1),
+                                    new HashSet<>(),
+                                    InflightDataRescalingDescriptor
+                                            .InflightDataGateOrPartitionRescalingDescriptor
+                                            .MappingType.IDENTITY)
+                        }),
+                spillTmpDirectories);
     }
 
     @Test
@@ -201,7 +253,8 @@ class InputChannelRecoveredStateHandlerTest extends RecoveredChannelStateHandler
 
     @Test
     void testPreFilterBufferIsolationFromNetworkBufferPool() throws Exception {
-        try (FilteringHandler filteringHandler = buildFilteringInputChannelStateHandler()) {
+        try (SpillingWithFilteringHandler filteringHandler =
+                buildFilteringInputChannelStateHandler()) {
             int availableBefore = networkBufferPool.getNumberOfAvailableMemorySegments();
 
             RecoveredChannelStateHandler.BufferWithContext<Buffer> bufferWithContext =
@@ -242,7 +295,8 @@ class InputChannelRecoveredStateHandlerTest extends RecoveredChannelStateHandler
 
     @Test
     void testPreFilterSegmentReusedAcrossCalls() throws Exception {
-        try (FilteringHandler filteringHandler = buildFilteringInputChannelStateHandler()) {
+        try (SpillingWithFilteringHandler filteringHandler =
+                buildFilteringInputChannelStateHandler()) {
             // First getBuffer() lazily allocates the segment.
             RecoveredChannelStateHandler.BufferWithContext<Buffer> first =
                     filteringHandler.getBuffer(channelInfo);
@@ -271,7 +325,8 @@ class InputChannelRecoveredStateHandlerTest extends RecoveredChannelStateHandler
 
     @Test
     void testGetBufferThrowsWhenPriorBufferNotRecycled() throws Exception {
-        try (FilteringHandler filteringHandler = buildFilteringInputChannelStateHandler()) {
+        try (SpillingWithFilteringHandler filteringHandler =
+                buildFilteringInputChannelStateHandler()) {
             RecoveredChannelStateHandler.BufferWithContext<Buffer> first =
                     filteringHandler.getBuffer(channelInfo);
             try {
@@ -337,7 +392,7 @@ class InputChannelRecoveredStateHandlerTest extends RecoveredChannelStateHandler
 
     @Test
     void testPreFilterSegmentFreedOnClose() throws Exception {
-        FilteringHandler filteringHandler = buildFilteringInputChannelStateHandler();
+        SpillingWithFilteringHandler filteringHandler = buildFilteringInputChannelStateHandler();
         RecoveredChannelStateHandler.BufferWithContext<Buffer> bufferWithContext =
                 filteringHandler.getBuffer(channelInfo);
         bufferWithContext.context.recycleBuffer();
@@ -350,5 +405,14 @@ class InputChannelRecoveredStateHandlerTest extends RecoveredChannelStateHandler
 
         assertThat(segment.isFreed()).isTrue();
         assertThat(filteringHandler.getPreFilterSegmentForTesting()).isNull();
+    }
+
+    @Test
+    void testSpillingHandlerRequiresSpillDirectories() {
+        assertThatThrownBy(() -> buildSpillingNoFilteringHandler(null))
+                .isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> buildSpillingNoFilteringHandler(new String[0]))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("spillTmpDirectories must not be empty");
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/TestSpillWriter.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/TestSpillWriter.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.checkpoint.channel;
+
+import org.apache.flink.core.memory.DataOutputSerializer;
+import org.apache.flink.runtime.checkpoint.InflightDataRescalingDescriptor;
+import org.apache.flink.runtime.io.network.partition.consumer.InputGate;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.nio.file.Path;
+
+/**
+ * Test-only helper that produces spill files in the {@link AbstractSpillingHandler} on-disk format,
+ * exposing the same {@code writeRecord} / {@code writePassThrough} surface the readers and drainers
+ * are tested against. It drives a minimal concrete {@link AbstractSpillingHandler} so tests need
+ * not stand up real input gates or run the recovery loop.
+ */
+final class TestSpillWriter implements Closeable {
+
+    private final FormatHandler handler;
+
+    TestSpillWriter(Path baseDir) {
+        this(baseDir, AbstractSpillingHandler.DEFAULT_SPILL_FILE_SIZE_BYTES);
+    }
+
+    TestSpillWriter(Path baseDir, long maxFileSizeBytes) {
+        this.handler = new FormatHandler(new String[] {baseDir.toString()}, maxFileSizeBytes);
+    }
+
+    /** Appends one length-prefixed record, mirroring the filtering path. */
+    void writeRecord(InputChannelInfo channelInfo, byte[] record, int recordLength)
+            throws IOException {
+        DataOutputSerializer segment = handler.segmentSerializerFor(channelInfo);
+        segment.writeInt(recordLength);
+        segment.write(record, 0, recordLength);
+    }
+
+    /** Appends verbatim bytes, mirroring the pass-through path. */
+    void writePassThrough(InputChannelInfo channelInfo, byte[] data, int offset, int length)
+            throws IOException {
+        handler.segmentSerializerFor(channelInfo).write(data, offset, length);
+    }
+
+    /** Opens (or switches to) a segment without writing any body, to exercise empty segments. */
+    void openSegment(InputChannelInfo channelInfo) throws IOException {
+        handler.segmentSerializerFor(channelInfo);
+    }
+
+    /**
+     * Seals the spilled segments and returns the produced state, already holding one lifecycle
+     * grant for the caller. Returns {@code null} if nothing was ever written.
+     */
+    FetchedChannelState getChannelState() throws IOException {
+        handler.close();
+        return handler.getProducedChannelState();
+    }
+
+    @Override
+    public void close() throws IOException {
+        handler.close();
+    }
+
+    private static final class FormatHandler extends AbstractSpillingHandler {
+
+        FormatHandler(String[] spillTmpDirectories, long maxFileSizeBytes) {
+            super(
+                    new InputGate[0],
+                    InflightDataRescalingDescriptor.NO_RESCALE,
+                    spillTmpDirectories,
+                    maxFileSizeBytes);
+        }
+
+        @Override
+        public void recover(
+                InputChannelInfo info,
+                int oldSubtaskIndex,
+                BufferWithContext<org.apache.flink.runtime.io.network.buffer.Buffer> ctx) {
+            throw new UnsupportedOperationException("not used in format tests");
+        }
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/TestSpillWriter.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/TestSpillWriter.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.checkpoint.channel;
+
+import org.apache.flink.core.memory.DataOutputSerializer;
+import org.apache.flink.runtime.checkpoint.InflightDataRescalingDescriptor;
+import org.apache.flink.runtime.io.network.partition.consumer.InputGate;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.nio.file.Path;
+
+/**
+ * Test-only helper that produces spill files in the {@link AbstractSpillingHandler} on-disk format,
+ * exposing the same {@code writeRecord} / {@code writePassThrough} surface the readers and drainers
+ * are tested against. It drives a minimal concrete {@link AbstractSpillingHandler} so tests need
+ * not stand up real input gates or run the recovery loop.
+ */
+final class TestSpillWriter implements Closeable {
+
+    private final FormatHandler handler;
+
+    TestSpillWriter(Path baseDir) {
+        this(
+                baseDir,
+                AbstractSpillingHandler.DEFAULT_SPILL_FILE_SIZE_BYTES,
+                AbstractSpillingHandler.DEFAULT_MAX_SEGMENT_SIZE_BYTES);
+    }
+
+    TestSpillWriter(Path baseDir, long maxFileSizeBytes, int maxSegmentSizeBytes) {
+        this.handler =
+                new FormatHandler(
+                        new String[] {baseDir.toString()}, maxFileSizeBytes, maxSegmentSizeBytes);
+    }
+
+    /** Appends one length-prefixed record, mirroring the filtering path. */
+    void writeRecord(InputChannelInfo channelInfo, byte[] record, int recordLength)
+            throws IOException {
+        DataOutputSerializer segment = handler.segmentSerializerFor(channelInfo);
+        segment.writeInt(recordLength);
+        segment.write(record, 0, recordLength);
+    }
+
+    /** Appends verbatim bytes, mirroring the pass-through path. */
+    void writePassThrough(InputChannelInfo channelInfo, byte[] data, int offset, int length)
+            throws IOException {
+        handler.segmentSerializerFor(channelInfo).write(data, offset, length);
+    }
+
+    /** Opens (or switches to) a segment without writing any body, to exercise empty segments. */
+    void openSegment(InputChannelInfo channelInfo) throws IOException {
+        handler.segmentSerializerFor(channelInfo);
+    }
+
+    /**
+     * Seals the spilled segments and returns the produced state, already holding one lifecycle
+     * grant for the caller. Returns {@code null} if nothing was ever written.
+     */
+    FetchedChannelState getChannelState() throws IOException {
+        handler.close();
+        return handler.getProducedChannelState();
+    }
+
+    @Override
+    public void close() throws IOException {
+        handler.close();
+    }
+
+    private static final class FormatHandler extends AbstractSpillingHandler {
+
+        FormatHandler(
+                String[] spillTmpDirectories, long maxFileSizeBytes, int maxSegmentSizeBytes) {
+            super(
+                    new InputGate[0],
+                    InflightDataRescalingDescriptor.NO_RESCALE,
+                    spillTmpDirectories,
+                    maxFileSizeBytes,
+                    maxSegmentSizeBytes);
+        }
+
+        @Override
+        public void recover(
+                InputChannelInfo info,
+                int oldSubtaskIndex,
+                BufferWithContext<org.apache.flink.runtime.io.network.buffer.Buffer> ctx) {
+            throw new UnsupportedOperationException("not used in format tests");
+        }
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/streaming/runtime/io/checkpointing/ChannelStateTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/streaming/runtime/io/checkpointing/ChannelStateTest.java
@@ -21,6 +21,7 @@ package org.apache.flink.streaming.runtime.io.checkpointing;
 import org.apache.flink.runtime.checkpoint.CheckpointException;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
 import org.apache.flink.runtime.checkpoint.CheckpointType;
+import org.apache.flink.runtime.checkpoint.channel.FetchedChannelStateReader;
 import org.apache.flink.runtime.checkpoint.channel.InputChannelInfo;
 import org.apache.flink.runtime.checkpoint.channel.RecoveryCheckpointTrigger;
 import org.apache.flink.runtime.io.network.api.CheckpointBarrier;
@@ -97,8 +98,9 @@ class ChannelStateTest {
         }
 
         @Override
-        public void snapshotAndInsertBarriers(long checkpointId) {
+        public FetchedChannelStateReader snapshotAndInsertBarriers(long checkpointId) {
             trace.add("trigger.snapshotAndInsertBarriers:" + checkpointId);
+            return FetchedChannelStateReader.emptyReader();
         }
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/streaming/runtime/io/checkpointing/ChannelStateTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/streaming/runtime/io/checkpointing/ChannelStateTest.java
@@ -21,6 +21,8 @@ package org.apache.flink.streaming.runtime.io.checkpointing;
 import org.apache.flink.runtime.checkpoint.CheckpointException;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
 import org.apache.flink.runtime.checkpoint.CheckpointType;
+import org.apache.flink.runtime.checkpoint.channel.FetchedChannelState;
+import org.apache.flink.runtime.checkpoint.channel.FetchedChannelStateSnapshot;
 import org.apache.flink.runtime.checkpoint.channel.InputChannelInfo;
 import org.apache.flink.runtime.checkpoint.channel.RecoveryCheckpointTrigger;
 import org.apache.flink.runtime.io.network.api.CheckpointBarrier;
@@ -97,8 +99,9 @@ class ChannelStateTest {
         }
 
         @Override
-        public void snapshotAndInsertBarriers(long checkpointId) {
+        public FetchedChannelStateSnapshot snapshotAndInsertBarriers(long checkpointId) {
             trace.add("trigger.snapshotAndInsertBarriers:" + checkpointId);
+            return FetchedChannelState.emptySnapshot();
         }
     }
 


### PR DESCRIPTION
This PR depends on https://github.com/apache/flink/pull/28651, https://github.com/apache/flink/pull/28652, https://github.com/apache/flink/pull/28659 and https://github.com/apache/flink/pull/28660

Please only review the last 5 commits (prefixed [FLINK-39524]).

## What is the purpose of the change

[FLINK-39524] Fetched channel state: spill files, filtered write, reader.

It's part 5 of FLINK-38544 (checkpointing during recovery of unaligned checkpoint state). This PR introduces the on-disk subsystem for recovered channel state: an append-only segmented spill-file format written by the recovery read path (optionally through the rescale record filter), a ref-counted file container with snapshot/resume semantics, and a forward-only reader. Runtime behavior is unchanged: the handler factory does not select the new handlers, so no production path produces or consumes spill files.

## Brief change log

- [FLINK-39524][checkpoint] Add FetchedChannelState spill-file container
- [FLINK-39524][checkpoint] Spill-writing handlers: segmented on-disk format
- [FLINK-39524][checkpoint] Rewrite ChannelStateFilteringHandler to emit into a spill segment
- [FLINK-39524][checkpoint] Forward-only spill reader with snapshot/resume
- [FLINK-39524][checkpoint] SequentialChannelStateReader#readInputData returns Optional<FetchedChannelState>

## Verifying this change

- New unit tests: FetchedChannelStateTest, FetchedChannelStateRefCountTest, FetchedChannelStateReaderTest, AbstractSpillingHandlerTest, ChannelStateFilteringHandlerTest, GateFilterHandlerTest, GateFilterHandlerBufferOwnershipTest, RecoveredChannelStateHandlerFilterRoutingTest, SequentialChannelStateReaderImplTest
- RecoveredStateFilteringLargeRecordITCase stays green (the in-memory filtering path is untouched)

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
