### PR TITLE
[FLINK-40084][build] maven-shade-plugin does not respect multi release jars

### DIFF
--- a/flink-filesystems/flink-azure-fs-hadoop/pom.xml
+++ b/flink-filesystems/flink-azure-fs-hadoop/pom.xml
@@ -162,6 +162,15 @@ under the License.
 									</excludes>
 								</filter>
 							</filters>
+							<transformers combine.children="append">
+								<!-- Bundled flink-fs-hadoop-shaded carries relocated multi-release (jackson) classes;
+								     mark the resulting jar as multi-release so the JVM honours META-INF/versions entries. -->
+								<transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+									<manifestEntries>
+										<Multi-Release>true</Multi-Release>
+									</manifestEntries>
+								</transformer>
+							</transformers>
 						</configuration>
 					</execution>
 				</executions>

--- a/flink-filesystems/flink-fs-hadoop-shaded/pom.xml
+++ b/flink-filesystems/flink-fs-hadoop-shaded/pom.xml
@@ -239,6 +239,41 @@ under the License.
 									<pattern>com.fasterxml</pattern>
 									<shadedPattern>org.apache.flink.fs.shaded.hadoop3.com.fasterxml</shadedPattern>
 								</relocation>
+								<!--
+								Manually relocate multi-release classes to the correct shaded package. This is needed
+								due to a bug in the Maven Shade plugin, which only relocates the content but not
+								the package structure itself, see https://github.com/apache/maven-shade-plugin/issues/652
+								-->
+								<relocation>
+									<pattern>META-INF/versions/(\d+)/com/fasterxml/</pattern>
+									<shadedPattern>META-INF/versions/$1/org/apache/flink/fs/shaded/hadoop3/com/fasterxml/</shadedPattern>
+									<rawString>true</rawString>
+								</relocation>
+								<!--
+								Same maven-shade-plugin#652 workaround as the jackson relocation above, extended to every
+								relocated package: keep each dependency's multi-release (META-INF/versions/N) classes aligned
+								with its relocated base classes. No-op for non-multi-release jars.
+								-->
+								<relocation>
+									<pattern>META-INF/versions/(\d+)/com/google/re2j/</pattern>
+									<shadedPattern>META-INF/versions/$1/org/apache/flink/fs/shaded/hadoop3/com/google/re2j/</shadedPattern>
+									<rawString>true</rawString>
+								</relocation>
+								<relocation>
+									<pattern>META-INF/versions/(\d+)/org/apache/htrace/</pattern>
+									<shadedPattern>META-INF/versions/$1/org/apache/flink/fs/shaded/hadoop3/org/apache/htrace/</shadedPattern>
+									<rawString>true</rawString>
+								</relocation>
+								<relocation>
+									<pattern>META-INF/versions/(\d+)/org/codehaus/</pattern>
+									<shadedPattern>META-INF/versions/$1/org/apache/flink/fs/shaded/hadoop3/org/codehaus/</shadedPattern>
+									<rawString>true</rawString>
+								</relocation>
+								<relocation>
+									<pattern>META-INF/versions/(\d+)/com/ctc/</pattern>
+									<shadedPattern>META-INF/versions/$1/org/apache/flink/fs/shaded/hadoop3/com/ctc/</shadedPattern>
+									<rawString>true</rawString>
+								</relocation>
 								<relocation>
 									<pattern>org.codehaus</pattern>
 									<shadedPattern>org.apache.flink.fs.shaded.hadoop3.org.codehaus</shadedPattern>
@@ -256,9 +291,18 @@ under the License.
 										<exclude>PropertyList-1.0.dtd</exclude>
 										<exclude>META-INF/services/javax.xml.stream.*</exclude>
 										<exclude>META-INF/LICENSE.txt</exclude>
+										<!-- Drop stale JPMS descriptor; after relocation it points at packages that no longer exist. -->
+										<exclude>META-INF/**/module-info.class</exclude>
 									</excludes>
 								</filter>
 							</filters>
+							<transformers combine.children="append">
+								<transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+									<manifestEntries>
+										<Multi-Release>true</Multi-Release>
+									</manifestEntries>
+								</transformer>
+							</transformers>
 						</configuration>
 					</execution>
 				</executions>

--- a/flink-filesystems/flink-gs-fs-hadoop/pom.xml
+++ b/flink-filesystems/flink-gs-fs-hadoop/pom.xml
@@ -252,6 +252,15 @@ under the License.
 									</excludes>
 								</filter>
 							</filters>
+							<transformers combine.children="append">
+								<!-- Bundled flink-fs-hadoop-shaded carries relocated multi-release (jackson) classes;
+								     mark the resulting jar as multi-release so the JVM honours META-INF/versions entries. -->
+								<transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+									<manifestEntries>
+										<Multi-Release>true</Multi-Release>
+									</manifestEntries>
+								</transformer>
+							</transformers>
 						</configuration>
 					</execution>
 				</executions>

--- a/flink-filesystems/flink-oss-fs-hadoop/pom.xml
+++ b/flink-filesystems/flink-oss-fs-hadoop/pom.xml
@@ -178,6 +178,15 @@ under the License.
 									</excludes>
 								</filter>
 							</filters>
+							<transformers combine.children="append">
+								<!-- Bundled flink-fs-hadoop-shaded carries relocated multi-release (jackson) classes;
+								     mark the resulting jar as multi-release so the JVM honours META-INF/versions entries. -->
+								<transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+									<manifestEntries>
+										<Multi-Release>true</Multi-Release>
+									</manifestEntries>
+								</transformer>
+							</transformers>
 						</configuration>
 					</execution>
 				</executions>

--- a/flink-formats/flink-sql-avro-confluent-registry/pom.xml
+++ b/flink-formats/flink-sql-avro-confluent-registry/pom.xml
@@ -89,6 +89,41 @@ under the License.
 									<pattern>com.fasterxml.jackson</pattern>
 									<shadedPattern>org.apache.flink.avro.shaded.com.fasterxml.jackson</shadedPattern>
 								</relocation>
+								<!--
+								Manually relocate multi-release classes to the correct shaded package. This is needed
+								due to a bug in the Maven Shade plugin, which only relocates the content but not
+								the package structure itself, see https://github.com/apache/maven-shade-plugin/issues/652
+								-->
+								<relocation>
+									<pattern>META-INF/versions/(\d+)/com/fasterxml/jackson/</pattern>
+									<shadedPattern>META-INF/versions/$1/org/apache/flink/avro/shaded/com/fasterxml/jackson/</shadedPattern>
+									<rawString>true</rawString>
+								</relocation>
+								<!--
+								Same maven-shade-plugin#652 workaround as the jackson relocation above, extended to every
+								relocated package: keep each dependency's multi-release (META-INF/versions/N) classes aligned
+								with its relocated base classes. No-op for non-multi-release jars.
+								-->
+								<relocation>
+									<pattern>META-INF/versions/(\d+)/org/apache/kafka/</pattern>
+									<shadedPattern>META-INF/versions/$1/org/apache/flink/avro/registry/confluent/shaded/org/apache/kafka/</shadedPattern>
+									<rawString>true</rawString>
+								</relocation>
+								<relocation>
+									<pattern>META-INF/versions/(\d+)/io/confluent/</pattern>
+									<shadedPattern>META-INF/versions/$1/org/apache/flink/avro/registry/confluent/shaded/io/confluent/</shadedPattern>
+									<rawString>true</rawString>
+								</relocation>
+								<relocation>
+									<pattern>META-INF/versions/(\d+)/org/apache/avro/</pattern>
+									<shadedPattern>META-INF/versions/$1/org/apache/flink/avro/shaded/org/apache/avro/</shadedPattern>
+									<rawString>true</rawString>
+								</relocation>
+								<relocation>
+									<pattern>META-INF/versions/(\d+)/org/apache/commons/compress/</pattern>
+									<shadedPattern>META-INF/versions/$1/org/apache/flink/avro/shaded/org/apache/commons/compress/</shadedPattern>
+									<rawString>true</rawString>
+								</relocation>
 								<relocation>
 									<pattern>org.apache.avro</pattern>
 									<shadedPattern>org.apache.flink.avro.shaded.org.apache.avro</shadedPattern>
@@ -111,7 +146,20 @@ under the License.
 										<exclude>common/**</exclude>
 									</excludes>
 								</filter>
+								<filter>
+									<artifact>*:*</artifact>
+									<excludes>
+										<exclude>META-INF/**/module-info.class</exclude>
+									</excludes>
+								</filter>
 							</filters>
+							<transformers combine.children="append">
+								<transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+									<manifestEntries>
+										<Multi-Release>true</Multi-Release>
+									</manifestEntries>
+								</transformer>
+							</transformers>
 						</configuration>
 					</execution>
 				</executions>

--- a/flink-formats/flink-sql-avro/pom.xml
+++ b/flink-formats/flink-sql-avro/pom.xml
@@ -80,6 +80,31 @@ under the License.
 									<pattern>com.fasterxml.jackson</pattern>
 									<shadedPattern>org.apache.flink.avro.shaded.com.fasterxml.jackson</shadedPattern>
 								</relocation>
+								<!--
+								Manually relocate multi-release classes to the correct shaded package. This is needed
+								due to a bug in the Maven Shade plugin, which only relocates the content but not
+								the package structure itself, see https://github.com/apache/maven-shade-plugin/issues/652
+								-->
+								<relocation>
+									<pattern>META-INF/versions/(\d+)/com/fasterxml/jackson/</pattern>
+									<shadedPattern>META-INF/versions/$1/org/apache/flink/avro/shaded/com/fasterxml/jackson/</shadedPattern>
+									<rawString>true</rawString>
+								</relocation>
+								<!--
+								Same maven-shade-plugin#652 workaround as the jackson relocation above, extended to every
+								relocated package: keep each dependency's multi-release (META-INF/versions/N) classes aligned
+								with its relocated base classes. No-op for non-multi-release jars.
+								-->
+								<relocation>
+									<pattern>META-INF/versions/(\d+)/org/apache/commons/compress/</pattern>
+									<shadedPattern>META-INF/versions/$1/org/apache/flink/avro/shaded/org/apache/commons/compress/</shadedPattern>
+									<rawString>true</rawString>
+								</relocation>
+								<relocation>
+									<pattern>META-INF/versions/(\d+)/org/apache/avro/</pattern>
+									<shadedPattern>META-INF/versions/$1/org/apache/flink/avro/shaded/org/apache/avro/</shadedPattern>
+									<rawString>true</rawString>
+								</relocation>
 								<relocation>
 									<pattern>org.apache.commons.compress</pattern>
 									<shadedPattern>org.apache.flink.avro.shaded.org.apache.commons.compress</shadedPattern>
@@ -89,6 +114,21 @@ under the License.
 									<shadedPattern>org.apache.flink.avro.shaded.org.apache.avro</shadedPattern>
 								</relocation>
 							</relocations>
+							<filters>
+								<filter>
+									<artifact>*:*</artifact>
+									<excludes>
+										<exclude>META-INF/**/module-info.class</exclude>
+									</excludes>
+								</filter>
+							</filters>
+							<transformers combine.children="append">
+								<transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+									<manifestEntries>
+										<Multi-Release>true</Multi-Release>
+									</manifestEntries>
+								</transformer>
+							</transformers>
 						</configuration>
 					</execution>
 				</executions>

--- a/flink-kubernetes/pom.xml
+++ b/flink-kubernetes/pom.xml
@@ -220,6 +220,31 @@ under the License.
 									<pattern>META-INF/versions/9/org/yaml/snakeyaml</pattern>
 									<shadedPattern>META-INF/versions/9/org/apache/flink/kubernetes/shaded/org/yaml/snakeyaml</shadedPattern>
 								</relocation>
+								<!--
+								Same maven-shade-plugin#652 workaround as the jackson relocation above, extended to every
+								relocated package: keep each dependency's multi-release (META-INF/versions/N) classes aligned
+								with its relocated base classes. No-op for non-multi-release jars.
+								-->
+								<relocation>
+									<pattern>META-INF/versions/(\d+)/okhttp3/</pattern>
+									<shadedPattern>META-INF/versions/$1/org/apache/flink/kubernetes/shaded/okhttp3/</shadedPattern>
+									<rawString>true</rawString>
+								</relocation>
+								<relocation>
+									<pattern>META-INF/versions/(\d+)/okio/</pattern>
+									<shadedPattern>META-INF/versions/$1/org/apache/flink/kubernetes/shaded/okio/</shadedPattern>
+									<rawString>true</rawString>
+								</relocation>
+								<relocation>
+									<pattern>META-INF/versions/(\d+)/io/fabric8/</pattern>
+									<shadedPattern>META-INF/versions/$1/org/apache/flink/kubernetes/shaded/io/fabric8/</shadedPattern>
+									<rawString>true</rawString>
+								</relocation>
+								<relocation>
+									<pattern>META-INF/versions/(\d+)/org/snakeyaml/</pattern>
+									<shadedPattern>META-INF/versions/$1/org/apache/flink/kubernetes/shaded/org/snakeyaml/</shadedPattern>
+									<rawString>true</rawString>
+								</relocation>
 								<relocation>
 									<pattern>org.yaml</pattern>
 									<shadedPattern>org.apache.flink.kubernetes.shaded.org.yaml</shadedPattern>
@@ -229,6 +254,13 @@ under the License.
 								    <shadedPattern>org.apache.flink.kubernetes.shaded.io.fabric8</shadedPattern>
 								</relocation>
 							</relocations>
+							<transformers combine.children="append">
+								<transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+									<manifestEntries>
+										<Multi-Release>true</Multi-Release>
+									</manifestEntries>
+								</transformer>
+							</transformers>
 						</configuration>
 					</execution>
 				</executions>

--- a/flink-models/flink-model-openai/pom.xml
+++ b/flink-models/flink-model-openai/pom.xml
@@ -170,6 +170,31 @@ under the License.
 									<pattern>com.fasterxml.jackson</pattern>
 									<shadedPattern>org.apache.flink.model.openai.com.fasterxml.jackson</shadedPattern>
 								</relocation>
+								<!--
+								Manually relocate multi-release classes to the correct shaded package. This is needed
+								due to a bug in the Maven Shade plugin, which only relocates the content but not
+								the package structure itself, see https://github.com/apache/maven-shade-plugin/issues/652
+								-->
+								<relocation>
+									<pattern>META-INF/versions/(\d+)/com/fasterxml/jackson/</pattern>
+									<shadedPattern>META-INF/versions/$1/org/apache/flink/model/openai/com/fasterxml/jackson/</shadedPattern>
+									<rawString>true</rawString>
+								</relocation>
+								<!--
+								Same maven-shade-plugin#652 workaround as the jackson relocation above, extended to every
+								relocated package: keep each dependency's multi-release (META-INF/versions/N) classes aligned
+								with its relocated base classes. No-op for non-multi-release jars.
+								-->
+								<relocation>
+									<pattern>META-INF/versions/(\d+)/org/apache/httpcomponents/</pattern>
+									<shadedPattern>META-INF/versions/$1/org/apache/flink/model/openai/org/apache/httpcomponents/</shadedPattern>
+									<rawString>true</rawString>
+								</relocation>
+								<relocation>
+									<pattern>META-INF/versions/(\d+)/com/squareup/</pattern>
+									<shadedPattern>META-INF/versions/$1/org/apache/flink/model/openai/com/squareup/</shadedPattern>
+									<rawString>true</rawString>
+								</relocation>
 								<relocation>
 									<pattern>org.apache.httpcomponents</pattern>
 									<shadedPattern>org.apache.flink.model.openai.org.apache.httpcomponents</shadedPattern>
@@ -186,7 +211,20 @@ under the License.
 										<exclude>okhttp3/internal/publicsuffix/NOTICE</exclude>
 									</excludes>
 								</filter>
+								<filter>
+									<artifact>com.fasterxml.jackson*:*</artifact>
+									<excludes>
+										<exclude>META-INF/**/module-info.class</exclude>
+									</excludes>
+								</filter>
 							</filters>
+							<transformers combine.children="append">
+								<transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+									<manifestEntries>
+										<Multi-Release>true</Multi-Release>
+									</manifestEntries>
+								</transformer>
+							</transformers>
 						</configuration>
 					</execution>
 				</executions>

--- a/flink-models/flink-model-triton/pom.xml
+++ b/flink-models/flink-model-triton/pom.xml
@@ -161,6 +161,26 @@ under the License.
 									<pattern>com.fasterxml.jackson</pattern>
 									<shadedPattern>org.apache.flink.model.triton.com.fasterxml.jackson</shadedPattern>
 								</relocation>
+								<!--
+								Manually relocate multi-release classes to the correct shaded package. This is needed
+								due to a bug in the Maven Shade plugin, which only relocates the content but not
+								the package structure itself, see https://github.com/apache/maven-shade-plugin/issues/652
+								-->
+								<relocation>
+									<pattern>META-INF/versions/(\d+)/com/fasterxml/jackson/</pattern>
+									<shadedPattern>META-INF/versions/$1/org/apache/flink/model/triton/com/fasterxml/jackson/</shadedPattern>
+									<rawString>true</rawString>
+								</relocation>
+								<!--
+								Same maven-shade-plugin#652 workaround as the jackson relocation above, extended to every
+								relocated package: keep each dependency's multi-release (META-INF/versions/N) classes aligned
+								with its relocated base classes. No-op for non-multi-release jars.
+								-->
+								<relocation>
+									<pattern>META-INF/versions/(\d+)/com/squareup/</pattern>
+									<shadedPattern>META-INF/versions/$1/org/apache/flink/model/triton/com/squareup/</shadedPattern>
+									<rawString>true</rawString>
+								</relocation>
 								<relocation>
 									<pattern>com.squareup</pattern>
 									<shadedPattern>org.apache.flink.model.triton.com.squareup</shadedPattern>
@@ -173,7 +193,20 @@ under the License.
 										<exclude>okhttp3/internal/publicsuffix/NOTICE</exclude>
 									</excludes>
 								</filter>
+								<filter>
+									<artifact>com.fasterxml.jackson*:*</artifact>
+									<excludes>
+										<exclude>META-INF/**/module-info.class</exclude>
+									</excludes>
+								</filter>
 							</filters>
+							<transformers combine.children="append">
+								<transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+									<manifestEntries>
+										<Multi-Release>true</Multi-Release>
+									</manifestEntries>
+								</transformer>
+							</transformers>
 						</configuration>
 					</execution>
 				</executions>

--- a/flink-python/pom.xml
+++ b/flink-python/pom.xml
@@ -710,6 +710,8 @@ under the License.
 										<exclude>LICENSE</exclude>
 										<exclude>META-INF/LICENSE.txt</exclude>
 										<exclude>*.proto</exclude>
+										<!-- Drop stale JPMS descriptors from relocated multi-release jars (e.g. jackson, netty) -->
+										<exclude>META-INF/**/module-info.class</exclude>
 									</excludes>
 								</filter>
 							</filters>
@@ -730,6 +732,61 @@ under the License.
 									<shadedPattern>
 										org.apache.flink.api.python.shaded.com.fasterxml.jackson
 									</shadedPattern>
+								</relocation>
+								<!--
+								Manually relocate multi-release classes to the correct shaded package. This is needed
+								due to a bug in the Maven Shade plugin, which only relocates the content but not
+								the package structure itself, see https://github.com/apache/maven-shade-plugin/issues/652
+								-->
+								<relocation>
+									<pattern>META-INF/versions/(\d+)/com/fasterxml/jackson/</pattern>
+									<shadedPattern>META-INF/versions/$1/org/apache/flink/api/python/shaded/com/fasterxml/jackson/</shadedPattern>
+									<rawString>true</rawString>
+								</relocation>
+								<!--
+								Same maven-shade-plugin#652 workaround as the jackson relocation above, extended to every
+								relocated package: keep each dependency's multi-release (META-INF/versions/N) classes aligned
+								with its relocated base classes. No-op for non-multi-release jars.
+								-->
+								<relocation>
+									<pattern>META-INF/versions/(\d+)/py4j/</pattern>
+									<shadedPattern>META-INF/versions/$1/org/apache/flink/api/python/shaded/py4j/</shadedPattern>
+									<rawString>true</rawString>
+								</relocation>
+								<relocation>
+									<pattern>META-INF/versions/(\d+)/net/razorvine/</pattern>
+									<shadedPattern>META-INF/versions/$1/org/apache/flink/api/python/shaded/net/razorvine/</shadedPattern>
+									<rawString>true</rawString>
+								</relocation>
+								<relocation>
+									<pattern>META-INF/versions/(\d+)/org/joda/time/</pattern>
+									<shadedPattern>META-INF/versions/$1/org/apache/flink/api/python/shaded/org/joda/time/</shadedPattern>
+									<rawString>true</rawString>
+								</relocation>
+								<relocation>
+									<pattern>META-INF/versions/(\d+)/com/google/protobuf/</pattern>
+									<shadedPattern>META-INF/versions/$1/org/apache/flink/api/python/shaded/com/google/protobuf/</shadedPattern>
+									<rawString>true</rawString>
+								</relocation>
+								<relocation>
+									<pattern>META-INF/versions/(\d+)/org/apache/arrow/</pattern>
+									<shadedPattern>META-INF/versions/$1/org/apache/flink/api/python/shaded/org/apache/arrow/</shadedPattern>
+									<rawString>true</rawString>
+								</relocation>
+								<relocation>
+									<pattern>META-INF/versions/(\d+)/io/netty/</pattern>
+									<shadedPattern>META-INF/versions/$1/org/apache/flink/api/python/shaded/io/netty/</shadedPattern>
+									<rawString>true</rawString>
+								</relocation>
+								<relocation>
+									<pattern>META-INF/versions/(\d+)/com/google/flatbuffers/</pattern>
+									<shadedPattern>META-INF/versions/$1/org/apache/flink/api/python/shaded/com/google/flatbuffers/</shadedPattern>
+									<rawString>true</rawString>
+								</relocation>
+								<relocation>
+									<pattern>META-INF/versions/(\d+)/org/apache/avro/</pattern>
+									<shadedPattern>META-INF/versions/$1/org/apache/flink/avro/shaded/org/apache/avro/</shadedPattern>
+									<rawString>true</rawString>
 								</relocation>
 								<relocation>
 									<pattern>org.joda.time</pattern>
@@ -772,6 +829,13 @@ under the License.
 									</shadedPattern>
 								</relocation>
 							</relocations>
+							<transformers combine.children="append">
+								<transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+									<manifestEntries>
+										<Multi-Release>true</Multi-Release>
+									</manifestEntries>
+								</transformer>
+							</transformers>
 						</configuration>
 					</execution>
 				</executions>

--- a/flink-rpc/flink-rpc-akka/pom.xml
+++ b/flink-rpc/flink-rpc-akka/pom.xml
@@ -190,6 +190,8 @@ under the License.
 										<!-- Only parts of NOTICE file actually apply to the netty JAR and have been manually
 											 copied into this modules's NOTICE file. -->
 										<exclude>META-INF/NOTICE.txt</exclude>
+										<!-- Drop stale JPMS descriptor; after relocation it points at packages that no longer exist. -->
+										<exclude>META-INF/**/module-info.class</exclude>
 									</excludes>
 								</filter>
 								<filter>


### PR DESCRIPTION

## What is the purpose of the change

The PR is to address maven-shade-plugin issue and take into account multi-release jars

## Brief change log

poms

## Verifying this change

different jdks
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change the checkbox below to `[X]` followed by the name of the tool, and uncomment the
"Generated-by" line. See the ASF Generative Tooling Guidance for details:
https://www.apache.org/legal/generative-tooling.html

You are responsible for the quality and correctness of every change in this PR
regardless of the tooling used. Low-effort AI-generated PRs will be closed. See
AGENTS.md for the full guidance.
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name and Version]
-->
