### PR TITLE
[FLINK-34380][table] Fix incorrect RowKind in MiniBatch join when INSERT is folded with retract

### DIFF
--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/stream/bundle/InputSideHasUniqueKeyBundle.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/stream/bundle/InputSideHasUniqueKeyBundle.java
@@ -25,6 +25,7 @@ import org.apache.flink.types.RowKind;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -33,8 +34,23 @@ import java.util.Set;
 /** For the case that input has uniqueKey which is not contained by joinKey. */
 public class InputSideHasUniqueKeyBundle extends BufferBundle<Map<RowData, List<RowData>>> {
 
+    /**
+     * Tracks (joinKey → set of uniqueKeys) whose first accumulate record (+I) was folded away with
+     * a retract in the same batch. A subsequent +U for such a unique key must be treated as +I.
+     */
+    private final Map<RowData, Set<RowData>> insertedAndCleared = new HashMap<>();
+
     @Override
     public int addRecord(RowData joinKey, RowData uniqueKey, RowData record) {
+        Set<RowData> clearedKeys = insertedAndCleared.get(joinKey);
+        if (clearedKeys != null && clearedKeys.remove(uniqueKey)) {
+            if (clearedKeys.isEmpty()) {
+                insertedAndCleared.remove(joinKey);
+            }
+            if (record.getRowKind() == RowKind.UPDATE_AFTER) {
+                record.setRowKind(RowKind.INSERT);
+            }
+        }
         bundle.computeIfAbsent(joinKey, k -> new HashMap<>())
                 .computeIfAbsent(uniqueKey, k -> new ArrayList<>());
         if (!foldRecord(joinKey, uniqueKey, record)) {
@@ -44,6 +60,12 @@ public class InputSideHasUniqueKeyBundle extends BufferBundle<Map<RowData, List<
                     .add(record);
         }
         return ++count;
+    }
+
+    @Override
+    public void clear() {
+        super.clear();
+        insertedAndCleared.clear();
     }
 
     @Override
@@ -70,13 +92,16 @@ public class InputSideHasUniqueKeyBundle extends BufferBundle<Map<RowData, List<
     // +--------------------------+----------------------------+----------------------------+
     // |   Before the last        |       Last record          |          Result            |
     // |--------------------------|----------------------------|----------------------------|
-    // |    +I/+U                 |        +U/+I               |    Only keep the last      |
-    // |                          |                            |       (+U/+I) record       |
+    // |    +I                    |        +U                  |    Keep +U as +I           |
+    // |    +I/+U                 |        +I                  |    Only keep the last (+I) |
+    // |    +U                    |        +U                  |    Only keep the last (+U) |
     // |--------------------------|----------------------------|----------------------------|
     // |    -D/-U                 |        -D/-U               |    Only keep the last      |
     // |                          |                            |       (-D/-U) record       |
     // |--------------------------|----------------------------|----------------------------|
-    // |    +I/+U                 |        -U/-D               |       Clear both           |
+    // |    +I                    |        -U/-D               |    Clear both; mark key    |
+    // |                          |                            |    in insertedAndCleared   |
+    // |    +U                    |        -U/-D               |       Clear both           |
     // +--------------------------+----------------------------+----------------------------+
 
     /**
@@ -96,6 +121,16 @@ public class InputSideHasUniqueKeyBundle extends BufferBundle<Map<RowData, List<
             if (RowDataUtil.isAccumulateMsg(last)) {
                 if (RowDataUtil.isRetractMsg(record)) {
                     shouldFoldRecord = true;
+                    if (last.getRowKind() == RowKind.INSERT) {
+                        // State was empty before this batch; track so a later +U is corrected.
+                        insertedAndCleared
+                                .computeIfAbsent(joinKey, k -> new HashSet<>())
+                                .add(uniqueKey);
+                    }
+                } else if (last.getRowKind() == RowKind.INSERT
+                        && record.getRowKind() == RowKind.UPDATE_AFTER) {
+                    // +I followed by +U within one batch: the net effect is an INSERT.
+                    record.setRowKind(RowKind.INSERT);
                 }
                 actualSize--;
                 list.remove(list.size() - 1);

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/stream/bundle/JoinKeyContainsUniqueKeyBundle.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/stream/bundle/JoinKeyContainsUniqueKeyBundle.java
@@ -25,9 +25,11 @@ import org.apache.flink.types.RowKind;
 import javax.annotation.Nullable;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 /**
  * For the case that input has joinKey contains uniqueKey. The size of records in state is not
@@ -35,14 +37,30 @@ import java.util.Optional;
  */
 public class JoinKeyContainsUniqueKeyBundle extends BufferBundle<List<RowData>> {
 
+    /**
+     * Tracks join keys whose first accumulate record (+I) was folded away together with a retract
+     * within the same batch, leaving state effectively empty. A subsequent +U for such a key must
+     * be treated as +I because no prior value exists downstream.
+     */
+    private final Set<RowData> insertedAndCleared = new HashSet<>();
+
     @Override
     public int addRecord(RowData joinKey, @Nullable RowData uniqueKey, RowData record) {
+        if (insertedAndCleared.remove(joinKey) && record.getRowKind() == RowKind.UPDATE_AFTER) {
+            record.setRowKind(RowKind.INSERT);
+        }
         bundle.computeIfAbsent(joinKey, key -> new ArrayList<>());
         if (!foldRecord(joinKey, record)) {
             actualSize++;
             bundle.computeIfAbsent(joinKey, key -> new ArrayList<>()).add(record);
         }
         return ++count;
+    }
+
+    @Override
+    public void clear() {
+        super.clear();
+        insertedAndCleared.clear();
     }
 
     @Override
@@ -60,13 +78,16 @@ public class JoinKeyContainsUniqueKeyBundle extends BufferBundle<List<RowData>> 
     // +--------------------------+----------------------------+----------------------------+
     // |   Before the last        |       Last record          |          Result            |
     // |--------------------------|----------------------------|----------------------------|
-    // |    +I/+U                 |        +U/+I               |    Only keep the last      |
-    // |                          |                            |       (+U/+I) record       |
+    // |    +I                    |        +U                  |    Keep +U as +I           |
+    // |    +I/+U                 |        +I                  |    Only keep the last (+I) |
+    // |    +U                    |        +U                  |    Only keep the last (+U) |
     // |--------------------------|----------------------------|----------------------------|
     // |    -D/-U                 |        -D/-U               |    Only keep the last      |
     // |                          |                            |       (-D/-U) record       |
     // |--------------------------|----------------------------|----------------------------|
-    // |    +I/+U                 |        -U/-D               |       Clear both           |
+    // |    +I                    |        -U/-D               |    Clear both; mark key    |
+    // |                          |                            |    in insertedAndCleared   |
+    // |    +U                    |        -U/-D               |       Clear both           |
     // +--------------------------+----------------------------+----------------------------+
 
     /**
@@ -87,6 +108,14 @@ public class JoinKeyContainsUniqueKeyBundle extends BufferBundle<List<RowData>> 
             if (RowDataUtil.isAccumulateMsg(last)) {
                 if (RowDataUtil.isRetractMsg(record)) {
                     shouldFoldRecord = true;
+                    if (last.getRowKind() == RowKind.INSERT) {
+                        // State was empty before this batch; track so a later +U is corrected.
+                        insertedAndCleared.add(joinKey);
+                    }
+                } else if (last.getRowKind() == RowKind.INSERT
+                        && record.getRowKind() == RowKind.UPDATE_AFTER) {
+                    // +I followed by +U within one batch: the net effect is an INSERT.
+                    record.setRowKind(RowKind.INSERT);
                 }
                 actualSize--;
                 list.remove(list.size() - 1);

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/join/stream/BufferBundleTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/join/stream/BufferBundleTest.java
@@ -229,8 +229,9 @@ class BufferBundleTest {
         // +--------------------------+----------------------------+----------------------------+
         // |   Before the last        |       Last record          |          Result            |
         // |--------------------------|----------------------------|----------------------------|
-        // |    +I/+U                 |        +U/+I               |    Only keep the last      |
-        // |                          |                            |       (+U/+I) record       |
+        // |    +I                    |        +U                  |    Keep +U as +I           |
+        // |    +I/+U                 |        +I                  |    Only keep the last (+I) |
+        // |    +U                    |        +U                  |    Only keep the last (+U) |
         // +--------------------------+----------------------------+----------------------------+
         List<RowData> records =
                 Stream.of(
@@ -272,7 +273,7 @@ class BufferBundleTest {
 
         List<RowData> expected =
                 Stream.of(
-                                updateAfterRecord(
+                                insertRecord(
                                         "Ord#1",
                                         "LineOrd#1",
                                         "7 Bellevue Drive, Pottstown, PL 19464"),
@@ -474,8 +475,9 @@ class BufferBundleTest {
         // +--------------------------+----------------------------+----------------------------+
         // |   Before the last        |       Last record          |          Result            |
         // |--------------------------|----------------------------|----------------------------|
-        // |         +I/+U            |        +U/+I               |    Only keep the last      |
-        // |                          |                            |       (+U/+I) record       |
+        // |         +I               |        +U                  |    Keep +U as +I           |
+        // |         +I/+U            |        +I                  |    Only keep the last (+I) |
+        // |         +U               |        +U                  |    Only keep the last (+U) |
         // |--------------------------|----------------------------|----------------------------|
         // |         +I/+U            |        -U/-D               |       Clear both           |
         // |--------------------------|----------------------------|----------------------------|
@@ -600,7 +602,7 @@ class BufferBundleTest {
         addRecordsToBuffer(records);
         List<RowData> result =
                 Stream.of(
-                                updateAfterRecord(
+                                insertRecord(
                                         "Ord#1",
                                         "LineOrd#1",
                                         "7 Bellevue Drive, Pottstown, PL 19464"),

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/join/stream/StreamingMiniBatchJoinOperatorTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/join/stream/StreamingMiniBatchJoinOperatorTest.java
@@ -396,7 +396,7 @@ final class StreamingMiniBatchJoinOperatorTest extends StreamingJoinOperatorTest
                         "LineOrd#6",
                         "RAILWAY"),
                 rowOfKind(
-                        RowKind.UPDATE_AFTER,
+                        RowKind.INSERT,
                         "Ord#2",
                         "LineOrd#1",
                         "4 Bellevue Drive, Pottstown, PB 19464",
@@ -564,6 +564,73 @@ final class StreamingMiniBatchJoinOperatorTest extends StreamingJoinOperatorTest
                         "TRUCK"));
     }
 
+    @Tag("miniBatchSize=4")
+    @Test
+    void testInnerJoinWithJoinKeyContainsUniqueKeyInsertThenUpdateAfterFoldEmitsInsert()
+            throws Exception {
+        // joinKey is LineOrd (same as uniqueKey for JoinKeyContainsUniqueKey)
+        // Batch: right +I, left +I, left -U, left +U  (4 records trigger the batch)
+        // Left fold: +I + -U folds to nothing; remaining +U has no prior state → must emit INSERT
+        testHarness.processElement2(insertRecord("Ord#X", "LineOrd#1", "AIR")); // right +I
+        testHarness.processElement1(
+                insertRecord(
+                        "Ord#1", "LineOrd#1", "3 Bellevue Drive, Pottstown, PA 19464")); // left +I
+        testHarness.processElement1(
+                updateBeforeRecord(
+                        "Ord#1",
+                        "LineOrd#1",
+                        "3 Bellevue Drive, Pottstown, PA 19464")); // left -U (+I -U folds away)
+        assertor.shouldEmitNothing(testHarness);
+        testHarness.processElement1(
+                updateAfterRecord(
+                        "Ord#2",
+                        "LineOrd#1",
+                        "4 Bellevue Drive, Pottstown, PB 19464")); // left +U (triggers batch)
+        assertor.shouldEmit(
+                testHarness,
+                rowOfKind(
+                        RowKind.INSERT,
+                        "Ord#2",
+                        "LineOrd#1",
+                        "4 Bellevue Drive, Pottstown, PB 19464",
+                        "Ord#X",
+                        "LineOrd#1",
+                        "AIR"));
+    }
+
+    @Tag("miniBatchSize=4")
+    @Test
+    void testInnerJoinWithHasUniqueKeyInsertThenUpdateAfterFoldEmitsInsert() throws Exception {
+        // joinKey is LineOrd, uniqueKey is Ord
+        // Batch: right +I(Ord#X), left +I(Ord#1), left -U(Ord#1), left +U(Ord#1) (4 triggers)
+        // Left fold for unique key Ord#1: +I + -U folds to nothing; +U follows → must emit INSERT
+        testHarness.processElement2(insertRecord("Ord#X", "LineOrd#1", "AIR")); // right +I
+        testHarness.processElement1(
+                insertRecord(
+                        "Ord#1", "LineOrd#1", "3 Bellevue Drive, Pottstown, PA 19464")); // left +I
+        testHarness.processElement1(
+                updateBeforeRecord(
+                        "Ord#1",
+                        "LineOrd#1",
+                        "3 Bellevue Drive, Pottstown, PA 19464")); // left -U (+I -U folds away)
+        assertor.shouldEmitNothing(testHarness);
+        testHarness.processElement1(
+                updateAfterRecord(
+                        "Ord#1",
+                        "LineOrd#1",
+                        "4 Bellevue Drive, Pottstown, PB 19464")); // left +U (triggers batch)
+        assertor.shouldEmit(
+                testHarness,
+                rowOfKind(
+                        RowKind.INSERT,
+                        "Ord#1",
+                        "LineOrd#1",
+                        "4 Bellevue Drive, Pottstown, PB 19464",
+                        "Ord#X",
+                        "LineOrd#1",
+                        "AIR"));
+    }
+
     @Tag("miniBatchSize=13")
     @Test
     void testInnerJoinWithHasUniqueKeyWithinBatch() throws Exception {
@@ -678,7 +745,7 @@ final class StreamingMiniBatchJoinOperatorTest extends StreamingJoinOperatorTest
         assertor.shouldEmit(
                 testHarness,
                 rowOfKind(
-                        RowKind.UPDATE_AFTER,
+                        RowKind.INSERT,
                         "Ord#4",
                         "LineOrd#4",
                         "xxx Bellevue Drive, Pottstown, PJ 19464",

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/join/stream/StreamingMiniBatchJoinOperatorTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/join/stream/StreamingMiniBatchJoinOperatorTest.java
@@ -631,6 +631,180 @@ final class StreamingMiniBatchJoinOperatorTest extends StreamingJoinOperatorTest
                         "AIR"));
     }
 
+    @Tag("miniBatchSize=4")
+    @Test
+    void testInnerJoinWithNoUniqueKeyInsertThenUpdateAfterFoldKeepsUpdateAfter() throws Exception {
+        // joinKey is LineOrd
+        // Batch: right +I, left +I, left -U, left +U  (4 records trigger the batch)
+        // Left fold: +I + -U folds to nothing; remaining +U keeps its RowKind without unique key
+        testHarness.processElement2(insertRecord("Ord#X", "LineOrd#1", "AIR")); // right +I
+        testHarness.processElement1(
+                insertRecord(
+                        "Ord#1", "LineOrd#1", "3 Bellevue Drive, Pottstown, PA 19464")); // left +I
+        testHarness.processElement1(
+                updateBeforeRecord(
+                        "Ord#1",
+                        "LineOrd#1",
+                        "3 Bellevue Drive, Pottstown, PA 19464")); // left -U (+I -U folds away)
+        assertor.shouldEmitNothing(testHarness);
+        testHarness.processElement1(
+                updateAfterRecord(
+                        "Ord#2",
+                        "LineOrd#1",
+                        "4 Bellevue Drive, Pottstown, PB 19464")); // left +U (triggers batch)
+        assertor.shouldEmit(
+                testHarness,
+                rowOfKind(
+                        RowKind.UPDATE_AFTER,
+                        "Ord#2",
+                        "LineOrd#1",
+                        "4 Bellevue Drive, Pottstown, PB 19464",
+                        "Ord#X",
+                        "LineOrd#1",
+                        "AIR"));
+    }
+
+    @Tag("miniBatchSize=2")
+    @Test
+    void testInnerJoinWithJoinKeyContainsUniqueKeyUpdateBeforeThenUpdateAfterKeepsUpdateAfter()
+            throws Exception {
+        // joinKey is LineOrd (same as uniqueKey for JoinKeyContainsUniqueKey)
+        testHarness.processElement2(insertRecord("Ord#X", "LineOrd#1", "AIR")); // right +I
+        testHarness.processElement1(
+                insertRecord(
+                        "Ord#1", "LineOrd#1", "3 Bellevue Drive, Pottstown, PA 19464")); // left +I
+        assertor.shouldEmit(
+                testHarness,
+                rowOfKind(
+                        RowKind.INSERT,
+                        "Ord#1",
+                        "LineOrd#1",
+                        "3 Bellevue Drive, Pottstown, PA 19464",
+                        "Ord#X",
+                        "LineOrd#1",
+                        "AIR"));
+
+        testHarness.processElement1(
+                updateBeforeRecord(
+                        "Ord#1", "LineOrd#1", "3 Bellevue Drive, Pottstown, PA 19464")); // left -U
+        assertor.shouldEmitNothing(testHarness);
+        testHarness.processElement1(
+                updateAfterRecord(
+                        "Ord#2", "LineOrd#1", "4 Bellevue Drive, Pottstown, PB 19464")); // left +U
+        assertor.shouldEmit(
+                testHarness,
+                rowOfKind(
+                        RowKind.UPDATE_BEFORE,
+                        "Ord#1",
+                        "LineOrd#1",
+                        "3 Bellevue Drive, Pottstown, PA 19464",
+                        "Ord#X",
+                        "LineOrd#1",
+                        "AIR"),
+                rowOfKind(
+                        RowKind.UPDATE_AFTER,
+                        "Ord#2",
+                        "LineOrd#1",
+                        "4 Bellevue Drive, Pottstown, PB 19464",
+                        "Ord#X",
+                        "LineOrd#1",
+                        "AIR"));
+    }
+
+    @Tag("miniBatchSize=2")
+    @Test
+    void testInnerJoinWithHasUniqueKeyUpdateBeforeThenUpdateAfterKeepsUpdateAfter()
+            throws Exception {
+        // joinKey is LineOrd, uniqueKey is Ord
+        testHarness.processElement2(insertRecord("Ord#X", "LineOrd#1", "AIR")); // right +I
+        testHarness.processElement1(
+                insertRecord(
+                        "Ord#1", "LineOrd#1", "3 Bellevue Drive, Pottstown, PA 19464")); // left +I
+        assertor.shouldEmit(
+                testHarness,
+                rowOfKind(
+                        RowKind.INSERT,
+                        "Ord#1",
+                        "LineOrd#1",
+                        "3 Bellevue Drive, Pottstown, PA 19464",
+                        "Ord#X",
+                        "LineOrd#1",
+                        "AIR"));
+
+        testHarness.processElement1(
+                updateBeforeRecord(
+                        "Ord#1", "LineOrd#1", "3 Bellevue Drive, Pottstown, PA 19464")); // left -U
+        assertor.shouldEmitNothing(testHarness);
+        testHarness.processElement1(
+                updateAfterRecord(
+                        "Ord#1", "LineOrd#1", "4 Bellevue Drive, Pottstown, PB 19464")); // left +U
+        assertor.shouldEmit(
+                testHarness,
+                rowOfKind(
+                        RowKind.UPDATE_BEFORE,
+                        "Ord#1",
+                        "LineOrd#1",
+                        "3 Bellevue Drive, Pottstown, PA 19464",
+                        "Ord#X",
+                        "LineOrd#1",
+                        "AIR"),
+                rowOfKind(
+                        RowKind.UPDATE_AFTER,
+                        "Ord#1",
+                        "LineOrd#1",
+                        "4 Bellevue Drive, Pottstown, PB 19464",
+                        "Ord#X",
+                        "LineOrd#1",
+                        "AIR"));
+    }
+
+    @Tag("miniBatchSize=2")
+    @Test
+    void testInnerJoinWithNoUniqueKeyUpdateBeforeThenUpdateAfterKeepsUpdateAfter()
+            throws Exception {
+        // joinKey is LineOrd
+        testHarness.processElement2(insertRecord("Ord#X", "LineOrd#1", "AIR")); // right +I
+        testHarness.processElement1(
+                insertRecord(
+                        "Ord#1", "LineOrd#1", "3 Bellevue Drive, Pottstown, PA 19464")); // left +I
+        assertor.shouldEmit(
+                testHarness,
+                rowOfKind(
+                        RowKind.INSERT,
+                        "Ord#1",
+                        "LineOrd#1",
+                        "3 Bellevue Drive, Pottstown, PA 19464",
+                        "Ord#X",
+                        "LineOrd#1",
+                        "AIR"));
+
+        testHarness.processElement1(
+                updateBeforeRecord(
+                        "Ord#1", "LineOrd#1", "3 Bellevue Drive, Pottstown, PA 19464")); // left -U
+        assertor.shouldEmitNothing(testHarness);
+        testHarness.processElement1(
+                updateAfterRecord(
+                        "Ord#2", "LineOrd#1", "4 Bellevue Drive, Pottstown, PB 19464")); // left +U
+        assertor.shouldEmitAll(
+                testHarness,
+                rowOfKind(
+                        RowKind.UPDATE_AFTER,
+                        "Ord#2",
+                        "LineOrd#1",
+                        "4 Bellevue Drive, Pottstown, PB 19464",
+                        "Ord#X",
+                        "LineOrd#1",
+                        "AIR"),
+                rowOfKind(
+                        RowKind.UPDATE_BEFORE,
+                        "Ord#1",
+                        "LineOrd#1",
+                        "3 Bellevue Drive, Pottstown, PA 19464",
+                        "Ord#X",
+                        "LineOrd#1",
+                        "AIR"));
+    }
+
     @Tag("miniBatchSize=13")
     @Test
     void testInnerJoinWithHasUniqueKeyWithinBatch() throws Exception {


### PR DESCRIPTION
## What is the purpose of the change

Fix MiniBatch join output RowKind when an INSERT is folded away with a retract in the same batch. A later UPDATE_AFTER for the same key should be emitted as INSERT if no prior row exists downstream.

## Brief change log

- Update `InputSideHasUniqueKeyBundle#addRecord` and `foldRecord` to track insert-and-cleared unique keys and convert the following UPDATE_AFTER to INSERT.
- Update `JoinKeyContainsUniqueKeyBundle#addRecord` and `foldRecord` with the same correction for join keys that contain the unique key.
- Clear the inserted-and-cleared tracking state when the bundle is cleared.

## Verifying this change

Updated `BufferBundleTest` to assert that `+I` followed by `+U` keeps the latest record as INSERT. Updated `StreamingMiniBatchJoinOperatorTest` with MiniBatch join cases for both join-key-contains-unique-key and input-side-has-unique-key paths, asserting that a `+I/-U/+U` sequence emits INSERT.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): yes
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable