### PR TITLE
[FLINK-39784][table] Forbid SNAPSHOT function outside LATERAL context

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/logical/ForbidSnapshotOutsideLateralRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/logical/ForbidSnapshotOutsideLateralRule.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.rules.logical;
+
+import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.planner.plan.nodes.logical.FlinkLogicalTableFunctionScan;
+import org.apache.flink.table.planner.plan.utils.LateralSnapshotJoinUtil;
+
+import org.apache.calcite.plan.RelOptRuleCall;
+import org.apache.calcite.plan.RelRule;
+import org.apache.calcite.rex.RexCall;
+import org.immutables.value.Value;
+
+/**
+ * Rejects any {@link FlinkLogicalTableFunctionScan} that is still backed by the built-in {@code
+ * SNAPSHOT} function, with a clear error message.
+ *
+ * <p>{@code SNAPSHOT} is a planner placeholder that is only valid as the build side of a {@code
+ * LATERAL} join, where {@link LogicalJoinToLateralSnapshotJoinRule} rewrites the surrounding join
+ * into a dedicated {@link
+ * org.apache.flink.table.planner.plan.nodes.logical.FlinkLogicalLateralSnapshotJoin} and removes
+ * the SNAPSHOT scan. This rule must therefore run <em>after</em> that rewrite (see {@code
+ * FlinkStreamRuleSets.LOGICAL_REWRITE}).
+ */
+@Value.Enclosing
+public class ForbidSnapshotOutsideLateralRule
+        extends RelRule<ForbidSnapshotOutsideLateralRule.ForbidSnapshotOutsideLateralRuleConfig> {
+
+    public static final ForbidSnapshotOutsideLateralRule INSTANCE =
+            ForbidSnapshotOutsideLateralRule.ForbidSnapshotOutsideLateralRuleConfig.DEFAULT
+                    .toRule();
+
+    private ForbidSnapshotOutsideLateralRule(ForbidSnapshotOutsideLateralRuleConfig config) {
+        super(config);
+    }
+
+    @Override
+    public boolean matches(RelOptRuleCall call) {
+        final FlinkLogicalTableFunctionScan scan = call.rel(0);
+        return scan.getCall() instanceof RexCall
+                && LateralSnapshotJoinUtil.isSnapshotCall((RexCall) scan.getCall());
+    }
+
+    @Override
+    public void onMatch(RelOptRuleCall call) {
+        throw new ValidationException(
+                "The SNAPSHOT function can only be used as the build side (right-hand side) of a "
+                        + "LATERAL join. It cannot be used as a standalone table function or "
+                        + "outside of a LATERAL context.");
+    }
+
+    /** Rule configuration. */
+    @Value.Immutable(singleton = false)
+    public interface ForbidSnapshotOutsideLateralRuleConfig extends RelRule.Config {
+
+        ForbidSnapshotOutsideLateralRule.ForbidSnapshotOutsideLateralRuleConfig DEFAULT =
+                ImmutableForbidSnapshotOutsideLateralRule.ForbidSnapshotOutsideLateralRuleConfig
+                        .builder()
+                        .build()
+                        .withOperandSupplier(
+                                b0 -> b0.operand(FlinkLogicalTableFunctionScan.class).anyInputs())
+                        .withDescription("ForbidSnapshotOutsideLateralRule");
+
+        @Override
+        default ForbidSnapshotOutsideLateralRule toRule() {
+            return new ForbidSnapshotOutsideLateralRule(this);
+        }
+    }
+}

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkStreamRuleSets.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkStreamRuleSets.scala
@@ -405,6 +405,9 @@ object FlinkStreamRuleSets {
     // Rewrites a join over a SNAPSHOT table function call into a dedicated
     // FlinkLogicalLateralSnapshotJoin for the LATERAL SNAPSHOT operator.
     LogicalJoinToLateralSnapshotJoinRule.INSTANCE,
+    // Rejects SNAPSHOT scans that survived the rewrite above, i.e. SNAPSHOT calls used outside a
+    // LATERAL context. Must run after LogicalJoinToLateralSnapshotJoinRule.
+    ForbidSnapshotOutsideLateralRule.INSTANCE,
     // Avoids accessing a field from the result (condition).
     PythonCalcSplitRule.SPLIT_CONDITION_REX_FIELD,
     // Avoids accessing a field from the result (projection).

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/stream/sql/SnapshotTableFunctionTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/stream/sql/SnapshotTableFunctionTest.java
@@ -19,6 +19,7 @@
 package org.apache.flink.table.planner.plan.stream.sql;
 
 import org.apache.flink.table.api.TableConfig;
+import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.planner.utils.TableTestBase;
 import org.apache.flink.table.planner.utils.TableTestUtil;
 
@@ -153,13 +154,14 @@ public class SnapshotTableFunctionTest extends TableTestBase {
 
     @Test
     void testFromContextRejectedOutsideLateral() {
-        // SNAPSHOT used outside a LATERAL context is not rewritten by the LATERAL SNAPSHOT rule and
-        // reaches the regular PTF physical rule. Because SNAPSHOT disables system arguments, that
-        // rule rejects it. FLINK-39784 will replace this with a clearer message
-        // ("SNAPSHOT can only be used inside a LATERAL clause").
+        // SNAPSHOT used outside a LATERAL context is not rewritten by the LATERAL SNAPSHOT rule.
+        // ForbidSnapshotOutsideLateralRule intercepts the surviving SNAPSHOT scan and rejects it
+        // with a clear message before it reaches the generic PTF translation.
         assertThatThrownBy(() -> util.verifyRelPlan("SELECT * FROM SNAPSHOT(input => TABLE Rates)"))
                 .satisfies(
                         anyCauseMatches(
-                                "Disabling system arguments is not supported for user-defined PTF."));
+                                ValidationException.class,
+                                "The SNAPSHOT function can only be used as the build side "
+                                        + "(right-hand side) of a LATERAL join"));
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

This PR builds on #28664 (FLINK-39783). Only the commits tagged with `FLINK-39784` are relevant for this PR.

## Brief change log

* add `ForbidSnapshotOutsideLateralRule` which throws an exception when it encounters a `FlinkLogicalTableFunctionScan` for a `SNAPSHOT` function.
* add `ForbidSnapshotOutsideLateralRule` to `LOGICAL_REWRITE` `RuleSet` after `LogicalJoinToLateralSnapshotJoinRule`, ensuring that the new rule is applied for all SNAPSHOT functions that were not rewritten be earlier rule(s).
* update a unit test to check on the new error message.

## Verifying this change

* updated the assertion of an existing test

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? n/a

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Co-authored-by: Claude Code 2.1.200 (Opus 4.8)