### PR TITLE
[FLINK-40079][table] Reject PTF calls with sys-args if they are disabled

### DIFF
--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/expressions/resolver/rules/ResolveCallByArgumentsRule.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/expressions/resolver/rules/ResolveCallByArgumentsRule.java
@@ -299,6 +299,9 @@ final class ResolveCallByArgumentsRule implements ResolverRule {
                                 functionName));
             }
 
+            SystemTypeInference.checkNoSystemArguments(
+                    inference.disableSystemArguments(), namedArgs.keySet(), functionName);
+
             fillInDefaultNamedArguments(declaredArgs, namedArgs);
             fillInPtfSpecificNamedArguments(
                     functionName, definition, declaredArgs, namedArgs, actualArgs);

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/SystemTypeInference.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/SystemTypeInference.java
@@ -147,8 +147,8 @@ public class SystemTypeInference {
             if (suppliedArgumentNames.contains(systemArg.getName())) {
                 throw new ValidationException(
                         String.format(
-                                "Invalid function call. The '%s' argument is not supported for "
-                                        + "function '%s' because it disables system arguments.",
+                                "Invalid function call. The '%s' argument is not supported "
+                                        + "because function '%s' does not use system arguments.",
                                 systemArg.getName(), functionName));
             }
         }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/SystemTypeInference.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/SystemTypeInference.java
@@ -46,6 +46,7 @@ import javax.annotation.Nullable;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -124,6 +125,33 @@ public class SystemTypeInference {
 
     public static boolean isInvalidUidForProcessTableFunction(String uid) {
         return !UID_FORMAT.test(uid);
+    }
+
+    /**
+     * Rejects the implicit system arguments ({@code on_time}, {@code uid}) for a function that
+     * disables them via {@link TypeInference#disableSystemArguments()}.
+     *
+     * <p>The system arguments are not part of such a function's signature. Enforcing this from
+     * every translation path (SQL operand checking and Table API call resolution) rejects them
+     * consistently, regardless of whether the function is processed by the generic PTF rule or a
+     * dedicated optimizer rule (e.g. ML_PREDICT, LATERAL SNAPSHOT).
+     */
+    public static void checkNoSystemArguments(
+            boolean sysArgsDisabled,
+            Collection<String> suppliedArgumentNames,
+            String functionName) {
+        if (!sysArgsDisabled) {
+            return;
+        }
+        for (StaticArgument systemArg : PROCESS_TABLE_FUNCTION_SYSTEM_ARGS) {
+            if (suppliedArgumentNames.contains(systemArg.getName())) {
+                throw new ValidationException(
+                        String.format(
+                                "Invalid function call. The '%s' argument is not supported for "
+                                        + "function '%s' because it disables system arguments.",
+                                systemArg.getName(), functionName));
+            }
+        }
     }
 
     // --------------------------------------------------------------------------------------------

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/calcite/FlinkCalciteSqlValidator.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/calcite/FlinkCalciteSqlValidator.java
@@ -34,7 +34,6 @@ import org.apache.flink.table.planner.functions.bridging.BridgingSqlFunction;
 import org.apache.flink.table.planner.plan.FlinkCalciteCatalogReader;
 import org.apache.flink.table.planner.plan.utils.FlinkRexUtil;
 import org.apache.flink.table.planner.utils.ShortcutUtils;
-import org.apache.flink.table.types.inference.StaticArgument;
 import org.apache.flink.table.types.inference.SystemTypeInference;
 import org.apache.flink.table.types.logical.DecimalType;
 
@@ -92,6 +91,7 @@ import java.math.BigDecimal;
 import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -463,34 +463,27 @@ public final class FlinkCalciteSqlValidator extends FlinkSqlParsingValidator {
     /**
      * Rejects the implicit PTF system arguments (on_time, uid) for functions that disable them.
      *
-     * <p>When a PTF sets {@code disableSystemArguments(true)}, the system arguments are not part of
-     * its signature. Enforcing this here covers all translation paths uniformly.
+     * <p>This must happen before Calcite permutes named arguments, because unknown named arguments
+     * are silently dropped during permutation and would otherwise be lost. The actual rule and
+     * error message live in {@link SystemTypeInference#checkNoSystemArguments} so that the Table
+     * API path (which resolves calls without this validator) enforces it identically.
      */
     private static void checkDisabledSystemArgs(SqlBasicCall call) {
-        if (!ShortcutUtils.isFunctionKind(call.getOperator(), FunctionKind.PROCESS_TABLE)) {
+        final SqlOperator operator = call.getOperator();
+        if (!(operator instanceof BridgingSqlFunction)
+                || !((BridgingSqlFunction) operator).getTypeInference().disableSystemArguments()) {
             return;
         }
-        if (!(call.getOperator() instanceof BridgingSqlFunction)) {
-            return;
-        }
-        final BridgingSqlFunction function = (BridgingSqlFunction) call.getOperator();
-        if (!function.getTypeInference().disableSystemArguments()) {
-            return;
-        }
-        final List<String> sysArgNames =
-                SystemTypeInference.PROCESS_TABLE_FUNCTION_SYSTEM_ARGS.stream()
-                        .map(StaticArgument::getName)
-                        .toList();
-
-        for (String argName : sysArgNames) {
-            if (extractOperandByArgName(call, argName) != null) {
-                throw new ValidationException(
-                        String.format(
-                                "Invalid function call. The '%s' argument is not supported for "
-                                        + "function '%s' because it disables system arguments.",
-                                argName, function.getName()));
+        final Set<String> suppliedArgNames = new HashSet<>();
+        for (SqlNode operand : call.getOperandList()) {
+            if (operand != null && operand.getKind() == SqlKind.ARGUMENT_ASSIGNMENT) {
+                final SqlNode nameNode = ((SqlCall) operand).operand(1);
+                if (nameNode instanceof SqlIdentifier) {
+                    suppliedArgNames.add(((SqlIdentifier) nameNode).getSimple());
+                }
             }
         }
+        SystemTypeInference.checkNoSystemArguments(true, suppliedArgNames, operator.getName());
     }
 
     @Override

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/calcite/FlinkCalciteSqlValidator.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/calcite/FlinkCalciteSqlValidator.java
@@ -30,9 +30,12 @@ import org.apache.flink.table.data.TimestampData;
 import org.apache.flink.table.functions.FunctionKind;
 import org.apache.flink.table.planner.catalog.CatalogSchemaModel;
 import org.apache.flink.table.planner.catalog.CatalogSchemaTable;
+import org.apache.flink.table.planner.functions.bridging.BridgingSqlFunction;
 import org.apache.flink.table.planner.plan.FlinkCalciteCatalogReader;
 import org.apache.flink.table.planner.plan.utils.FlinkRexUtil;
 import org.apache.flink.table.planner.utils.ShortcutUtils;
+import org.apache.flink.table.types.inference.StaticArgument;
+import org.apache.flink.table.types.inference.SystemTypeInference;
 import org.apache.flink.table.types.logical.DecimalType;
 
 import org.apache.calcite.plan.RelOptCluster;
@@ -383,6 +386,7 @@ public final class FlinkCalciteSqlValidator extends FlinkSqlParsingValidator {
 
         final SqlBasicCall call = (SqlBasicCall) node;
         checkNoNamedAndPositionalMixedArgs(call);
+        checkDisabledSystemArgs(call);
 
         // Special case for MODEL
         if (node instanceof SqlExplicitModelCall) {
@@ -453,6 +457,39 @@ public final class FlinkCalciteSqlValidator extends FlinkSqlParsingValidator {
                             + call.getOperator().getName()
                             + "'. Use either all positional arguments or all named arguments "
                             + "(e.g. arg => value).");
+        }
+    }
+
+    /**
+     * Rejects the implicit PTF system arguments (on_time, uid) for functions that disable them.
+     *
+     * <p>When a PTF sets {@code disableSystemArguments(true)}, the system arguments are not part of
+     * its signature. Enforcing this here covers all translation paths uniformly.
+     */
+    private static void checkDisabledSystemArgs(SqlBasicCall call) {
+        if (!ShortcutUtils.isFunctionKind(call.getOperator(), FunctionKind.PROCESS_TABLE)) {
+            return;
+        }
+        if (!(call.getOperator() instanceof BridgingSqlFunction)) {
+            return;
+        }
+        final BridgingSqlFunction function = (BridgingSqlFunction) call.getOperator();
+        if (!function.getTypeInference().disableSystemArguments()) {
+            return;
+        }
+        final List<String> sysArgNames =
+                SystemTypeInference.PROCESS_TABLE_FUNCTION_SYSTEM_ARGS.stream()
+                        .map(StaticArgument::getName)
+                        .toList();
+
+        for (String argName : sysArgNames) {
+            if (extractOperandByArgName(call, argName) != null) {
+                throw new ValidationException(
+                        String.format(
+                                "Invalid function call. The '%s' argument is not supported for "
+                                        + "function '%s' because it disables system arguments.",
+                                argName, function.getName()));
+            }
         }
     }
 

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/stream/sql/MLPredictTableFunctionTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/stream/sql/MLPredictTableFunctionTest.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 
+import static org.apache.flink.core.testutils.FlinkAssertions.anyCauseMatches;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Tests for model table value function in stream mode. */
@@ -102,5 +103,31 @@ public class MLPredictTableFunctionTest extends MLPredictTableFunctionTestBase {
                 .isInstanceOf(TableException.class)
                 .hasMessageContaining(
                         "StreamPhysicalMLPredictTableFunction doesn't support consuming update and delete changes which is produced by node TableSourceScan(table=[[default_catalog, default_database, CdcTable]], fields=[a, b])");
+    }
+
+    @Test
+    public void testOnTimeArgumentNotAllowed() {
+        // ML_PREDICT disables the implicit system arguments. Supplying `on_time` must be rejected
+        // at the SQL level even though ML_PREDICT is handled by a dedicated optimizer rule.
+        String sql =
+                "SELECT * FROM TABLE(ML_PREDICT(INPUT => TABLE MyTable, MODEL => MODEL MyModel, "
+                        + "ARGS => DESCRIPTOR(a, b), on_time => DESCRIPTOR(rowtime)))";
+        assertThatThrownBy(() -> util.verifyRelPlan(sql))
+                .satisfies(
+                        anyCauseMatches(
+                                "The 'on_time' argument is not supported for function 'ML_PREDICT' "
+                                        + "because it disables system arguments."));
+    }
+
+    @Test
+    public void testUidArgumentNotAllowed() {
+        String sql =
+                "SELECT * FROM TABLE(ML_PREDICT(INPUT => TABLE MyTable, MODEL => MODEL MyModel, "
+                        + "ARGS => DESCRIPTOR(a, b), uid => 'my-uid'))";
+        assertThatThrownBy(() -> util.verifyRelPlan(sql))
+                .satisfies(
+                        anyCauseMatches(
+                                "The 'uid' argument is not supported for function 'ML_PREDICT' "
+                                        + "because it disables system arguments."));
     }
 }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/stream/sql/MLPredictTableFunctionTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/stream/sql/MLPredictTableFunctionTest.java
@@ -77,8 +77,7 @@ public class MLPredictTableFunctionTest extends MLPredictTableFunctionTestBase {
     @Test
     public void testInputTableIsInsertOnlyStream() {
         String sql =
-                "SELECT *\n"
-                        + "FROM TABLE(ML_PREDICT(TABLE MyTable, MODEL MyModel, DESCRIPTOR(a, b)))";
+                "SELECT *\n" + "FROM ML_PREDICT(TABLE MyTable, MODEL MyModel, DESCRIPTOR(a, b))";
         util.verifyRelPlan(
                 sql,
                 JavaScalaConversionUtil.toScala(
@@ -110,24 +109,24 @@ public class MLPredictTableFunctionTest extends MLPredictTableFunctionTestBase {
         // ML_PREDICT disables the implicit system arguments. Supplying `on_time` must be rejected
         // at the SQL level even though ML_PREDICT is handled by a dedicated optimizer rule.
         String sql =
-                "SELECT * FROM TABLE(ML_PREDICT(INPUT => TABLE MyTable, MODEL => MODEL MyModel, "
-                        + "ARGS => DESCRIPTOR(a, b), on_time => DESCRIPTOR(rowtime)))";
+                "SELECT * FROM ML_PREDICT(INPUT => TABLE MyTable, MODEL => MODEL MyModel, "
+                        + "ARGS => DESCRIPTOR(a, b), on_time => DESCRIPTOR(rowtime))";
         assertThatThrownBy(() -> util.verifyRelPlan(sql))
                 .satisfies(
                         anyCauseMatches(
-                                "The 'on_time' argument is not supported for function 'ML_PREDICT' "
-                                        + "because it disables system arguments."));
+                                "The 'on_time' argument is not supported because function "
+                                        + "'ML_PREDICT' does not use system arguments."));
     }
 
     @Test
     void testUidArgumentNotAllowed() {
         String sql =
-                "SELECT * FROM TABLE(ML_PREDICT(INPUT => TABLE MyTable, MODEL => MODEL MyModel, "
-                        + "ARGS => DESCRIPTOR(a, b), uid => 'my-uid'))";
+                "SELECT * FROM ML_PREDICT(INPUT => TABLE MyTable, MODEL => MODEL MyModel, "
+                        + "ARGS => DESCRIPTOR(a, b), uid => 'my-uid')";
         assertThatThrownBy(() -> util.verifyRelPlan(sql))
                 .satisfies(
                         anyCauseMatches(
-                                "The 'uid' argument is not supported for function 'ML_PREDICT' "
-                                        + "because it disables system arguments."));
+                                "The 'uid' argument is not supported because function "
+                                        + "'ML_PREDICT' does not use system arguments."));
     }
 }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/stream/sql/MLPredictTableFunctionTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/stream/sql/MLPredictTableFunctionTest.java
@@ -106,7 +106,7 @@ public class MLPredictTableFunctionTest extends MLPredictTableFunctionTestBase {
     }
 
     @Test
-    public void testOnTimeArgumentNotAllowed() {
+    void testOnTimeArgumentNotAllowed() {
         // ML_PREDICT disables the implicit system arguments. Supplying `on_time` must be rejected
         // at the SQL level even though ML_PREDICT is handled by a dedicated optimizer rule.
         String sql =
@@ -120,7 +120,7 @@ public class MLPredictTableFunctionTest extends MLPredictTableFunctionTestBase {
     }
 
     @Test
-    public void testUidArgumentNotAllowed() {
+    void testUidArgumentNotAllowed() {
         String sql =
                 "SELECT * FROM TABLE(ML_PREDICT(INPUT => TABLE MyTable, MODEL => MODEL MyModel, "
                         + "ARGS => DESCRIPTOR(a, b), uid => 'my-uid'))";

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/stream/sql/ProcessTableFunctionTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/stream/sql/ProcessTableFunctionTest.java
@@ -309,6 +309,20 @@ class ProcessTableFunctionTest extends TableTestBase {
     }
 
     @Test
+    void testSystemArgRejectedByNameBeforeTypeCheck() {
+        // System arguments are rejected by name, rather than a type mismatch.
+        util.addTemporarySystemFunction("f", NoSystemArgsTableFunction.class);
+        assertThatThrownBy(
+                        () ->
+                                util.verifyRelPlan(
+                                        "SELECT * FROM f(r => TABLE t, i => 1, on_time => 1);"))
+                .satisfies(
+                        anyCauseMatches(
+                                "The 'on_time' argument is not supported because function "
+                                        + "'f' does not use system arguments."));
+    }
+
+    @Test
     void testSystemArgRejectedForDisabledPtfViaTableApi() {
         // The same enforcement applies to the Table API path, which resolves calls via
         // ResolveCallByArgumentsRule instead of the SQL validator.

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/stream/sql/ProcessTableFunctionTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/stream/sql/ProcessTableFunctionTest.java
@@ -294,8 +294,8 @@ class ProcessTableFunctionTest extends TableTestBase {
                                                 + "on_time => DESCRIPTOR(ts));"))
                 .satisfies(
                         anyCauseMatches(
-                                "The 'on_time' argument is not supported for function 'f' "
-                                        + "because it disables system arguments."));
+                                "The 'on_time' argument is not supported because function "
+                                        + "'f' does not use system arguments."));
     }
 
     @Test
@@ -304,8 +304,8 @@ class ProcessTableFunctionTest extends TableTestBase {
         assertThatThrownBy(() -> util.verifyRelPlan("SELECT * FROM f(i => 1, uid => 'my-uid');"))
                 .satisfies(
                         anyCauseMatches(
-                                "The 'uid' argument is not supported for function 'f' "
-                                        + "because it disables system arguments."));
+                                "The 'uid' argument is not supported because function "
+                                        + "'f' does not use system arguments."));
     }
 
     @Test
@@ -323,8 +323,8 @@ class ProcessTableFunctionTest extends TableTestBase {
                                                 lit("my-uid").asArgument("uid")))
                 .satisfies(
                         anyCauseMatches(
-                                "The 'uid' argument is not supported for function 'f' "
-                                        + "because it disables system arguments."));
+                                "The 'uid' argument is not supported because function "
+                                        + "'f' does not use system arguments."));
     }
 
     @Test

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/stream/sql/ProcessTableFunctionTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/stream/sql/ProcessTableFunctionTest.java
@@ -76,6 +76,7 @@ import static org.apache.flink.table.annotation.ArgumentTrait.ROW_SEMANTIC_TABLE
 import static org.apache.flink.table.annotation.ArgumentTrait.SET_SEMANTIC_TABLE;
 import static org.apache.flink.table.annotation.ArgumentTrait.SUPPORT_UPDATES;
 import static org.apache.flink.table.api.Expressions.$;
+import static org.apache.flink.table.api.Expressions.lit;
 import static org.apache.flink.table.api.Expressions.row;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -301,6 +302,25 @@ class ProcessTableFunctionTest extends TableTestBase {
     void testUidArgRejectedForDisabledPtf() {
         util.addTemporarySystemFunction("f", NoSystemArgsScalarFunction.class);
         assertThatThrownBy(() -> util.verifyRelPlan("SELECT * FROM f(i => 1, uid => 'my-uid');"))
+                .satisfies(
+                        anyCauseMatches(
+                                "The 'uid' argument is not supported for function 'f' "
+                                        + "because it disables system arguments."));
+    }
+
+    @Test
+    void testSystemArgRejectedForDisabledPtfViaTableApi() {
+        // The same enforcement applies to the Table API path, which resolves calls via
+        // ResolveCallByArgumentsRule instead of the SQL validator.
+        util.addTemporarySystemFunction("f", NoSystemArgsTableFunction.class);
+        assertThatThrownBy(
+                        () ->
+                                util.tableEnv()
+                                        .fromCall(
+                                                "f",
+                                                util.tableEnv().from("t").asArgument("r"),
+                                                lit(1).asArgument("i"),
+                                                lit("my-uid").asArgument("uid")))
                 .satisfies(
                         anyCauseMatches(
                                 "The 'uid' argument is not supported for function 'f' "

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/stream/sql/ProcessTableFunctionTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/stream/sql/ProcessTableFunctionTest.java
@@ -284,6 +284,30 @@ class ProcessTableFunctionTest extends TableTestBase {
     }
 
     @Test
+    void testOnTimeArgRejectedForDisabledPtf() {
+        util.addTemporarySystemFunction("f", NoSystemArgsTableFunction.class);
+        assertThatThrownBy(
+                        () ->
+                                util.verifyRelPlan(
+                                        "SELECT * FROM f(r => TABLE t_watermarked, i => 1, "
+                                                + "on_time => DESCRIPTOR(ts));"))
+                .satisfies(
+                        anyCauseMatches(
+                                "The 'on_time' argument is not supported for function 'f' "
+                                        + "because it disables system arguments."));
+    }
+
+    @Test
+    void testUidArgRejectedForDisabledPtf() {
+        util.addTemporarySystemFunction("f", NoSystemArgsScalarFunction.class);
+        assertThatThrownBy(() -> util.verifyRelPlan("SELECT * FROM f(i => 1, uid => 'my-uid');"))
+                .satisfies(
+                        anyCauseMatches(
+                                "The 'uid' argument is not supported for function 'f' "
+                                        + "because it disables system arguments."));
+    }
+
+    @Test
     void testUidPipelineSplitIntoTwoFunctions() {
         util.addTemporarySystemFunction("f", SetSemanticTableFunction.class);
         util.verifyExecPlan(

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/stream/sql/SnapshotTableFunctionTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/stream/sql/SnapshotTableFunctionTest.java
@@ -24,7 +24,6 @@ import org.apache.flink.table.planner.utils.TableTestBase;
 import org.apache.flink.table.planner.utils.TableTestUtil;
 
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import static org.apache.flink.core.testutils.FlinkAssertions.anyCauseMatches;
@@ -121,9 +120,6 @@ public class SnapshotTableFunctionTest extends TableTestBase {
     }
 
     @Test
-    @Disabled(
-            "SNAPSHOT sets disableSystemArguments(true), but that flag is currently not enforced. "
-                    + "Re-enable once FLINK-40079 is fixed.")
     void testSystemArgumentsNotAllowed() {
         // SNAPSHOT disables the implicit system arguments (e.g. `on_time`). Passing one in a
         // LATERAL context must be rejected because the argument is not part of the function
@@ -136,7 +132,10 @@ public class SnapshotTableFunctionTest extends TableTestBase {
                                                 + "input => TABLE Rates, "
                                                 + "on_time => DESCRIPTOR(rate_time))) AS r "
                                                 + "WHERE o.currency = r.currency"))
-                .satisfies(anyCauseMatches("on_time"));
+                .satisfies(
+                        anyCauseMatches(
+                                "The 'on_time' argument is not supported because function "
+                                        + "'SNAPSHOT' does not use system arguments."));
     }
 
     @Test

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/MLPredictTableFunctionTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/MLPredictTableFunctionTest.xml
@@ -869,7 +869,7 @@ Calc(select=[a, b, c, d, rowtime, PROCTIME_MATERIALIZE(proctime) AS proctime, c0
   <TestCase name="testInputTableIsInsertOnlyStream">
     <Resource name="sql">
       <![CDATA[SELECT *
-FROM TABLE(ML_PREDICT(TABLE MyTable, MODEL MyModel, DESCRIPTOR(a, b)))]]>
+FROM ML_PREDICT(TABLE MyTable, MODEL MyModel, DESCRIPTOR(a, b))]]>
     </Resource>
     <Resource name="ast">
       <![CDATA[


### PR DESCRIPTION
## What is the purpose of the change

Add a check in SqlValidator to reject PTF calls with system-args (`on_time`, `uid`) if the function disabled them.
Before, system-args were either accepted but ignored (custom implementation like MLPredict) or the generic PTF handling framework throws an exception later (this part is untouched because the execution framework expects these args in the function signature even if not set).

## Brief change log

* add check to `FlinkCalciteSqlValidator`
* add unit tests to `ProcessTableFunctionTest`
* add unit tests for `MLPredict` function

## Verifying this change

Added unit tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? n/A

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: Claude Code 2.1.200 (Opus 4.8)
