### PR TITLE
[FLINK-40088][tests] Tolerate HTTP-level responses in RestClientITCase TLS check

### DIFF
--- a/flink-end-to-end-tests/flink-end-to-end-tests-restclient/src/test/java/org/apache/flink/runtime/rest/RestClientITCase.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-restclient/src/test/java/org/apache/flink/runtime/rest/RestClientITCase.java
@@ -23,7 +23,9 @@ import org.apache.flink.runtime.rest.messages.EmptyMessageParameters;
 import org.apache.flink.runtime.rest.messages.EmptyRequestBody;
 import org.apache.flink.runtime.rest.messages.ResponseBody;
 import org.apache.flink.runtime.rest.messages.RuntimeMessageHeaders;
+import org.apache.flink.runtime.rest.util.RestClientException;
 import org.apache.flink.runtime.rest.versioning.RestAPIVersion;
+import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.TestLoggerExtension;
 import org.apache.flink.util.concurrent.Executors;
 
@@ -36,7 +38,10 @@ import java.net.URL;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashMap;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for {@link RestClient} that rely on external connections. */
 @ExtendWith(TestLoggerExtension.class)
@@ -51,14 +56,22 @@ class RestClientITCase {
                         "apache/flink/master/flink-runtime-web/web-dashboard/package.json");
         try (final RestClient restClient =
                 RestClient.forUrl(config, Executors.directExecutor(), httpsUrl)) {
-            restClient
-                    .sendRequest(
-                            httpsUrl.getHost(),
-                            443,
-                            testUrlMessageHeaders,
-                            EmptyMessageParameters.getInstance(),
-                            EmptyRequestBody.getInstance())
-                    .get(60, TimeUnit.SECONDS);
+            try {
+                restClient
+                        .sendRequest(
+                                httpsUrl.getHost(),
+                                443,
+                                testUrlMessageHeaders,
+                                EmptyMessageParameters.getInstance(),
+                                EmptyRequestBody.getInstance())
+                        .get(60, TimeUnit.SECONDS);
+            } catch (ExecutionException e) {
+                // A 429/non-JSON body arrives as RestClientException only after a successful TLS
+                // handshake; a cert/trust failure surfaces as SSLException instead.
+                assertThat(ExceptionUtils.findThrowable(e, RestClientException.class))
+                        .as("expected an HTTP response proving the TLS handshake succeeded")
+                        .isPresent();
+            }
         }
     }
 


### PR DESCRIPTION
## What is the purpose of the change

Stabilize `RestClientITCase#testHttpsConnectionWithDefaultCerts`. The test proves that `RestClient` completes a TLS handshake against a public CA-signed endpoint using the default JDK truststore, but it additionally required the response body to be valid JSON. On GitHub Actions, runners share egress IPs and GitHub periodically returns a plain-text `429 Too Many Requests`, failing the test even though the handshake — the thing under test — succeeded (example: master run [28791132983](https://github.com/apache/flink/actions/runs/28791132983), leg "Default (Java 17) / E2E (group 4)").

A `RestClientException` is only produced in `RestClient#readRawResponse` after a full HTTP response has been received, i.e. after a successful handshake; a genuine certificate/trust failure surfaces as an `SSLException` from Netty's `SslHandler` instead. The test now asserts on exactly that distinction.

## Brief change log

  - On a failed request, assert that the failure chain contains a `RestClientException` (proof an HTTP-layer response arrived, hence the default-truststore handshake completed).
  - Tolerates 429/403/5xx/non-JSON bodies; still fails on SSL/certificate regressions, and also on connection-level failures (connection refused, DNS, reset) where no handshake occurred.

## Verifying this change

This change is a test-only stabilization, verified by running the test (`-Prun-end-to-end-tests`) in three configurations:

  - Against the regular endpoint (valid TLS, JSON body): passes.
  - Temporarily pointed at a valid-TLS non-JSON body — the exact `RestClientException` branch a 429 takes: passes (failed before this change).
  - Temporarily pointed at `https://expired.badssl.com` (genuine certificate failure): fails as expected.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (Claude Fable 5)

Generated-by: Claude Fable 5
