### PR TITLE
[FLINK-37732][table] FLIP-527: name-based state schema evolution for RowData

### DIFF
--- a/docs/layouts/shortcodes/generated/execution_config_configuration.html
+++ b/docs/layouts/shortcodes/generated/execution_config_configuration.html
@@ -357,6 +357,12 @@ By default no operator is disabled.</td>
             <td>Whether to compress spilled data. Currently we only support compress spilled data for sort and hash-agg and hash-join operators.</td>
         </tr>
         <tr>
+            <td><h5>table.exec.state.schema-evolution.enabled</h5><br> <span class="label label-primary">Streaming</span></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>When enabled, RowData state serializers retain field names so that backward-compatible schema changes (adding nullable fields, reordering by name, nested ROW evolution) are migrated on state restore. Disabled by default; when disabled the serializer behaves exactly as today and any type-array change is rejected as incompatible.</td>
+        </tr>
+        <tr>
             <td><h5>table.exec.state.ttl</h5><br> <span class="label label-primary">Streaming</span></td>
             <td style="word-wrap: break-word;">0 ms</td>
             <td>Duration</td>

--- a/flink-core/src/main/java/org/apache/flink/api/common/serialization/SerializerConfig.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/serialization/SerializerConfig.java
@@ -72,6 +72,16 @@ public interface SerializerConfig extends Serializable {
     TernaryBoolean isForceKryoAvroEnabled();
 
     /**
+     * Whether state schema evolution for {@code RowData} state is enabled, mirroring the table
+     * option {@code table.exec.state.schema-evolution.enabled}. When enabled, the Table runtime
+     * builds RowData state serializers that retain field names so backward-compatible schema
+     * changes can be migrated on restore.
+     */
+    default boolean isStateSchemaEvolutionEnabled() {
+        return false;
+    }
+
+    /**
      * Sets all relevant options contained in the {@link ReadableConfig} such as e.g. {@link
      * PipelineOptions#FORCE_KRYO}.
      *

--- a/flink-core/src/main/java/org/apache/flink/api/common/serialization/SerializerConfigImpl.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/serialization/SerializerConfigImpl.java
@@ -23,6 +23,8 @@ import org.apache.flink.api.common.SerializableSerializer;
 import org.apache.flink.api.common.functions.InvalidTypesException;
 import org.apache.flink.api.common.typeinfo.TypeInfoFactory;
 import org.apache.flink.api.java.typeutils.TypeExtractor;
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.ConfigOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.ConfigurationUtils;
 import org.apache.flink.configuration.PipelineOptions;
@@ -46,6 +48,14 @@ import java.util.stream.Collectors;
 public final class SerializerConfigImpl implements SerializerConfig {
 
     private static final long serialVersionUID = 1L;
+
+    // Mirrors org.apache.flink.table.api.config.ExecutionConfigOptions
+    //   .TABLE_EXEC_STATE_SCHEMA_EVOLUTION_ENABLED by key string (flink-core cannot depend on
+    //   flink-table-api-java). The value travels in the shared job Configuration.
+    private static final ConfigOption<Boolean> STATE_SCHEMA_EVOLUTION_ENABLED =
+            ConfigOptions.key("table.exec.state.schema-evolution.enabled")
+                    .booleanType()
+                    .defaultValue(false);
 
     private final Configuration configuration;
 
@@ -259,6 +269,11 @@ public final class SerializerConfigImpl implements SerializerConfig {
         configuration.set(PipelineOptions.FORCE_KRYO, forceKryo);
     }
 
+    @Override
+    public boolean isStateSchemaEvolutionEnabled() {
+        return configuration.get(STATE_SCHEMA_EVOLUTION_ENABLED);
+    }
+
     /** Returns whether the Apache Avro is the serializer for POJOs. */
     public boolean isForceAvroEnabled() {
         return configuration.get(PipelineOptions.FORCE_AVRO);
@@ -357,6 +372,10 @@ public final class SerializerConfigImpl implements SerializerConfig {
         configuration
                 .getOptional(PipelineOptions.SERIALIZATION_CONFIG)
                 .ifPresent(c -> parseSerializationConfigWithExceptionHandling(classLoader, c));
+        configuration
+                .getOptional(STATE_SCHEMA_EVOLUTION_ENABLED)
+                .ifPresent(
+                        enabled -> this.configuration.set(STATE_SCHEMA_EVOLUTION_ENABLED, enabled));
     }
 
     @SuppressWarnings("unchecked")

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/TypeSerializerSnapshot.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/TypeSerializerSnapshot.java
@@ -134,6 +134,27 @@ public interface TypeSerializerSnapshot<T> {
     TypeSerializerSchemaCompatibility<T> resolveSchemaCompatibility(
             TypeSerializerSnapshot<T> oldSerializerSnapshot);
 
+    /**
+     * Migrates a single state value from the schema described by {@code oldSerializerSnapshot} to
+     * the schema described by this (new) snapshot. Like {@link
+     * #resolveSchemaCompatibility(TypeSerializerSnapshot)}, this is invoked on the new snapshot and
+     * receives the old snapshot as its argument.
+     *
+     * <p>The default implementation returns the value unchanged: a value already deserialized with
+     * the prior serializer is structurally compatible with the current serializer, so the caller
+     * can re-serialize it as-is. Serializers whose in-memory representation is coupled to the
+     * schema (such as the serializer for {@code RowData}) override this to transform the value into
+     * the new layout -- for example by inserting nulls for added fields or reordering fields by
+     * name.
+     *
+     * @param oldSerializerSnapshot snapshot of the serializer that wrote the value.
+     * @param value the value, already deserialized with the prior serializer.
+     * @return the value adapted to the schema of the current serializer.
+     */
+    default T migrate(TypeSerializerSnapshot<T> oldSerializerSnapshot, T value) {
+        return value;
+    }
+
     // ------------------------------------------------------------------------
     //  read / write utilities
     // ------------------------------------------------------------------------

--- a/flink-core/src/test/java/org/apache/flink/api/common/serialization/SerializerConfigImplTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/serialization/SerializerConfigImplTest.java
@@ -20,6 +20,8 @@ package org.apache.flink.api.common.serialization;
 
 import org.apache.flink.api.common.typeinfo.TypeInfoFactory;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.ConfigOptions;
 import org.apache.flink.configuration.Configuration;
 
 import com.esotericsoftware.kryo.Kryo;
@@ -42,6 +44,41 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class SerializerConfigImplTest {
+
+    private static final ConfigOption<Boolean> STATE_SCHEMA_EVOLUTION_ENABLED =
+            ConfigOptions.key("table.exec.state.schema-evolution.enabled")
+                    .booleanType()
+                    .defaultValue(false);
+
+    @Test
+    void testStateSchemaEvolutionFlagSurvivesConstructionAndCopy() {
+        Configuration configuration = new Configuration();
+        configuration.set(STATE_SCHEMA_EVOLUTION_ENABLED, true);
+
+        SerializerConfigImpl serializerConfig = new SerializerConfigImpl(configuration);
+        assertThat(serializerConfig.isStateSchemaEvolutionEnabled()).isTrue();
+        assertThat(serializerConfig.copy().isStateSchemaEvolutionEnabled()).isTrue();
+    }
+
+    @Test
+    void testStateSchemaEvolutionFlagDefaultsFalseThroughCopy() {
+        SerializerConfigImpl serializerConfig = new SerializerConfigImpl();
+        assertThat(serializerConfig.isStateSchemaEvolutionEnabled()).isFalse();
+        assertThat(serializerConfig.copy().isStateSchemaEvolutionEnabled()).isFalse();
+    }
+
+    @Test
+    void testStateSchemaEvolutionFlagSurvivesConfigure() {
+        Configuration configuration = new Configuration();
+        configuration.set(STATE_SCHEMA_EVOLUTION_ENABLED, true);
+
+        SerializerConfigImpl serializerConfig = new SerializerConfigImpl();
+        serializerConfig.configure(configuration, SerializerConfigImplTest.class.getClassLoader());
+
+        assertThat(serializerConfig.isStateSchemaEvolutionEnabled()).isTrue();
+        assertThat(serializerConfig.copy().isStateSchemaEvolutionEnabled()).isTrue();
+    }
+
     @Test
     void testReadingDefaultConfig() {
         SerializerConfig config = new SerializerConfigImpl();

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/TypeSerializerSnapshotTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/TypeSerializerSnapshotTest.java
@@ -54,6 +54,17 @@ class TypeSerializerSnapshotTest {
                 .isTrue();
     }
 
+    @Test
+    void testMigrateReturnsValueUnchangedByDefault() {
+        // NotCompletedTypeSerializerSnapshot does not override migrate, so the default
+        // identity implementation applies.
+        TypeSerializerSnapshot<Integer> oldSnapshot = new NotCompletedTypeSerializerSnapshot();
+        TypeSerializerSnapshot<Integer> newSnapshot = new NotCompletedTypeSerializerSnapshot();
+        Integer value = 42;
+
+        assertThat(newSnapshot.migrate(oldSnapshot, value)).isSameAs(value);
+    }
+
     private static class NotCompletedTypeSerializer extends TypeSerializer<Integer> {
 
         @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/ttl/TtlAwareSerializer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/ttl/TtlAwareSerializer.java
@@ -128,29 +128,49 @@ public class TtlAwareSerializer<T, S extends TypeSerializer<T>> extends TypeSeri
         return Objects.hash(isTtlEnabled, typeSerializer);
     }
 
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings({"unchecked", "rawtypes"})
     public void migrateValueFromPriorSerializer(
             TtlAwareSerializer<T, ?> priorTtlAwareSerializer,
             SupplierWithException<T, IOException> inputSupplier,
             DataOutputView target,
             TtlTimeProvider ttlTimeProvider)
             throws IOException {
+        T priorValue = inputSupplier.get();
+        // Unwrap the prior value to its bare (non-TTL) form.
+        Object bareValue =
+                priorTtlAwareSerializer.isTtlEnabled
+                        ? ((TtlValue<?>) priorValue).getUserValue()
+                        : priorValue;
+        // Migrate the bare value to the current schema. The hook is identity for serializers
+        // that do not override it, so non-RowData state is byte-identical to before; the RowData
+        // serializer overrides it to remap fields on a backward-compatible schema change.
+        TypeSerializerSnapshot oldInnerSnapshot =
+                innerValueSerializer(priorTtlAwareSerializer).snapshotConfiguration();
+        TypeSerializerSnapshot newInnerSnapshot =
+                innerValueSerializer(this).snapshotConfiguration();
+        Object migratedValue = newInnerSnapshot.migrate(oldInnerSnapshot, bareValue);
+        // Re-wrap in a TtlValue when this serializer is TTL-enabled, preserving the prior
+        // timestamp when the prior value already carried one.
         T outputRecord;
         if (this.isTtlEnabled()) {
-            outputRecord =
+            long lastAccessTimestamp =
                     priorTtlAwareSerializer.isTtlEnabled
-                            ? inputSupplier.get()
-                            : (T)
-                                    new TtlValue<>(
-                                            inputSupplier.get(),
-                                            ttlTimeProvider.currentTimestamp());
+                            ? ((TtlValue<?>) priorValue).getLastAccessTimestamp()
+                            : ttlTimeProvider.currentTimestamp();
+            outputRecord = (T) new TtlValue<>(migratedValue, lastAccessTimestamp);
         } else {
-            outputRecord =
-                    priorTtlAwareSerializer.isTtlEnabled
-                            ? ((TtlValue<T>) inputSupplier.get()).getUserValue()
-                            : inputSupplier.get();
+            outputRecord = (T) migratedValue;
         }
         this.serialize(outputRecord, target);
+    }
+
+    // The serializer for the bare (non-TTL) value: the inner value serializer for a TTL
+    // serializer, otherwise the serializer itself.
+    private static TypeSerializer<?> innerValueSerializer(TtlAwareSerializer<?, ?> serializer) {
+        TypeSerializer<?> original = serializer.getOriginalTypeSerializer();
+        return serializer.isTtlEnabled()
+                ? ((TtlStateFactory.TtlSerializer<?>) original).getValueSerializer()
+                : original;
     }
 
     @Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/TtlAwareSerializerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/TtlAwareSerializerTest.java
@@ -24,12 +24,21 @@ import org.apache.flink.api.common.typeutils.base.ListSerializerSnapshot;
 import org.apache.flink.api.common.typeutils.base.LongSerializer;
 import org.apache.flink.api.common.typeutils.base.MapSerializer;
 import org.apache.flink.api.common.typeutils.base.MapSerializerSnapshot;
+import org.apache.flink.api.common.typeutils.base.StringSerializer;
+import org.apache.flink.core.memory.DataInputDeserializer;
+import org.apache.flink.core.memory.DataOutputSerializer;
 
 import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 class TtlAwareSerializerTest {
+
+    private static final long PRIOR_TIMESTAMP = 1_000L;
+    private static final long CURRENT_TIMESTAMP = 9_999L;
+    private static final TtlTimeProvider FIXED_TIME_PROVIDER = () -> CURRENT_TIMESTAMP;
 
     @Test
     void testSerializerTtlEnabled() {
@@ -146,5 +155,68 @@ class TtlAwareSerializerTest {
                         (((MapSerializerSnapshot) mapTtlAwareSerializer.snapshotConfiguration())
                                 .getValueSerializerSnapshot()))
                 .isInstanceOf(TtlAwareSerializerSnapshot.class);
+    }
+
+    @Test
+    void testMigrateValueNoTtlToNoTtl() throws IOException {
+        Object result = migrate(false, false, "value");
+        assertThat(result).isEqualTo("value");
+    }
+
+    @Test
+    void testMigrateValueNoTtlToTtl() throws IOException {
+        Object result = migrate(true, false, "value");
+        assertThat(result).isInstanceOf(TtlValue.class);
+        TtlValue<?> ttlValue = (TtlValue<?>) result;
+        assertThat(ttlValue.getUserValue()).isEqualTo("value");
+        assertThat(ttlValue.getLastAccessTimestamp()).isEqualTo(CURRENT_TIMESTAMP);
+    }
+
+    @Test
+    void testMigrateValueTtlToNoTtl() throws IOException {
+        Object result = migrate(false, true, new TtlValue<>("value", PRIOR_TIMESTAMP));
+        assertThat(result).isEqualTo("value");
+    }
+
+    @Test
+    void testMigrateValueTtlToTtlPreservesTimestamp() throws IOException {
+        Object result = migrate(true, true, new TtlValue<>("value", PRIOR_TIMESTAMP));
+        assertThat(result).isInstanceOf(TtlValue.class);
+        TtlValue<?> ttlValue = (TtlValue<?>) result;
+        assertThat(ttlValue.getUserValue()).isEqualTo("value");
+        // The prior timestamp must be preserved, not reset to the current time.
+        assertThat(ttlValue.getLastAccessTimestamp()).isEqualTo(PRIOR_TIMESTAMP);
+    }
+
+    /**
+     * Runs {@code migrateValueFromPriorSerializer} for a non-RowData inner value type across a
+     * given (current TTL, prior TTL) combination and returns the value read back with the current
+     * serializer. {@code priorValue} is the bare {@code String} when {@code priorTtlEnabled} is
+     * false, or a {@code TtlValue<String>} when it is true.
+     */
+    private static Object migrate(
+            boolean currentTtlEnabled, boolean priorTtlEnabled, Object priorValue)
+            throws IOException {
+        TtlAwareSerializer<?, ?> prior = stringSerializer(priorTtlEnabled);
+        TtlAwareSerializer<?, ?> current = stringSerializer(currentTtlEnabled);
+
+        DataOutputSerializer output = new DataOutputSerializer(64);
+        @SuppressWarnings({"unchecked", "rawtypes"})
+        TtlAwareSerializer<Object, ?> currentRaw = (TtlAwareSerializer) current;
+        @SuppressWarnings({"unchecked", "rawtypes"})
+        TtlAwareSerializer<Object, ?> priorRaw = (TtlAwareSerializer) prior;
+        currentRaw.migrateValueFromPriorSerializer(
+                priorRaw, () -> priorValue, output, FIXED_TIME_PROVIDER);
+
+        return current.deserialize(new DataInputDeserializer(output.getCopyOfBuffer()));
+    }
+
+    private static TtlAwareSerializer<?, ?> stringSerializer(boolean ttlEnabled) {
+        if (ttlEnabled) {
+            return TtlAwareSerializer.wrapTtlAwareSerializer(
+                    new TtlStateFactory.TtlSerializer<>(
+                            LongSerializer.INSTANCE, StringSerializer.INSTANCE));
+        }
+        return TtlAwareSerializer.wrapTtlAwareSerializer(StringSerializer.INSTANCE);
     }
 }

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/config/ExecutionConfigOptions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/config/ExecutionConfigOptions.java
@@ -58,6 +58,19 @@ public class ExecutionConfigOptions {
                                     + "NOTE: Cleaning up state requires additional overhead for bookkeeping. "
                                     + "Default value is 0, which means that it will never clean up state.");
 
+    @Documentation.TableOption(execMode = Documentation.ExecMode.STREAMING)
+    public static final ConfigOption<Boolean> TABLE_EXEC_STATE_SCHEMA_EVOLUTION_ENABLED =
+            key("table.exec.state.schema-evolution.enabled")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription(
+                            "When enabled, RowData state serializers retain field names so that "
+                                    + "backward-compatible schema changes (adding nullable fields, "
+                                    + "reordering by name, nested ROW evolution) are migrated on "
+                                    + "state restore. Disabled by default; when disabled the "
+                                    + "serializer behaves exactly as today and any type-array change "
+                                    + "is rejected as incompatible.");
+
     // ------------------------------------------------------------------------
     //  Source Options
     // ------------------------------------------------------------------------

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/sql/RowDataStateSchemaEvolutionMigrationTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/sql/RowDataStateSchemaEvolutionMigrationTest.java
@@ -1,0 +1,366 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.runtime.stream.sql;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.state.MapState;
+import org.apache.flink.api.common.state.MapStateDescriptor;
+import org.apache.flink.api.common.state.StateTtlConfig;
+import org.apache.flink.api.common.state.ValueState;
+import org.apache.flink.api.common.state.ValueStateDescriptor;
+import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
+import org.apache.flink.api.common.typeutils.base.IntSerializer;
+import org.apache.flink.core.fs.CloseableRegistry;
+import org.apache.flink.runtime.checkpoint.CheckpointOptions;
+import org.apache.flink.runtime.operators.testutils.MockEnvironment;
+import org.apache.flink.runtime.state.CheckpointStorageLocationReference;
+import org.apache.flink.runtime.state.CheckpointStreamFactory;
+import org.apache.flink.runtime.state.CheckpointableKeyedStateBackend;
+import org.apache.flink.runtime.state.KeyGroupRange;
+import org.apache.flink.runtime.state.KeyedStateBackendParametersImpl;
+import org.apache.flink.runtime.state.KeyedStateHandle;
+import org.apache.flink.runtime.state.SharedStateRegistry;
+import org.apache.flink.runtime.state.SharedStateRegistryImpl;
+import org.apache.flink.runtime.state.SnapshotResult;
+import org.apache.flink.runtime.state.VoidNamespace;
+import org.apache.flink.runtime.state.VoidNamespaceSerializer;
+import org.apache.flink.runtime.state.storage.JobManagerCheckpointStorage;
+import org.apache.flink.runtime.state.ttl.TtlTimeProvider;
+import org.apache.flink.state.rocksdb.EmbeddedRocksDBStateBackend;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
+import org.apache.flink.table.runtime.typeutils.RowDataSerializer;
+import org.apache.flink.table.types.logical.BigIntType;
+import org.apache.flink.table.types.logical.IntType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.types.logical.VarCharType;
+import org.apache.flink.types.RowKind;
+import org.apache.flink.util.StateMigrationException;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.RunnableFuture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Drives the full RowData state-migration stack end-to-end against the RocksDB keyed state backend:
+ * register a {@code ValueState<RowData>} / {@code MapState<RowData, RowData>} with an old-schema
+ * name-retaining serializer, snapshot, then restore with an evolved new-schema name-retaining
+ * serializer. The restore exercises {@code TtlAwareSerializer.migrateValueFromPriorSerializer} ->
+ * {@code RowDataSerializerSnapshot.migrate}.
+ *
+ * <p>This is the deterministic proof for the RowData state schema-evolution feature: when the value
+ * serializer retains field names, an added-nullable-field / reordered evolution restores with old
+ * fields preserved by name and added fields null; a leaf type change is rejected.
+ */
+class RowDataStateSchemaEvolutionMigrationTest {
+
+    // old schema: (id INT NOT NULL, name VARCHAR)
+    private static final RowType OLD_TYPE =
+            RowType.of(
+                    new LogicalType[] {new IntType(false), new VarCharType(VarCharType.MAX_LENGTH)},
+                    new String[] {"id", "name"});
+
+    // new schema: name "name" reordered before "id", with an added nullable field "score BIGINT"
+    private static final RowType NEW_TYPE =
+            RowType.of(
+                    new LogicalType[] {
+                        new VarCharType(VarCharType.MAX_LENGTH),
+                        new IntType(false),
+                        new BigIntType(true)
+                    },
+                    new String[] {"name", "id", "score"});
+
+    // a leaf type change: id INT -> BIGINT (incompatible)
+    private static final RowType TYPE_CHANGED_TYPE =
+            RowType.of(
+                    new LogicalType[] {
+                        new BigIntType(false), new VarCharType(VarCharType.MAX_LENGTH)
+                    },
+                    new String[] {"id", "name"});
+
+    private MockEnvironment env;
+
+    @BeforeEach
+    void before() throws Exception {
+        env = MockEnvironment.builder().build();
+        env.setCheckpointStorageAccess(
+                new JobManagerCheckpointStorage().createCheckpointStorage(new JobID()));
+    }
+
+    @AfterEach
+    void after() throws Exception {
+        if (env != null) {
+            env.close();
+        }
+    }
+
+    @Test
+    void testValueStateMigrationPreservesFieldsByName() throws Exception {
+        RowData migrated = migrateValueState(stateTtlConfig(), oldValue());
+        assertEvolved(migrated);
+    }
+
+    @Test
+    void testValueStateMigrationWithoutTtl() throws Exception {
+        RowData migrated = migrateValueState(StateTtlConfig.DISABLED, oldValue());
+        assertEvolved(migrated);
+    }
+
+    @Test
+    void testMapValueMigrationPreservesFieldsByName() throws Exception {
+        RowData migrated = migrateMapValue(stateTtlConfig(), oldValue());
+        assertEvolved(migrated);
+    }
+
+    @Test
+    void testLeafTypeChangeIsRejected() {
+        assertThatThrownBy(
+                        () ->
+                                runValueStateUpgrade(
+                                        stateTtlConfig(),
+                                        descriptor("state", stateTtlConfig(), OLD_TYPE),
+                                        descriptor("state", stateTtlConfig(), TYPE_CHANGED_TYPE),
+                                        oldValue()))
+                .satisfiesAnyOf(
+                        e -> assertThat(e).isInstanceOf(StateMigrationException.class),
+                        e -> assertThat(e).hasCauseInstanceOf(StateMigrationException.class));
+    }
+
+    /**
+     * Proves the gate through a public, observable contract: with schema evolution enabled the
+     * value serializer retains field names, so a name-based (added-nullable / reordered) evolution
+     * resolves to {@code compatibleAfterMigration}; with it disabled the names-less serializer
+     * keeps today's behavior and the same evolution resolves to {@code incompatible}.
+     */
+    @Test
+    void testEvolutionFlagControlsSchemaEvolutionCompatibility() {
+        InternalTypeInfo<RowData> oldRecordType = InternalTypeInfo.of(OLD_TYPE);
+        InternalTypeInfo<RowData> newRecordType = InternalTypeInfo.of(NEW_TYPE);
+
+        // evolution enabled: names retained on both sides -> compatibleAfterMigration
+        RowDataSerializer evolutionOnNew = RowDataSerializer.withFieldNames(NEW_TYPE);
+        TypeSerializerSnapshot<RowData> evolutionOnOld =
+                RowDataSerializer.withFieldNames(OLD_TYPE).snapshotConfiguration();
+        assertThat(
+                        evolutionOnNew
+                                .snapshotConfiguration()
+                                .resolveSchemaCompatibility(evolutionOnOld)
+                                .isCompatibleAfterMigration())
+                .isTrue();
+
+        // evolution disabled: names-less serializers (the existing TypeInformation path) -> today's
+        // behavior, a differing layout is incompatible
+        RowDataSerializer evolutionOffNew =
+                (RowDataSerializer)
+                        newRecordType.createSerializer(
+                                env.getExecutionConfig().getSerializerConfig());
+        TypeSerializerSnapshot<RowData> evolutionOffOld =
+                oldRecordType
+                        .createSerializer(env.getExecutionConfig().getSerializerConfig())
+                        .snapshotConfiguration();
+        assertThat(
+                        evolutionOffNew
+                                .snapshotConfiguration()
+                                .resolveSchemaCompatibility(evolutionOffOld)
+                                .isIncompatible())
+                .isTrue();
+    }
+
+    // ------------------------------------------------------------------------------------
+
+    private static GenericRowData oldValue() {
+        GenericRowData value = new GenericRowData(2);
+        value.setRowKind(RowKind.UPDATE_AFTER);
+        value.setField(0, 42);
+        value.setField(1, StringData.fromString("alice"));
+        return value;
+    }
+
+    private static void assertEvolved(RowData migrated) {
+        assertThat(migrated.getRowKind()).isEqualTo(RowKind.UPDATE_AFTER);
+        // new order: name, id, score
+        assertThat(migrated.getString(0).toString()).isEqualTo("alice");
+        assertThat(migrated.getInt(1)).isEqualTo(42);
+        assertThat(migrated.isNullAt(2)).isTrue();
+    }
+
+    private static StateTtlConfig stateTtlConfig() {
+        return StateTtlConfig.newBuilder(Duration.ofHours(1))
+                .setUpdateType(StateTtlConfig.UpdateType.OnCreateAndWrite)
+                .setStateVisibility(StateTtlConfig.StateVisibility.NeverReturnExpired)
+                .build();
+    }
+
+    private static ValueStateDescriptor<RowData> descriptor(
+            String name, StateTtlConfig ttlConfig, RowType rowType) {
+        ValueStateDescriptor<RowData> descriptor =
+                new ValueStateDescriptor<>(name, RowDataSerializer.withFieldNames(rowType));
+        if (ttlConfig.isEnabled()) {
+            descriptor.enableTimeToLive(ttlConfig);
+        }
+        return descriptor;
+    }
+
+    private RowData migrateValueState(StateTtlConfig ttlConfig, RowData oldValue) throws Exception {
+        return runValueStateUpgrade(
+                ttlConfig,
+                descriptor("state", ttlConfig, OLD_TYPE),
+                descriptor("state", ttlConfig, NEW_TYPE),
+                oldValue);
+    }
+
+    private RowData runValueStateUpgrade(
+            StateTtlConfig ttlConfig,
+            ValueStateDescriptor<RowData> oldDescriptor,
+            ValueStateDescriptor<RowData> newDescriptor,
+            RowData oldValue)
+            throws Exception {
+        SharedStateRegistry registry = new SharedStateRegistryImpl();
+        CheckpointableKeyedStateBackend<Integer> backend = createBackend(Collections.emptyList());
+        KeyedStateHandle snapshot;
+        try {
+            ValueState<RowData> state = partitionedValueState(backend, oldDescriptor);
+            backend.setCurrentKey(1);
+            state.update(oldValue);
+            snapshot = snapshot(backend, registry);
+        } finally {
+            backend.dispose();
+        }
+
+        backend = createBackend(Collections.singletonList(snapshot));
+        try {
+            ValueState<RowData> state = partitionedValueState(backend, newDescriptor);
+            backend.setCurrentKey(1);
+            return state.value();
+        } finally {
+            backend.dispose();
+        }
+    }
+
+    private RowData migrateMapValue(StateTtlConfig ttlConfig, RowData oldValue) throws Exception {
+        RowData uniqueKey = GenericRowData.of(7);
+        RowType keyType = RowType.of(new IntType(false));
+
+        SharedStateRegistry registry = new SharedStateRegistryImpl();
+        CheckpointableKeyedStateBackend<Integer> backend = createBackend(Collections.emptyList());
+        KeyedStateHandle snapshot;
+        try {
+            MapState<RowData, RowData> state =
+                    partitionedMapState(backend, mapDescriptor(ttlConfig, keyType, OLD_TYPE));
+            backend.setCurrentKey(1);
+            state.put(uniqueKey, oldValue);
+            snapshot = snapshot(backend, registry);
+        } finally {
+            backend.dispose();
+        }
+
+        backend = createBackend(Collections.singletonList(snapshot));
+        try {
+            MapState<RowData, RowData> state =
+                    partitionedMapState(backend, mapDescriptor(ttlConfig, keyType, NEW_TYPE));
+            backend.setCurrentKey(1);
+            return state.get(uniqueKey);
+        } finally {
+            backend.dispose();
+        }
+    }
+
+    private static MapStateDescriptor<RowData, RowData> mapDescriptor(
+            StateTtlConfig ttlConfig, RowType keyType, RowType valueType) {
+        MapStateDescriptor<RowData, RowData> descriptor =
+                new MapStateDescriptor<>(
+                        "state",
+                        new RowDataSerializer(keyType),
+                        RowDataSerializer.withFieldNames(valueType));
+        if (ttlConfig.isEnabled()) {
+            descriptor.enableTimeToLive(ttlConfig);
+        }
+        return descriptor;
+    }
+
+    private static ValueState<RowData> partitionedValueState(
+            CheckpointableKeyedStateBackend<Integer> backend,
+            ValueStateDescriptor<RowData> descriptor)
+            throws Exception {
+        return backend.getPartitionedState(
+                VoidNamespace.INSTANCE, VoidNamespaceSerializer.INSTANCE, descriptor);
+    }
+
+    private static MapState<RowData, RowData> partitionedMapState(
+            CheckpointableKeyedStateBackend<Integer> backend,
+            MapStateDescriptor<RowData, RowData> descriptor)
+            throws Exception {
+        return backend.getPartitionedState(
+                VoidNamespace.INSTANCE, VoidNamespaceSerializer.INSTANCE, descriptor);
+    }
+
+    private CheckpointableKeyedStateBackend<Integer> createBackend(
+            List<KeyedStateHandle> restoreState) throws Exception {
+        return new EmbeddedRocksDBStateBackend()
+                .createKeyedStateBackend(
+                        new KeyedStateBackendParametersImpl<>(
+                                env,
+                                new JobID(),
+                                "test_op",
+                                IntSerializer.INSTANCE,
+                                10,
+                                new KeyGroupRange(0, 9),
+                                env.getTaskKvStateRegistry(),
+                                TtlTimeProvider.DEFAULT,
+                                env.getMetricGroup(),
+                                restoreState,
+                                new CloseableRegistry()));
+    }
+
+    private KeyedStateHandle snapshot(
+            CheckpointableKeyedStateBackend<Integer> backend, SharedStateRegistry registry)
+            throws Exception {
+        CheckpointStreamFactory streamFactory =
+                new JobManagerCheckpointStorage()
+                        .createCheckpointStorage(new JobID())
+                        .resolveCheckpointStorageLocation(
+                                1L, CheckpointStorageLocationReference.getDefault());
+        RunnableFuture<SnapshotResult<KeyedStateHandle>> future =
+                backend.snapshot(
+                        1L,
+                        2L,
+                        streamFactory,
+                        CheckpointOptions.forCheckpointWithDefaultLocation());
+        if (!future.isDone()) {
+            future.run();
+        }
+        SnapshotResult<KeyedStateHandle> result = future.get();
+        KeyedStateHandle handle = result.getJobManagerOwnedSnapshot();
+        if (handle != null) {
+            handle.registerSharedStates(registry, 0L);
+        }
+        return handle;
+    }
+}

--- a/flink-table/flink-table-type-utils/src/main/java/org/apache/flink/table/runtime/typeutils/InternalTypeInfo.java
+++ b/flink-table/flink-table-type-utils/src/main/java/org/apache/flink/table/runtime/typeutils/InternalTypeInfo.java
@@ -26,6 +26,7 @@ import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.DataTypeQueryable;
 import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.LogicalTypeRoot;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.logical.utils.LogicalTypeUtils;
 import org.apache.flink.table.types.utils.DataTypeUtils;
@@ -194,7 +195,13 @@ public final class InternalTypeInfo<T> extends TypeInformation<T> implements Dat
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public TypeSerializer<T> createSerializer(SerializerConfig config) {
+        if (config != null
+                && config.isStateSchemaEvolutionEnabled()
+                && type.is(LogicalTypeRoot.ROW)) {
+            return (TypeSerializer<T>) RowDataSerializer.withFieldNames(toRowType());
+        }
         return typeSerializer;
     }
 

--- a/flink-table/flink-table-type-utils/src/main/java/org/apache/flink/table/runtime/typeutils/RowDataSerializer.java
+++ b/flink-table/flink-table-type-utils/src/main/java/org/apache/flink/table/runtime/typeutils/RowDataSerializer.java
@@ -19,6 +19,7 @@
 package org.apache.flink.table.runtime.typeutils;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.typeutils.CompositeTypeSerializerUtil;
 import org.apache.flink.api.common.typeutils.NestedSerializersSnapshotDelegate;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
@@ -37,11 +38,15 @@ import org.apache.flink.table.data.binary.NestedRowData;
 import org.apache.flink.table.data.writer.BinaryRowWriter;
 import org.apache.flink.table.data.writer.BinaryWriter;
 import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.LogicalTypeRoot;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.util.InstantiationUtil;
 
+import javax.annotation.Nullable;
+
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.List;
 import java.util.stream.IntStream;
 
 /** Serializer for {@link RowData}. */
@@ -51,6 +56,7 @@ public class RowDataSerializer extends AbstractRowDataSerializer<RowData> {
 
     private BinaryRowDataSerializer binarySerializer;
     private final LogicalType[] types;
+    private final @Nullable String[] fieldNames;
     private final TypeSerializer[] fieldSerializers;
     private final RowData.FieldGetter[] fieldGetters;
 
@@ -74,13 +80,54 @@ public class RowDataSerializer extends AbstractRowDataSerializer<RowData> {
     }
 
     public RowDataSerializer(LogicalType[] types, TypeSerializer<?>[] fieldSerializers) {
+        this(types, fieldSerializers, null);
+    }
+
+    private RowDataSerializer(
+            LogicalType[] types,
+            TypeSerializer<?>[] fieldSerializers,
+            @Nullable String[] fieldNames) {
         this.types = types;
+        this.fieldNames = fieldNames;
         this.fieldSerializers = fieldSerializers;
         this.binarySerializer = new BinaryRowDataSerializer(types.length);
         this.fieldGetters =
                 IntStream.range(0, types.length)
                         .mapToObj(i -> RowData.createFieldGetter(types[i], i))
                         .toArray(RowData.FieldGetter[]::new);
+    }
+
+    /**
+     * Creates a serializer that retains the field names of {@code rowType} so that state written by
+     * this serializer can be migrated by matching fields on name. Nested {@code ROW} children are
+     * built recursively so their field names are retained at every level; all other children use
+     * the default name-less serializers. Used for state-value serializers when schema evolution is
+     * enabled; the name-less constructors remain the default (e.g. for state keys).
+     */
+    public static RowDataSerializer withFieldNames(RowType rowType) {
+        List<LogicalType> children = rowType.getChildren();
+        LogicalType[] types = children.toArray(new LogicalType[0]);
+        TypeSerializer<?>[] fieldSerializers = new TypeSerializer[children.size()];
+        for (int i = 0; i < children.size(); i++) {
+            LogicalType child = children.get(i);
+            fieldSerializers[i] =
+                    child.getTypeRoot() == LogicalTypeRoot.ROW
+                            ? withFieldNames((RowType) child)
+                            : InternalSerializers.create(child);
+        }
+        return new RowDataSerializer(
+                types, fieldSerializers, rowType.getFieldNames().toArray(new String[0]));
+    }
+
+    @VisibleForTesting
+    @Nullable
+    String[] getFieldNames() {
+        return fieldNames;
+    }
+
+    @VisibleForTesting
+    TypeSerializer[] fieldSerializers() {
+        return fieldSerializers;
     }
 
     @Override
@@ -274,14 +321,15 @@ public class RowDataSerializer extends AbstractRowDataSerializer<RowData> {
 
     @Override
     public TypeSerializerSnapshot<RowData> snapshotConfiguration() {
-        return new RowDataSerializerSnapshot(types, fieldSerializers);
+        return new RowDataSerializerSnapshot(types, fieldSerializers, fieldNames);
     }
 
     /** {@link TypeSerializerSnapshot} for {@link BinaryRowDataSerializer}. */
     public static final class RowDataSerializerSnapshot implements TypeSerializerSnapshot<RowData> {
-        private static final int CURRENT_VERSION = 3;
+        private static final int CURRENT_VERSION = 4;
 
         private LogicalType[] types;
+        private @Nullable String[] fieldNames;
         private NestedSerializersSnapshotDelegate nestedSerializersSnapshotDelegate;
 
         @SuppressWarnings("unused")
@@ -289,10 +337,18 @@ public class RowDataSerializer extends AbstractRowDataSerializer<RowData> {
             // this constructor is used when restoring from a checkpoint/savepoint.
         }
 
-        RowDataSerializerSnapshot(LogicalType[] types, TypeSerializer[] serializers) {
+        RowDataSerializerSnapshot(
+                LogicalType[] types, TypeSerializer[] serializers, @Nullable String[] fieldNames) {
             this.types = types;
+            this.fieldNames = fieldNames;
             this.nestedSerializersSnapshotDelegate =
                     new NestedSerializersSnapshotDelegate(serializers);
+        }
+
+        @VisibleForTesting
+        @Nullable
+        String[] getFieldNames() {
+            return fieldNames;
         }
 
         @Override
@@ -306,6 +362,13 @@ public class RowDataSerializer extends AbstractRowDataSerializer<RowData> {
             DataOutputViewStream stream = new DataOutputViewStream(out);
             for (LogicalType previousType : types) {
                 InstantiationUtil.serializeObject(stream, previousType);
+            }
+            boolean hasFieldNames = fieldNames != null;
+            out.writeBoolean(hasFieldNames);
+            if (hasFieldNames) {
+                for (String fieldName : fieldNames) {
+                    out.writeUTF(fieldName);
+                }
             }
             nestedSerializersSnapshotDelegate.writeNestedSerializerSnapshots(out);
         }
@@ -324,6 +387,15 @@ public class RowDataSerializer extends AbstractRowDataSerializer<RowData> {
                     throw new IOException(e);
                 }
             }
+            if (readVersion >= 4) {
+                boolean hasFieldNames = in.readBoolean();
+                if (hasFieldNames) {
+                    fieldNames = new String[length];
+                    for (int i = 0; i < length; i++) {
+                        fieldNames[i] = in.readUTF();
+                    }
+                }
+            }
             this.nestedSerializersSnapshotDelegate =
                     NestedSerializersSnapshotDelegate.readNestedSerializerSnapshots(
                             in, userCodeClassLoader);
@@ -332,7 +404,9 @@ public class RowDataSerializer extends AbstractRowDataSerializer<RowData> {
         @Override
         public RowDataSerializer restoreSerializer() {
             return new RowDataSerializer(
-                    types, nestedSerializersSnapshotDelegate.getRestoredNestedSerializers());
+                    types,
+                    nestedSerializersSnapshotDelegate.getRestoredNestedSerializers(),
+                    fieldNames);
         }
 
         @Override

--- a/flink-table/flink-table-type-utils/src/main/java/org/apache/flink/table/runtime/typeutils/RowDataSerializer.java
+++ b/flink-table/flink-table-type-utils/src/main/java/org/apache/flink/table/runtime/typeutils/RowDataSerializer.java
@@ -138,7 +138,9 @@ public class RowDataSerializer extends AbstractRowDataSerializer<RowData> {
         for (int i = 0; i < fieldSerializers.length; i++) {
             duplicateFieldSerializers[i] = fieldSerializers[i].duplicate();
         }
-        return new RowDataSerializer(types, duplicateFieldSerializers);
+        // Field names must be carried through duplication: state backends duplicate the registered
+        // serializer, and name-based schema-evolution compatibility relies on them being present.
+        return new RowDataSerializer(types, duplicateFieldSerializers, fieldNames);
     }
 
     @Override

--- a/flink-table/flink-table-type-utils/src/main/java/org/apache/flink/table/runtime/typeutils/RowDataSerializer.java
+++ b/flink-table/flink-table-type-utils/src/main/java/org/apache/flink/table/runtime/typeutils/RowDataSerializer.java
@@ -46,7 +46,9 @@ import javax.annotation.Nullable;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.IntStream;
 
 /** Serializer for {@link RowData}. */
@@ -415,28 +417,149 @@ public class RowDataSerializer extends AbstractRowDataSerializer<RowData> {
             if (!(oldSerializerSnapshot instanceof RowDataSerializerSnapshot)) {
                 return TypeSerializerSchemaCompatibility.incompatible();
             }
-
-            RowDataSerializerSnapshot oldRowDataSerializerSnapshot =
+            RowDataSerializerSnapshot oldSnapshot =
                     (RowDataSerializerSnapshot) oldSerializerSnapshot;
-            if (!Arrays.equals(types, oldRowDataSerializerSnapshot.types)) {
+
+            // Identical layout: preserve today's nested composite behavior exactly (no regression).
+            if (Arrays.equals(types, oldSnapshot.types)) {
+                CompositeTypeSerializerUtil.IntermediateCompatibilityResult<RowData>
+                        intermediateResult =
+                                CompositeTypeSerializerUtil
+                                        .constructIntermediateCompatibilityResult(
+                                                nestedSerializersSnapshotDelegate
+                                                        .getNestedSerializerSnapshots(),
+                                                oldSnapshot.nestedSerializersSnapshotDelegate
+                                                        .getNestedSerializerSnapshots());
+                if (intermediateResult.isCompatibleWithReconfiguredSerializer()) {
+                    return TypeSerializerSchemaCompatibility.compatibleWithReconfiguredSerializer(
+                            restoreSerializer());
+                }
+                return intermediateResult.getFinalResult();
+            }
+
+            // Differing layout: name-based evolution requires field names on BOTH sides.
+            if (fieldNames != null && oldSnapshot.fieldNames != null) {
+                return checkNameBasedEvolution(oldSnapshot);
+            }
+
+            // Names absent on a side: preserve today's behavior (no positional relaxation).
+            return TypeSerializerSchemaCompatibility.incompatible();
+        }
+
+        private TypeSerializerSchemaCompatibility<RowData> checkNameBasedEvolution(
+                RowDataSerializerSnapshot oldSnapshot) {
+            int[] oldToNew = buildNameMapping(oldSnapshot.fieldNames, this.fieldNames);
+            int[] newToOld = buildNameMapping(this.fieldNames, oldSnapshot.fieldNames);
+
+            // (A) Every new-only field (no matching old field) must be nullable.
+            for (int newPos = 0; newPos < newToOld.length; newPos++) {
+                if (newToOld[newPos] == -1 && !types[newPos].isNullable()) {
+                    return TypeSerializerSchemaCompatibility.incompatible();
+                }
+            }
+
+            // (B) Every old field must survive with a compatible type, and nested snapshots are
+            //     aligned old->new so nested ROW evolution can recurse. Leaf (non-ROW) fields
+            //     require an exactly equal type; ROW fields defer to the nested recursion in (C).
+            TypeSerializerSnapshot<?>[] newNested =
+                    nestedSerializersSnapshotDelegate.getNestedSerializerSnapshots();
+            TypeSerializerSnapshot<?>[] alignedNewNested =
+                    new TypeSerializerSnapshot<?>[oldSnapshot.types.length];
+            for (int oldPos = 0; oldPos < oldToNew.length; oldPos++) {
+                int newPos = oldToNew[oldPos];
+                if (newPos == -1) {
+                    return TypeSerializerSchemaCompatibility.incompatible(); // field removed
+                }
+                LogicalType oldType = oldSnapshot.types[oldPos];
+                LogicalType newType = types[newPos];
+                boolean bothRow =
+                        oldType.getTypeRoot() == LogicalTypeRoot.ROW
+                                && newType.getTypeRoot() == LogicalTypeRoot.ROW;
+                if (!bothRow && !oldType.equals(newType)) {
+                    return TypeSerializerSchemaCompatibility.incompatible(); // leaf type changed
+                }
+                alignedNewNested[oldPos] = newNested[newPos];
+            }
+
+            // (C) Recurse: nested snapshot pairs run their own resolveSchemaCompatibility
+            //     (nested ROW evolution is validated here).
+            CompositeTypeSerializerUtil.IntermediateCompatibilityResult<RowData> nested =
+                    CompositeTypeSerializerUtil.constructIntermediateCompatibilityResult(
+                            alignedNewNested,
+                            oldSnapshot.nestedSerializersSnapshotDelegate
+                                    .getNestedSerializerSnapshots());
+            if (nested.isIncompatible()) {
                 return TypeSerializerSchemaCompatibility.incompatible();
             }
+            return TypeSerializerSchemaCompatibility.compatibleAfterMigration();
+        }
 
-            CompositeTypeSerializerUtil.IntermediateCompatibilityResult<RowData>
-                    intermediateResult =
-                            CompositeTypeSerializerUtil.constructIntermediateCompatibilityResult(
-                                    nestedSerializersSnapshotDelegate
-                                            .getNestedSerializerSnapshots(),
-                                    oldRowDataSerializerSnapshot.nestedSerializersSnapshotDelegate
-                                            .getNestedSerializerSnapshots());
+        @Override
+        public RowData migrate(
+                TypeSerializerSnapshot<RowData> oldSerializerSnapshot, RowData value) {
+            RowDataSerializerSnapshot oldSnapshot =
+                    (RowDataSerializerSnapshot) oldSerializerSnapshot;
+            RowDataSerializer oldSerializer = oldSnapshot.restoreSerializer();
+            RowDataSerializer newSerializer = restoreSerializer();
+            return getNewRowData(value, oldSerializer, newSerializer);
+        }
 
-            if (intermediateResult.isCompatibleWithReconfiguredSerializer()) {
-                RowDataSerializer reconfiguredCompositeSerializer = restoreSerializer();
-                return TypeSerializerSchemaCompatibility.compatibleWithReconfiguredSerializer(
-                        reconfiguredCompositeSerializer);
+        // Remaps oldData into the new layout. Name-based when both serializers carry field names;
+        // otherwise positions map 1:1 up to the common field count. RowKind preserved; added
+        // fields and null sources become null; nested ROW values are remapped recursively.
+        private static GenericRowData getNewRowData(
+                RowData oldData, RowDataSerializer oldSerializer, RowDataSerializer newSerializer) {
+            GenericRowData newData = new GenericRowData(newSerializer.getArity());
+            newData.setRowKind(oldData.getRowKind());
+            int[] positions = buildPositionMapping(oldData, oldSerializer, newSerializer);
+            for (int newPos = 0; newPos < newSerializer.getArity(); newPos++) {
+                int oldPos = positions[newPos];
+                if (oldPos != -1 && !oldData.isNullAt(oldPos)) {
+                    Object fieldValue = oldSerializer.fieldGetters[oldPos].getFieldOrNull(oldData);
+                    if (fieldValue instanceof RowData) {
+                        fieldValue =
+                                getNewRowData(
+                                        (RowData) fieldValue,
+                                        (RowDataSerializer) oldSerializer.fieldSerializers[oldPos],
+                                        (RowDataSerializer) newSerializer.fieldSerializers[newPos]);
+                    }
+                    newData.setField(newPos, fieldValue);
+                } else {
+                    newData.setField(newPos, null);
+                }
             }
+            return newData;
+        }
 
-            return intermediateResult.getFinalResult();
+        // positions[newPos] = matching old position, or -1 for an added field.
+        private static int[] buildPositionMapping(
+                RowData oldData, RowDataSerializer oldSerializer, RowDataSerializer newSerializer) {
+            int[] positions = new int[newSerializer.getArity()];
+            if (oldSerializer.getFieldNames() != null && newSerializer.getFieldNames() != null) {
+                int[] newToOld =
+                        buildNameMapping(
+                                newSerializer.getFieldNames(), oldSerializer.getFieldNames());
+                System.arraycopy(newToOld, 0, positions, 0, newToOld.length);
+            } else {
+                int commonFields = Math.min(oldData.getArity(), newSerializer.getArity());
+                for (int i = 0; i < newSerializer.getArity(); i++) {
+                    positions[i] = i < commonFields ? i : -1;
+                }
+            }
+            return positions;
+        }
+
+        // mapping[i] = index in toNames of the field named fromNames[i], or -1 if absent.
+        private static int[] buildNameMapping(String[] fromNames, String[] toNames) {
+            Map<String, Integer> toIndex = new HashMap<>(toNames.length);
+            for (int i = 0; i < toNames.length; i++) {
+                toIndex.put(toNames[i], i);
+            }
+            int[] mapping = new int[fromNames.length];
+            for (int i = 0; i < fromNames.length; i++) {
+                mapping[i] = toIndex.getOrDefault(fromNames[i], -1);
+            }
+            return mapping;
         }
     }
 }

--- a/flink-table/flink-table-type-utils/src/test/java/org/apache/flink/table/runtime/typeutils/InternalTypeInfoSchemaEvolutionTest.java
+++ b/flink-table/flink-table-type-utils/src/test/java/org/apache/flink/table/runtime/typeutils/InternalTypeInfoSchemaEvolutionTest.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.typeutils;
+
+import org.apache.flink.api.common.serialization.SerializerConfigImpl;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.types.logical.BigIntType;
+import org.apache.flink.table.types.logical.IntType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.RowType;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests the global gate at {@link InternalTypeInfo#createSerializer}: when the table option {@code
+ * table.exec.state.schema-evolution.enabled} is on, a {@code ROW} type's serializer retains field
+ * names so backward-compatible schema changes can be migrated on restore; when off, the serializer
+ * is byte-identical to today's names-less one.
+ */
+class InternalTypeInfoSchemaEvolutionTest {
+
+    private static final RowType ROW_TYPE =
+            RowType.of(
+                    new LogicalType[] {new IntType(), new BigIntType()}, new String[] {"f0", "f1"});
+
+    private static SerializerConfigImpl configWithEvolution(boolean enabled) {
+        Configuration configuration = new Configuration();
+        configuration.setString(
+                "table.exec.state.schema-evolution.enabled", String.valueOf(enabled));
+        return new SerializerConfigImpl(configuration);
+    }
+
+    @Test
+    void evolutionEnabledRetainsFieldNames() {
+        InternalTypeInfo<RowData> typeInfo = InternalTypeInfo.of(ROW_TYPE);
+
+        TypeSerializer<RowData> serializer = typeInfo.createSerializer(configWithEvolution(true));
+
+        assertThat(serializer).isInstanceOf(RowDataSerializer.class);
+        assertThat(((RowDataSerializer) serializer).getFieldNames()).containsExactly("f0", "f1");
+    }
+
+    @Test
+    void evolutionDisabledLeavesNamesNull() {
+        InternalTypeInfo<RowData> typeInfo = InternalTypeInfo.of(ROW_TYPE);
+
+        TypeSerializer<RowData> serializer = typeInfo.createSerializer(new SerializerConfigImpl());
+
+        assertThat(serializer).isInstanceOf(RowDataSerializer.class);
+        assertThat(((RowDataSerializer) serializer).getFieldNames()).isNull();
+    }
+
+    @Test
+    void evolutionEnabledRecursesIntoNestedRow() {
+        RowType nested =
+                RowType.of(
+                        new LogicalType[] {new IntType(), new BigIntType()},
+                        new String[] {"a", "b"});
+        RowType rowType =
+                RowType.of(
+                        new LogicalType[] {nested, new IntType()}, new String[] {"outer", "tail"});
+        InternalTypeInfo<RowData> typeInfo = InternalTypeInfo.of(rowType);
+
+        TypeSerializer<RowData> serializer = typeInfo.createSerializer(configWithEvolution(true));
+
+        TypeSerializer<?> nestedChild = ((RowDataSerializer) serializer).fieldSerializers()[0];
+        assertThat(nestedChild).isInstanceOf(RowDataSerializer.class);
+        assertThat(((RowDataSerializer) nestedChild).getFieldNames()).containsExactly("a", "b");
+    }
+}

--- a/flink-table/flink-table-type-utils/src/test/java/org/apache/flink/table/runtime/typeutils/RowDataSerializerFieldNamesTest.java
+++ b/flink-table/flink-table-type-utils/src/test/java/org/apache/flink/table/runtime/typeutils/RowDataSerializerFieldNamesTest.java
@@ -1,0 +1,148 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.typeutils;
+
+import org.apache.flink.api.common.typeutils.NestedSerializersSnapshotDelegate;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
+import org.apache.flink.api.java.typeutils.runtime.DataOutputViewStream;
+import org.apache.flink.core.memory.DataInputDeserializer;
+import org.apache.flink.core.memory.DataOutputSerializer;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.runtime.typeutils.RowDataSerializer.RowDataSerializerSnapshot;
+import org.apache.flink.table.types.logical.BigIntType;
+import org.apache.flink.table.types.logical.IntType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.types.logical.VarCharType;
+import org.apache.flink.util.InstantiationUtil;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for the name-retaining construction path of {@link RowDataSerializer} and the V4 snapshot
+ * format that carries field names. These are separate from {@link RowDataSerializerTest} because
+ * they assert metadata (field names, snapshot version, V3 backward compatibility) rather than
+ * per-record serialization round trips.
+ */
+class RowDataSerializerFieldNamesTest {
+
+    private static RowType rowType(String[] names, LogicalType... types) {
+        return RowType.of(types, names);
+    }
+
+    @Test
+    void withFieldNamesRetainsTopLevelNames() {
+        RowType rowType = rowType(new String[] {"f0", "f1"}, new IntType(), new BigIntType());
+
+        assertThat(RowDataSerializer.withFieldNames(rowType).getFieldNames())
+                .containsExactly("f0", "f1");
+    }
+
+    @Test
+    void withFieldNamesRecursesIntoNestedRow() {
+        RowType nested = rowType(new String[] {"a", "b"}, new IntType(), VarCharType.STRING_TYPE);
+        RowType rowType = rowType(new String[] {"outer", "tail"}, nested, new IntType());
+
+        RowDataSerializer serializer = RowDataSerializer.withFieldNames(rowType);
+        TypeSerializer<?> nestedChild = serializer.fieldSerializers()[0];
+
+        assertThat(nestedChild).isInstanceOf(RowDataSerializer.class);
+        assertThat(((RowDataSerializer) nestedChild).getFieldNames()).containsExactly("a", "b");
+    }
+
+    @Test
+    void nameLessConstructorsLeaveNamesNull() {
+        RowType rowType = rowType(new String[] {"f0", "f1"}, new IntType(), new BigIntType());
+
+        assertThat(new RowDataSerializer(rowType).getFieldNames()).isNull();
+        assertThat(new RowDataSerializer(new IntType(), new BigIntType()).getFieldNames()).isNull();
+    }
+
+    @Test
+    void snapshotVersionIsFour() {
+        RowType rowType = rowType(new String[] {"f0", "f1"}, new IntType(), new BigIntType());
+
+        assertThat(
+                        RowDataSerializer.withFieldNames(rowType)
+                                .snapshotConfiguration()
+                                .getCurrentVersion())
+                .isEqualTo(4);
+    }
+
+    @Test
+    void namesSurviveSnapshotRoundTrip() throws IOException {
+        RowType rowType = rowType(new String[] {"f0", "f1"}, new IntType(), new BigIntType());
+        TypeSerializerSnapshot<RowData> snapshot =
+                RowDataSerializer.withFieldNames(rowType).snapshotConfiguration();
+
+        DataOutputSerializer out = new DataOutputSerializer(128);
+        TypeSerializerSnapshot.writeVersionedSnapshot(out, snapshot);
+        DataInputDeserializer in = new DataInputDeserializer(out.getCopyOfBuffer());
+        TypeSerializerSnapshot<RowData> restored =
+                TypeSerializerSnapshot.readVersionedSnapshot(in, getClass().getClassLoader());
+
+        RowDataSerializer restoredSerializer = (RowDataSerializer) restored.restoreSerializer();
+        assertThat(restoredSerializer.getFieldNames()).containsExactly("f0", "f1");
+    }
+
+    @Test
+    void readsV3SnapshotWithoutFieldNames() throws IOException {
+        RowType rowType = rowType(new String[] {"f0", "f1"}, new IntType(), new BigIntType());
+        LogicalType[] types = rowType.getChildren().toArray(new LogicalType[0]);
+        TypeSerializer<?>[] fieldSerializers = {
+            InternalSerializers.create(types[0]), InternalSerializers.create(types[1])
+        };
+
+        // Hand-craft a genuine V3 stream: versioned header + V3 body, where the V3 body is the
+        // types section followed directly by the nested-delegate section, with no names block.
+        DataOutputSerializer out = new DataOutputSerializer(128);
+        out.writeUTF(RowDataSerializerSnapshot.class.getName());
+        out.writeInt(3);
+        out.writeInt(types.length);
+        DataOutputViewStream stream = new DataOutputViewStream(out);
+        for (LogicalType type : types) {
+            InstantiationUtil.serializeObject(stream, type);
+        }
+        new NestedSerializersSnapshotDelegate(fieldSerializers).writeNestedSerializerSnapshots(out);
+
+        DataInputDeserializer in = new DataInputDeserializer(out.getCopyOfBuffer());
+        TypeSerializerSnapshot<RowData> restored =
+                TypeSerializerSnapshot.readVersionedSnapshot(in, getClass().getClassLoader());
+
+        assertThat(restored).isInstanceOf(RowDataSerializerSnapshot.class);
+        assertThat(((RowDataSerializerSnapshot) restored).getFieldNames()).isNull();
+
+        // The nested delegate was read at the correct offset (no phantom names consumed): the
+        // restored serializer round-trips a sample row.
+        RowDataSerializer serializer = (RowDataSerializer) restored.restoreSerializer();
+        GenericRowData sample = GenericRowData.of(7, 11L);
+        DataOutputSerializer rowOut = new DataOutputSerializer(32);
+        serializer.serialize(sample, rowOut);
+        RowData deserialized =
+                serializer.deserialize(new DataInputDeserializer(rowOut.getCopyOfBuffer()));
+        assertThat(deserialized.getInt(0)).isEqualTo(7);
+        assertThat(deserialized.getLong(1)).isEqualTo(11L);
+    }
+}

--- a/flink-table/flink-table-type-utils/src/test/java/org/apache/flink/table/runtime/typeutils/RowDataSerializerSchemaEvolutionTest.java
+++ b/flink-table/flink-table-type-utils/src/test/java/org/apache/flink/table/runtime/typeutils/RowDataSerializerSchemaEvolutionTest.java
@@ -1,0 +1,252 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.typeutils;
+
+import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
+import org.apache.flink.core.memory.DataInputDeserializer;
+import org.apache.flink.core.memory.DataOutputSerializer;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.runtime.typeutils.RowDataSerializer.RowDataSerializerSnapshot;
+import org.apache.flink.table.types.logical.BigIntType;
+import org.apache.flink.table.types.logical.IntType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.types.logical.VarCharType;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.apache.flink.table.data.StringData.fromString;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests name-based schema evolution on {@link RowDataSerializerSnapshot}: the compatibility verdict
+ * for differing layouts and the {@code migrate} remap that adapts a deserialized {@link RowData} to
+ * the new layout. These complement {@link RowDataSerializerFieldNamesTest} (field-name metadata and
+ * V4 snapshot format) by exercising the actual evolution algorithm.
+ */
+class RowDataSerializerSchemaEvolutionTest {
+
+    private static RowType row(String[] names, LogicalType... types) {
+        return RowType.of(types, names);
+    }
+
+    private static LogicalType nullableInt() {
+        return new IntType(true);
+    }
+
+    /**
+     * Builds a name-retaining snapshot and round-trips it through the versioned snapshot format, so
+     * nested field names flow through the nested delegate exactly as they would on a real restore.
+     */
+    private static RowDataSerializerSnapshot snapshot(RowType rowType) throws IOException {
+        TypeSerializerSnapshot<RowData> snapshot =
+                RowDataSerializer.withFieldNames(rowType).snapshotConfiguration();
+        DataOutputSerializer out = new DataOutputSerializer(256);
+        TypeSerializerSnapshot.writeVersionedSnapshot(out, snapshot);
+        DataInputDeserializer in = new DataInputDeserializer(out.getCopyOfBuffer());
+        return (RowDataSerializerSnapshot)
+                TypeSerializerSnapshot.<RowData>readVersionedSnapshot(
+                        in, RowDataSerializerSchemaEvolutionTest.class.getClassLoader());
+    }
+
+    @Test
+    void addNullableFieldAtEnd() throws IOException {
+        RowDataSerializerSnapshot oldSnap =
+                snapshot(row(new String[] {"a", "b"}, new IntType(), VarCharType.STRING_TYPE));
+        RowDataSerializerSnapshot newSnap =
+                snapshot(
+                        row(
+                                new String[] {"a", "b", "c"},
+                                new IntType(),
+                                VarCharType.STRING_TYPE,
+                                nullableInt()));
+
+        assertThat(newSnap.resolveSchemaCompatibility(oldSnap).isCompatibleAfterMigration())
+                .isTrue();
+
+        GenericRowData oldValue = GenericRowData.of(1, fromString("x"));
+        RowData migrated = newSnap.migrate(oldSnap, oldValue);
+
+        assertThat(migrated.getArity()).isEqualTo(3);
+        assertThat(migrated.getInt(0)).isEqualTo(1);
+        assertThat(migrated.getString(1)).isEqualTo(fromString("x"));
+        assertThat(migrated.isNullAt(2)).isTrue();
+        assertThat(migrated.getRowKind()).isEqualTo(oldValue.getRowKind());
+    }
+
+    @Test
+    void addNullableFieldInMiddle() throws IOException {
+        RowDataSerializerSnapshot oldSnap =
+                snapshot(row(new String[] {"a", "c"}, new IntType(), new BigIntType()));
+        RowDataSerializerSnapshot newSnap =
+                snapshot(
+                        row(
+                                new String[] {"a", "b", "c"},
+                                new IntType(),
+                                nullableInt(),
+                                new BigIntType()));
+
+        assertThat(newSnap.resolveSchemaCompatibility(oldSnap).isCompatibleAfterMigration())
+                .isTrue();
+
+        GenericRowData oldValue = GenericRowData.of(1, 99L);
+        RowData migrated = newSnap.migrate(oldSnap, oldValue);
+
+        assertThat(migrated.getInt(0)).isEqualTo(1);
+        assertThat(migrated.isNullAt(1)).isTrue();
+        assertThat(migrated.getLong(2)).isEqualTo(99L);
+    }
+
+    @Test
+    void reorderExistingFieldsByName() throws IOException {
+        RowDataSerializerSnapshot oldSnap =
+                snapshot(row(new String[] {"a", "b"}, new IntType(), new BigIntType()));
+        RowDataSerializerSnapshot newSnap =
+                snapshot(row(new String[] {"b", "a"}, new BigIntType(), new IntType()));
+
+        assertThat(newSnap.resolveSchemaCompatibility(oldSnap).isCompatibleAfterMigration())
+                .isTrue();
+
+        GenericRowData oldValue = GenericRowData.of(7, 42L);
+        RowData migrated = newSnap.migrate(oldSnap, oldValue);
+
+        // new position 0 == "b" (42L), new position 1 == "a" (7).
+        assertThat(migrated.getLong(0)).isEqualTo(42L);
+        assertThat(migrated.getInt(1)).isEqualTo(7);
+    }
+
+    /**
+     * The key case for the ROW exemption in the type check: a nested ROW that gains a nullable
+     * field has a different top-level {@code LogicalType}, so requiring {@code .equals} there would
+     * wrongly reject the evolution. The nested recursion must validate it instead.
+     */
+    @Test
+    void nestedRowEvolution() throws IOException {
+        RowType oldNested = row(new String[] {"x", "y"}, new IntType(), VarCharType.STRING_TYPE);
+        RowType newNested =
+                row(
+                        new String[] {"x", "y", "z"},
+                        new IntType(),
+                        VarCharType.STRING_TYPE,
+                        nullableInt());
+        RowDataSerializerSnapshot oldSnap =
+                snapshot(row(new String[] {"id", "nested"}, new IntType(), oldNested));
+        RowDataSerializerSnapshot newSnap =
+                snapshot(row(new String[] {"id", "nested"}, new IntType(), newNested));
+
+        assertThat(newSnap.resolveSchemaCompatibility(oldSnap).isCompatibleAfterMigration())
+                .isTrue();
+
+        GenericRowData oldValue = GenericRowData.of(5, GenericRowData.of(8, fromString("hi")));
+        RowData migrated = newSnap.migrate(oldSnap, oldValue);
+
+        assertThat(migrated.getInt(0)).isEqualTo(5);
+        RowData migratedNested = migrated.getRow(1, 3);
+        assertThat(migratedNested.getInt(0)).isEqualTo(8);
+        assertThat(migratedNested.getString(1)).isEqualTo(fromString("hi"));
+        assertThat(migratedNested.isNullAt(2)).isTrue();
+    }
+
+    /**
+     * The rejection counterpart to {@link #nestedRowEvolution}: a nested ROW with an incompatible
+     * leaf change (a: INT -> BIGINT). The ROW exemption skips the top-level {@code .equals} on the
+     * nested field, so the verdict depends on the nested recursion reporting incompatibility and
+     * that propagating up to a top-level {@code incompatible()}.
+     */
+    @Test
+    void rejectNestedRowIncompatibleChange() throws IOException {
+        RowType oldNested = row(new String[] {"a"}, new IntType());
+        RowType newNested = row(new String[] {"a"}, new BigIntType());
+        RowDataSerializerSnapshot oldSnap =
+                snapshot(row(new String[] {"id", "nested"}, new IntType(), oldNested));
+        RowDataSerializerSnapshot newSnap =
+                snapshot(row(new String[] {"id", "nested"}, new IntType(), newNested));
+
+        assertThat(newSnap.resolveSchemaCompatibility(oldSnap).isIncompatible()).isTrue();
+    }
+
+    @Test
+    void rejectFieldRemoval() throws IOException {
+        RowDataSerializerSnapshot oldSnap =
+                snapshot(row(new String[] {"a", "b"}, new IntType(), new BigIntType()));
+        RowDataSerializerSnapshot newSnap = snapshot(row(new String[] {"a"}, new IntType()));
+
+        assertThat(newSnap.resolveSchemaCompatibility(oldSnap).isIncompatible()).isTrue();
+    }
+
+    @Test
+    void rejectLeafTypeChange() throws IOException {
+        RowDataSerializerSnapshot oldSnap =
+                snapshot(row(new String[] {"a", "b"}, new IntType(), new IntType()));
+        RowDataSerializerSnapshot newSnap =
+                snapshot(row(new String[] {"a", "b"}, new IntType(), new BigIntType()));
+
+        assertThat(newSnap.resolveSchemaCompatibility(oldSnap).isIncompatible()).isTrue();
+    }
+
+    @Test
+    void rejectRename() throws IOException {
+        // "b" is removed and "c" added (with a differing type so the layout differs and the
+        // name-based path runs): the old "b" has no name match in the new schema -> removal.
+        RowDataSerializerSnapshot oldSnap =
+                snapshot(row(new String[] {"a", "b"}, new IntType(), new BigIntType()));
+        RowDataSerializerSnapshot newSnap =
+                snapshot(row(new String[] {"a", "c"}, new IntType(), nullableInt()));
+
+        assertThat(newSnap.resolveSchemaCompatibility(oldSnap).isIncompatible()).isTrue();
+    }
+
+    @Test
+    void rejectNonNullableAddedField() throws IOException {
+        RowDataSerializerSnapshot oldSnap = snapshot(row(new String[] {"a"}, new IntType()));
+        RowDataSerializerSnapshot newSnap =
+                snapshot(
+                        row(
+                                new String[] {"a", "b"},
+                                new IntType(),
+                                new IntType(false))); // NOT NULL added field
+
+        assertThat(newSnap.resolveSchemaCompatibility(oldSnap).isIncompatible()).isTrue();
+    }
+
+    @Test
+    void namesLessDifferingLayoutIsIncompatible() throws IOException {
+        // Old side is names-less (plain constructor); layouts differ -> no positional relaxation.
+        RowDataSerializerSnapshot oldSnap =
+                (RowDataSerializerSnapshot)
+                        new RowDataSerializer(new IntType()).snapshotConfiguration();
+        RowDataSerializerSnapshot newSnap =
+                snapshot(row(new String[] {"a", "b"}, new IntType(), nullableInt()));
+
+        assertThat(newSnap.resolveSchemaCompatibility(oldSnap).isIncompatible()).isTrue();
+    }
+
+    @Test
+    void identicalLayoutStaysCompatible() throws IOException {
+        RowDataSerializerSnapshot oldSnap =
+                snapshot(row(new String[] {"a", "b"}, new IntType(), new BigIntType()));
+        RowDataSerializerSnapshot newSnap =
+                snapshot(row(new String[] {"a", "b"}, new IntType(), new BigIntType()));
+
+        assertThat(newSnap.resolveSchemaCompatibility(oldSnap).isIncompatible()).isFalse();
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

This pull request adds an opt-in, name-based **state schema evolution** path for `RowData` keyed state, implementing [FLIP-527](https://cwiki.apache.org/confluence/display/FLINK/FLIP-527) (JIRA: FLINK-37732).

Today `RowDataSerializer.resolveSchemaCompatibility` returns `incompatible()` on any field-level change, so a Flink SQL job whose keyed state holds a `RowData` whose schema evolves — for example an upstream Avro/CDC source adds a nullable column — cannot restore from a savepoint. This change lets such state migrate on restore by matching fields **by name** (nullable additions, reordering, and nested-`ROW` recursion), rather than by position.

The feature is **opt-in and off by default** (`table.exec.state.schema-evolution.enabled = false`) and, in this first PR, **scoped to the RocksDB state backend**. The opt-in is enforced at serializer construction: when the option is off, RowData state serializers are built name-less exactly as today, so `resolveSchemaCompatibility` still returns `incompatible()` and restore behavior is unchanged. The design fails closed — nothing migrates unless a user explicitly enables the feature.

This PR is intended to accompany the FLIP-527 discussion and is opened as a **draft**; it is not intended to merge until the FLIP is approved.

## Brief change log

  - *(core)* Add an object-level `migrate(TypeSerializerSnapshot<T> old, T value)` default method to `TypeSerializerSnapshot` (default = identity; only `RowData` overrides it), so a serializer can remap a value written by a prior, compatible schema.
  - *(table)* Add `String[] fieldNames` to `RowDataSerializer` and bump `RowDataSerializerSnapshot` `V3 → V4` (append field names; V4 reads V3 with names absent → position-based behavior, preserving old savepoints).
  - *(table)* Implement name-based `resolveSchemaCompatibility` (returns `compatibleAfterMigration()` only when both snapshots carry names and the change is backward-compatible: nullable additions, reorder, nested `ROW`; rejects removals, renames, type changes, non-nullable additions) plus the `migrate` remap into a `GenericRowData` of the new arity (preserves `RowKind`, nulls for added fields, recurses nested `ROW`).
  - *(table)* Add the `table.exec.state.schema-evolution.enabled` option (default `false`).
  - *(runtime)* Drive the object-level `migrate` through `TtlAwareSerializer.migrateValueFromPriorSerializer` (polymorphic; preserves the TTL timestamp; no `flink-table` dependency), so TTL and non-TTL value state share one migration path.
  - *(table/core)* Gate field-name population on the option through a single global point: a new `@PublicEvolving SerializerConfig.isStateSchemaEvolutionEnabled()` (default `false`) that `InternalTypeInfo.createSerializer` reads to build a name-retaining `RowData` serializer only when the option is on. This covers every operator whose keyed-state serializer is built from an `InternalTypeInfo` descriptor (regular/interval/temporal joins, group aggregate, deduplicate, rank, over-aggregate) in one place, with no per-operator code.

## Verifying this change

This change added tests and can be verified as follows:

  - Serializer-level evolution and rejection cases (nullable-add at various positions, reorder, nested `ROW`, combinations; rejections for removal, rename, type change, non-nullable add) in `flink-table-type-utils`.
  - `V3 → V4` snapshot backward-read (a genuine V3-layout snapshot restores with `fieldNames` null and position-based behavior).
  - The opt-in flag transport/copy regression (`SerializerConfigImplTest`) — the flag survives `configure()`/`copy()` on the shared job `Configuration`.
  - A deterministic RocksDB-backed migration test driving the full stack (RocksDB restore → `TtlAwareSerializer.migrateValueFromPriorSerializer` → `RowDataSerializerSnapshot.migrate`) for value state (TTL and non-TTL) and map value, plus a leaf type-change rejection.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **yes** — a new `@PublicEvolving` default method `TypeSerializerSnapshot.migrate(...)`, a new `@PublicEvolving` default method `SerializerConfig.isStateSchemaEvolutionEnabled()`, and a new `@PublicEvolving` config option `table.exec.state.schema-evolution.enabled`. All are `default`/additive, so existing implementors remain source- and binary-compatible.
  - The serializers: **yes** — `RowDataSerializer` gains optional field names and its snapshot format is bumped `V3 → V4` (backward-compatible read of V3).
  - The runtime per-record code paths (performance sensitive): **no** — field names are metadata used only at compatibility resolution and restore-time migration; per-record serialization/deserialization is unchanged and `equals`/`hashCode` ignore names.
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: **yes** — savepoint/checkpoint state restore. The snapshot format bump reads old (V3) snapshots unchanged, and the new migration path only activates when the opt-in is enabled; with the option off, restore compatibility is identical to today.
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **yes**
  - If yes, how is the feature documented? **docs** (the `table.exec.state.schema-evolution.enabled` option is generated into the configuration reference) **and JavaDocs** on the new public methods. A dedicated documentation page describing supported schema changes and the RocksDB scope is a planned follow-up.

Scope note for reviewers: this first PR is RocksDB-scoped and covers operators whose keyed-state serializer is built from an `InternalTypeInfo` descriptor. Operators that pre-build their state serializer (window, lookup, process-table, sink materializer), outer joins (composite-wrapped value), and other backends (ForSt, Heap) are intentionally out of scope and fail closed (their state does not evolve yet); each is tracked as a follow-up under FLINK-37732.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (Claude Code, Opus 4.8)

Generated-by: Claude Code (Opus 4.8)
