### PR TITLE
[FLINK-XXXXX][table] Add GEOGRAPHY Java API and runtime representation

### DIFF
--- a/docs/static/generated/rest_v1_sql_gateway.yml
+++ b/docs/static/generated/rest_v1_sql_gateway.yml
@@ -403,6 +403,7 @@ components:
       - DESCRIPTOR
       - VARIANT
       - BITMAP
+      - GEOGRAPHY
     OpenSessionRequestBody:
       type: object
       properties:

--- a/docs/static/generated/rest_v2_sql_gateway.yml
+++ b/docs/static/generated/rest_v2_sql_gateway.yml
@@ -477,6 +477,7 @@ components:
       - DESCRIPTOR
       - VARIANT
       - BITMAP
+      - GEOGRAPHY
     OpenSessionRequestBody:
       type: object
       properties:

--- a/docs/static/generated/rest_v3_sql_gateway.yml
+++ b/docs/static/generated/rest_v3_sql_gateway.yml
@@ -506,6 +506,7 @@ components:
       - DESCRIPTOR
       - VARIANT
       - BITMAP
+      - GEOGRAPHY
     OpenSessionRequestBody:
       type: object
       properties:

--- a/docs/static/generated/rest_v4_sql_gateway.yml
+++ b/docs/static/generated/rest_v4_sql_gateway.yml
@@ -516,6 +516,7 @@ components:
       - DESCRIPTOR
       - VARIANT
       - BITMAP
+      - GEOGRAPHY
     OpenSessionRequestBody:
       type: object
       properties:

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/asyncprocessing/operators/AbstractAsyncRunnableStreamOperatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/asyncprocessing/operators/AbstractAsyncRunnableStreamOperatorTest.java
@@ -253,8 +253,11 @@ public class AbstractAsyncRunnableStreamOperatorTest {
                             });
             ((AbstractAsyncRunnableStreamOperator<String>) testHarness.getOperator())
                     .postProcessElement();
-            assertThat(asyncExecutionController.getInFlightRecordNum()).isEqualTo(1);
-            unblockAsyncRequest.complete(null);
+            try {
+                assertThat(asyncExecutionController.getInFlightRecordNum()).isEqualTo(1);
+            } finally {
+                unblockAsyncRequest.complete(null);
+            }
             testHarness.drainAsyncRequests();
             assertThat(asyncExecutionController.getInFlightRecordNum()).isEqualTo(0);
         }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/api/DataTypes.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/api/DataTypes.java
@@ -44,6 +44,7 @@ import org.apache.flink.table.types.logical.DecimalType;
 import org.apache.flink.table.types.logical.DescriptorType;
 import org.apache.flink.table.types.logical.DoubleType;
 import org.apache.flink.table.types.logical.FloatType;
+import org.apache.flink.table.types.logical.GeographyType;
 import org.apache.flink.table.types.logical.IntType;
 import org.apache.flink.table.types.logical.LocalZonedTimestampType;
 import org.apache.flink.table.types.logical.LogicalType;
@@ -1073,6 +1074,15 @@ public final class DataTypes {
      */
     public static DataType BITMAP() {
         return new AtomicDataType(new BitmapType());
+    }
+
+    /**
+     * Data type of geography data.
+     *
+     * @see GeographyType
+     */
+    public static DataType GEOGRAPHY() {
+        return new AtomicDataType(new GeographyType());
     }
 
     // --------------------------------------------------------------------------------------------

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/ArrayData.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/ArrayData.java
@@ -123,6 +123,12 @@ public interface ArrayData {
                 "This ArrayData implementation does not support Bitmap type.");
     }
 
+    /** Returns the geography value at the given position. */
+    default GeographyData getGeography(int pos) {
+        throw new UnsupportedOperationException(
+                "This ArrayData implementation does not support Geography type.");
+    }
+
     // ------------------------------------------------------------------------------------------
     // Conversion Utilities
     // ------------------------------------------------------------------------------------------
@@ -224,6 +230,9 @@ public interface ArrayData {
                 break;
             case BITMAP:
                 elementGetter = ArrayData::getBitmap;
+                break;
+            case GEOGRAPHY:
+                elementGetter = ArrayData::getGeography;
                 break;
             case NULL:
             case SYMBOL:

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/GenericArrayData.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/GenericArrayData.java
@@ -265,6 +265,11 @@ public final class GenericArrayData implements ArrayData {
         return (Bitmap) getObject(pos);
     }
 
+    @Override
+    public GeographyData getGeography(int pos) {
+        return (GeographyData) getObject(pos);
+    }
+
     private Object getObject(int pos) {
         return ((Object[]) array)[pos];
     }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/GenericRowData.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/GenericRowData.java
@@ -193,6 +193,11 @@ public final class GenericRowData implements RowData {
     }
 
     @Override
+    public GeographyData getGeography(int pos) {
+        return (GeographyData) this.fields[pos];
+    }
+
+    @Override
     public ArrayData getArray(int pos) {
         return (ArrayData) this.fields[pos];
     }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/GeographyData.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/GeographyData.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.data;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.table.data.binary.BinaryGeographyData;
+import org.apache.flink.table.types.logical.GeographyType;
+
+/** An internal data structure representing data of {@link GeographyType}. */
+@PublicEvolving
+public interface GeographyData {
+
+    /** ISO WKB subtype ID for Point geometries. */
+    int POINT = 1;
+
+    /** ISO WKB subtype ID for LineString geometries. */
+    int LINE_STRING = 2;
+
+    /** ISO WKB subtype ID for Polygon geometries. */
+    int POLYGON = 3;
+
+    /** ISO WKB subtype ID for MultiPoint geometries. */
+    int MULTI_POINT = 4;
+
+    /** ISO WKB subtype ID for MultiLineString geometries. */
+    int MULTI_LINE_STRING = 5;
+
+    /** ISO WKB subtype ID for MultiPolygon geometries. */
+    int MULTI_POLYGON = 6;
+
+    /** ISO WKB subtype ID for GeometryCollection geometries. */
+    int GEOMETRY_COLLECTION = 7;
+
+    /**
+     * Converts this {@link GeographyData} object to an ISO WKB byte array.
+     *
+     * <p>Note: The returned byte array may be reused.
+     */
+    byte[] toBytes();
+
+    /** Returns the ISO WKB subtype ID. */
+    int subtypeId();
+
+    /** Returns the size in bytes of the ISO WKB payload. */
+    int sizeInBytes();
+
+    // ------------------------------------------------------------------------------------------
+    // Construction Utilities
+    // ------------------------------------------------------------------------------------------
+
+    /**
+     * Creates an instance of {@link GeographyData} from the given ISO WKB byte array. Returns
+     * {@code null} if the input is {@code null}.
+     */
+    static GeographyData fromBytes(byte[] bytes) {
+        return BinaryGeographyData.fromBytes(bytes);
+    }
+
+    /**
+     * Creates an instance of {@link GeographyData} from the given ISO WKB byte range. Returns
+     * {@code null} if the input is {@code null}.
+     */
+    static GeographyData fromBytes(byte[] bytes, int offset, int numBytes) {
+        return BinaryGeographyData.fromBytes(bytes, offset, numBytes);
+    }
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/RowData.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/RowData.java
@@ -111,6 +111,8 @@ import static org.apache.flink.table.types.logical.utils.LogicalTypeChecks.getSc
  * +--------------------------------+-----------------------------------------+
  * | BITMAP                         | {@link Bitmap}                          |
  * +--------------------------------+-----------------------------------------+
+ * | GEOGRAPHY                      | {@link GeographyData}                   |
+ * +--------------------------------+-----------------------------------------+
  * </pre>
  *
  * <p>Nullability is always handled by the container data structure.
@@ -214,6 +216,12 @@ public interface RowData {
                 "This RowData implementation does not support Bitmap type.");
     }
 
+    /** Returns the geography value at the given position. */
+    default GeographyData getGeography(int pos) {
+        throw new UnsupportedOperationException(
+                "This RowData implementation does not support Geography type.");
+    }
+
     // ------------------------------------------------------------------------------------------
     // Access Utilities
     // ------------------------------------------------------------------------------------------
@@ -298,6 +306,9 @@ public interface RowData {
                 break;
             case BITMAP:
                 fieldGetter = row -> row.getBitmap(fieldPos);
+                break;
+            case GEOGRAPHY:
+                fieldGetter = row -> row.getGeography(fieldPos);
                 break;
             case NULL:
             case SYMBOL:

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/binary/BinaryArrayData.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/binary/BinaryArrayData.java
@@ -23,6 +23,7 @@ import org.apache.flink.core.memory.MemorySegment;
 import org.apache.flink.core.memory.MemorySegmentFactory;
 import org.apache.flink.table.data.ArrayData;
 import org.apache.flink.table.data.DecimalData;
+import org.apache.flink.table.data.GeographyData;
 import org.apache.flink.table.data.MapData;
 import org.apache.flink.table.data.RawValueData;
 import org.apache.flink.table.data.RowData;
@@ -95,6 +96,7 @@ public final class BinaryArrayData extends BinarySection implements ArrayData, T
             case RAW:
             case VARIANT:
             case BITMAP:
+            case GEOGRAPHY:
                 // long and double are 8 bytes;
                 // otherwise it stores the length and offset of the variable-length part for types
                 // such as is string, map, etc.
@@ -267,6 +269,14 @@ public final class BinaryArrayData extends BinarySection implements ArrayData, T
         int fieldOffset = getElementOffset(pos, 8);
         final long offsetAndSize = BinarySegmentUtils.getLong(segments, fieldOffset);
         return BinarySegmentUtils.readBinary(segments, offset, fieldOffset, offsetAndSize);
+    }
+
+    @Override
+    public GeographyData getGeography(int pos) {
+        assertIndexIsValid(pos);
+        int fieldOffset = getElementOffset(pos, 8);
+        final long offsetAndSize = BinarySegmentUtils.getLong(segments, fieldOffset);
+        return BinarySegmentUtils.readGeographyData(segments, offset, fieldOffset, offsetAndSize);
     }
 
     @Override

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/binary/BinaryGeographyData.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/binary/BinaryGeographyData.java
@@ -1,0 +1,269 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.data.binary;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.core.memory.MemorySegment;
+import org.apache.flink.core.memory.MemorySegmentFactory;
+import org.apache.flink.table.api.TableRuntimeException;
+import org.apache.flink.table.data.GeographyData;
+
+import java.util.Arrays;
+
+/**
+ * A binary implementation of {@link GeographyData} backed by raw ISO WKB bytes.
+ *
+ * <p>GEOGRAPHY uses OGC:CRS84 by contract, but ISO WKB does not encode CRS or SRID metadata. This
+ * container stores the raw ISO WKB payload only; CRS validation, CRS transformation, and EWKB/SRID
+ * handling belong to constructors, functions, and connector schema mapping.
+ */
+@Internal
+public final class BinaryGeographyData extends BinarySection implements GeographyData {
+
+    private static final int MIN_WKB_HEADER_SIZE = 5;
+    private static final int WKB_COUNT_SIZE = 4;
+    private static final int WKB_POINT_COORDINATE_SIZE = 16;
+    private static final int BIG_ENDIAN = 0;
+    private static final int LITTLE_ENDIAN = 1;
+
+    private final int subtypeId;
+
+    private BinaryGeographyData(MemorySegment[] segments, int offset, int sizeInBytes) {
+        super(segments, offset, sizeInBytes);
+        this.subtypeId = readSubtypeId(segments, offset, sizeInBytes);
+    }
+
+    /** Creates a {@link BinaryGeographyData} instance from the given address and length. */
+    public static BinaryGeographyData fromAddress(
+            MemorySegment[] segments, int offset, int numBytes) {
+        return new BinaryGeographyData(segments, offset, numBytes);
+    }
+
+    /** Creates a {@link BinaryGeographyData} instance from the given ISO WKB bytes. */
+    public static BinaryGeographyData fromBytes(byte[] bytes) {
+        return bytes == null ? null : fromBytes(bytes, 0, bytes.length);
+    }
+
+    /** Creates a {@link BinaryGeographyData} instance from the given ISO WKB byte range. */
+    public static BinaryGeographyData fromBytes(byte[] bytes, int offset, int numBytes) {
+        if (bytes == null) {
+            return null;
+        }
+        checkRange(bytes, offset, numBytes);
+        byte[] copy = Arrays.copyOfRange(bytes, offset, offset + numBytes);
+        return fromAddress(new MemorySegment[] {MemorySegmentFactory.wrap(copy)}, 0, copy.length);
+    }
+
+    @Override
+    public byte[] toBytes() {
+        return BinarySegmentUtils.copyToBytes(segments, offset, sizeInBytes);
+    }
+
+    @Override
+    public int subtypeId() {
+        return subtypeId;
+    }
+
+    @Override
+    public int sizeInBytes() {
+        return sizeInBytes;
+    }
+
+    private static void checkRange(byte[] bytes, int offset, int numBytes) {
+        if (offset < 0 || numBytes < 0 || offset > bytes.length - numBytes) {
+            throw new TableRuntimeException(
+                    String.format(
+                            "Invalid ISO WKB byte range: offset %d, length %d, array length %d.",
+                            offset, numBytes, bytes.length));
+        }
+    }
+
+    private static int readSubtypeId(MemorySegment[] segments, int offset, int sizeInBytes) {
+        final long endOffset = (long) offset + sizeInBytes;
+        final GeometryHeader header = readHeader(segments, offset, endOffset);
+        final long consumedOffset = validateGeometry(segments, offset, endOffset);
+        if (consumedOffset != endOffset) {
+            throw new TableRuntimeException(
+                    String.format(
+                            "Malformed ISO WKB payload. Found %d trailing byte(s).",
+                            endOffset - consumedOffset));
+        }
+        return header.subtypeId;
+    }
+
+    private static long validateGeometry(
+            MemorySegment[] segments, long geometryOffset, long endOffset) {
+        final GeometryHeader header = readHeader(segments, geometryOffset, endOffset);
+        long cursor = geometryOffset + MIN_WKB_HEADER_SIZE;
+
+        switch (header.subtypeId) {
+            case GeographyData.POINT:
+                return requireBytes(
+                                cursor, WKB_POINT_COORDINATE_SIZE, endOffset, "POINT coordinates")
+                        + WKB_POINT_COORDINATE_SIZE;
+            case GeographyData.LINE_STRING:
+                return skipCoordinateSequence(segments, cursor, endOffset, header.byteOrder);
+            case GeographyData.POLYGON:
+                return skipPolygon(segments, cursor, endOffset, header.byteOrder);
+            case GeographyData.MULTI_POINT:
+                return skipTypedGeometryCollection(
+                        segments, cursor, endOffset, header.byteOrder, GeographyData.POINT);
+            case GeographyData.MULTI_LINE_STRING:
+                return skipTypedGeometryCollection(
+                        segments, cursor, endOffset, header.byteOrder, GeographyData.LINE_STRING);
+            case GeographyData.MULTI_POLYGON:
+                return skipTypedGeometryCollection(
+                        segments, cursor, endOffset, header.byteOrder, GeographyData.POLYGON);
+            case GeographyData.GEOMETRY_COLLECTION:
+                return skipGeometryCollection(segments, cursor, endOffset, header.byteOrder);
+            default:
+                throw new TableRuntimeException(
+                        String.format(
+                                "Malformed ISO WKB payload. Unsupported geography subtype ID %d.",
+                                header.subtypeId));
+        }
+    }
+
+    private static long skipCoordinateSequence(
+            MemorySegment[] segments, long offset, long endOffset, int byteOrder) {
+        final long numPoints =
+                readUnsignedInt(segments, offset, endOffset, byteOrder, "point count");
+        long cursor = offset + WKB_COUNT_SIZE;
+        final long coordinateSequenceSize =
+                multiplyExact(numPoints, WKB_POINT_COORDINATE_SIZE, "coordinate sequence");
+        return requireBytes(cursor, coordinateSequenceSize, endOffset, "coordinate sequence")
+                + coordinateSequenceSize;
+    }
+
+    private static long skipPolygon(
+            MemorySegment[] segments, long offset, long endOffset, int byteOrder) {
+        final long numRings = readUnsignedInt(segments, offset, endOffset, byteOrder, "ring count");
+        long cursor = offset + WKB_COUNT_SIZE;
+        for (long i = 0; i < numRings; i++) {
+            cursor = skipCoordinateSequence(segments, cursor, endOffset, byteOrder);
+        }
+        return cursor;
+    }
+
+    private static long skipTypedGeometryCollection(
+            MemorySegment[] segments,
+            long offset,
+            long endOffset,
+            int byteOrder,
+            int expectedSubtypeId) {
+        final long numGeometries =
+                readUnsignedInt(segments, offset, endOffset, byteOrder, "geometry count");
+        long cursor = offset + WKB_COUNT_SIZE;
+        for (long i = 0; i < numGeometries; i++) {
+            final GeometryHeader nestedHeader = readHeader(segments, cursor, endOffset);
+            if (nestedHeader.subtypeId != expectedSubtypeId) {
+                throw new TableRuntimeException(
+                        String.format(
+                                "Malformed ISO WKB payload. Expected nested subtype ID %d but found %d.",
+                                expectedSubtypeId, nestedHeader.subtypeId));
+            }
+            cursor = validateGeometry(segments, cursor, endOffset);
+        }
+        return cursor;
+    }
+
+    private static long skipGeometryCollection(
+            MemorySegment[] segments, long offset, long endOffset, int byteOrder) {
+        final long numGeometries =
+                readUnsignedInt(segments, offset, endOffset, byteOrder, "geometry count");
+        long cursor = offset + WKB_COUNT_SIZE;
+        for (long i = 0; i < numGeometries; i++) {
+            cursor = validateGeometry(segments, cursor, endOffset);
+        }
+        return cursor;
+    }
+
+    private static GeometryHeader readHeader(
+            MemorySegment[] segments, long offset, long endOffset) {
+        requireBytes(offset, MIN_WKB_HEADER_SIZE, endOffset, "WKB header");
+
+        final int byteOrder = BinarySegmentUtils.getByte(segments, (int) offset) & 0xFF;
+        if (byteOrder != BIG_ENDIAN && byteOrder != LITTLE_ENDIAN) {
+            throw new TableRuntimeException(
+                    String.format(
+                            "Malformed ISO WKB payload. Unsupported byte order %d.", byteOrder));
+        }
+
+        final long subtypeId =
+                readUnsignedInt(segments, offset + 1, endOffset, byteOrder, "subtype ID");
+
+        if (subtypeId < GeographyData.POINT || subtypeId > GeographyData.GEOMETRY_COLLECTION) {
+            throw new TableRuntimeException(
+                    String.format(
+                            "Malformed ISO WKB payload. Unsupported geography subtype ID %d.",
+                            subtypeId));
+        }
+        return new GeometryHeader(byteOrder, (int) subtypeId);
+    }
+
+    private static long readUnsignedInt(
+            MemorySegment[] segments,
+            long offset,
+            long endOffset,
+            int byteOrder,
+            String fieldName) {
+        requireBytes(offset, WKB_COUNT_SIZE, endOffset, fieldName);
+
+        if (byteOrder == LITTLE_ENDIAN) {
+            return (BinarySegmentUtils.getByte(segments, (int) offset) & 0xFFL)
+                    | ((BinarySegmentUtils.getByte(segments, (int) offset + 1) & 0xFFL) << 8)
+                    | ((BinarySegmentUtils.getByte(segments, (int) offset + 2) & 0xFFL) << 16)
+                    | ((BinarySegmentUtils.getByte(segments, (int) offset + 3) & 0xFFL) << 24);
+        }
+        return ((BinarySegmentUtils.getByte(segments, (int) offset) & 0xFFL) << 24)
+                | ((BinarySegmentUtils.getByte(segments, (int) offset + 1) & 0xFFL) << 16)
+                | ((BinarySegmentUtils.getByte(segments, (int) offset + 2) & 0xFFL) << 8)
+                | (BinarySegmentUtils.getByte(segments, (int) offset + 3) & 0xFFL);
+    }
+
+    private static long requireBytes(
+            long offset, long numBytes, long endOffset, String componentName) {
+        if (offset > endOffset || endOffset - offset < numBytes) {
+            throw new TableRuntimeException(
+                    String.format(
+                            "Malformed ISO WKB payload. Incomplete %s: expected %d byte(s) but found %d.",
+                            componentName, numBytes, Math.max(0, endOffset - offset)));
+        }
+        return offset;
+    }
+
+    private static long multiplyExact(long value, int factor, String componentName) {
+        final long result = value * factor;
+        if (value != 0 && result / value != factor) {
+            throw new TableRuntimeException(
+                    String.format("Malformed ISO WKB payload. %s size overflows.", componentName));
+        }
+        return result;
+    }
+
+    private static final class GeometryHeader {
+        private final int byteOrder;
+        private final int subtypeId;
+
+        private GeometryHeader(int byteOrder, int subtypeId) {
+            this.byteOrder = byteOrder;
+            this.subtypeId = subtypeId;
+        }
+    }
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/binary/BinaryRowData.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/binary/BinaryRowData.java
@@ -22,6 +22,7 @@ import org.apache.flink.core.memory.MemorySegment;
 import org.apache.flink.core.memory.MemorySegmentFactory;
 import org.apache.flink.table.data.ArrayData;
 import org.apache.flink.table.data.DecimalData;
+import org.apache.flink.table.data.GeographyData;
 import org.apache.flink.table.data.MapData;
 import org.apache.flink.table.data.RawValueData;
 import org.apache.flink.table.data.RowData;
@@ -370,6 +371,14 @@ public final class BinaryRowData extends BinarySection
         int fieldOffset = getFieldOffset(pos);
         final long offsetAndLen = segments[0].getLong(fieldOffset);
         return BinarySegmentUtils.readBinary(segments, offset, fieldOffset, offsetAndLen);
+    }
+
+    @Override
+    public GeographyData getGeography(int pos) {
+        assertIndexIsValid(pos);
+        int fieldOffset = getFieldOffset(pos);
+        final long offsetAndLen = segments[0].getLong(fieldOffset);
+        return BinarySegmentUtils.readGeographyData(segments, offset, fieldOffset, offsetAndLen);
     }
 
     @Override

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/binary/BinarySegmentUtils.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/binary/BinarySegmentUtils.java
@@ -1057,6 +1057,34 @@ public final class BinarySegmentUtils {
     }
 
     /**
+     * Get geography data, if len less than 8, it will be included in variablePartOffsetAndLen.
+     *
+     * @param baseOffset base offset of composite binary format.
+     * @param fieldOffset absolute start offset of 'variablePartOffsetAndLen'.
+     * @param variablePartOffsetAndLen a long value, real data or offset and len.
+     */
+    public static BinaryGeographyData readGeographyData(
+            MemorySegment[] segments,
+            int baseOffset,
+            int fieldOffset,
+            long variablePartOffsetAndLen) {
+        long mark = variablePartOffsetAndLen & HIGHEST_FIRST_BIT;
+        if (mark == 0) {
+            final int subOffset = (int) (variablePartOffsetAndLen >> 32);
+            final int len = (int) variablePartOffsetAndLen;
+            return BinaryGeographyData.fromAddress(segments, baseOffset + subOffset, len);
+        } else {
+            int len = (int) ((variablePartOffsetAndLen & HIGHEST_SECOND_TO_EIGHTH_BIT) >>> 56);
+            if (BinarySegmentUtils.LITTLE_ENDIAN) {
+                return BinaryGeographyData.fromAddress(segments, fieldOffset, len);
+            } else {
+                // fieldOffset + 1 to skip header.
+                return BinaryGeographyData.fromAddress(segments, fieldOffset + 1, len);
+            }
+        }
+    }
+
+    /**
      * Get binary string, if len less than 8, will be include in variablePartOffsetAndLen.
      *
      * <p>Note: Need to consider the ByteOrder.

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/binary/NestedRowData.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/binary/NestedRowData.java
@@ -21,6 +21,7 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.core.memory.MemorySegmentFactory;
 import org.apache.flink.table.data.ArrayData;
 import org.apache.flink.table.data.DecimalData;
+import org.apache.flink.table.data.GeographyData;
 import org.apache.flink.table.data.MapData;
 import org.apache.flink.table.data.RawValueData;
 import org.apache.flink.table.data.RowData;
@@ -292,6 +293,14 @@ public final class NestedRowData extends BinarySection implements RowData, Typed
         int fieldOffset = getFieldOffset(pos);
         final long offsetAndLen = BinarySegmentUtils.getLong(segments, fieldOffset);
         return BinarySegmentUtils.readBinary(segments, offset, fieldOffset, offsetAndLen);
+    }
+
+    @Override
+    public GeographyData getGeography(int pos) {
+        assertIndexIsValid(pos);
+        int fieldOffset = getFieldOffset(pos);
+        final long offsetAndLen = BinarySegmentUtils.getLong(segments, fieldOffset);
+        return BinarySegmentUtils.readGeographyData(segments, offset, fieldOffset, offsetAndLen);
     }
 
     @Override

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/columnar/ColumnarArrayData.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/columnar/ColumnarArrayData.java
@@ -21,6 +21,7 @@ package org.apache.flink.table.data.columnar;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.table.data.ArrayData;
 import org.apache.flink.table.data.DecimalData;
+import org.apache.flink.table.data.GeographyData;
 import org.apache.flink.table.data.MapData;
 import org.apache.flink.table.data.RawValueData;
 import org.apache.flink.table.data.RowData;
@@ -145,6 +146,12 @@ public final class ColumnarArrayData implements ArrayData, TypedSetters {
             return Arrays.copyOfRange(
                     byteArray.data, byteArray.offset, byteArray.offset + byteArray.len);
         }
+    }
+
+    @Override
+    public GeographyData getGeography(int pos) {
+        BytesColumnVector.Bytes byteArray = getByteArray(pos);
+        return GeographyData.fromBytes(byteArray.data, byteArray.offset, byteArray.len);
     }
 
     @Override

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/columnar/ColumnarRowData.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/columnar/ColumnarRowData.java
@@ -21,6 +21,7 @@ package org.apache.flink.table.data.columnar;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.table.data.ArrayData;
 import org.apache.flink.table.data.DecimalData;
+import org.apache.flink.table.data.GeographyData;
 import org.apache.flink.table.data.MapData;
 import org.apache.flink.table.data.RawValueData;
 import org.apache.flink.table.data.RowData;
@@ -150,6 +151,12 @@ public final class ColumnarRowData implements RowData, TypedSetters {
             System.arraycopy(byteArray.data, byteArray.offset, ret, 0, byteArray.len);
             return ret;
         }
+    }
+
+    @Override
+    public GeographyData getGeography(int pos) {
+        Bytes byteArray = vectorizedColumnBatch.getByteArray(rowId, pos);
+        return GeographyData.fromBytes(byteArray.data, byteArray.offset, byteArray.len);
     }
 
     @Override

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/utils/JoinedRowData.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/utils/JoinedRowData.java
@@ -21,6 +21,7 @@ package org.apache.flink.table.data.utils;
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.table.data.ArrayData;
 import org.apache.flink.table.data.DecimalData;
+import org.apache.flink.table.data.GeographyData;
 import org.apache.flink.table.data.MapData;
 import org.apache.flink.table.data.RawValueData;
 import org.apache.flink.table.data.RowData;
@@ -266,6 +267,15 @@ public class JoinedRowData implements RowData {
             return row1.getBitmap(pos);
         } else {
             return row2.getBitmap(pos - row1.getArity());
+        }
+    }
+
+    @Override
+    public GeographyData getGeography(int pos) {
+        if (pos < row1.getArity()) {
+            return row1.getGeography(pos);
+        } else {
+            return row2.getGeography(pos - row1.getArity());
         }
     }
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/utils/ProjectedRowData.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/utils/ProjectedRowData.java
@@ -22,6 +22,7 @@ import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.table.connector.Projection;
 import org.apache.flink.table.data.ArrayData;
 import org.apache.flink.table.data.DecimalData;
+import org.apache.flink.table.data.GeographyData;
 import org.apache.flink.table.data.MapData;
 import org.apache.flink.table.data.RawValueData;
 import org.apache.flink.table.data.RowData;
@@ -176,6 +177,11 @@ public class ProjectedRowData implements RowData {
     @Override
     public Bitmap getBitmap(int pos) {
         return row.getBitmap(indexMapping[pos]);
+    }
+
+    @Override
+    public GeographyData getGeography(int pos) {
+        return row.getGeography(indexMapping[pos]);
     }
 
     @Override

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/GeographyType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/GeographyType.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.types.logical;
+
+import org.apache.flink.annotation.PublicEvolving;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Data type of geography data.
+ *
+ * <p>The serializable string representation of this type is {@code GEOGRAPHY}.
+ */
+@PublicEvolving
+public final class GeographyType extends LogicalType {
+
+    private static final long serialVersionUID = 1L;
+
+    private static final String FORMAT = "GEOGRAPHY";
+
+    private static final Class<?> INPUT_OUTPUT_CONVERSION = Object.class;
+
+    public GeographyType(boolean isNullable) {
+        super(isNullable, LogicalTypeRoot.GEOGRAPHY);
+    }
+
+    public GeographyType() {
+        this(true);
+    }
+
+    @Override
+    public LogicalType copy(boolean isNullable) {
+        return new GeographyType(isNullable);
+    }
+
+    @Override
+    public String asSerializableString() {
+        return withNullability(FORMAT);
+    }
+
+    @Override
+    public boolean supportsInputConversion(Class<?> clazz) {
+        return INPUT_OUTPUT_CONVERSION == clazz;
+    }
+
+    @Override
+    public boolean supportsOutputConversion(Class<?> clazz) {
+        return INPUT_OUTPUT_CONVERSION == clazz;
+    }
+
+    @Override
+    public Class<?> getDefaultConversion() {
+        return INPUT_OUTPUT_CONVERSION;
+    }
+
+    @Override
+    public List<LogicalType> getChildren() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public <R> R accept(LogicalTypeVisitor<R> visitor) {
+        return visitor.visit(this);
+    }
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/GeographyType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/GeographyType.java
@@ -19,6 +19,7 @@
 package org.apache.flink.table.types.logical;
 
 import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.table.data.GeographyData;
 
 import java.util.Collections;
 import java.util.List;
@@ -35,7 +36,7 @@ public final class GeographyType extends LogicalType {
 
     private static final String FORMAT = "GEOGRAPHY";
 
-    private static final Class<?> INPUT_OUTPUT_CONVERSION = Object.class;
+    private static final Class<?> INPUT_OUTPUT_CONVERSION = GeographyData.class;
 
     public GeographyType(boolean isNullable) {
         super(isNullable, LogicalTypeRoot.GEOGRAPHY);
@@ -57,12 +58,12 @@ public final class GeographyType extends LogicalType {
 
     @Override
     public boolean supportsInputConversion(Class<?> clazz) {
-        return INPUT_OUTPUT_CONVERSION == clazz;
+        return INPUT_OUTPUT_CONVERSION.isAssignableFrom(clazz);
     }
 
     @Override
     public boolean supportsOutputConversion(Class<?> clazz) {
-        return INPUT_OUTPUT_CONVERSION == clazz;
+        return INPUT_OUTPUT_CONVERSION.isAssignableFrom(clazz);
     }
 
     @Override

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/LogicalTypeRoot.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/LogicalTypeRoot.java
@@ -145,7 +145,9 @@ public enum LogicalTypeRoot {
 
     VARIANT(LogicalTypeFamily.EXTENSION),
 
-    BITMAP(LogicalTypeFamily.EXTENSION);
+    BITMAP(LogicalTypeFamily.EXTENSION),
+
+    GEOGRAPHY(LogicalTypeFamily.EXTENSION);
 
     private final Set<LogicalTypeFamily> families;
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/LogicalTypeVisitor.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/LogicalTypeVisitor.java
@@ -101,5 +101,9 @@ public interface LogicalTypeVisitor<R> {
         return visit((LogicalType) bitmapType);
     }
 
+    default R visit(GeographyType geographyType) {
+        return visit((LogicalType) geographyType);
+    }
+
     R visit(LogicalType other);
 }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/utils/LogicalTypeDefaultVisitor.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/utils/LogicalTypeDefaultVisitor.java
@@ -31,6 +31,7 @@ import org.apache.flink.table.types.logical.DecimalType;
 import org.apache.flink.table.types.logical.DistinctType;
 import org.apache.flink.table.types.logical.DoubleType;
 import org.apache.flink.table.types.logical.FloatType;
+import org.apache.flink.table.types.logical.GeographyType;
 import org.apache.flink.table.types.logical.IntType;
 import org.apache.flink.table.types.logical.LocalZonedTimestampType;
 import org.apache.flink.table.types.logical.LogicalType;
@@ -201,6 +202,11 @@ public abstract class LogicalTypeDefaultVisitor<R> implements LogicalTypeVisitor
     @Override
     public R visit(BitmapType bitmapType) {
         return defaultMethod(bitmapType);
+    }
+
+    @Override
+    public R visit(GeographyType geographyType) {
+        return defaultMethod(geographyType);
     }
 
     @Override

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/utils/LogicalTypeParser.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/utils/LogicalTypeParser.java
@@ -36,6 +36,7 @@ import org.apache.flink.table.types.logical.DecimalType;
 import org.apache.flink.table.types.logical.DescriptorType;
 import org.apache.flink.table.types.logical.DoubleType;
 import org.apache.flink.table.types.logical.FloatType;
+import org.apache.flink.table.types.logical.GeographyType;
 import org.apache.flink.table.types.logical.IntType;
 import org.apache.flink.table.types.logical.LegacyTypeInformationType;
 import org.apache.flink.table.types.logical.LocalZonedTimestampType;
@@ -336,7 +337,8 @@ public final class LogicalTypeParser {
         DESCRIPTOR,
         STRUCTURED,
         VARIANT,
-        BITMAP
+        BITMAP,
+        GEOGRAPHY
     }
 
     private static final Set<String> KEYWORDS =
@@ -586,6 +588,8 @@ public final class LogicalTypeParser {
                     return new VariantType();
                 case BITMAP:
                     return new BitmapType();
+                case GEOGRAPHY:
+                    return new GeographyType();
                 default:
                     throw parsingError("Unsupported type: " + token().value);
             }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/utils/LogicalTypeUtils.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/utils/LogicalTypeUtils.java
@@ -21,6 +21,7 @@ package org.apache.flink.table.types.logical.utils;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.table.data.ArrayData;
 import org.apache.flink.table.data.DecimalData;
+import org.apache.flink.table.data.GeographyData;
 import org.apache.flink.table.data.MapData;
 import org.apache.flink.table.data.RawValueData;
 import org.apache.flink.table.data.RowData;
@@ -115,6 +116,8 @@ public final class LogicalTypeUtils {
                 return Variant.class;
             case BITMAP:
                 return Bitmap.class;
+            case GEOGRAPHY:
+                return GeographyData.class;
             case SYMBOL:
             case UNRESOLVED:
             default:

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/utils/LogicalTypeDataTypeConverter.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/utils/LogicalTypeDataTypeConverter.java
@@ -38,6 +38,7 @@ import org.apache.flink.table.types.logical.DescriptorType;
 import org.apache.flink.table.types.logical.DistinctType;
 import org.apache.flink.table.types.logical.DoubleType;
 import org.apache.flink.table.types.logical.FloatType;
+import org.apache.flink.table.types.logical.GeographyType;
 import org.apache.flink.table.types.logical.IntType;
 import org.apache.flink.table.types.logical.LocalZonedTimestampType;
 import org.apache.flink.table.types.logical.LogicalType;
@@ -263,6 +264,11 @@ public final class LogicalTypeDataTypeConverter {
         @Override
         public DataType visit(BitmapType bitmapType) {
             return new AtomicDataType(bitmapType);
+        }
+
+        @Override
+        public DataType visit(GeographyType geographyType) {
+            return new AtomicDataType(geographyType);
         }
 
         @Override

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/api/SchemaTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/api/SchemaTest.java
@@ -51,5 +51,21 @@ class SchemaTest {
 
             assertThat(newSchema.resolve(new TestSchemaResolver())).isEqualTo(originalSchema);
         }
+
+        @Test
+        void testGeographyColumn() {
+            final Schema schema =
+                    Schema.newBuilder()
+                            .column("location", DataTypes.GEOGRAPHY())
+                            .column("required_location", DataTypes.GEOGRAPHY().notNull())
+                            .build();
+
+            assertThat(schema.resolve(new TestSchemaResolver()))
+                    .isEqualTo(
+                            ResolvedSchema.of(
+                                    Column.physical("location", DataTypes.GEOGRAPHY()),
+                                    Column.physical(
+                                            "required_location", DataTypes.GEOGRAPHY().notNull())));
+        }
     }
 }

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/data/binary/BinaryGeographyDataTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/data/binary/BinaryGeographyDataTest.java
@@ -1,0 +1,331 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.data.binary;
+
+import org.apache.flink.core.memory.MemorySegment;
+import org.apache.flink.core.memory.MemorySegmentFactory;
+import org.apache.flink.table.api.TableRuntimeException;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.GeographyData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.types.logical.GeographyType;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.Arrays;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Tests for {@link BinaryGeographyData}. */
+class BinaryGeographyDataTest {
+
+    private static final int BIG_ENDIAN = 0;
+    private static final int LITTLE_ENDIAN = 1;
+    private static final byte[] POINT_WKB = pointWkb(LITTLE_ENDIAN);
+
+    @Test
+    void testValidWkbRoundTrip() {
+        final GeographyData geography = GeographyData.fromBytes(POINT_WKB);
+
+        assertThat(geography).isInstanceOf(BinaryGeographyData.class);
+        assertThat(geography.toBytes()).isEqualTo(POINT_WKB);
+        assertThat(geography.subtypeId()).isEqualTo(GeographyData.POINT);
+        assertThat(geography.sizeInBytes()).isEqualTo(POINT_WKB.length);
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("supportedSubtypePayloads")
+    void testSupported2dSubtypePayloads(String name, int subtypeId, byte[] wkb) {
+        final BinaryGeographyData geography = BinaryGeographyData.fromBytes(wkb);
+
+        assertThat(geography.subtypeId()).isEqualTo(subtypeId);
+        assertThat(geography.toBytes()).isEqualTo(wkb);
+        assertThat(geography.sizeInBytes()).isEqualTo(wkb.length);
+    }
+
+    static Stream<Arguments> supportedSubtypePayloads() {
+        return Stream.of(
+                Arguments.of("Point", GeographyData.POINT, pointWkb(LITTLE_ENDIAN)),
+                Arguments.of("LineString", GeographyData.LINE_STRING, lineStringWkb(LITTLE_ENDIAN)),
+                Arguments.of("Polygon", GeographyData.POLYGON, polygonWkb(LITTLE_ENDIAN)),
+                Arguments.of("MultiPoint", GeographyData.MULTI_POINT, multiPointWkb(LITTLE_ENDIAN)),
+                Arguments.of(
+                        "MultiLineString",
+                        GeographyData.MULTI_LINE_STRING,
+                        multiLineStringWkb(LITTLE_ENDIAN)),
+                Arguments.of(
+                        "MultiPolygon",
+                        GeographyData.MULTI_POLYGON,
+                        multiPolygonWkb(LITTLE_ENDIAN)),
+                Arguments.of(
+                        "GeometryCollection",
+                        GeographyData.GEOMETRY_COLLECTION,
+                        geometryCollectionWkb(LITTLE_ENDIAN)));
+    }
+
+    @Test
+    void testBigEndianSubtypeExtraction() {
+        final BinaryGeographyData point = BinaryGeographyData.fromBytes(pointWkb(BIG_ENDIAN));
+        final BinaryGeographyData lineString =
+                BinaryGeographyData.fromBytes(lineStringWkb(BIG_ENDIAN));
+
+        assertThat(point.subtypeId()).isEqualTo(GeographyData.POINT);
+        assertThat(lineString.subtypeId()).isEqualTo(GeographyData.LINE_STRING);
+    }
+
+    @Test
+    void testNullHandling() {
+        assertThat(GeographyData.fromBytes((byte[]) null)).isNull();
+        assertThat(GeographyData.fromBytes(null, 0, 0)).isNull();
+        assertThat(BinaryGeographyData.fromBytes((byte[]) null)).isNull();
+        assertThat(BinaryGeographyData.fromBytes(null, 0, 0)).isNull();
+    }
+
+    @Test
+    void testGenericRowDataNullPath() {
+        final RowData.FieldGetter getter = RowData.createFieldGetter(new GeographyType(), 0);
+        final GenericRowData nullRow = GenericRowData.of((Object) null);
+        final GeographyData geography = GeographyData.fromBytes(POINT_WKB);
+        final GenericRowData valueRow = GenericRowData.of(geography);
+
+        assertThat(getter.getFieldOrNull(nullRow)).isNull();
+        assertThat(getter.getFieldOrNull(valueRow)).isSameAs(geography);
+    }
+
+    @Test
+    void testBinaryRowDataNullPath() {
+        final RowData.FieldGetter getter = RowData.createFieldGetter(new GeographyType(), 0);
+        final int fixedLength = BinaryRowData.calculateFixPartSizeInBytes(1);
+        final BinaryRowData nullRow = new BinaryRowData(1);
+        nullRow.pointTo(MemorySegmentFactory.wrap(new byte[fixedLength]), 0, fixedLength);
+        nullRow.setNullAt(0);
+
+        assertThat(getter.getFieldOrNull(nullRow)).isNull();
+    }
+
+    @Test
+    void testBinaryRowDataValuePath() {
+        final BinaryRowData row = binaryRowWithGeography(POINT_WKB);
+
+        assertThat(row.getGeography(0).toBytes()).isEqualTo(POINT_WKB);
+        assertThat(row.getGeography(0).subtypeId()).isEqualTo(GeographyData.POINT);
+    }
+
+    @Test
+    void testByteRangeCopiesOnlySelectedPayload() {
+        final byte[] bytes = concat(bytes(42), POINT_WKB, bytes(99));
+        final BinaryGeographyData geography =
+                BinaryGeographyData.fromBytes(bytes, 1, POINT_WKB.length);
+
+        bytes[1] = 0;
+
+        assertThat(geography.toBytes()).isEqualTo(POINT_WKB);
+        assertThat(geography.subtypeId()).isEqualTo(GeographyData.POINT);
+    }
+
+    @Test
+    void testFromAddressSupportsSegmentBoundary() {
+        final byte[] first = concat(new byte[14], Arrays.copyOfRange(POINT_WKB, 0, 2));
+        final byte[] second = Arrays.copyOfRange(POINT_WKB, 2, 18);
+        final byte[] third =
+                concat(Arrays.copyOfRange(POINT_WKB, 18, POINT_WKB.length), new byte[13]);
+        final MemorySegment[] segments =
+                new MemorySegment[] {
+                    MemorySegmentFactory.wrap(first),
+                    MemorySegmentFactory.wrap(second),
+                    MemorySegmentFactory.wrap(third)
+                };
+
+        final BinaryGeographyData geography =
+                BinaryGeographyData.fromAddress(segments, 14, POINT_WKB.length);
+
+        assertThat(geography.toBytes()).isEqualTo(POINT_WKB);
+        assertThat(geography.subtypeId()).isEqualTo(GeographyData.POINT);
+    }
+
+    @Test
+    void testMalformedPayloadBoundaries() {
+        assertThatThrownBy(() -> BinaryGeographyData.fromBytes(bytes()))
+                .isInstanceOf(TableRuntimeException.class)
+                .hasMessageContaining("Incomplete WKB header");
+
+        assertThatThrownBy(() -> BinaryGeographyData.fromBytes(bytes(1, 1, 0, 0)))
+                .isInstanceOf(TableRuntimeException.class)
+                .hasMessageContaining("Incomplete WKB header");
+
+        assertThatThrownBy(() -> BinaryGeographyData.fromBytes(bytes(2, 1, 0, 0, 0)))
+                .isInstanceOf(TableRuntimeException.class)
+                .hasMessageContaining("Unsupported byte order 2");
+
+        assertThatThrownBy(() -> BinaryGeographyData.fromBytes(header(LITTLE_ENDIAN, 0)))
+                .isInstanceOf(TableRuntimeException.class)
+                .hasMessageContaining("Unsupported geography subtype ID 0");
+
+        assertThatThrownBy(() -> BinaryGeographyData.fromBytes(header(LITTLE_ENDIAN, 8)))
+                .isInstanceOf(TableRuntimeException.class)
+                .hasMessageContaining("Unsupported geography subtype ID 8");
+    }
+
+    @Test
+    void testStructurallyIncompletePayloads() {
+        assertThatThrownBy(
+                        () ->
+                                BinaryGeographyData.fromBytes(
+                                        header(LITTLE_ENDIAN, GeographyData.POINT)))
+                .isInstanceOf(TableRuntimeException.class)
+                .hasMessageContaining("Incomplete POINT coordinates");
+
+        assertThatThrownBy(
+                        () ->
+                                BinaryGeographyData.fromBytes(
+                                        concat(
+                                                header(LITTLE_ENDIAN, GeographyData.LINE_STRING),
+                                                unsignedInt(LITTLE_ENDIAN, 1),
+                                                new byte[15])))
+                .isInstanceOf(TableRuntimeException.class)
+                .hasMessageContaining("Incomplete coordinate sequence");
+
+        assertThatThrownBy(
+                        () ->
+                                BinaryGeographyData.fromBytes(
+                                        concat(
+                                                header(LITTLE_ENDIAN, GeographyData.MULTI_POINT),
+                                                unsignedInt(LITTLE_ENDIAN, 1),
+                                                lineStringWkb(LITTLE_ENDIAN))))
+                .isInstanceOf(TableRuntimeException.class)
+                .hasMessageContaining("Expected nested subtype ID 1 but found 2");
+
+        assertThatThrownBy(
+                        () ->
+                                BinaryGeographyData.fromBytes(
+                                        concat(pointWkb(LITTLE_ENDIAN), bytes(42))))
+                .isInstanceOf(TableRuntimeException.class)
+                .hasMessageContaining("trailing byte");
+    }
+
+    @Test
+    void testInvalidByteRanges() {
+        assertThatThrownBy(() -> BinaryGeographyData.fromBytes(POINT_WKB, -1, POINT_WKB.length))
+                .isInstanceOf(TableRuntimeException.class)
+                .hasMessageContaining("Invalid ISO WKB byte range");
+
+        assertThatThrownBy(() -> BinaryGeographyData.fromBytes(POINT_WKB, 0, POINT_WKB.length + 1))
+                .isInstanceOf(TableRuntimeException.class)
+                .hasMessageContaining("Invalid ISO WKB byte range");
+    }
+
+    private static BinaryRowData binaryRowWithGeography(byte[] wkb) {
+        final int fixedLength = BinaryRowData.calculateFixPartSizeInBytes(1);
+        final byte[] rowBytes = new byte[fixedLength + wkb.length];
+        final MemorySegment segment = MemorySegmentFactory.wrap(rowBytes);
+        segment.putLong(8, ((long) fixedLength << 32) | wkb.length);
+        segment.put(fixedLength, wkb, 0, wkb.length);
+
+        final BinaryRowData row = new BinaryRowData(1);
+        row.pointTo(segment, 0, rowBytes.length);
+        return row;
+    }
+
+    private static byte[] pointWkb(int byteOrder) {
+        return concat(header(byteOrder, GeographyData.POINT), new byte[16]);
+    }
+
+    private static byte[] lineStringWkb(int byteOrder) {
+        return concat(
+                header(byteOrder, GeographyData.LINE_STRING),
+                unsignedInt(byteOrder, 2),
+                new byte[32]);
+    }
+
+    private static byte[] polygonWkb(int byteOrder) {
+        return concat(
+                header(byteOrder, GeographyData.POLYGON),
+                unsignedInt(byteOrder, 1),
+                unsignedInt(byteOrder, 4),
+                new byte[64]);
+    }
+
+    private static byte[] multiPointWkb(int byteOrder) {
+        return concat(
+                header(byteOrder, GeographyData.MULTI_POINT),
+                unsignedInt(byteOrder, 1),
+                pointWkb(byteOrder));
+    }
+
+    private static byte[] multiLineStringWkb(int byteOrder) {
+        return concat(
+                header(byteOrder, GeographyData.MULTI_LINE_STRING),
+                unsignedInt(byteOrder, 1),
+                lineStringWkb(byteOrder));
+    }
+
+    private static byte[] multiPolygonWkb(int byteOrder) {
+        return concat(
+                header(byteOrder, GeographyData.MULTI_POLYGON),
+                unsignedInt(byteOrder, 1),
+                polygonWkb(byteOrder));
+    }
+
+    private static byte[] geometryCollectionWkb(int byteOrder) {
+        return concat(
+                header(byteOrder, GeographyData.GEOMETRY_COLLECTION),
+                unsignedInt(byteOrder, 2),
+                pointWkb(byteOrder),
+                lineStringWkb(byteOrder));
+    }
+
+    private static byte[] header(int byteOrder, int subtypeId) {
+        return concat(bytes(byteOrder), unsignedInt(byteOrder, subtypeId));
+    }
+
+    private static byte[] unsignedInt(int byteOrder, int value) {
+        if (byteOrder == LITTLE_ENDIAN) {
+            return bytes(value, value >>> 8, value >>> 16, value >>> 24);
+        }
+        return bytes(value >>> 24, value >>> 16, value >>> 8, value);
+    }
+
+    private static byte[] concat(byte[]... values) {
+        int length = 0;
+        for (byte[] value : values) {
+            length += value.length;
+        }
+
+        final byte[] result = new byte[length];
+        int offset = 0;
+        for (byte[] value : values) {
+            System.arraycopy(value, 0, result, offset, value.length);
+            offset += value.length;
+        }
+        return result;
+    }
+
+    private static byte[] bytes(int... values) {
+        final byte[] result = new byte[values.length];
+        for (int i = 0; i < values.length; i++) {
+            result[i] = (byte) values[i];
+        }
+        return result;
+    }
+}

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/DataTypesTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/DataTypesTest.java
@@ -21,6 +21,7 @@ package org.apache.flink.table.types;
 import org.apache.flink.api.common.typeinfo.Types;
 import org.apache.flink.api.common.typeutils.base.VoidSerializer;
 import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.data.GeographyData;
 import org.apache.flink.table.types.logical.ArrayType;
 import org.apache.flink.table.types.logical.BigIntType;
 import org.apache.flink.table.types.logical.BinaryType;
@@ -32,6 +33,7 @@ import org.apache.flink.table.types.logical.DayTimeIntervalType;
 import org.apache.flink.table.types.logical.DecimalType;
 import org.apache.flink.table.types.logical.DoubleType;
 import org.apache.flink.table.types.logical.FloatType;
+import org.apache.flink.table.types.logical.GeographyType;
 import org.apache.flink.table.types.logical.IntType;
 import org.apache.flink.table.types.logical.LocalZonedTimestampType;
 import org.apache.flink.table.types.logical.LogicalType;
@@ -82,6 +84,7 @@ import static org.apache.flink.table.api.DataTypes.DECIMAL;
 import static org.apache.flink.table.api.DataTypes.DOUBLE;
 import static org.apache.flink.table.api.DataTypes.FIELD;
 import static org.apache.flink.table.api.DataTypes.FLOAT;
+import static org.apache.flink.table.api.DataTypes.GEOGRAPHY;
 import static org.apache.flink.table.api.DataTypes.INT;
 import static org.apache.flink.table.api.DataTypes.INTERVAL;
 import static org.apache.flink.table.api.DataTypes.MAP;
@@ -231,6 +234,9 @@ class DataTypesTest {
                 TestSpec.forDataType(BITMAP())
                         .expectLogicalType(new BitmapType())
                         .expectConversionClass(Bitmap.class),
+                TestSpec.forDataType(GEOGRAPHY())
+                        .expectLogicalType(new GeographyType())
+                        .expectConversionClass(GeographyData.class),
                 TestSpec.forUnresolvedDataType(RAW(Types.VOID))
                         .expectUnresolvedString("[RAW('java.lang.Void', '?')]")
                         .lookupReturns(dummyRaw(Void.class))

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LogicalTypeParserTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LogicalTypeParserTest.java
@@ -39,6 +39,7 @@ import org.apache.flink.table.types.logical.DecimalType;
 import org.apache.flink.table.types.logical.DescriptorType;
 import org.apache.flink.table.types.logical.DoubleType;
 import org.apache.flink.table.types.logical.FloatType;
+import org.apache.flink.table.types.logical.GeographyType;
 import org.apache.flink.table.types.logical.IntType;
 import org.apache.flink.table.types.logical.LegacyTypeInformationType;
 import org.apache.flink.table.types.logical.LocalZonedTimestampType;
@@ -309,6 +310,8 @@ public class LogicalTypeParserTest {
                 TestSpec.forString("VARIANT NOT NULL").expectType(new VariantType(false)),
                 TestSpec.forString("BITMAP").expectType(new BitmapType()),
                 TestSpec.forString("BITMAP NOT NULL").expectType(new BitmapType(false)),
+                TestSpec.forString("GEOGRAPHY").expectType(new GeographyType()),
+                TestSpec.forString("GEOGRAPHY NOT NULL").expectType(new GeographyType(false)),
 
                 // error message testing
 

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LogicalTypesTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LogicalTypesTest.java
@@ -40,6 +40,7 @@ import org.apache.flink.table.types.logical.DecimalType;
 import org.apache.flink.table.types.logical.DistinctType;
 import org.apache.flink.table.types.logical.DoubleType;
 import org.apache.flink.table.types.logical.FloatType;
+import org.apache.flink.table.types.logical.GeographyType;
 import org.apache.flink.table.types.logical.IntType;
 import org.apache.flink.table.types.logical.LocalZonedTimestampType;
 import org.apache.flink.table.types.logical.LogicalType;
@@ -627,6 +628,20 @@ public class LogicalTypesTest {
                                 new Class[] {Bitmap.class, RoaringBitmapData.class},
                                 new LogicalType[] {},
                                 new BitmapType(false)));
+    }
+
+    @Test
+    void testGeographyType() {
+        assertThat(new GeographyType())
+                .isJavaSerializable()
+                .satisfies(
+                        baseAssertions(
+                                "GEOGRAPHY",
+                                "GEOGRAPHY",
+                                new Class[] {Object.class},
+                                new Class[] {Object.class},
+                                new LogicalType[] {},
+                                new GeographyType(false)));
     }
 
     @Test

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LogicalTypesTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LogicalTypesTest.java
@@ -26,6 +26,8 @@ import org.apache.flink.api.java.typeutils.runtime.kryo.KryoSerializer;
 import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.catalog.ObjectIdentifier;
 import org.apache.flink.table.catalog.UnresolvedIdentifier;
+import org.apache.flink.table.data.GeographyData;
+import org.apache.flink.table.data.binary.BinaryGeographyData;
 import org.apache.flink.table.expressions.TimeIntervalUnit;
 import org.apache.flink.table.legacy.types.logical.TypeInformationRawType;
 import org.apache.flink.table.types.logical.ArrayType;
@@ -638,8 +640,8 @@ public class LogicalTypesTest {
                         baseAssertions(
                                 "GEOGRAPHY",
                                 "GEOGRAPHY",
-                                new Class[] {Object.class},
-                                new Class[] {Object.class},
+                                new Class[] {GeographyData.class, BinaryGeographyData.class},
+                                new Class[] {GeographyData.class, BinaryGeographyData.class},
                                 new LogicalType[] {},
                                 new GeographyType(false)));
     }

--- a/flink-table/flink-table-type-utils/src/main/java/org/apache/flink/table/data/conversion/DataStructureConverters.java
+++ b/flink-table/flink-table-type-utils/src/main/java/org/apache/flink/table/data/conversion/DataStructureConverters.java
@@ -22,11 +22,13 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.table.api.TableException;
 import org.apache.flink.table.data.ArrayData;
 import org.apache.flink.table.data.DecimalData;
+import org.apache.flink.table.data.GeographyData;
 import org.apache.flink.table.data.MapData;
 import org.apache.flink.table.data.RawValueData;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.data.TimestampData;
+import org.apache.flink.table.data.binary.BinaryGeographyData;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.LogicalTypeRoot;
@@ -200,6 +202,8 @@ public final class DataStructureConverters {
         putConverter(LogicalTypeRoot.VARIANT, Variant.class, identity());
         putConverter(LogicalTypeRoot.BITMAP, Bitmap.class, constructor(BitmapBitmapConverter::new));
         putConverter(LogicalTypeRoot.BITMAP, RoaringBitmapData.class, identity());
+        putConverter(LogicalTypeRoot.GEOGRAPHY, GeographyData.class, identity());
+        putConverter(LogicalTypeRoot.GEOGRAPHY, BinaryGeographyData.class, identity());
     }
 
     /** Returns a converter for the given {@link DataType}. */

--- a/flink-table/flink-table-type-utils/src/main/java/org/apache/flink/table/data/writer/AbstractBinaryWriter.java
+++ b/flink-table/flink-table-type-utils/src/main/java/org/apache/flink/table/data/writer/AbstractBinaryWriter.java
@@ -24,6 +24,7 @@ import org.apache.flink.core.memory.MemorySegment;
 import org.apache.flink.core.memory.MemorySegmentFactory;
 import org.apache.flink.table.data.ArrayData;
 import org.apache.flink.table.data.DecimalData;
+import org.apache.flink.table.data.GeographyData;
 import org.apache.flink.table.data.MapData;
 import org.apache.flink.table.data.RawValueData;
 import org.apache.flink.table.data.RowData;
@@ -139,6 +140,11 @@ abstract class AbstractBinaryWriter implements BinaryWriter {
     public void writeBitmap(int pos, Bitmap bitmap) {
         byte[] bytes = bitmap.toBytes();
         writeBytesToVarLenPart(pos, bytes, bytes.length);
+    }
+
+    @Override
+    public void writeGeography(int pos, GeographyData geography) {
+        writeBinary(pos, geography.toBytes());
     }
 
     private DataOutputViewStreamWrapper getOutputView() {

--- a/flink-table/flink-table-type-utils/src/main/java/org/apache/flink/table/data/writer/BinaryArrayWriter.java
+++ b/flink-table/flink-table-type-utils/src/main/java/org/apache/flink/table/data/writer/BinaryArrayWriter.java
@@ -247,6 +247,7 @@ public final class BinaryArrayWriter extends AbstractBinaryWriter {
             case RAW:
             case VARIANT:
             case BITMAP:
+            case GEOGRAPHY:
                 return BinaryArrayWriter::setNullLong;
             case BOOLEAN:
                 return BinaryArrayWriter::setNullBoolean;

--- a/flink-table/flink-table-type-utils/src/main/java/org/apache/flink/table/data/writer/BinaryWriter.java
+++ b/flink-table/flink-table-type-utils/src/main/java/org/apache/flink/table/data/writer/BinaryWriter.java
@@ -21,6 +21,7 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.table.data.ArrayData;
 import org.apache.flink.table.data.DecimalData;
+import org.apache.flink.table.data.GeographyData;
 import org.apache.flink.table.data.MapData;
 import org.apache.flink.table.data.RawValueData;
 import org.apache.flink.table.data.RowData;
@@ -90,6 +91,8 @@ public interface BinaryWriter {
     void writeVariant(int pos, Variant variant);
 
     void writeBitmap(int pos, Bitmap bitmap);
+
+    void writeGeography(int pos, GeographyData geography);
 
     /** Finally, complete write to set real size to binary. */
     void complete();
@@ -174,6 +177,9 @@ public interface BinaryWriter {
             case BITMAP:
                 writer.writeBitmap(pos, (Bitmap) o);
                 break;
+            case GEOGRAPHY:
+                writer.writeGeography(pos, (GeographyData) o);
+                break;
             default:
                 throw new UnsupportedOperationException("Not support type: " + type);
         }
@@ -253,6 +259,8 @@ public interface BinaryWriter {
                 return (writer, pos, value) -> writer.writeVariant(pos, (Variant) value);
             case BITMAP:
                 return (writer, pos, value) -> writer.writeBitmap(pos, (Bitmap) value);
+            case GEOGRAPHY:
+                return (writer, pos, value) -> writer.writeGeography(pos, (GeographyData) value);
             case NULL:
             case SYMBOL:
             case UNRESOLVED:

--- a/flink-table/flink-table-type-utils/src/main/java/org/apache/flink/table/runtime/typeutils/GeographyDataSerializer.java
+++ b/flink-table/flink-table-type-utils/src/main/java/org/apache/flink/table/runtime/typeutils/GeographyDataSerializer.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.typeutils;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.typeutils.SimpleTypeSerializerSnapshot;
+import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
+import org.apache.flink.api.common.typeutils.base.TypeSerializerSingleton;
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.core.memory.DataOutputView;
+import org.apache.flink.table.data.GeographyData;
+
+import java.io.IOException;
+
+/** Serializer for {@link GeographyData}. */
+@Internal
+public final class GeographyDataSerializer extends TypeSerializerSingleton<GeographyData> {
+
+    private static final long serialVersionUID = 1L;
+
+    private static final byte[] EMPTY_GEOMETRY_COLLECTION =
+            new byte[] {1, GeographyData.GEOMETRY_COLLECTION, 0, 0, 0, 0, 0, 0, 0};
+
+    public static final GeographyDataSerializer INSTANCE = new GeographyDataSerializer();
+
+    private GeographyDataSerializer() {}
+
+    @Override
+    public boolean isImmutableType() {
+        return true;
+    }
+
+    @Override
+    public GeographyData createInstance() {
+        return GeographyData.fromBytes(EMPTY_GEOMETRY_COLLECTION);
+    }
+
+    @Override
+    public GeographyData copy(GeographyData from) {
+        return GeographyData.fromBytes(from.toBytes());
+    }
+
+    @Override
+    public GeographyData copy(GeographyData from, GeographyData reuse) {
+        return copy(from);
+    }
+
+    @Override
+    public int getLength() {
+        return -1;
+    }
+
+    @Override
+    public void serialize(GeographyData record, DataOutputView target) throws IOException {
+        final byte[] bytes = record.toBytes();
+        target.writeInt(bytes.length);
+        target.write(bytes);
+    }
+
+    @Override
+    public GeographyData deserialize(DataInputView source) throws IOException {
+        final int length = source.readInt();
+        final byte[] bytes = new byte[length];
+        source.readFully(bytes);
+        return GeographyData.fromBytes(bytes);
+    }
+
+    @Override
+    public GeographyData deserialize(GeographyData reuse, DataInputView source) throws IOException {
+        return deserialize(source);
+    }
+
+    @Override
+    public void copy(DataInputView source, DataOutputView target) throws IOException {
+        final int length = source.readInt();
+        target.writeInt(length);
+        target.write(source, length);
+    }
+
+    @Override
+    public TypeSerializerSnapshot<GeographyData> snapshotConfiguration() {
+        return new GeographyDataSerializerSnapshot();
+    }
+
+    /** Serializer configuration snapshot for compatibility and format evolution. */
+    @SuppressWarnings("WeakerAccess")
+    public static final class GeographyDataSerializerSnapshot
+            extends SimpleTypeSerializerSnapshot<GeographyData> {
+
+        public GeographyDataSerializerSnapshot() {
+            super(() -> INSTANCE);
+        }
+    }
+}

--- a/flink-table/flink-table-type-utils/src/main/java/org/apache/flink/table/runtime/typeutils/InternalSerializers.java
+++ b/flink-table/flink-table-type-utils/src/main/java/org/apache/flink/table/runtime/typeutils/InternalSerializers.java
@@ -129,6 +129,8 @@ public final class InternalSerializers {
                 return VariantSerializer.INSTANCE;
             case BITMAP:
                 return BitmapSerializer.INSTANCE;
+            case GEOGRAPHY:
+                return GeographyDataSerializer.INSTANCE;
             case NULL:
             case SYMBOL:
             case UNRESOLVED:

--- a/flink-table/flink-table-type-utils/src/test/java/org/apache/flink/table/runtime/typeutils/GeographyDataSerializerTest.java
+++ b/flink-table/flink-table-type-utils/src/test/java/org/apache/flink/table/runtime/typeutils/GeographyDataSerializerTest.java
@@ -1,0 +1,153 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.typeutils;
+
+import org.apache.flink.api.common.typeutils.SerializerTestBase;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.core.memory.DataInputViewStreamWrapper;
+import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
+import org.apache.flink.table.data.GenericArrayData;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.GeographyData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.binary.BinaryArrayData;
+import org.apache.flink.table.data.binary.BinaryRowData;
+import org.apache.flink.table.types.logical.GeographyType;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link GeographyDataSerializer}. */
+class GeographyDataSerializerTest extends SerializerTestBase<GeographyData> {
+
+    private static final byte[] POINT_WKB =
+            new byte[] {
+                1, GeographyData.POINT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+            };
+
+    private static final byte[] BIG_ENDIAN_POINT_WKB =
+            new byte[] {
+                0, 0, 0, 0, GeographyData.POINT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+            };
+
+    @Override
+    protected TypeSerializer<GeographyData> createSerializer() {
+        return GeographyDataSerializer.INSTANCE;
+    }
+
+    @Override
+    protected int getLength() {
+        return -1;
+    }
+
+    @Override
+    protected Class<GeographyData> getTypeClass() {
+        return GeographyData.class;
+    }
+
+    @Override
+    protected GeographyData[] getTestData() {
+        return new GeographyData[] {
+            GeographyData.fromBytes(POINT_WKB),
+            GeographyData.fromBytes(BIG_ENDIAN_POINT_WKB),
+            GeographyDataSerializer.INSTANCE.createInstance()
+        };
+    }
+
+    @Override
+    protected void deepEquals(String message, GeographyData should, GeographyData is) {
+        assertThat(is.toBytes()).as(message).isEqualTo(should.toBytes());
+    }
+
+    @Test
+    void testInternalSerializerRoundTripsRawWkb() throws Exception {
+        final TypeSerializer<GeographyData> serializer =
+                InternalSerializers.create(new GeographyType());
+        final GeographyData geography = GeographyData.fromBytes(POINT_WKB);
+        final ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+
+        serializer.serialize(geography, new DataOutputViewStreamWrapper(bytes));
+        final GeographyData deserialized =
+                serializer.deserialize(
+                        new DataInputViewStreamWrapper(
+                                new ByteArrayInputStream(bytes.toByteArray())));
+
+        assertThat(deserialized.toBytes()).isEqualTo(POINT_WKB);
+        assertThat(deserialized.subtypeId()).isEqualTo(GeographyData.POINT);
+    }
+
+    @Test
+    void testCopyPreservesRawWkbBytes() {
+        final GeographyData geography = GeographyData.fromBytes(POINT_WKB);
+        final GeographyData copied = GeographyDataSerializer.INSTANCE.copy(geography);
+
+        assertThat(copied).isNotSameAs(geography);
+        assertThat(copied.toBytes()).isEqualTo(POINT_WKB);
+        assertThat(copied.subtypeId()).isEqualTo(GeographyData.POINT);
+    }
+
+    @Test
+    void testCreateInstanceReturnsValidGeographyData() {
+        final GeographyData instance = GeographyDataSerializer.INSTANCE.createInstance();
+
+        assertThat(instance.subtypeId()).isEqualTo(GeographyData.GEOMETRY_COLLECTION);
+        assertThat(instance.sizeInBytes()).isEqualTo(9);
+    }
+
+    @Test
+    void testRowDataSerializerConvertsGenericRowToBinaryRow() {
+        final RowDataSerializer serializer =
+                InternalTypeInfo.<RowData>ofFields(new GeographyType()).toRowSerializer();
+        final GeographyData geography = GeographyData.fromBytes(POINT_WKB);
+        final GenericRowData row = GenericRowData.of(geography);
+
+        final BinaryRowData binaryRow = serializer.toBinaryRow(row, true);
+
+        assertThat(binaryRow.getGeography(0).toBytes()).isEqualTo(POINT_WKB);
+        assertThat(binaryRow.getGeography(0).subtypeId()).isEqualTo(GeographyData.POINT);
+    }
+
+    @Test
+    void testRowDataSerializerPreservesNullGeography() {
+        final RowDataSerializer serializer =
+                InternalTypeInfo.<RowData>ofFields(new GeographyType()).toRowSerializer();
+        final GenericRowData row = GenericRowData.of((Object) null);
+
+        final BinaryRowData binaryRow = serializer.toBinaryRow(row, true);
+
+        assertThat(binaryRow.isNullAt(0)).isTrue();
+    }
+
+    @Test
+    void testArrayDataSerializerConvertsGenericArrayToBinaryArray() {
+        final ArrayDataSerializer serializer = new ArrayDataSerializer(new GeographyType());
+        final GenericArrayData array =
+                new GenericArrayData(new Object[] {GeographyData.fromBytes(POINT_WKB), null});
+
+        final BinaryArrayData binaryArray = serializer.toBinaryArray(array);
+
+        assertThat(binaryArray.getGeography(0).toBytes()).isEqualTo(POINT_WKB);
+        assertThat(binaryArray.getGeography(0).subtypeId()).isEqualTo(GeographyData.POINT);
+        assertThat(binaryArray.isNullAt(1)).isTrue();
+    }
+}

--- a/flink-table/flink-table-type-utils/src/test/java/org/apache/flink/table/runtime/typeutils/RowDataSerializerTest.java
+++ b/flink-table/flink-table-type-utils/src/test/java/org/apache/flink/table/runtime/typeutils/RowDataSerializerTest.java
@@ -24,6 +24,7 @@ import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.java.typeutils.runtime.kryo.KryoSerializer;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.GeographyData;
 import org.apache.flink.table.data.RawValueData;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.StringData;
@@ -41,6 +42,7 @@ import org.apache.flink.table.types.logical.DayTimeIntervalType;
 import org.apache.flink.table.types.logical.DecimalType;
 import org.apache.flink.table.types.logical.DoubleType;
 import org.apache.flink.table.types.logical.FloatType;
+import org.apache.flink.table.types.logical.GeographyType;
 import org.apache.flink.table.types.logical.IntType;
 import org.apache.flink.table.types.logical.LocalZonedTimestampType;
 import org.apache.flink.table.types.logical.LogicalType;
@@ -61,6 +63,11 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Test for {@link RowDataSerializer}. */
 abstract class RowDataSerializerTest extends SerializerTestInstance<RowData> {
+
+    private static final byte[] POINT_WKB =
+            new byte[] {
+                1, GeographyData.POINT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+            };
 
     private final RowDataSerializer serializer;
     private final RowData[] testData;
@@ -228,6 +235,28 @@ abstract class RowDataSerializerTest extends SerializerTestInstance<RowData> {
         private static RowDataSerializer getRowSerializer() {
             InternalTypeInfo<RowData> typeInfo =
                     InternalTypeInfo.ofFields(new IntType(), VarCharType.STRING_TYPE);
+
+            return typeInfo.toRowSerializer();
+        }
+    }
+
+    static final class RowDataSerializerWithGeographyTest extends RowDataSerializerTest {
+        public RowDataSerializerWithGeographyTest() {
+            super(getRowSerializer(), getData());
+        }
+
+        private static RowData[] getData() {
+            GenericRowData row1 = new GenericRowData(1);
+            row1.setField(0, GeographyData.fromBytes(POINT_WKB));
+
+            GenericRowData row2 = new GenericRowData(1);
+            row2.setField(0, null);
+
+            return new RowData[] {row1, row2};
+        }
+
+        private static RowDataSerializer getRowSerializer() {
+            InternalTypeInfo<RowData> typeInfo = InternalTypeInfo.ofFields(new GeographyType());
 
             return typeInfo.toRowSerializer();
         }

--- a/flink-tests/src/test/java/org/apache/flink/test/completeness/TypeSerializerTestCoverageTest.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/completeness/TypeSerializerTestCoverageTest.java
@@ -83,6 +83,7 @@ import org.apache.flink.table.runtime.typeutils.ArrayDataSerializer;
 import org.apache.flink.table.runtime.typeutils.BinaryRowDataSerializer;
 import org.apache.flink.table.runtime.typeutils.DecimalDataSerializer;
 import org.apache.flink.table.runtime.typeutils.ExternalSerializer;
+import org.apache.flink.table.runtime.typeutils.GeographyDataSerializer;
 import org.apache.flink.table.runtime.typeutils.LinkedListSerializer;
 import org.apache.flink.table.runtime.typeutils.MapDataSerializer;
 import org.apache.flink.table.runtime.typeutils.RawValueDataSerializer;
@@ -196,6 +197,7 @@ class TypeSerializerTestCoverageTest {
                         SharedBufferEdge.SharedBufferEdgeSerializer.class.getName(),
                         RowDataSerializer.class.getName(),
                         DecimalDataSerializer.class.getName(),
+                        GeographyDataSerializer.class.getName(),
                         AvroSerializer.class.getName());
 
         //  type serializer whitelist for TypeSerializerUpgradeTestBase test coverage
@@ -258,6 +260,7 @@ class TypeSerializerTestCoverageTest {
                         SharedBufferEdge.SharedBufferEdgeSerializer.class.getName(),
                         RowDataSerializer.class.getName(),
                         DecimalDataSerializer.class.getName(),
+                        GeographyDataSerializer.class.getName(),
                         AvroSerializer.class.getName(),
                         // KeyAndValueSerializer shouldn't be used to serialize data to state and
                         // doesn't need to ensure upgrade compatibility.


### PR DESCRIPTION
## What is the purpose of the change

This draft PR adds the initial Java Table API entry point and runtime data
representation for the proposed native Flink GEOGRAPHY type.

It is part of the prototype for the ongoing FLIP discussion around native
GEOGRAPHY support in Flink SQL / Table API [1].

This PR is stacked on top of the GEOGRAPHY logical type model PR [2] and is not
intended to be merged before the FLIP direction is agreed.

[1] https://lists.apache.org/thread/flbj8dfdfgs26klrxt7xch3r9785ky67
[2] https://github.com/apache/flink/pull/28679

## Brief change log

- Add `DataTypes.GEOGRAPHY()`.
- Add `GeographyData`.
- Add `BinaryGeographyData` backed by raw ISO WKB bytes.
- Add `GEOGRAPHY` accessors to row and array data structures.
- Add binary row/array support for `GEOGRAPHY`.
- Add `GeographyDataSerializer`.
- Add tests for the Java API, binary representation, and serializer.

## Verifying this change

This change adds and extends tests for the GEOGRAPHY API and runtime
representation:

- `DataTypesTest`
- `SchemaTest`
- `BinaryGeographyDataTest`
- `GeographyDataSerializerTest`
- `RowDataSerializerTest`
- `TypeSerializerTestCoverageTest`

## Does this pull request potentially affect one of the following parts:

- Dependencies: no
- Public API: yes, adds `DataTypes.GEOGRAPHY()` as part of the proposed type API
- Serializers: yes, adds `GeographyDataSerializer`
- Runtime per-record code paths: yes, adds row/array access paths for GEOGRAPHY values
- Deployment or recovery: no
- S3 file system connector: no

## Documentation

- Does this pull request introduce a new feature? yes
- If yes, how is the feature documented? not documented yet; this is a draft PR for the FLIP discussion