### PR TITLE
[BP-2.3][hotfix] Bump download-artifact action to v8 as GHA requires

### DIFF
--- a/.github/workflows/template.flink-ci.yml
+++ b/.github/workflows/template.flink-ci.yml
@@ -148,7 +148,7 @@ jobs:
           target_directory: ${{ env.CONTAINER_LOCAL_WORKING_DIR }}
 
       - name: "Download build artifacts from compile job"
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           name: build-artifacts-${{ needs.compile.outputs.stringified-workflow-name }}-${{ github.run_number }}
           path: ${{ env.FLINK_ARTIFACT_DIR }}
@@ -224,7 +224,7 @@ jobs:
         run: sudo sysctl -w kernel.core_pattern=core.%p
 
       - name: "Download build artifacts from compile job"
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           name: build-artifacts-${{ needs.compile.outputs.stringified-workflow-name }}-${{ github.run_number }}
           path: ${{ env.FLINK_ARTIFACT_DIR }}
@@ -365,7 +365,7 @@ jobs:
           sudo apt install ./libssl1.0.0_*.deb
 
       - name: "Download build artifacts from compile job"
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           name: build-artifacts-${{ needs.compile.outputs.stringified-workflow-name }}-${{ github.run_number }}
           path: ${{ env.FLINK_ARTIFACT_DIR }}


### PR DESCRIPTION
cherry-pick of https://github.com/apache/flink/commit/b50d5f0e2c4f8415731070942359b0c94f511c29
to fix GHA warning