### PR TITLE
[FLINK-40096] Migrate EXPLAIN CTAS/RTAS Explain tests to Java

### DIFF
--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/stream/sql/ExplainTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/stream/sql/ExplainTest.java
@@ -174,15 +174,95 @@ public class ExplainTest extends TableTestBase {
                         + "    MyTable");
     }
 
+    @Test
+    void testExplainCreateTableAsSelect() {
+        verifyExplain(
+                "CREATE TABLE MyCtasTable\n"
+                        + " WITH (\n"
+                        + "   'connector' = 'values'\n"
+                        + ") AS\n"
+                        + "  SELECT\n"
+                        + "    `a`,\n"
+                        + "    `b`\n"
+                        + "  FROM\n"
+                        + "    MyTable",
+                "testExplainCtas");
+    }
+
+    @Test
+    void testExplainReplaceTableAsSelect() {
+        // Produces the same plan as CREATE TABLE AS SELECT.
+        verifyExplain(
+                "REPLACE TABLE MyCtasTable\n"
+                        + " WITH (\n"
+                        + "   'connector' = 'values'\n"
+                        + ") AS\n"
+                        + "  SELECT\n"
+                        + "    `a`,\n"
+                        + "    `b`\n"
+                        + "  FROM\n"
+                        + "    MyTable",
+                "testExplainCtas");
+    }
+
+    @Test
+    void testExplainCreateTableAsSelectWithColumnsInCreateAndQueryParts() {
+        verifyExplain(
+                "CREATE TABLE MyCtasTable(\n"
+                        + "  `votes` INT,\n"
+                        + "  `votes_2x` AS `b` * 2,\n"
+                        + "  `metadata_col` BIGINT METADATA,\n"
+                        + "  `virtual_col` STRING METADATA VIRTUAL\n"
+                        + ")\n"
+                        + " WITH (\n"
+                        + "   'connector' = 'values',\n"
+                        + "   'readable-metadata' = 'metadata_col:BIGINT, virtual_col:STRING',\n"
+                        + "   'writable-metadata' = 'metadata_col:BIGINT'\n"
+                        + ") AS\n"
+                        + "  SELECT\n"
+                        + "    `a`,\n"
+                        + "    `b`\n"
+                        + "  FROM\n"
+                        + "    MyTable",
+                "testExplainCtasWithColumnsInCreateAndQueryParts");
+    }
+
+    @Test
+    void testExplainReplaceTableAsSelectWithColumnsInCreateAndQueryParts() {
+        // Produces the same plan as CREATE TABLE AS SELECT.
+        verifyExplain(
+                "REPLACE TABLE MyCtasTable(\n"
+                        + "  `votes` INT,\n"
+                        + "  `votes_2x` AS `b` * 2,\n"
+                        + "  `metadata_col` BIGINT METADATA,\n"
+                        + "  `virtual_col` STRING METADATA VIRTUAL\n"
+                        + ")\n"
+                        + " WITH (\n"
+                        + "   'connector' = 'values',\n"
+                        + "   'readable-metadata' = 'metadata_col:BIGINT, virtual_col:STRING',\n"
+                        + "   'writable-metadata' = 'metadata_col:BIGINT'\n"
+                        + ") AS\n"
+                        + "  SELECT\n"
+                        + "    `a`,\n"
+                        + "    `b`\n"
+                        + "  FROM\n"
+                        + "    MyTable",
+                "testExplainCtasWithColumnsInCreateAndQueryParts");
+    }
+
     private void verifyExplain(final String statement) {
-        final String actual = util.getTableEnv().explainSql(statement);
         final String displayName = this.testInfo.getDisplayName();
-        final String fileName = displayName.substring(0, displayName.length() - 2) + ".out";
+        verifyExplain(statement, displayName.substring(0, displayName.length() - 2));
+    }
+
+    private void verifyExplain(final String statement, final String fileName) {
+        final String actual = util.getTableEnv().explainSql(statement);
+        final String fullFileName = fileName + ".out";
         if (REGENERATE_FILES) {
-            writeToResource(fileName, actual);
+            writeToResource(fullFileName, actual);
             return;
         }
-        final String expected = TableTestUtil.readFromResource("/explain/" + fileName);
+        final String expected = TableTestUtil.readFromResource("/explain/" + fullFileName);
         assertThat(TableTestUtil.replaceStageId(actual))
                 .isEqualTo(TableTestUtil.replaceStageId(expected));
     }

--- a/flink-table/flink-table-planner/src/test/resources/explain/testExplainCtas.out
+++ b/flink-table/flink-table-planner/src/test/resources/explain/testExplainCtas.out
@@ -5,10 +5,8 @@ LogicalSink(table=[default_catalog.default_database.MyCtasTable], fields=[a, b])
 
 == Optimized Physical Plan ==
 Sink(table=[default_catalog.default_database.MyCtasTable], fields=[a, b])
-+- Calc(select=[a, b])
-   +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c])
++- TableSourceScan(table=[[default_catalog, default_database, MyTable, project=[a, b], metadata=[]]], fields=[a, b])
 
 == Optimized Execution Plan ==
 Sink(table=[default_catalog.default_database.MyCtasTable], fields=[a, b])
-+- Calc(select=[a, b])
-   +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c])
++- TableSourceScan(table=[[default_catalog, default_database, MyTable, project=[a, b], metadata=[]]], fields=[a, b])

--- a/flink-table/flink-table-planner/src/test/resources/explain/testExplainCtasWithColumnsInCreateAndQueryParts.out
+++ b/flink-table/flink-table-planner/src/test/resources/explain/testExplainCtasWithColumnsInCreateAndQueryParts.out
@@ -6,9 +6,9 @@ LogicalSink(table=[default_catalog.default_database.MyCtasTable], fields=[votes,
 == Optimized Physical Plan ==
 Sink(table=[default_catalog.default_database.MyCtasTable], fields=[votes, a, b, metadata_col])
 +- Calc(select=[null:INTEGER AS votes, a, b, null:BIGINT AS metadata_col])
-   +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c])
+   +- TableSourceScan(table=[[default_catalog, default_database, MyTable, project=[a, b], metadata=[]]], fields=[a, b])
 
 == Optimized Execution Plan ==
 Sink(table=[default_catalog.default_database.MyCtasTable], fields=[votes, a, b, metadata_col])
 +- Calc(select=[null:INTEGER AS votes, a, b, null:BIGINT AS metadata_col])
-   +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c])
+   +- TableSourceScan(table=[[default_catalog, default_database, MyTable, project=[a, b], metadata=[]]], fields=[a, b])

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/TableSinkTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/TableSinkTest.scala
@@ -26,11 +26,10 @@ import org.apache.flink.table.connector.ChangelogMode
 import org.apache.flink.table.connector.source.{DynamicTableSource, ScanTableSource}
 import org.apache.flink.table.data.RowData
 import org.apache.flink.table.factories.{DynamicTableFactory, DynamicTableSourceFactory}
-import org.apache.flink.table.planner.utils.{TableTestBase, TableTestUtil, TestingTableEnvironment}
+import org.apache.flink.table.planner.utils.{TableTestBase, TestingTableEnvironment}
 
 import org.assertj.core.api.Assertions
 import org.assertj.core.api.Assertions.assertThatThrownBy
-import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
 import java.util
@@ -845,104 +844,6 @@ class TableSinkTest extends TableTestBase {
       .assertThatThrownBy(() => util.verifyExecPlan(stmtSet))
       .hasMessageContaining(
         "Table 'default_catalog.default_database.sink' is a bucketed table and it supports [HASH, UNKNOWN], but algorithm RANGE was requested.")
-  }
-
-  @Test
-  def testExplainCreateTableAsSelect(): Unit = {
-    val actual = util.tableEnv.explainSql("""
-                                            |CREATE TABLE MyCtasTable
-                                            | WITH (
-                                            |   'connector' = 'values'
-                                            |) AS
-                                            |  SELECT
-                                            |    `a`,
-                                            |    `b`
-                                            |  FROM
-                                            |    MyTable
-                                            |""".stripMargin)
-
-    val expected = TableTestUtil.readFromResource("/explain/testExplainCtas.out")
-
-    assertEquals(TableTestUtil.replaceStageId(expected), TableTestUtil.replaceStageId(actual))
-  }
-
-  @Test
-  def testExplainReplaceTableAsSelect(): Unit = {
-    val actual = util.tableEnv.explainSql("""
-                                            |REPLACE TABLE MyCtasTable
-                                            | WITH (
-                                            |   'connector' = 'values'
-                                            |) AS
-                                            |  SELECT
-                                            |    `a`,
-                                            |    `b`
-                                            |  FROM
-                                            |    MyTable
-                                            |""".stripMargin)
-
-    // Same as CTAS
-    val expected = TableTestUtil.readFromResource("/explain/testExplainCtas.out")
-
-    assertEquals(TableTestUtil.replaceStageId(expected), TableTestUtil.replaceStageId(actual))
-  }
-
-  @Test
-  def testExplainCreateTableAsSelectWithColumnsInCreateAndQueryParts(): Unit = {
-    val actual =
-      util.tableEnv.explainSql(
-        """
-          |CREATE TABLE MyCtasTable(
-          |  `votes` INT,
-          |  `votes_2x` AS `b` * 2,
-          |  `metadata_col` BIGINT METADATA,
-          |  `virtual_col` STRING METADATA VIRTUAL
-          |)
-          | WITH (
-          |   'connector' = 'values',
-          |   'readable-metadata' = 'metadata_col:BIGINT, virtual_col:STRING',
-          |   'writable-metadata' = 'metadata_col:BIGINT'
-          |) AS
-          |  SELECT
-          |    `a`,
-          |    `b`
-          |  FROM
-          |    MyTable
-          |""".stripMargin)
-
-    val expected =
-      TableTestUtil.readFromResource("/explain/testExplainCtasWithColumnsInCreateAndQueryParts.out")
-
-    assertEquals(TableTestUtil.replaceStageId(expected), TableTestUtil.replaceStageId(actual))
-  }
-
-  @Test
-  def testExplainReplaceTableAsSelectWithColumnsInCreateAndQueryParts(): Unit = {
-    val actual =
-      util.tableEnv.explainSql(
-        """
-          |REPLACE TABLE MyCtasTable(
-          |  `votes` INT,
-          |  `votes_2x` AS `b` * 2,
-          |  `metadata_col` BIGINT METADATA,
-          |  `virtual_col` STRING METADATA VIRTUAL
-          |)
-          | WITH (
-          |   'connector' = 'values',
-          |   'readable-metadata' = 'metadata_col:BIGINT, virtual_col:STRING',
-          |   'writable-metadata' = 'metadata_col:BIGINT'
-          |) AS
-          |  SELECT
-          |    `a`,
-          |    `b`
-          |  FROM
-          |    MyTable
-          |""".stripMargin)
-
-    // Same as CTAS
-    val expected =
-      TableTestUtil.readFromResource("/explain/testExplainCtasWithColumnsInCreateAndQueryParts.out")
-
-    assertEquals(TableTestUtil.replaceStageId(expected), TableTestUtil.replaceStageId(actual))
   }
 
   @Test


### PR DESCRIPTION
## What is the purpose of the change                                                                                                                                                                    
                                                                                                                                                                                                        
Consolidates the `CREATE`/`REPLACE TABLE AS SELECT` EXPLAIN tests into the dedicated `ExplainTest`, next to the other `.out`-based explain goldens. This is a test-only cleanup, no production code  changes. This is a follow-up PR on: https://issues.apache.org/jira/browse/FLINK-40039                                                                                                                                                                                              
                                                                                                                                                                                                        
## Brief change log                                                                                                                                                                                     
                                                                                                                                                                                                        
  - Moved the four CTAS/RTAS explain tests from `TableSinkTest` (Scala) to `ExplainTest` (Java)                                                                                                         
  - Added a `verifyExplain(statement, fileName)` overload so REPLACE can reuse the CTAS golden                                                                                                        
  - Regenerated the two goldens: `MyTable` is a `values` source in `ExplainTest`, so the scan node changes from `DataStreamScan` to `TableSourceScan` (AST unchanged)                                   
                                                                                                                                                                                                        
## Verifying this change                                                                                                                                                                                
                                                                                                                                                                                                        
This change is a test-only rework. It is covered by the moved tests in `ExplainTest`, verified with `mvn test -pl flink-table/flink-table-planner -Dtest=ExplainTest`.                                  
                                                                                                                                                                                                        
## Does this pull request potentially affect one of the following parts:                                                                                                                                
                                                                                                                                                                                                        
  - Dependencies (does it add or upgrade a dependency): no                                                                                                                                              
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no                                                                                                                   
  - The serializers: no                                                                                                                                                                                 
  - The runtime per-record code paths (performance sensitive): no                                                                                                                                       
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no                                                                        
  - The S3 file system connector: no                                                                                                                                                                    
                                                                                                                                                                                                        
## Documentation                                                                                                                                                                                        
                                                                                                                                                                                                        
  - Does this pull request introduce a new feature? no                                                                                                                                                  
  - If yes, how is the feature documented? not applicable  

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change the checkbox below to `[X]` followed by the name of the tool, and uncomment the
"Generated-by" line. See the ASF Generative Tooling Guidance for details:
https://www.apache.org/legal/generative-tooling.html

You are responsible for the quality and correctness of every change in this PR
regardless of the tooling used. Low-effort AI-generated PRs will be closed. See
AGENTS.md for the full guidance.
-->

- [X] Yes (please specify the tool below)


Generated-by: Opus 4.8

