### PR TITLE
[FLINK-40098][test-utils] Add FailingCheckpointedSource for exactly-once source tests

### DIFF
--- a/flink-test-utils-parent/flink-test-utils-connector/pom.xml
+++ b/flink-test-utils-parent/flink-test-utils-connector/pom.xml
@@ -49,6 +49,15 @@ under the License.
 			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>
+
+		<!-- For the source mocks (MockSplitEnumeratorContext) -->
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-core</artifactId>
+			<version>${project.version}</version>
+			<type>test-jar</type>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 </project>

--- a/flink-test-utils-parent/flink-test-utils-connector/src/main/java/org/apache/flink/test/util/source/FailingCheckpointedSource.java
+++ b/flink-test-utils-parent/flink-test-utils-connector/src/main/java/org/apache/flink/test/util/source/FailingCheckpointedSource.java
@@ -1,0 +1,438 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.test.util.source;
+
+import org.apache.flink.annotation.Experimental;
+import org.apache.flink.api.common.eventtime.Watermark;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.connector.source.Boundedness;
+import org.apache.flink.api.connector.source.ReaderOutput;
+import org.apache.flink.api.connector.source.Source;
+import org.apache.flink.api.connector.source.SourceReader;
+import org.apache.flink.api.connector.source.SourceReaderContext;
+import org.apache.flink.api.connector.source.SplitEnumerator;
+import org.apache.flink.api.connector.source.SplitEnumeratorContext;
+import org.apache.flink.api.java.typeutils.ResultTypeQueryable;
+import org.apache.flink.core.io.InputStatus;
+import org.apache.flink.core.io.SimpleVersionedSerializer;
+import org.apache.flink.util.FlinkRuntimeException;
+
+import javax.annotation.Nullable;
+
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+import static org.apache.flink.util.Preconditions.checkState;
+
+/**
+ * A test source with a checkpointed emission position that fails subtask 0 exactly once after a
+ * completed checkpoint and resumes from the restored position, for verifying exactly-once behavior
+ * across recovery.
+ *
+ * <p>Emission holds just past the {@link FailurePolicy} arming threshold until a snapshot arms the
+ * failure, continues to the failure position, and throws once the armed checkpoint completes.
+ * Recovery therefore always replays the records between the arming and failure positions,
+ * independent of emission speed. A failing policy requires checkpointing to be enabled. All records
+ * of one {@link EventGenerator#emit} call are emitted in a single {@code pollNext} and cannot be
+ * split by a checkpoint. Rescaling is not supported; use a fixed source parallelism.
+ *
+ * <p>{@link #withIdleAfterEmission()} keeps the source idle instead of finishing (for
+ * processing-time tests); {@link #withSimulatedStateLossOnRecovery()} deliberately breaks
+ * exactly-once, only for validating that a test still detects duplicates.
+ */
+@Experimental
+public class FailingCheckpointedSource<T>
+        implements Source<T, SequenceSplit, Void>, ResultTypeQueryable<T> {
+
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Generates and emits the records (and optionally timestamps and watermarks) for one sequence
+     * number of one subtask.
+     */
+    @FunctionalInterface
+    public interface EventGenerator<T> extends Serializable {
+        void emit(int subtaskIndex, long sequenceNo, GeneratorOutput<T> output);
+    }
+
+    /** Output for the {@link EventGenerator}, bridging to the reader output. */
+    public interface GeneratorOutput<T> {
+        void collect(T record);
+
+        void collect(T record, long timestamp);
+
+        void emitWatermark(long timestamp);
+    }
+
+    /** Determines whether and when the source fails. */
+    public static final class FailurePolicy implements Serializable {
+
+        private static final long serialVersionUID = 1L;
+        private static final long NEVER = -1;
+
+        private final long failAfterEmitCalls;
+        private final long armAfterEmitCalls;
+
+        private FailurePolicy(long failAfterEmitCalls, long armAfterEmitCalls) {
+            this.failAfterEmitCalls = failAfterEmitCalls;
+            this.armAfterEmitCalls = armAfterEmitCalls;
+        }
+
+        /**
+         * Fails subtask 0 once, after it has emitted {@code emitCalls} generator invocations and a
+         * checkpoint taken past half of that has completed.
+         */
+        public static FailurePolicy failAfterEmitCalls(long emitCalls) {
+            checkArgument(emitCalls >= 1, "emitCalls must be >= 1");
+            return new FailurePolicy(emitCalls, emitCalls / 2);
+        }
+
+        /** Never fails; the source just emits and finishes. */
+        public static FailurePolicy neverFail() {
+            return new FailurePolicy(NEVER, NEVER);
+        }
+
+        boolean fails() {
+            return failAfterEmitCalls != NEVER;
+        }
+    }
+
+    private final EventGenerator<T> generator;
+    private final long emitCallsPerSubtask;
+    private final FailurePolicy failurePolicy;
+    private final TypeInformation<T> producedType;
+    private final boolean idleAfterEmission;
+    private final boolean simulateStateLossOnRecovery;
+
+    private FailingCheckpointedSource(
+            EventGenerator<T> generator,
+            long emitCallsPerSubtask,
+            FailurePolicy failurePolicy,
+            TypeInformation<T> producedType,
+            boolean idleAfterEmission,
+            boolean simulateStateLossOnRecovery) {
+        this.generator = checkNotNull(generator);
+        this.emitCallsPerSubtask = emitCallsPerSubtask;
+        this.failurePolicy = checkNotNull(failurePolicy);
+        this.producedType = checkNotNull(producedType);
+        this.idleAfterEmission = idleAfterEmission;
+        this.simulateStateLossOnRecovery = simulateStateLossOnRecovery;
+        checkArgument(emitCallsPerSubtask >= 1, "emitCallsPerSubtask must be >= 1");
+        checkArgument(
+                !failurePolicy.fails() || failurePolicy.failAfterEmitCalls <= emitCallsPerSubtask,
+                "the failure position must not lie beyond the emitted sequence");
+    }
+
+    public static <T> FailingCheckpointedSource<T> of(
+            EventGenerator<T> generator,
+            long emitCallsPerSubtask,
+            FailurePolicy failurePolicy,
+            TypeInformation<T> producedType) {
+        return new FailingCheckpointedSource<>(
+                generator, emitCallsPerSubtask, failurePolicy, producedType, false, false);
+    }
+
+    /**
+     * Returns a copy of this source that stays idle after emitting all sequence numbers instead of
+     * finishing, for processing-time tests whose job is terminated externally.
+     */
+    public FailingCheckpointedSource<T> withIdleAfterEmission() {
+        return new FailingCheckpointedSource<>(
+                generator,
+                emitCallsPerSubtask,
+                failurePolicy,
+                producedType,
+                true,
+                simulateStateLossOnRecovery);
+    }
+
+    /**
+     * Returns a copy of this source whose readers discard the restored position after recovery.
+     * Only for validating that a test detects exactly-once violations; never use in a test's normal
+     * path.
+     */
+    public FailingCheckpointedSource<T> withSimulatedStateLossOnRecovery() {
+        return new FailingCheckpointedSource<>(
+                generator,
+                emitCallsPerSubtask,
+                failurePolicy,
+                producedType,
+                idleAfterEmission,
+                true);
+    }
+
+    @Override
+    public Boundedness getBoundedness() {
+        return Boundedness.CONTINUOUS_UNBOUNDED;
+    }
+
+    @Override
+    public SourceReader<T, SequenceSplit> createReader(SourceReaderContext readerContext) {
+        return new FailingCheckpointedSourceReader<>(
+                generator,
+                emitCallsPerSubtask,
+                failurePolicy,
+                idleAfterEmission,
+                simulateStateLossOnRecovery);
+    }
+
+    @Override
+    public SplitEnumerator<SequenceSplit, Void> createEnumerator(
+            SplitEnumeratorContext<SequenceSplit> enumContext) {
+        return new SequenceSplitEnumerator(enumContext, true);
+    }
+
+    @Override
+    public SplitEnumerator<SequenceSplit, Void> restoreEnumerator(
+            SplitEnumeratorContext<SequenceSplit> enumContext, Void checkpoint) {
+        // After restore the readers recover their splits from their own state, so the enumerator
+        // must not assign fresh splits to re-registering readers.
+        return new SequenceSplitEnumerator(enumContext, false);
+    }
+
+    @Override
+    public SimpleVersionedSerializer<SequenceSplit> getSplitSerializer() {
+        return SequenceSplit.SERIALIZER;
+    }
+
+    @Override
+    public SimpleVersionedSerializer<Void> getEnumeratorCheckpointSerializer() {
+        return VoidSerializer.INSTANCE;
+    }
+
+    @Override
+    public TypeInformation<T> getProducedType() {
+        return producedType;
+    }
+
+    /** Assigns one position split per subtask on fresh starts. */
+    private static final class SequenceSplitEnumerator
+            implements SplitEnumerator<SequenceSplit, Void> {
+
+        private final SplitEnumeratorContext<SequenceSplit> context;
+        private final boolean assignSplitsOnRegistration;
+        private final Map<Integer, SequenceSplit> splitsToReassign = new HashMap<>();
+        private final Set<Integer> assignedSubtasks = new HashSet<>();
+
+        private SequenceSplitEnumerator(
+                SplitEnumeratorContext<SequenceSplit> context, boolean assignSplitsOnRegistration) {
+            this.context = context;
+            this.assignSplitsOnRegistration = assignSplitsOnRegistration;
+        }
+
+        @Override
+        public void start() {}
+
+        @Override
+        public void handleSplitRequest(int subtaskId, @Nullable String requesterHostname) {}
+
+        @Override
+        public void addSplitsBack(List<SequenceSplit> splits, int subtaskId) {
+            for (SequenceSplit split : splits) {
+                splitsToReassign.put(split.getSubtaskIndex(), split);
+            }
+        }
+
+        @Override
+        public void addReader(int subtaskId) {
+            final SequenceSplit returnedSplit = splitsToReassign.remove(subtaskId);
+            if (returnedSplit != null) {
+                context.assignSplit(returnedSplit, subtaskId);
+            } else if (assignSplitsOnRegistration && assignedSubtasks.add(subtaskId)) {
+                // only assign on the very first registration; on partial failover this
+                // enumerator survives and the reader recovers its split from its own state
+                context.assignSplit(new SequenceSplit(subtaskId, 0), subtaskId);
+            }
+        }
+
+        @Override
+        public Void snapshotState(long checkpointId) {
+            return null;
+        }
+
+        @Override
+        public void close() {}
+    }
+
+    /**
+     * The reader. All methods are invoked in the task's mailbox thread, so no synchronization is
+     * required between emission, snapshots, and checkpoint notifications.
+     */
+    private static final class FailingCheckpointedSourceReader<T>
+            implements SourceReader<T, SequenceSplit> {
+
+        private final EventGenerator<T> generator;
+        private final long emitCallsPerSubtask;
+        private final FailurePolicy failurePolicy;
+        private final boolean idleAfterEmission;
+        private final boolean simulateStateLossOnRecovery;
+        private final BridgingGeneratorOutput generatorOutput = new BridgingGeneratorOutput();
+
+        private boolean hasSplit;
+        private int subtaskIndex;
+        private long position;
+        private boolean eligibleToFail;
+        @Nullable private Long armedCheckpointId;
+        private boolean failureRequested;
+        private CompletableFuture<Void> availability = CompletableFuture.completedFuture(null);
+
+        private FailingCheckpointedSourceReader(
+                EventGenerator<T> generator,
+                long emitCallsPerSubtask,
+                FailurePolicy failurePolicy,
+                boolean idleAfterEmission,
+                boolean simulateStateLossOnRecovery) {
+            this.generator = generator;
+            this.emitCallsPerSubtask = emitCallsPerSubtask;
+            this.failurePolicy = failurePolicy;
+            this.idleAfterEmission = idleAfterEmission;
+            this.simulateStateLossOnRecovery = simulateStateLossOnRecovery;
+        }
+
+        @Override
+        public void start() {}
+
+        @Override
+        public InputStatus pollNext(ReaderOutput<T> output) {
+            if (failureRequested && position >= failurePolicy.failAfterEmitCalls) {
+                throw new FlinkRuntimeException("Artificial Failure");
+            }
+            if (!hasSplit) {
+                return pause();
+            }
+            if (eligibleToFail) {
+                if (armedCheckpointId == null && position > failurePolicy.armAfterEmitCalls) {
+                    // hold until a snapshot arms, so the armed checkpoint provably captures a
+                    // pre-failure position and recovery replays the records in between
+                    return pause();
+                }
+                if (position >= failurePolicy.failAfterEmitCalls) {
+                    // hold at the failure position until the armed checkpoint completes
+                    return pause();
+                }
+            }
+            if (position >= emitCallsPerSubtask) {
+                return idleAfterEmission ? pause() : InputStatus.END_OF_INPUT;
+            }
+            generatorOutput.delegate = output;
+            generator.emit(subtaskIndex, position++, generatorOutput);
+            return InputStatus.MORE_AVAILABLE;
+        }
+
+        private InputStatus pause() {
+            if (availability.isDone()) {
+                availability = new CompletableFuture<>();
+            }
+            return InputStatus.NOTHING_AVAILABLE;
+        }
+
+        @Override
+        public List<SequenceSplit> snapshotState(long checkpointId) {
+            if (!hasSplit) {
+                return Collections.emptyList();
+            }
+            // only arm past the threshold, so recovery demonstrably restores progress
+            if (eligibleToFail
+                    && armedCheckpointId == null
+                    && position > failurePolicy.armAfterEmitCalls) {
+                armedCheckpointId = checkpointId;
+                // resume emission toward the failure position
+                availability.complete(null);
+            }
+            return Collections.singletonList(new SequenceSplit(subtaskIndex, position));
+        }
+
+        @Override
+        public void notifyCheckpointComplete(long checkpointId) {
+            if (eligibleToFail && armedCheckpointId != null && armedCheckpointId == checkpointId) {
+                failureRequested = true;
+                availability.complete(null);
+            }
+        }
+
+        @Override
+        public void notifyCheckpointAborted(long checkpointId) {
+            // let a later snapshot re-arm after an abort
+            if (armedCheckpointId != null && armedCheckpointId == checkpointId) {
+                armedCheckpointId = null;
+            }
+        }
+
+        @Override
+        public void addSplits(List<SequenceSplit> splits) {
+            checkState(
+                    !hasSplit && splits.size() == 1,
+                    "expecting exactly one split per subtask, got %s (split already present: %s)",
+                    splits,
+                    hasSplit);
+            final SequenceSplit split = splits.get(0);
+            hasSplit = true;
+            subtaskIndex = split.getSubtaskIndex();
+            position = simulateStateLossOnRecovery ? 0 : split.getPosition();
+            // restored position > 0 identifies the recovery attempt (no attempt number in
+            // SourceReaderContext)
+            eligibleToFail =
+                    failurePolicy.fails()
+                            && split.getSubtaskIndex() == 0
+                            && split.getPosition() == 0;
+            availability.complete(null);
+        }
+
+        @Override
+        public CompletableFuture<Void> isAvailable() {
+            return availability;
+        }
+
+        @Override
+        public void notifyNoMoreSplits() {}
+
+        @Override
+        public void close() {
+            availability.complete(null);
+        }
+
+        private final class BridgingGeneratorOutput implements GeneratorOutput<T> {
+
+            @Nullable private ReaderOutput<T> delegate;
+
+            @Override
+            public void collect(T record) {
+                delegate.collect(record);
+            }
+
+            @Override
+            public void collect(T record, long timestamp) {
+                delegate.collect(record, timestamp);
+            }
+
+            @Override
+            public void emitWatermark(long timestamp) {
+                delegate.emitWatermark(new Watermark(timestamp));
+            }
+        }
+    }
+}

--- a/flink-test-utils-parent/flink-test-utils-connector/src/main/java/org/apache/flink/test/util/source/FailingCheckpointedSource.java
+++ b/flink-test-utils-parent/flink-test-utils-connector/src/main/java/org/apache/flink/test/util/source/FailingCheckpointedSource.java
@@ -1,0 +1,458 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.test.util.source;
+
+import org.apache.flink.annotation.Experimental;
+import org.apache.flink.api.common.eventtime.Watermark;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.connector.source.Boundedness;
+import org.apache.flink.api.connector.source.ReaderOutput;
+import org.apache.flink.api.connector.source.Source;
+import org.apache.flink.api.connector.source.SourceReader;
+import org.apache.flink.api.connector.source.SourceReaderContext;
+import org.apache.flink.api.connector.source.SourceSplit;
+import org.apache.flink.api.connector.source.SplitEnumerator;
+import org.apache.flink.api.connector.source.SplitEnumeratorContext;
+import org.apache.flink.api.java.typeutils.ResultTypeQueryable;
+import org.apache.flink.core.io.InputStatus;
+import org.apache.flink.core.io.SimpleVersionedSerializer;
+import org.apache.flink.core.memory.DataInputDeserializer;
+import org.apache.flink.core.memory.DataOutputSerializer;
+import org.apache.flink.util.FlinkRuntimeException;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+import static org.apache.flink.util.Preconditions.checkState;
+
+/**
+ * A test source with a checkpointed emission position that fails subtask 0 exactly once after a
+ * completed checkpoint and resumes from the restored position, for verifying exactly-once behavior
+ * across recovery.
+ *
+ * <p>Each subtask invokes the {@link EventGenerator} once per sequence number. Subtask 0 fails
+ * after half of its emit calls, like the legacy {@code FailingSource}: a snapshot taken past a
+ * quarter of the emit calls arms the failure, emission continues to the failure position, and the
+ * reader throws once the armed checkpoint completes. Emission holds just past the arming threshold
+ * until a snapshot arms, so recovery always replays the records between the arming and failure
+ * positions, independent of emission speed. Checkpointing must be enabled. All records of one
+ * {@link EventGenerator#emit} call are emitted in a single {@code pollNext} and cannot be split by
+ * a checkpoint. Rescaling is not supported; use a fixed source parallelism.
+ *
+ * <p>{@link #withIdleAfterEmission()} keeps the source idle instead of finishing, for
+ * processing-time tests whose job is terminated externally.
+ */
+@Experimental
+public class FailingCheckpointedSource<T>
+        implements Source<T, FailingCheckpointedSource.SequenceSplit, Void>,
+                ResultTypeQueryable<T> {
+
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Generates and emits the records (and optionally timestamps and watermarks) for one sequence
+     * number of one subtask.
+     */
+    @FunctionalInterface
+    public interface EventGenerator<T> extends Serializable {
+        void emit(int subtaskIndex, long sequenceNo, GeneratorOutput<T> output);
+    }
+
+    /** Output for the {@link EventGenerator}, bridging to the reader output. */
+    public interface GeneratorOutput<T> {
+        void collect(T record);
+
+        void collect(T record, long timestamp);
+
+        void emitWatermark(long timestamp);
+    }
+
+    private final EventGenerator<T> generator;
+    private final long emitCallsPerSubtask;
+    private final long failAfterEmitCalls;
+    private final long armAfterEmitCalls;
+    private final TypeInformation<T> producedType;
+    private final boolean idleAfterEmission;
+
+    private FailingCheckpointedSource(
+            EventGenerator<T> generator,
+            long emitCallsPerSubtask,
+            TypeInformation<T> producedType,
+            boolean idleAfterEmission) {
+        // fewer than two emit calls leave no checkpointable position before the failure
+        checkArgument(emitCallsPerSubtask >= 2, "emitCallsPerSubtask must be >= 2");
+        this.generator = checkNotNull(generator);
+        this.emitCallsPerSubtask = emitCallsPerSubtask;
+        this.failAfterEmitCalls = emitCallsPerSubtask / 2;
+        this.armAfterEmitCalls = failAfterEmitCalls / 2;
+        this.producedType = checkNotNull(producedType);
+        this.idleAfterEmission = idleAfterEmission;
+    }
+
+    /**
+     * Creates a source whose subtasks each invoke the generator {@code emitCallsPerSubtask} times
+     * and whose subtask 0 fails once after half of them.
+     */
+    public static <T> FailingCheckpointedSource<T> of(
+            EventGenerator<T> generator,
+            long emitCallsPerSubtask,
+            TypeInformation<T> producedType) {
+        return new FailingCheckpointedSource<>(generator, emitCallsPerSubtask, producedType, false);
+    }
+
+    /**
+     * Returns a copy of this source that stays idle after emitting all sequence numbers instead of
+     * finishing, for processing-time tests whose job is terminated externally.
+     */
+    public FailingCheckpointedSource<T> withIdleAfterEmission() {
+        return new FailingCheckpointedSource<>(generator, emitCallsPerSubtask, producedType, true);
+    }
+
+    @Override
+    public Boundedness getBoundedness() {
+        return Boundedness.CONTINUOUS_UNBOUNDED;
+    }
+
+    @Override
+    public SourceReader<T, SequenceSplit> createReader(SourceReaderContext readerContext) {
+        return new FailingCheckpointedSourceReader<>(
+                generator,
+                emitCallsPerSubtask,
+                failAfterEmitCalls,
+                armAfterEmitCalls,
+                idleAfterEmission);
+    }
+
+    @Override
+    public SplitEnumerator<SequenceSplit, Void> createEnumerator(
+            SplitEnumeratorContext<SequenceSplit> enumContext) {
+        return new SequenceSplitEnumerator(enumContext, true);
+    }
+
+    @Override
+    public SplitEnumerator<SequenceSplit, Void> restoreEnumerator(
+            SplitEnumeratorContext<SequenceSplit> enumContext, Void checkpoint) {
+        // After restore the readers recover their splits from their own state, so the enumerator
+        // must not assign fresh splits to re-registering readers.
+        return new SequenceSplitEnumerator(enumContext, false);
+    }
+
+    @Override
+    public SimpleVersionedSerializer<SequenceSplit> getSplitSerializer() {
+        return SequenceSplit.SERIALIZER;
+    }
+
+    @Override
+    public SimpleVersionedSerializer<Void> getEnumeratorCheckpointSerializer() {
+        return VoidSerializer.INSTANCE;
+    }
+
+    @Override
+    public TypeInformation<T> getProducedType() {
+        return producedType;
+    }
+
+    /**
+     * A split carrying the emission position of one source subtask, so that the reader can resume
+     * from the checkpointed position after recovery. The subtask index assumes a fixed source
+     * parallelism.
+     */
+    static final class SequenceSplit implements SourceSplit {
+
+        static final SimpleVersionedSerializer<SequenceSplit> SERIALIZER =
+                new SequenceSplitSerializer();
+
+        private final int subtaskIndex;
+        private final long position;
+
+        SequenceSplit(int subtaskIndex, long position) {
+            this.subtaskIndex = subtaskIndex;
+            this.position = position;
+        }
+
+        int getSubtaskIndex() {
+            return subtaskIndex;
+        }
+
+        long getPosition() {
+            return position;
+        }
+
+        @Override
+        public String splitId() {
+            return "sequence-split-" + subtaskIndex;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (!(o instanceof SequenceSplit)) {
+                return false;
+            }
+            final SequenceSplit that = (SequenceSplit) o;
+            return subtaskIndex == that.subtaskIndex && position == that.position;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(subtaskIndex, position);
+        }
+
+        @Override
+        public String toString() {
+            return "SequenceSplit{subtaskIndex=" + subtaskIndex + ", position=" + position + "}";
+        }
+    }
+
+    private static final class SequenceSplitSerializer
+            implements SimpleVersionedSerializer<SequenceSplit> {
+
+        @Override
+        public int getVersion() {
+            return 1;
+        }
+
+        @Override
+        public byte[] serialize(SequenceSplit split) throws IOException {
+            final DataOutputSerializer out = new DataOutputSerializer(12);
+            out.writeInt(split.subtaskIndex);
+            out.writeLong(split.position);
+            return out.getCopyOfBuffer();
+        }
+
+        @Override
+        public SequenceSplit deserialize(int version, byte[] serialized) throws IOException {
+            final DataInputDeserializer in = new DataInputDeserializer(serialized);
+            return new SequenceSplit(in.readInt(), in.readLong());
+        }
+    }
+
+    /** Assigns one position split per subtask on fresh starts. */
+    private static final class SequenceSplitEnumerator
+            implements SplitEnumerator<SequenceSplit, Void> {
+
+        private final SplitEnumeratorContext<SequenceSplit> context;
+        private final boolean assignSplitsOnRegistration;
+        private final Map<Integer, SequenceSplit> splitsToReassign = new HashMap<>();
+        private final Set<Integer> assignedSubtasks = new HashSet<>();
+
+        private SequenceSplitEnumerator(
+                SplitEnumeratorContext<SequenceSplit> context, boolean assignSplitsOnRegistration) {
+            this.context = context;
+            this.assignSplitsOnRegistration = assignSplitsOnRegistration;
+        }
+
+        @Override
+        public void start() {}
+
+        @Override
+        public void handleSplitRequest(int subtaskId, @Nullable String requesterHostname) {}
+
+        @Override
+        public void addSplitsBack(List<SequenceSplit> splits, int subtaskId) {
+            for (SequenceSplit split : splits) {
+                splitsToReassign.put(split.getSubtaskIndex(), split);
+            }
+        }
+
+        @Override
+        public void addReader(int subtaskId) {
+            final SequenceSplit returnedSplit = splitsToReassign.remove(subtaskId);
+            if (returnedSplit != null) {
+                context.assignSplit(returnedSplit, subtaskId);
+            } else if (assignSplitsOnRegistration && assignedSubtasks.add(subtaskId)) {
+                // only assign on the very first registration; on partial failover this
+                // enumerator survives and the reader recovers its split from its own state
+                context.assignSplit(new SequenceSplit(subtaskId, 0), subtaskId);
+            }
+        }
+
+        @Override
+        public Void snapshotState(long checkpointId) {
+            return null;
+        }
+
+        @Override
+        public void close() {}
+    }
+
+    /**
+     * The reader. All methods are invoked in the task's mailbox thread, so no synchronization is
+     * required between emission, snapshots, and checkpoint notifications.
+     */
+    private static final class FailingCheckpointedSourceReader<T>
+            implements SourceReader<T, SequenceSplit> {
+
+        private final EventGenerator<T> generator;
+        private final long emitCallsPerSubtask;
+        private final long failAfterEmitCalls;
+        private final long armAfterEmitCalls;
+        private final boolean idleAfterEmission;
+        private final BridgingGeneratorOutput generatorOutput = new BridgingGeneratorOutput();
+
+        private boolean hasSplit;
+        private int subtaskIndex;
+        private long position;
+        private boolean eligibleToFail;
+        @Nullable private Long armedCheckpointId;
+        private boolean failureRequested;
+        private CompletableFuture<Void> availability = CompletableFuture.completedFuture(null);
+
+        private FailingCheckpointedSourceReader(
+                EventGenerator<T> generator,
+                long emitCallsPerSubtask,
+                long failAfterEmitCalls,
+                long armAfterEmitCalls,
+                boolean idleAfterEmission) {
+            this.generator = generator;
+            this.emitCallsPerSubtask = emitCallsPerSubtask;
+            this.failAfterEmitCalls = failAfterEmitCalls;
+            this.armAfterEmitCalls = armAfterEmitCalls;
+            this.idleAfterEmission = idleAfterEmission;
+        }
+
+        @Override
+        public void start() {}
+
+        @Override
+        public InputStatus pollNext(ReaderOutput<T> output) {
+            if (failureRequested && position >= failAfterEmitCalls) {
+                throw new FlinkRuntimeException("Artificial Failure");
+            }
+            if (!hasSplit) {
+                return pause();
+            }
+            if (eligibleToFail) {
+                if (armedCheckpointId == null && position > armAfterEmitCalls) {
+                    // hold until a snapshot arms, so the armed checkpoint provably captures a
+                    // pre-failure position and recovery replays the records in between
+                    return pause();
+                }
+                if (position >= failAfterEmitCalls) {
+                    // hold at the failure position until the armed checkpoint completes
+                    return pause();
+                }
+            }
+            if (position >= emitCallsPerSubtask) {
+                return idleAfterEmission ? pause() : InputStatus.END_OF_INPUT;
+            }
+            generatorOutput.delegate = output;
+            generator.emit(subtaskIndex, position++, generatorOutput);
+            return InputStatus.MORE_AVAILABLE;
+        }
+
+        private InputStatus pause() {
+            if (availability.isDone()) {
+                availability = new CompletableFuture<>();
+            }
+            return InputStatus.NOTHING_AVAILABLE;
+        }
+
+        @Override
+        public List<SequenceSplit> snapshotState(long checkpointId) {
+            if (!hasSplit) {
+                return Collections.emptyList();
+            }
+            // only arm past the threshold, so recovery demonstrably restores progress
+            if (eligibleToFail && armedCheckpointId == null && position > armAfterEmitCalls) {
+                armedCheckpointId = checkpointId;
+                // resume emission toward the failure position
+                availability.complete(null);
+            }
+            return Collections.singletonList(new SequenceSplit(subtaskIndex, position));
+        }
+
+        @Override
+        public void notifyCheckpointComplete(long checkpointId) {
+            if (eligibleToFail && armedCheckpointId != null && armedCheckpointId == checkpointId) {
+                failureRequested = true;
+                availability.complete(null);
+            }
+        }
+
+        @Override
+        public void notifyCheckpointAborted(long checkpointId) {
+            // let a later snapshot re-arm after an abort
+            if (armedCheckpointId != null && armedCheckpointId == checkpointId) {
+                armedCheckpointId = null;
+            }
+        }
+
+        @Override
+        public void addSplits(List<SequenceSplit> splits) {
+            checkState(
+                    !hasSplit && splits.size() == 1,
+                    "expecting exactly one split per subtask, got %s (split already present: %s)",
+                    splits,
+                    hasSplit);
+            final SequenceSplit split = splits.get(0);
+            hasSplit = true;
+            subtaskIndex = split.getSubtaskIndex();
+            position = split.getPosition();
+            // restored position > 0 identifies the recovery attempt (no attempt number in
+            // SourceReaderContext)
+            eligibleToFail = split.getSubtaskIndex() == 0 && split.getPosition() == 0;
+            availability.complete(null);
+        }
+
+        @Override
+        public CompletableFuture<Void> isAvailable() {
+            return availability;
+        }
+
+        @Override
+        public void notifyNoMoreSplits() {}
+
+        @Override
+        public void close() {
+            availability.complete(null);
+        }
+
+        private final class BridgingGeneratorOutput implements GeneratorOutput<T> {
+
+            @Nullable private ReaderOutput<T> delegate;
+
+            @Override
+            public void collect(T record) {
+                delegate.collect(record);
+            }
+
+            @Override
+            public void collect(T record, long timestamp) {
+                delegate.collect(record, timestamp);
+            }
+
+            @Override
+            public void emitWatermark(long timestamp) {
+                delegate.emitWatermark(new Watermark(timestamp));
+            }
+        }
+    }
+}

--- a/flink-test-utils-parent/flink-test-utils-connector/src/main/java/org/apache/flink/test/util/source/SequenceSplit.java
+++ b/flink-test-utils-parent/flink-test-utils-connector/src/main/java/org/apache/flink/test/util/source/SequenceSplit.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.test.util.source;
+
+import org.apache.flink.annotation.Experimental;
+import org.apache.flink.api.connector.source.SourceSplit;
+import org.apache.flink.core.io.SimpleVersionedSerializer;
+import org.apache.flink.core.memory.DataInputDeserializer;
+import org.apache.flink.core.memory.DataOutputSerializer;
+
+import java.io.IOException;
+import java.util.Objects;
+
+/**
+ * A split carrying the emission position of one source subtask, so that a test source can resume
+ * from the checkpointed position after recovery. The subtask index assumes a fixed source
+ * parallelism.
+ */
+@Experimental
+public class SequenceSplit implements SourceSplit {
+
+    /** Serializer for {@link SequenceSplit} instances. */
+    public static final SimpleVersionedSerializer<SequenceSplit> SERIALIZER =
+            new SequenceSplitSerializer();
+
+    private final int subtaskIndex;
+    private final long position;
+
+    public SequenceSplit(int subtaskIndex, long position) {
+        this.subtaskIndex = subtaskIndex;
+        this.position = position;
+    }
+
+    public int getSubtaskIndex() {
+        return subtaskIndex;
+    }
+
+    public long getPosition() {
+        return position;
+    }
+
+    @Override
+    public String splitId() {
+        return "sequence-split-" + subtaskIndex;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof SequenceSplit)) {
+            return false;
+        }
+        final SequenceSplit that = (SequenceSplit) o;
+        return subtaskIndex == that.subtaskIndex && position == that.position;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(subtaskIndex, position);
+    }
+
+    @Override
+    public String toString() {
+        return "SequenceSplit{subtaskIndex=" + subtaskIndex + ", position=" + position + "}";
+    }
+
+    private static class SequenceSplitSerializer
+            implements SimpleVersionedSerializer<SequenceSplit> {
+
+        @Override
+        public int getVersion() {
+            return 1;
+        }
+
+        @Override
+        public byte[] serialize(SequenceSplit split) throws IOException {
+            final DataOutputSerializer out = new DataOutputSerializer(12);
+            out.writeInt(split.subtaskIndex);
+            out.writeLong(split.position);
+            return out.getCopyOfBuffer();
+        }
+
+        @Override
+        public SequenceSplit deserialize(int version, byte[] serialized) throws IOException {
+            final DataInputDeserializer in = new DataInputDeserializer(serialized);
+            return new SequenceSplit(in.readInt(), in.readLong());
+        }
+    }
+}

--- a/flink-test-utils-parent/flink-test-utils-connector/src/test/java/org/apache/flink/test/util/source/FailingCheckpointedSourceTest.java
+++ b/flink-test-utils-parent/flink-test-utils-connector/src/test/java/org/apache/flink/test/util/source/FailingCheckpointedSourceTest.java
@@ -1,0 +1,355 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.test.util.source;
+
+import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.api.connector.source.SourceReader;
+import org.apache.flink.api.connector.source.SplitEnumerator;
+import org.apache.flink.api.connector.source.mocks.MockSplitEnumeratorContext;
+import org.apache.flink.core.io.InputStatus;
+import org.apache.flink.util.FlinkRuntimeException;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.LongStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Tests for the failure protocol of {@link FailingCheckpointedSource}: arm on a snapshot past the
+ * threshold, pause at the failure position, fail once the armed checkpoint completes, and resume
+ * from the restored position without failing again.
+ */
+class FailingCheckpointedSourceTest {
+
+    private static final long EMIT_CALLS = 20;
+    private static final long FAILURE_POSITION = 10;
+
+    private static FailingCheckpointedSource<Long> failingSource() {
+        return FailingCheckpointedSource.of(
+                (subtaskIndex, sequenceNo, output) -> output.collect(sequenceNo),
+                EMIT_CALLS,
+                FailingCheckpointedSource.FailurePolicy.failAfterEmitCalls(FAILURE_POSITION),
+                Types.LONG);
+    }
+
+    private static SourceReader<Long, SequenceSplit> readerWithSplit(
+            FailingCheckpointedSource<Long> source, SequenceSplit split) {
+        final SourceReader<Long, SequenceSplit> reader = source.createReader(null);
+        reader.addSplits(Collections.singletonList(split));
+        return reader;
+    }
+
+    private static List<Long> range(long startInclusive, long endExclusive) {
+        return LongStream.range(startInclusive, endExclusive).boxed().collect(Collectors.toList());
+    }
+
+    @Test
+    void testFailsOnceAfterArmedCheckpointCompletes() throws Exception {
+        final SourceReader<Long, SequenceSplit> reader =
+                readerWithSplit(failingSource(), new SequenceSplit(0, 0));
+        final TestReaderOutput<Long> output = new TestReaderOutput<>();
+
+        // Emission holds just past the arming threshold until a snapshot arms the failure.
+        final long armHoldPosition = FAILURE_POSITION / 2 + 1;
+        for (long i = 0; i < armHoldPosition; i++) {
+            assertThat(reader.pollNext(output)).isEqualTo(InputStatus.MORE_AVAILABLE);
+        }
+        assertThat(reader.pollNext(output)).isEqualTo(InputStatus.NOTHING_AVAILABLE);
+        assertThat(reader.isAvailable()).isNotDone();
+        assertThat(output.getCollected()).isEqualTo(range(0, armHoldPosition));
+
+        // The arming snapshot captures a position strictly before the failure position, so
+        // recovery is guaranteed to replay the records in between.
+        final List<SequenceSplit> snapshot = reader.snapshotState(1);
+        assertThat(snapshot).hasSize(1);
+        assertThat(snapshot.get(0).getPosition())
+                .isEqualTo(armHoldPosition)
+                .isLessThan(FAILURE_POSITION);
+        assertThat(reader.isAvailable()).isDone();
+
+        // Emission resumes to the failure position and holds for the armed checkpoint.
+        for (long i = armHoldPosition; i < FAILURE_POSITION; i++) {
+            assertThat(reader.pollNext(output)).isEqualTo(InputStatus.MORE_AVAILABLE);
+        }
+        assertThat(reader.pollNext(output)).isEqualTo(InputStatus.NOTHING_AVAILABLE);
+        assertThat(reader.isAvailable()).isNotDone();
+
+        reader.notifyCheckpointComplete(1);
+        assertThat(reader.isAvailable()).isDone();
+        assertThatThrownBy(() -> reader.pollNext(output))
+                .isInstanceOf(FlinkRuntimeException.class)
+                .hasMessage("Artificial Failure");
+        assertThat(output.getCollected()).isEqualTo(range(0, FAILURE_POSITION));
+    }
+
+    @Test
+    void testDoesNotArmOnCheckpointBeforeThreshold() throws Exception {
+        final SourceReader<Long, SequenceSplit> reader =
+                readerWithSplit(failingSource(), new SequenceSplit(0, 0));
+        final TestReaderOutput<Long> output = new TestReaderOutput<>();
+
+        // Only 3 emit calls: below the arming threshold of FAILURE_POSITION / 2.
+        for (long i = 0; i < 3; i++) {
+            reader.pollNext(output);
+        }
+        reader.snapshotState(1);
+        reader.notifyCheckpointComplete(1);
+
+        // The early checkpoint must not trigger the failure; emission continues to the arm hold.
+        final long armHoldPosition = FAILURE_POSITION / 2 + 1;
+        for (long i = 3; i < armHoldPosition; i++) {
+            assertThat(reader.pollNext(output)).isEqualTo(InputStatus.MORE_AVAILABLE);
+        }
+        assertThat(reader.pollNext(output)).isEqualTo(InputStatus.NOTHING_AVAILABLE);
+
+        reader.snapshotState(2);
+        for (long i = armHoldPosition; i < FAILURE_POSITION; i++) {
+            assertThat(reader.pollNext(output)).isEqualTo(InputStatus.MORE_AVAILABLE);
+        }
+        assertThat(reader.pollNext(output)).isEqualTo(InputStatus.NOTHING_AVAILABLE);
+        reader.notifyCheckpointComplete(2);
+        assertThatThrownBy(() -> reader.pollNext(output))
+                .isInstanceOf(FlinkRuntimeException.class)
+                .hasMessage("Artificial Failure");
+    }
+
+    @Test
+    void testRestoredReaderResumesWithoutFailingAgain() throws Exception {
+        final SourceReader<Long, SequenceSplit> reader =
+                readerWithSplit(failingSource(), new SequenceSplit(0, FAILURE_POSITION));
+        final TestReaderOutput<Long> output = new TestReaderOutput<>();
+
+        InputStatus status = InputStatus.MORE_AVAILABLE;
+        while (status == InputStatus.MORE_AVAILABLE) {
+            status = reader.pollNext(output);
+        }
+        assertThat(status).isEqualTo(InputStatus.END_OF_INPUT);
+        assertThat(output.getCollected()).isEqualTo(range(FAILURE_POSITION, EMIT_CALLS));
+    }
+
+    @Test
+    void testNonZeroSubtaskNeverFails() throws Exception {
+        final SourceReader<Long, SequenceSplit> reader =
+                readerWithSplit(failingSource(), new SequenceSplit(1, 0));
+        final TestReaderOutput<Long> output = new TestReaderOutput<>();
+
+        InputStatus status = InputStatus.MORE_AVAILABLE;
+        while (status == InputStatus.MORE_AVAILABLE) {
+            reader.snapshotState(output.getCollectedCount());
+            reader.notifyCheckpointComplete(output.getCollectedCount());
+            status = reader.pollNext(output);
+        }
+        assertThat(status).isEqualTo(InputStatus.END_OF_INPUT);
+        assertThat(output.getCollected()).isEqualTo(range(0, EMIT_CALLS));
+    }
+
+    @Test
+    void testNeverFailPolicyEmitsAllAndFinishes() throws Exception {
+        final FailingCheckpointedSource<Long> source =
+                FailingCheckpointedSource.of(
+                        (subtaskIndex, sequenceNo, output) -> output.collect(sequenceNo),
+                        EMIT_CALLS,
+                        FailingCheckpointedSource.FailurePolicy.neverFail(),
+                        Types.LONG);
+        final SourceReader<Long, SequenceSplit> reader =
+                readerWithSplit(source, new SequenceSplit(0, 0));
+        final TestReaderOutput<Long> output = new TestReaderOutput<>();
+
+        InputStatus status = InputStatus.MORE_AVAILABLE;
+        while (status == InputStatus.MORE_AVAILABLE) {
+            status = reader.pollNext(output);
+        }
+        assertThat(status).isEqualTo(InputStatus.END_OF_INPUT);
+        assertThat(output.getCollected()).isEqualTo(range(0, EMIT_CALLS));
+    }
+
+    @Test
+    void testIdleAfterEmissionKeepsReaderAlive() throws Exception {
+        final SourceReader<Long, SequenceSplit> reader =
+                readerWithSplit(
+                        failingSource().withIdleAfterEmission(),
+                        new SequenceSplit(0, FAILURE_POSITION));
+        final TestReaderOutput<Long> output = new TestReaderOutput<>();
+
+        InputStatus status = InputStatus.MORE_AVAILABLE;
+        while (status == InputStatus.MORE_AVAILABLE) {
+            status = reader.pollNext(output);
+        }
+        assertThat(status).isEqualTo(InputStatus.NOTHING_AVAILABLE);
+        assertThat(reader.isAvailable()).isNotDone();
+        assertThat(output.getCollected()).isEqualTo(range(FAILURE_POSITION, EMIT_CALLS));
+    }
+
+    @Test
+    void testSimulatedStateLossReemitsFromZero() throws Exception {
+        // Red-check knob: a restored reader discards its position, producing duplicates that an
+        // exactly-once test must detect.
+        final SourceReader<Long, SequenceSplit> reader =
+                readerWithSplit(
+                        failingSource().withSimulatedStateLossOnRecovery(),
+                        new SequenceSplit(0, FAILURE_POSITION));
+        final TestReaderOutput<Long> output = new TestReaderOutput<>();
+
+        InputStatus status = InputStatus.MORE_AVAILABLE;
+        while (status == InputStatus.MORE_AVAILABLE) {
+            status = reader.pollNext(output);
+        }
+        assertThat(status).isEqualTo(InputStatus.END_OF_INPUT);
+        assertThat(output.getCollected()).isEqualTo(range(0, EMIT_CALLS));
+    }
+
+    @Test
+    void testGeneratorEmitsMultipleRecordsWithTimestampsAtomically() throws Exception {
+        final FailingCheckpointedSource<Long> source =
+                FailingCheckpointedSource.of(
+                        (subtaskIndex, sequenceNo, output) -> {
+                            output.collect(sequenceNo, sequenceNo);
+                            output.collect(-sequenceNo, sequenceNo);
+                            output.emitWatermark(sequenceNo);
+                        },
+                        3,
+                        FailingCheckpointedSource.FailurePolicy.neverFail(),
+                        Types.LONG);
+        final SourceReader<Long, SequenceSplit> reader =
+                readerWithSplit(source, new SequenceSplit(0, 0));
+        final TestReaderOutput<Long> output = new TestReaderOutput<>();
+
+        assertThat(reader.pollNext(output)).isEqualTo(InputStatus.MORE_AVAILABLE);
+        assertThat(output.getCollected()).containsExactly(0L, 0L);
+
+        assertThat(reader.pollNext(output)).isEqualTo(InputStatus.MORE_AVAILABLE);
+        assertThat(output.getCollected()).containsExactly(0L, 0L, 1L, -1L);
+    }
+
+    @Test
+    void testAbortedArmedCheckpointRearmsOnNextSnapshot() throws Exception {
+        final SourceReader<Long, SequenceSplit> reader =
+                readerWithSplit(failingSource(), new SequenceSplit(0, 0));
+        final TestReaderOutput<Long> output = new TestReaderOutput<>();
+
+        final long armHoldPosition = FAILURE_POSITION / 2 + 1;
+        for (long i = 0; i < armHoldPosition; i++) {
+            reader.pollNext(output);
+        }
+        assertThat(reader.pollNext(output)).isEqualTo(InputStatus.NOTHING_AVAILABLE);
+
+        reader.snapshotState(1);
+        reader.notifyCheckpointAborted(1);
+        // the aborted checkpoint must not trigger the failure and must not stay armed; the
+        // reader holds at the arming position again
+        reader.notifyCheckpointComplete(1);
+        assertThat(reader.pollNext(output)).isEqualTo(InputStatus.NOTHING_AVAILABLE);
+
+        reader.snapshotState(2);
+        for (long i = armHoldPosition; i < FAILURE_POSITION; i++) {
+            assertThat(reader.pollNext(output)).isEqualTo(InputStatus.MORE_AVAILABLE);
+        }
+        assertThat(reader.pollNext(output)).isEqualTo(InputStatus.NOTHING_AVAILABLE);
+        reader.notifyCheckpointComplete(2);
+        assertThatThrownBy(() -> reader.pollNext(output))
+                .isInstanceOf(FlinkRuntimeException.class)
+                .hasMessage("Artificial Failure");
+    }
+
+    @Test
+    void testEnumeratorAssignsOneSplitPerSubtaskOnFreshStart() throws Exception {
+        final MockSplitEnumeratorContext<SequenceSplit> context =
+                new MockSplitEnumeratorContext<>(2);
+        final SplitEnumerator<SequenceSplit, Void> enumerator =
+                failingSource().createEnumerator(context);
+
+        enumerator.addReader(0);
+        enumerator.addReader(1);
+
+        assertThat(assignedSplits(context, 0)).containsExactly(new SequenceSplit(0, 0));
+        assertThat(assignedSplits(context, 1)).containsExactly(new SequenceSplit(1, 0));
+    }
+
+    @Test
+    void testEnumeratorDoesNotReassignOnReRegistration() throws Exception {
+        // Regression test: on a partial failover the enumerator instance survives and the
+        // restarted reader re-registers; it recovers its split from its own checkpointed state,
+        // so the enumerator must not assign a second, fresh split.
+        final MockSplitEnumeratorContext<SequenceSplit> context =
+                new MockSplitEnumeratorContext<>(1);
+        final SplitEnumerator<SequenceSplit, Void> enumerator =
+                failingSource().createEnumerator(context);
+
+        enumerator.addReader(0);
+        enumerator.addReader(0);
+
+        assertThat(assignedSplits(context, 0)).containsExactly(new SequenceSplit(0, 0));
+    }
+
+    @Test
+    void testEnumeratorReassignsSplitsReturnedAfterFailure() throws Exception {
+        final MockSplitEnumeratorContext<SequenceSplit> context =
+                new MockSplitEnumeratorContext<>(1);
+        final SplitEnumerator<SequenceSplit, Void> enumerator =
+                failingSource().createEnumerator(context);
+
+        enumerator.addReader(0);
+        enumerator.addSplitsBack(
+                Collections.singletonList(new SequenceSplit(0, FAILURE_POSITION)), 0);
+        enumerator.addReader(0);
+
+        assertThat(assignedSplits(context, 0))
+                .containsExactly(new SequenceSplit(0, 0), new SequenceSplit(0, FAILURE_POSITION));
+    }
+
+    @Test
+    void testRestoredEnumeratorAssignsNothingOnRegistration() throws Exception {
+        final MockSplitEnumeratorContext<SequenceSplit> context =
+                new MockSplitEnumeratorContext<>(1);
+        final SplitEnumerator<SequenceSplit, Void> enumerator =
+                failingSource().restoreEnumerator(context, null);
+
+        enumerator.addReader(0);
+
+        assertThat(context.getSplitsAssignmentSequence()).isEmpty();
+    }
+
+    private static List<SequenceSplit> assignedSplits(
+            MockSplitEnumeratorContext<SequenceSplit> context, int subtask) {
+        return context.getSplitsAssignmentSequence().stream()
+                .flatMap(
+                        assignment ->
+                                assignment
+                                        .assignment()
+                                        .getOrDefault(subtask, Collections.emptyList())
+                                        .stream())
+                .collect(Collectors.toList());
+    }
+
+    @Test
+    void testSplitSerializerRoundTrip() throws Exception {
+        final SequenceSplit split = new SequenceSplit(3, 42);
+        final byte[] bytes = SequenceSplit.SERIALIZER.serialize(split);
+        final SequenceSplit restored =
+                SequenceSplit.SERIALIZER.deserialize(SequenceSplit.SERIALIZER.getVersion(), bytes);
+        assertThat(restored.getSubtaskIndex()).isEqualTo(3);
+        assertThat(restored.getPosition()).isEqualTo(42);
+        assertThat(restored.splitId()).isEqualTo(split.splitId());
+    }
+}

--- a/flink-test-utils-parent/flink-test-utils-connector/src/test/java/org/apache/flink/test/util/source/FailingCheckpointedSourceTest.java
+++ b/flink-test-utils-parent/flink-test-utils-connector/src/test/java/org/apache/flink/test/util/source/FailingCheckpointedSourceTest.java
@@ -1,0 +1,329 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.test.util.source;
+
+import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.api.connector.source.SourceReader;
+import org.apache.flink.api.connector.source.SplitEnumerator;
+import org.apache.flink.api.connector.source.mocks.MockSplitEnumeratorContext;
+import org.apache.flink.core.io.InputStatus;
+import org.apache.flink.test.util.source.FailingCheckpointedSource.SequenceSplit;
+import org.apache.flink.util.FlinkRuntimeException;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.LongStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Tests for the failure protocol of {@link FailingCheckpointedSource}: arm on a snapshot past the
+ * threshold, pause at the failure position, fail once the armed checkpoint completes, and resume
+ * from the restored position without failing again.
+ */
+class FailingCheckpointedSourceTest {
+
+    private static final long EMIT_CALLS = 20;
+    private static final long FAILURE_POSITION = EMIT_CALLS / 2;
+
+    private static FailingCheckpointedSource<Long> failingSource() {
+        return FailingCheckpointedSource.of(
+                (subtaskIndex, sequenceNo, output) -> output.collect(sequenceNo),
+                EMIT_CALLS,
+                Types.LONG);
+    }
+
+    private static SourceReader<Long, SequenceSplit> readerWithSplit(
+            FailingCheckpointedSource<Long> source, SequenceSplit split) {
+        final SourceReader<Long, SequenceSplit> reader = source.createReader(null);
+        reader.addSplits(Collections.singletonList(split));
+        return reader;
+    }
+
+    private static List<Long> range(long startInclusive, long endExclusive) {
+        return LongStream.range(startInclusive, endExclusive).boxed().collect(Collectors.toList());
+    }
+
+    @Test
+    void testFailsOnceAfterArmedCheckpointCompletes() throws Exception {
+        final SourceReader<Long, SequenceSplit> reader =
+                readerWithSplit(failingSource(), new SequenceSplit(0, 0));
+        final TestReaderOutput<Long> output = new TestReaderOutput<>();
+
+        // Emission holds just past the arming threshold until a snapshot arms the failure.
+        final long armHoldPosition = FAILURE_POSITION / 2 + 1;
+        for (long i = 0; i < armHoldPosition; i++) {
+            assertThat(reader.pollNext(output)).isEqualTo(InputStatus.MORE_AVAILABLE);
+        }
+        assertThat(reader.pollNext(output)).isEqualTo(InputStatus.NOTHING_AVAILABLE);
+        assertThat(reader.isAvailable()).isNotDone();
+        assertThat(output.getCollected()).isEqualTo(range(0, armHoldPosition));
+
+        // The arming snapshot captures a position strictly before the failure position, so
+        // recovery is guaranteed to replay the records in between.
+        final List<SequenceSplit> snapshot = reader.snapshotState(1);
+        assertThat(snapshot).hasSize(1);
+        assertThat(snapshot.get(0).getPosition())
+                .isEqualTo(armHoldPosition)
+                .isLessThan(FAILURE_POSITION);
+        assertThat(reader.isAvailable()).isDone();
+
+        // Emission resumes to the failure position and holds for the armed checkpoint.
+        for (long i = armHoldPosition; i < FAILURE_POSITION; i++) {
+            assertThat(reader.pollNext(output)).isEqualTo(InputStatus.MORE_AVAILABLE);
+        }
+        assertThat(reader.pollNext(output)).isEqualTo(InputStatus.NOTHING_AVAILABLE);
+        assertThat(reader.isAvailable()).isNotDone();
+
+        reader.notifyCheckpointComplete(1);
+        assertThat(reader.isAvailable()).isDone();
+        assertThatThrownBy(() -> reader.pollNext(output))
+                .isInstanceOf(FlinkRuntimeException.class)
+                .hasMessage("Artificial Failure");
+        assertThat(output.getCollected()).isEqualTo(range(0, FAILURE_POSITION));
+    }
+
+    @Test
+    void testDoesNotArmOnCheckpointBeforeThreshold() throws Exception {
+        final SourceReader<Long, SequenceSplit> reader =
+                readerWithSplit(failingSource(), new SequenceSplit(0, 0));
+        final TestReaderOutput<Long> output = new TestReaderOutput<>();
+
+        // Only 3 emit calls: below the arming threshold of FAILURE_POSITION / 2.
+        for (long i = 0; i < 3; i++) {
+            reader.pollNext(output);
+        }
+        reader.snapshotState(1);
+        reader.notifyCheckpointComplete(1);
+
+        // The early checkpoint must not trigger the failure; emission continues to the arm hold.
+        final long armHoldPosition = FAILURE_POSITION / 2 + 1;
+        for (long i = 3; i < armHoldPosition; i++) {
+            assertThat(reader.pollNext(output)).isEqualTo(InputStatus.MORE_AVAILABLE);
+        }
+        assertThat(reader.pollNext(output)).isEqualTo(InputStatus.NOTHING_AVAILABLE);
+
+        reader.snapshotState(2);
+        for (long i = armHoldPosition; i < FAILURE_POSITION; i++) {
+            assertThat(reader.pollNext(output)).isEqualTo(InputStatus.MORE_AVAILABLE);
+        }
+        assertThat(reader.pollNext(output)).isEqualTo(InputStatus.NOTHING_AVAILABLE);
+        reader.notifyCheckpointComplete(2);
+        assertThatThrownBy(() -> reader.pollNext(output))
+                .isInstanceOf(FlinkRuntimeException.class)
+                .hasMessage("Artificial Failure");
+    }
+
+    @Test
+    void testRestoredReaderResumesWithoutFailingAgain() throws Exception {
+        final SourceReader<Long, SequenceSplit> reader =
+                readerWithSplit(failingSource(), new SequenceSplit(0, FAILURE_POSITION));
+        final TestReaderOutput<Long> output = new TestReaderOutput<>();
+
+        InputStatus status = InputStatus.MORE_AVAILABLE;
+        while (status == InputStatus.MORE_AVAILABLE) {
+            status = reader.pollNext(output);
+        }
+        assertThat(status).isEqualTo(InputStatus.END_OF_INPUT);
+        assertThat(output.getCollected()).isEqualTo(range(FAILURE_POSITION, EMIT_CALLS));
+    }
+
+    @Test
+    void testNonZeroSubtaskNeverFails() throws Exception {
+        final SourceReader<Long, SequenceSplit> reader =
+                readerWithSplit(failingSource(), new SequenceSplit(1, 0));
+        final TestReaderOutput<Long> output = new TestReaderOutput<>();
+
+        InputStatus status = InputStatus.MORE_AVAILABLE;
+        while (status == InputStatus.MORE_AVAILABLE) {
+            reader.snapshotState(output.getCollectedCount());
+            reader.notifyCheckpointComplete(output.getCollectedCount());
+            status = reader.pollNext(output);
+        }
+        assertThat(status).isEqualTo(InputStatus.END_OF_INPUT);
+        assertThat(output.getCollected()).isEqualTo(range(0, EMIT_CALLS));
+    }
+
+    @Test
+    void testIdleAfterEmissionKeepsReaderAlive() throws Exception {
+        final SourceReader<Long, SequenceSplit> reader =
+                readerWithSplit(
+                        failingSource().withIdleAfterEmission(),
+                        new SequenceSplit(0, FAILURE_POSITION));
+        final TestReaderOutput<Long> output = new TestReaderOutput<>();
+
+        InputStatus status = InputStatus.MORE_AVAILABLE;
+        while (status == InputStatus.MORE_AVAILABLE) {
+            status = reader.pollNext(output);
+        }
+        assertThat(status).isEqualTo(InputStatus.NOTHING_AVAILABLE);
+        assertThat(reader.isAvailable()).isNotDone();
+        assertThat(output.getCollected()).isEqualTo(range(FAILURE_POSITION, EMIT_CALLS));
+    }
+
+    @Test
+    void testGeneratorEmitsMultipleRecordsWithTimestampsAtomically() throws Exception {
+        final FailingCheckpointedSource<Long> source =
+                FailingCheckpointedSource.of(
+                        (subtaskIndex, sequenceNo, output) -> {
+                            output.collect(sequenceNo, sequenceNo);
+                            output.collect(-sequenceNo, sequenceNo);
+                            output.emitWatermark(sequenceNo);
+                        },
+                        3,
+                        Types.LONG);
+        // subtask 1 never fails, so the whole sequence is observable without a checkpoint
+        final SourceReader<Long, SequenceSplit> reader =
+                readerWithSplit(source, new SequenceSplit(1, 0));
+        final TestReaderOutput<Long> output = new TestReaderOutput<>();
+
+        assertThat(reader.pollNext(output)).isEqualTo(InputStatus.MORE_AVAILABLE);
+        assertThat(output.getCollected()).containsExactly(0L, 0L);
+
+        assertThat(reader.pollNext(output)).isEqualTo(InputStatus.MORE_AVAILABLE);
+        assertThat(output.getCollected()).containsExactly(0L, 0L, 1L, -1L);
+    }
+
+    @Test
+    void testRejectsFewerThanTwoEmitCalls() {
+        assertThatThrownBy(
+                        () ->
+                                FailingCheckpointedSource.of(
+                                        (subtaskIndex, sequenceNo, output) ->
+                                                output.collect(sequenceNo),
+                                        1,
+                                        Types.LONG))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void testAbortedArmedCheckpointRearmsOnNextSnapshot() throws Exception {
+        final SourceReader<Long, SequenceSplit> reader =
+                readerWithSplit(failingSource(), new SequenceSplit(0, 0));
+        final TestReaderOutput<Long> output = new TestReaderOutput<>();
+
+        final long armHoldPosition = FAILURE_POSITION / 2 + 1;
+        for (long i = 0; i < armHoldPosition; i++) {
+            reader.pollNext(output);
+        }
+        assertThat(reader.pollNext(output)).isEqualTo(InputStatus.NOTHING_AVAILABLE);
+
+        reader.snapshotState(1);
+        reader.notifyCheckpointAborted(1);
+        // the aborted checkpoint must not trigger the failure and must not stay armed; the
+        // reader holds at the arming position again
+        reader.notifyCheckpointComplete(1);
+        assertThat(reader.pollNext(output)).isEqualTo(InputStatus.NOTHING_AVAILABLE);
+
+        reader.snapshotState(2);
+        for (long i = armHoldPosition; i < FAILURE_POSITION; i++) {
+            assertThat(reader.pollNext(output)).isEqualTo(InputStatus.MORE_AVAILABLE);
+        }
+        assertThat(reader.pollNext(output)).isEqualTo(InputStatus.NOTHING_AVAILABLE);
+        reader.notifyCheckpointComplete(2);
+        assertThatThrownBy(() -> reader.pollNext(output))
+                .isInstanceOf(FlinkRuntimeException.class)
+                .hasMessage("Artificial Failure");
+    }
+
+    @Test
+    void testEnumeratorAssignsOneSplitPerSubtaskOnFreshStart() throws Exception {
+        final MockSplitEnumeratorContext<SequenceSplit> context =
+                new MockSplitEnumeratorContext<>(2);
+        final SplitEnumerator<SequenceSplit, Void> enumerator =
+                failingSource().createEnumerator(context);
+
+        enumerator.addReader(0);
+        enumerator.addReader(1);
+
+        assertThat(assignedSplits(context, 0)).containsExactly(new SequenceSplit(0, 0));
+        assertThat(assignedSplits(context, 1)).containsExactly(new SequenceSplit(1, 0));
+    }
+
+    @Test
+    void testEnumeratorDoesNotReassignOnReRegistration() throws Exception {
+        // Regression test: on a partial failover the enumerator instance survives and the
+        // restarted reader re-registers; it recovers its split from its own checkpointed state,
+        // so the enumerator must not assign a second, fresh split.
+        final MockSplitEnumeratorContext<SequenceSplit> context =
+                new MockSplitEnumeratorContext<>(1);
+        final SplitEnumerator<SequenceSplit, Void> enumerator =
+                failingSource().createEnumerator(context);
+
+        enumerator.addReader(0);
+        enumerator.addReader(0);
+
+        assertThat(assignedSplits(context, 0)).containsExactly(new SequenceSplit(0, 0));
+    }
+
+    @Test
+    void testEnumeratorReassignsSplitsReturnedAfterFailure() throws Exception {
+        final MockSplitEnumeratorContext<SequenceSplit> context =
+                new MockSplitEnumeratorContext<>(1);
+        final SplitEnumerator<SequenceSplit, Void> enumerator =
+                failingSource().createEnumerator(context);
+
+        enumerator.addReader(0);
+        enumerator.addSplitsBack(
+                Collections.singletonList(new SequenceSplit(0, FAILURE_POSITION)), 0);
+        enumerator.addReader(0);
+
+        assertThat(assignedSplits(context, 0))
+                .containsExactly(new SequenceSplit(0, 0), new SequenceSplit(0, FAILURE_POSITION));
+    }
+
+    @Test
+    void testRestoredEnumeratorAssignsNothingOnRegistration() throws Exception {
+        final MockSplitEnumeratorContext<SequenceSplit> context =
+                new MockSplitEnumeratorContext<>(1);
+        final SplitEnumerator<SequenceSplit, Void> enumerator =
+                failingSource().restoreEnumerator(context, null);
+
+        enumerator.addReader(0);
+
+        assertThat(context.getSplitsAssignmentSequence()).isEmpty();
+    }
+
+    private static List<SequenceSplit> assignedSplits(
+            MockSplitEnumeratorContext<SequenceSplit> context, int subtask) {
+        return context.getSplitsAssignmentSequence().stream()
+                .flatMap(
+                        assignment ->
+                                assignment
+                                        .assignment()
+                                        .getOrDefault(subtask, Collections.emptyList())
+                                        .stream())
+                .collect(Collectors.toList());
+    }
+
+    @Test
+    void testSplitSerializerRoundTrip() throws Exception {
+        final SequenceSplit split = new SequenceSplit(3, 42);
+        final byte[] bytes = SequenceSplit.SERIALIZER.serialize(split);
+        final SequenceSplit restored =
+                SequenceSplit.SERIALIZER.deserialize(SequenceSplit.SERIALIZER.getVersion(), bytes);
+        assertThat(restored.getSubtaskIndex()).isEqualTo(3);
+        assertThat(restored.getPosition()).isEqualTo(42);
+        assertThat(restored.splitId()).isEqualTo(split.splitId());
+    }
+}

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/EventTimeAllWindowCheckpointingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/EventTimeAllWindowCheckpointingITCase.java
@@ -18,8 +18,11 @@
 
 package org.apache.flink.test.checkpointing;
 
+import org.apache.flink.api.common.eventtime.WatermarkStrategy;
 import org.apache.flink.api.common.functions.OpenContext;
 import org.apache.flink.api.common.functions.ReduceFunction;
+import org.apache.flink.api.common.typeinfo.TypeHint;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.tuple.Tuple4;
 import org.apache.flink.configuration.Configuration;
@@ -27,16 +30,17 @@ import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.configuration.RpcOptions;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
+import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.windowing.RichAllWindowFunction;
 import org.apache.flink.streaming.api.windowing.assigners.SlidingEventTimeWindows;
 import org.apache.flink.streaming.api.windowing.assigners.TumblingEventTimeWindows;
 import org.apache.flink.streaming.api.windowing.windows.TimeWindow;
 import org.apache.flink.streaming.util.RestartStrategyUtils;
-import org.apache.flink.test.checkpointing.utils.FailingSource;
 import org.apache.flink.test.checkpointing.utils.IntType;
 import org.apache.flink.test.checkpointing.utils.ValidatingSink;
 import org.apache.flink.test.junit5.MiniClusterExtension;
+import org.apache.flink.test.util.source.FailingCheckpointedSource;
 import org.apache.flink.util.Collector;
 import org.apache.flink.util.TestLoggerExtension;
 
@@ -75,6 +79,24 @@ class EventTimeAllWindowCheckpointingITCase {
         return config;
     }
 
+    private static DataStream<Tuple2<Long, IntType>> createFailingSourceStream(
+            StreamExecutionEnvironment env,
+            int numKeys,
+            int numElementsPerWindow,
+            int numElementsPerKey) {
+        final FailingCheckpointedSource<Tuple2<Long, IntType>> source =
+                FailingCheckpointedSource.of(
+                        new EventTimeWindowCheckpointingITCase.KeyedEventTimeGenerator(
+                                numKeys, numElementsPerWindow),
+                        numElementsPerKey,
+                        FailingCheckpointedSource.FailurePolicy.failAfterEmitCalls(
+                                numElementsPerKey / 2),
+                        TypeInformation.of(new TypeHint<Tuple2<Long, IntType>>() {}));
+        // like the legacy FailingSource, the source is non-parallel
+        return env.fromSource(source, WatermarkStrategy.noWatermarks(), "Failing Source")
+                .setParallelism(1);
+    }
+
     // ------------------------------------------------------------------------
 
     @Test
@@ -88,11 +110,7 @@ class EventTimeAllWindowCheckpointingITCase {
         env.enableCheckpointing(100);
         RestartStrategyUtils.configureFixedDelayRestartStrategy(env, 1, 0L);
 
-        env.addSource(
-                        new FailingSource(
-                                new EventTimeWindowCheckpointingITCase.KeyedEventTimeGenerator(
-                                        numKeys, windowSize),
-                                numElementsPerKey))
+        createFailingSourceStream(env, numKeys, windowSize, numElementsPerKey)
                 .rebalance()
                 .windowAll(TumblingEventTimeWindows.of(Duration.ofMillis(windowSize)))
                 .apply(
@@ -160,11 +178,7 @@ class EventTimeAllWindowCheckpointingITCase {
         env.enableCheckpointing(100);
         RestartStrategyUtils.configureFixedDelayRestartStrategy(env, 1, 0L);
 
-        env.addSource(
-                        new FailingSource(
-                                new EventTimeWindowCheckpointingITCase.KeyedEventTimeGenerator(
-                                        numKeys, windowSlide),
-                                numElementsPerKey))
+        createFailingSourceStream(env, numKeys, windowSlide, numElementsPerKey)
                 .rebalance()
                 .windowAll(
                         SlidingEventTimeWindows.of(
@@ -233,11 +247,7 @@ class EventTimeAllWindowCheckpointingITCase {
         env.enableCheckpointing(100);
         RestartStrategyUtils.configureFixedDelayRestartStrategy(env, 1, 0L);
 
-        env.addSource(
-                        new FailingSource(
-                                new EventTimeWindowCheckpointingITCase.KeyedEventTimeGenerator(
-                                        numKeys, windowSize),
-                                numElementsPerKey))
+        createFailingSourceStream(env, numKeys, windowSize, numElementsPerKey)
                 .rebalance()
                 .windowAll(TumblingEventTimeWindows.of(Duration.ofMillis(windowSize)))
                 .reduce(
@@ -309,11 +319,7 @@ class EventTimeAllWindowCheckpointingITCase {
         env.enableCheckpointing(100);
         RestartStrategyUtils.configureFixedDelayRestartStrategy(env, 1, 0L);
 
-        env.addSource(
-                        new FailingSource(
-                                new EventTimeWindowCheckpointingITCase.KeyedEventTimeGenerator(
-                                        numKeys, windowSlide),
-                                numElementsPerKey))
+        createFailingSourceStream(env, numKeys, windowSlide, numElementsPerKey)
                 .rebalance()
                 .windowAll(
                         SlidingEventTimeWindows.of(

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/EventTimeAllWindowCheckpointingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/EventTimeAllWindowCheckpointingITCase.java
@@ -18,8 +18,11 @@
 
 package org.apache.flink.test.checkpointing;
 
+import org.apache.flink.api.common.eventtime.WatermarkStrategy;
 import org.apache.flink.api.common.functions.OpenContext;
 import org.apache.flink.api.common.functions.ReduceFunction;
+import org.apache.flink.api.common.typeinfo.TypeHint;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.tuple.Tuple4;
 import org.apache.flink.configuration.Configuration;
@@ -27,16 +30,17 @@ import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.configuration.RpcOptions;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
+import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.windowing.RichAllWindowFunction;
 import org.apache.flink.streaming.api.windowing.assigners.SlidingEventTimeWindows;
 import org.apache.flink.streaming.api.windowing.assigners.TumblingEventTimeWindows;
 import org.apache.flink.streaming.api.windowing.windows.TimeWindow;
 import org.apache.flink.streaming.util.RestartStrategyUtils;
-import org.apache.flink.test.checkpointing.utils.FailingSource;
 import org.apache.flink.test.checkpointing.utils.IntType;
 import org.apache.flink.test.checkpointing.utils.ValidatingSink;
 import org.apache.flink.test.junit5.MiniClusterExtension;
+import org.apache.flink.test.util.source.FailingCheckpointedSource;
 import org.apache.flink.util.Collector;
 import org.apache.flink.util.TestLoggerExtension;
 
@@ -75,6 +79,22 @@ class EventTimeAllWindowCheckpointingITCase {
         return config;
     }
 
+    private static DataStream<Tuple2<Long, IntType>> createFailingSourceStream(
+            StreamExecutionEnvironment env,
+            int numKeys,
+            int numElementsPerWindow,
+            int numElementsPerKey) {
+        final FailingCheckpointedSource<Tuple2<Long, IntType>> source =
+                FailingCheckpointedSource.of(
+                        new EventTimeWindowCheckpointingITCase.KeyedEventTimeGenerator(
+                                numKeys, numElementsPerWindow),
+                        numElementsPerKey,
+                        TypeInformation.of(new TypeHint<Tuple2<Long, IntType>>() {}));
+        // like the legacy FailingSource, the source is non-parallel
+        return env.fromSource(source, WatermarkStrategy.noWatermarks(), "Failing Source")
+                .setParallelism(1);
+    }
+
     // ------------------------------------------------------------------------
 
     @Test
@@ -88,11 +108,7 @@ class EventTimeAllWindowCheckpointingITCase {
         env.enableCheckpointing(100);
         RestartStrategyUtils.configureFixedDelayRestartStrategy(env, 1, 0L);
 
-        env.addSource(
-                        new FailingSource(
-                                new EventTimeWindowCheckpointingITCase.KeyedEventTimeGenerator(
-                                        numKeys, windowSize),
-                                numElementsPerKey))
+        createFailingSourceStream(env, numKeys, windowSize, numElementsPerKey)
                 .rebalance()
                 .windowAll(TumblingEventTimeWindows.of(Duration.ofMillis(windowSize)))
                 .apply(
@@ -160,11 +176,7 @@ class EventTimeAllWindowCheckpointingITCase {
         env.enableCheckpointing(100);
         RestartStrategyUtils.configureFixedDelayRestartStrategy(env, 1, 0L);
 
-        env.addSource(
-                        new FailingSource(
-                                new EventTimeWindowCheckpointingITCase.KeyedEventTimeGenerator(
-                                        numKeys, windowSlide),
-                                numElementsPerKey))
+        createFailingSourceStream(env, numKeys, windowSlide, numElementsPerKey)
                 .rebalance()
                 .windowAll(
                         SlidingEventTimeWindows.of(
@@ -233,11 +245,7 @@ class EventTimeAllWindowCheckpointingITCase {
         env.enableCheckpointing(100);
         RestartStrategyUtils.configureFixedDelayRestartStrategy(env, 1, 0L);
 
-        env.addSource(
-                        new FailingSource(
-                                new EventTimeWindowCheckpointingITCase.KeyedEventTimeGenerator(
-                                        numKeys, windowSize),
-                                numElementsPerKey))
+        createFailingSourceStream(env, numKeys, windowSize, numElementsPerKey)
                 .rebalance()
                 .windowAll(TumblingEventTimeWindows.of(Duration.ofMillis(windowSize)))
                 .reduce(
@@ -309,11 +317,7 @@ class EventTimeAllWindowCheckpointingITCase {
         env.enableCheckpointing(100);
         RestartStrategyUtils.configureFixedDelayRestartStrategy(env, 1, 0L);
 
-        env.addSource(
-                        new FailingSource(
-                                new EventTimeWindowCheckpointingITCase.KeyedEventTimeGenerator(
-                                        numKeys, windowSlide),
-                                numElementsPerKey))
+        createFailingSourceStream(env, numKeys, windowSlide, numElementsPerKey)
                 .rebalance()
                 .windowAll(
                         SlidingEventTimeWindows.of(

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/EventTimeWindowCheckpointingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/EventTimeWindowCheckpointingITCase.java
@@ -52,6 +52,7 @@ import org.apache.flink.test.checkpointing.utils.FailingSource;
 import org.apache.flink.test.checkpointing.utils.IntType;
 import org.apache.flink.test.checkpointing.utils.ValidatingSink;
 import org.apache.flink.test.util.MiniClusterWithClientResource;
+import org.apache.flink.test.util.source.FailingCheckpointedSource;
 import org.apache.flink.testutils.junit.extensions.parameterized.Parameter;
 import org.apache.flink.testutils.junit.extensions.parameterized.ParameterizedTestExtension;
 import org.apache.flink.testutils.junit.extensions.parameterized.Parameters;
@@ -795,7 +796,11 @@ class EventTimeWindowCheckpointingITCase {
         }
     }
 
-    static class KeyedEventTimeGenerator implements FailingSource.EventEmittingGenerator {
+    // implements both generator interfaces until all FailingSource consumers are migrated to
+    // FailingCheckpointedSource
+    static class KeyedEventTimeGenerator
+            implements FailingSource.EventEmittingGenerator,
+                    FailingCheckpointedSource.EventGenerator<Tuple2<Long, IntType>> {
 
         private final int keyUniverseSize;
         private final int watermarkTrailing;
@@ -818,6 +823,19 @@ class EventTimeWindowCheckpointingITCase {
             }
 
             ctx.emitWatermark(new Watermark(eventSequenceNo - watermarkTrailing));
+        }
+
+        @Override
+        public void emit(
+                int subtaskIndex,
+                long sequenceNo,
+                FailingCheckpointedSource.GeneratorOutput<Tuple2<Long, IntType>> output) {
+            final IntType intTypeNext = new IntType((int) sequenceNo);
+            for (long i = 0; i < keyUniverseSize; i++) {
+                output.collect(new Tuple2<>(i, intTypeNext), sequenceNo);
+            }
+
+            output.emitWatermark(sequenceNo - watermarkTrailing);
         }
     }
 

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/ProcessingTimeWindowCheckpointingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/ProcessingTimeWindowCheckpointingITCase.java
@@ -18,26 +18,30 @@
 
 package org.apache.flink.test.checkpointing;
 
+import org.apache.flink.api.common.eventtime.WatermarkStrategy;
 import org.apache.flink.api.common.functions.MapFunction;
 import org.apache.flink.api.common.functions.OpenContext;
 import org.apache.flink.api.common.functions.ReduceFunction;
+import org.apache.flink.api.common.typeinfo.TypeHint;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
+import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
-import org.apache.flink.streaming.api.functions.source.legacy.SourceFunction;
 import org.apache.flink.streaming.api.functions.windowing.RichWindowFunction;
 import org.apache.flink.streaming.api.windowing.assigners.SlidingProcessingTimeWindows;
 import org.apache.flink.streaming.api.windowing.assigners.TumblingProcessingTimeWindows;
 import org.apache.flink.streaming.api.windowing.windows.TimeWindow;
 import org.apache.flink.streaming.util.RestartStrategyUtils;
-import org.apache.flink.test.checkpointing.utils.FailingSource;
 import org.apache.flink.test.checkpointing.utils.IntType;
 import org.apache.flink.test.checkpointing.utils.ValidatingSink;
 import org.apache.flink.test.junit5.MiniClusterExtension;
+import org.apache.flink.test.util.source.FailingCheckpointedSource;
 import org.apache.flink.util.Collector;
+import org.apache.flink.util.FlinkRuntimeException;
 import org.apache.flink.util.TestLoggerExtension;
 
 import org.junit.jupiter.api.Test;
@@ -75,6 +79,20 @@ class ProcessingTimeWindowCheckpointingITCase {
         return config;
     }
 
+    private static DataStream<Tuple2<Long, IntType>> createFailingSourceStream(
+            StreamExecutionEnvironment env, int numElements) {
+        final FailingCheckpointedSource<Tuple2<Long, IntType>> source =
+                FailingCheckpointedSource.of(
+                                new Generator(),
+                                numElements,
+                                TypeInformation.of(new TypeHint<Tuple2<Long, IntType>>() {}))
+                        // the sink terminates the job once all windows are validated
+                        .withIdleAfterEmission();
+        // like the legacy FailingSource, the source is non-parallel
+        return env.fromSource(source, WatermarkStrategy.noWatermarks(), "Failing Source")
+                .setParallelism(1);
+    }
+
     // ------------------------------------------------------------------------
 
     @Test
@@ -90,7 +108,7 @@ class ProcessingTimeWindowCheckpointingITCase {
         SinkValidatorUpdaterAndChecker updaterAndChecker =
                 new SinkValidatorUpdaterAndChecker(numElements, 1);
 
-        env.addSource(new FailingSource(new Generator(), numElements, true))
+        createFailingSourceStream(env, numElements)
                 .rebalance()
                 .keyBy(x -> x.f0)
                 .window(TumblingProcessingTimeWindows.of(Duration.ofMillis(100)))
@@ -143,7 +161,7 @@ class ProcessingTimeWindowCheckpointingITCase {
         RestartStrategyUtils.configureFixedDelayRestartStrategy(env, 1, 0L);
         SinkValidatorUpdaterAndChecker updaterAndChecker =
                 new SinkValidatorUpdaterAndChecker(numElements, 3);
-        env.addSource(new FailingSource(new Generator(), numElements, true))
+        createFailingSourceStream(env, numElements)
                 .rebalance()
                 .keyBy(x -> x.f0)
                 .window(
@@ -198,7 +216,7 @@ class ProcessingTimeWindowCheckpointingITCase {
         RestartStrategyUtils.configureFixedDelayRestartStrategy(env, 1, 0L);
         SinkValidatorUpdaterAndChecker updaterAndChecker =
                 new SinkValidatorUpdaterAndChecker(numElements, 1);
-        env.addSource(new FailingSource(new Generator(), numElements, true))
+        createFailingSourceStream(env, numElements)
                 .map(
                         new MapFunction<Tuple2<Long, IntType>, Tuple2<Long, IntType>>() {
                             @Override
@@ -236,7 +254,7 @@ class ProcessingTimeWindowCheckpointingITCase {
         RestartStrategyUtils.configureFixedDelayRestartStrategy(env, 1, 0L);
         SinkValidatorUpdaterAndChecker updaterAndChecker =
                 new SinkValidatorUpdaterAndChecker(numElements, 3);
-        env.addSource(new FailingSource(new Generator(), numElements, true))
+        createFailingSourceStream(env, numElements)
                 .map(
                         new MapFunction<Tuple2<Long, IntType>, Tuple2<Long, IntType>>() {
                             @Override
@@ -268,12 +286,24 @@ class ProcessingTimeWindowCheckpointingITCase {
     //  Utilities
     // ------------------------------------------------------------------------
 
-    static class Generator implements FailingSource.EventEmittingGenerator {
+    static class Generator
+            implements FailingCheckpointedSource.EventGenerator<Tuple2<Long, IntType>> {
 
         @Override
-        public void emitEvent(
-                SourceFunction.SourceContext<Tuple2<Long, IntType>> ctx, int eventSequenceNo) {
-            ctx.collect(new Tuple2<>((long) eventSequenceNo, new IntType(eventSequenceNo)));
+        public void emit(
+                int subtaskIndex,
+                long sequenceNo,
+                FailingCheckpointedSource.GeneratorOutput<Tuple2<Long, IntType>> output) {
+            output.collect(new Tuple2<>(sequenceNo, new IntType((int) sequenceNo)));
+            // Spread the elements over many processing-time windows, like the legacy
+            // FailingSource did, so that every run restores open window state and rolls back
+            // sink output on recovery. Duplicate detection itself does not depend on this.
+            try {
+                Thread.sleep(1);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new FlinkRuntimeException(e);
+            }
         }
     }
 


### PR DESCRIPTION
## What is the purpose of the change

FLINK-32695 migrates test code off the deprecated `SourceFunction` API to Source V2 (FLIP-27). Roughly 15 checkpointing ITCases depend on a legacy `FailingSource` pattern: a source with a checkpointed position that fails exactly once after a completed checkpoint and resumes from the restored position. No Source V2 test utility offered these semantics.

This PR adds `FailingCheckpointedSource` to `flink-test-utils-connector` and migrates `EventTimeAllWindowCheckpointingITCase` as the first consumer. The remaining consumers follow in separate PRs under the umbrella.

## Brief change log

- Add `FailingCheckpointedSource` + `SequenceSplit` (a position-carrying split) to `flink-test-utils-connector`:
  - A snapshot past the arming threshold arms the failure; emission then pauses at the failure position; completion of the armed checkpoint triggers the throw; an aborted armed checkpoint re-arms on a later snapshot.
  - The reader holds emission just past the arming threshold until a snapshot arms, so recovery deterministically replays the arming-to-failure window regardless of emission speed or state backend (the legacy source relied on 1ms-per-element pacing for this; at full V2 speed the armed checkpoint would otherwise capture the failure position itself, losing detection power).
  - Recovery attempts are detected via the restored non-zero split position (`SourceReaderContext` exposes no attempt number).
  - The enumerator assigns one split per subtask only on first registration (a surviving enumerator on partial failover must not double-assign).
  - `withSimulatedStateLossOnRecovery()` exists purely so consuming tests can validate that they still detect exactly-once violations. Rescaling is unsupported (documented).
- Migrate `EventTimeAllWindowCheckpointingITCase` off `FailingSource`. `KeyedEventTimeGenerator` (in the not-yet-migrated `EventTimeWindowCheckpointingITCase`) temporarily implements both generator interfaces so it can be shared; that file is touched only for this reason.

## Verifying this change

- 14 unit tests in `FailingCheckpointedSourceTest` cover the failure protocol, arming threshold, abort re-arm, restore-without-refailing, enumerator assignment/regression paths, and the serializer.
- `EventTimeAllWindowCheckpointingITCase` passes 4/4.
- Red check: with `withSimulatedStateLossOnRecovery()` temporarily wired in, `testTumblingTimeWindow` fails on duplicated window sums (e.g. `[Window start: 1300 end: 1400] expected: 134950`), proving the migrated test still detects exactly-once violations. Reverted afterwards.

## Notes for reviewers

- **New classes are annotated `@Experimental`** 
- `flink-core`'s test-jar is added as a test-scope dependency of `flink-test-utils-connector` (for `MockSplitEnumeratorContext`).

## Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): **no** (test-scope only: flink-core test-jar)
- The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no** (new classes are `@Experimental`, test-scoped)
- The serializers: **no**
- The runtime per-record code paths (performance sensitive): **no**
- Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: **no** (test-only)
- The S3 file system connector: **no**

## Documentation

- Does this pull request introduce a new feature? **no** (test infrastructure)
- If yes, how is the feature documented? **not applicable**

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (Claude Fable 5)

Generated-by: Claude Fable 5