### PR TITLE
[FLINK-40099] Fix flaky YARNSessionFIFOSecuredITCase by verifying Kerberos keytab logs before the application is killed

### DIFF
--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNSessionFIFOITCase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNSessionFIFOITCase.java
@@ -23,6 +23,7 @@ import org.apache.flink.configuration.GlobalConfiguration;
 import org.apache.flink.runtime.testutils.CommonTestUtils;
 import org.apache.flink.test.testdata.WordCountData;
 import org.apache.flink.testutils.logging.LoggerAuditingExtension;
+import org.apache.flink.util.function.ThrowingConsumer;
 import org.apache.flink.yarn.cli.FlinkYarnSessionCli;
 import org.apache.flink.yarn.configuration.YarnConfigOptions;
 
@@ -94,6 +95,23 @@ class YARNSessionFIFOITCase extends YarnTestBase {
     /** Test regular operation, including command line parameter parsing. */
     ApplicationId runDetachedModeTest(
             Map<String, String> securityProperties, String viewAcls, String modifyAcls)
+            throws Exception {
+        return runDetachedModeTest(securityProperties, viewAcls, modifyAcls, ignored -> {});
+    }
+
+    /**
+     * Test regular operation, including command line parameter parsing.
+     *
+     * @param verifyWhileRunning verification that is invoked once the job has finished but while
+     *     the YARN application and its containers are still alive, before the application is
+     *     killed. This allows subclasses to inspect complete container logs and live container
+     *     state, which is no longer possible once the application has been torn down.
+     */
+    ApplicationId runDetachedModeTest(
+            Map<String, String> securityProperties,
+            String viewAcls,
+            String modifyAcls,
+            ThrowingConsumer<ApplicationId, Exception> verifyWhileRunning)
             throws Exception {
         log.info("Starting testDetachedMode()");
 
@@ -177,6 +195,10 @@ class YARNSessionFIFOITCase extends YarnTestBase {
                                 applicationId,
                                 "jobmanager.log"),
                 testConditionIntervalInMillis);
+
+        // Run verification that requires the application and its containers to still be alive, such
+        // as reading the freshly written container logs, before the application is killed below.
+        verifyWhileRunning.accept(applicationId);
 
         // kill application "externally".
         try {

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNSessionFIFOSecuredITCase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNSessionFIFOSecuredITCase.java
@@ -23,6 +23,7 @@ import org.apache.flink.configuration.SecurityOptions;
 import org.apache.flink.runtime.security.SecurityConfiguration;
 import org.apache.flink.runtime.security.SecurityUtils;
 import org.apache.flink.runtime.security.contexts.HadoopSecurityContext;
+import org.apache.flink.runtime.testutils.CommonTestUtils;
 import org.apache.flink.test.util.SecureTestEnvironment;
 import org.apache.flink.test.util.TestingSecurityContext;
 import org.apache.flink.yarn.configuration.YarnConfigOptions;
@@ -155,9 +156,12 @@ class YARNSessionFIFOSecuredITCase extends YARNSessionFIFOITCase {
                                 SecurityOptions.KERBEROS_LOGIN_PRINCIPAL.key(),
                                 SecureTestEnvironment.getHadoopServicePrincipal());
                     }
-                    final ApplicationId applicationId =
-                            runDetachedModeTest(securityProperties, VIEW_ACLS, MODIFY_ACLS);
-                    verifyResultContainsKerberosKeytab(applicationId, VIEW_ACLS, MODIFY_ACLS);
+                    runDetachedModeTest(
+                            securityProperties,
+                            VIEW_ACLS,
+                            MODIFY_ACLS,
+                            YARNSessionFIFOSecuredITCase::verifyKerberosKeytabInLogs);
+                    verifyTokenAndAclsInContainers(VIEW_ACLS, MODIFY_ACLS);
                 });
     }
 
@@ -177,29 +181,38 @@ class YARNSessionFIFOSecuredITCase extends YARNSessionFIFOITCase {
                                 SecurityOptions.KERBEROS_LOGIN_PRINCIPAL.key(),
                                 SecureTestEnvironment.getHadoopServicePrincipal());
                     }
-                    final ApplicationId applicationId =
-                            runDetachedModeTest(securityProperties, VIEW_ACLS, MODIFY_ACLS);
-                    verifyResultContainsKerberosKeytab(applicationId, VIEW_ACLS, MODIFY_ACLS);
-                    final ApplicationId applicationIdWithWildcard =
-                            runDetachedModeTest(
-                                    securityProperties,
-                                    VIEW_ACLS_WITH_WILDCARD,
-                                    MODIFY_ACLS_WITH_WILDCARD);
-                    verifyResultContainsKerberosKeytab(
-                            applicationIdWithWildcard, WILDCARD, WILDCARD);
+                    runDetachedModeTest(
+                            securityProperties,
+                            VIEW_ACLS,
+                            MODIFY_ACLS,
+                            YARNSessionFIFOSecuredITCase::verifyKerberosKeytabInLogs);
+                    verifyTokenAndAclsInContainers(VIEW_ACLS, MODIFY_ACLS);
+                    runDetachedModeTest(
+                            securityProperties,
+                            VIEW_ACLS_WITH_WILDCARD,
+                            MODIFY_ACLS_WITH_WILDCARD,
+                            YARNSessionFIFOSecuredITCase::verifyKerberosKeytabInLogs);
+                    verifyTokenAndAclsInContainers(WILDCARD, WILDCARD);
                 });
     }
 
-    private static void verifyResultContainsKerberosKeytab(
-            ApplicationId applicationId, String viewAcls, String modifyAcls) throws Exception {
+    /**
+     * Verifies that both the JobManager and TaskManager logged a Kerberos keytab login. The
+     * container log files are polled rather than read once, and this must run while the containers
+     * are still alive so the logs are complete. A short-lived TaskManager can otherwise be torn
+     * down before its startup log becomes durably readable.
+     */
+    private static void verifyKerberosKeytabInLogs(ApplicationId applicationId) throws Exception {
         final String[] mustHave = {"Login successful for user", "using keytab file"};
-        final boolean jobManagerRunsWithKerberos =
-                verifyStringsInNamedLogFiles(mustHave, applicationId, "jobmanager.log");
-        final boolean taskManagerRunsWithKerberos =
-                verifyStringsInNamedLogFiles(mustHave, applicationId, "taskmanager.log");
+        for (final String logFile : new String[] {"jobmanager.log", "taskmanager.log"}) {
+            log.info("Waiting until {} contains the Kerberos keytab login", logFile);
+            CommonTestUtils.waitUntilCondition(
+                    () -> verifyStringsInNamedLogFiles(mustHave, applicationId, logFile), 500);
+        }
+    }
 
-        assertThat(jobManagerRunsWithKerberos && taskManagerRunsWithKerberos).isTrue();
-
+    private static void verifyTokenAndAclsInContainers(String viewAcls, String modifyAcls)
+            throws Exception {
         final List<String> amRMTokens =
                 Lists.newArrayList(AMRMTokenIdentifier.KIND_NAME.toString());
         final String jobmanagerContainerId = getContainerIdByLogName("jobmanager.log");


### PR DESCRIPTION
## What is the purpose of the change                                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                            
`YARNSessionFIFOSecuredITCase.testDetachedMode` is flaky. It fails at `verifyResultContainsKerberosKeytab`: "Expecting value to be true but was false".                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                                          
The verification reads jobmanager.log and taskmanager.log once, looking for the Kerberos keytab login lines, but it runs after runDetachedModeTest has already killed the YARN application. The TaskManager container is short-lived (launched, job finished, and SIGTERM-killed within ~3 seconds). The log read happens ~200ms after the kill, and the TaskManager's startup login line is sometimes not yet durably readable at that instant, so the assertion fails. This is the same symptom as FLINK-17662.                                                                                                                                                                                                                                                                   
                                                                                                                                                                                                                                                                                          
## Brief change log                                                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                          
  - YARNSessionFIFOITCase.runDetachedModeTest now accepts an optional verification callback that runs after the job reaches FINISHED but before the application is killed, while the containers and their logs are still intact. The existing overload delegates with a no-op, so the base test is unchanged.                                                                                                                                                                                                          
  - In YARNSessionFIFOSecuredITCase the Kerberos keytab log check is moved into that pre-kill callback and now polls the log files (waitUntilCondition) instead of reading them once.                                                                                                                                                                                                                                                         
  - The AM-RM token and ACL checks are unchanged and still run after the kill.                                                                                                                                                                                                            
                                                                                                                                                                                                                                                                                          
## Verifying this change                                                                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                                                          
This change fixes a flaky test and is covered by the modified `YARNSessionFIFOSecuredITCase`. A genuine regression still fails: if the login strings never appear, the bounded poll exhausts its retries and the test fails.                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                                          
## Does this pull request potentially affect one of the following parts:                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                                                          
  - Dependencies (does it add or upgrade a dependency): no                                                                                                                                                                                                                                
  - The public API, i.e., is any changed class annotated with @Public(Evolving): no                                                                                                                                                                                                       
  - The serializers: no                                                                                                                                                                                                                                                                   
  - The runtime per-record code paths (performance sensitive): no                                                                                                                                                                                                                         
  - Anything that affects deployment or recovery: JobManager, Checkpointing, Kubernetes/Yarn, ZooKeeper: no                                                                                                                                                                               
  - The S3 file system connector: no                                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                          
## Documentation                                                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                                          
  - Does this pull request introduce a new feature? no                                                                                                                                                                                                                                    
  - If yes, how is the feature documented? not applicable

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change the checkbox below to `[X]` followed by the name of the tool, and uncomment the
"Generated-by" line. See the ASF Generative Tooling Guidance for details:
https://www.apache.org/legal/generative-tooling.html

You are responsible for the quality and correctness of every change in this PR
regardless of the tooling used. Low-effort AI-generated PRs will be closed. See
AGENTS.md for the full guidance.
-->

- [X] Yes (please specify the tool below)

Generated-by: Opus 4.8
