### PR TITLE
[FLINK-40109] Verify Kerberos keytab logs after the YARN application is killed

### DIFF
--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNSessionFIFOITCase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNSessionFIFOITCase.java
@@ -23,7 +23,6 @@ import org.apache.flink.configuration.GlobalConfiguration;
 import org.apache.flink.runtime.testutils.CommonTestUtils;
 import org.apache.flink.test.testdata.WordCountData;
 import org.apache.flink.testutils.logging.LoggerAuditingExtension;
-import org.apache.flink.util.function.ThrowingConsumer;
 import org.apache.flink.yarn.cli.FlinkYarnSessionCli;
 import org.apache.flink.yarn.configuration.YarnConfigOptions;
 
@@ -95,23 +94,6 @@ class YARNSessionFIFOITCase extends YarnTestBase {
     /** Test regular operation, including command line parameter parsing. */
     ApplicationId runDetachedModeTest(
             Map<String, String> securityProperties, String viewAcls, String modifyAcls)
-            throws Exception {
-        return runDetachedModeTest(securityProperties, viewAcls, modifyAcls, ignored -> {});
-    }
-
-    /**
-     * Test regular operation, including command line parameter parsing.
-     *
-     * @param verifyWhileRunning verification that is invoked once the job has finished but while
-     *     the YARN application and its containers are still alive, before the application is
-     *     killed. This allows subclasses to inspect complete container logs and live container
-     *     state, which is no longer possible once the application has been torn down.
-     */
-    ApplicationId runDetachedModeTest(
-            Map<String, String> securityProperties,
-            String viewAcls,
-            String modifyAcls,
-            ThrowingConsumer<ApplicationId, Exception> verifyWhileRunning)
             throws Exception {
         log.info("Starting testDetachedMode()");
 
@@ -195,10 +177,6 @@ class YARNSessionFIFOITCase extends YarnTestBase {
                                 applicationId,
                                 "jobmanager.log"),
                 testConditionIntervalInMillis);
-
-        // Run verification that requires the application and its containers to still be alive, such
-        // as reading the freshly written container logs, before the application is killed below.
-        verifyWhileRunning.accept(applicationId);
 
         // kill application "externally".
         try {

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNSessionFIFOSecuredITCase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNSessionFIFOSecuredITCase.java
@@ -20,10 +20,10 @@ package org.apache.flink.yarn;
 
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.SecurityOptions;
+import org.apache.flink.core.testutils.CommonTestUtils;
 import org.apache.flink.runtime.security.SecurityConfiguration;
 import org.apache.flink.runtime.security.SecurityUtils;
 import org.apache.flink.runtime.security.contexts.HadoopSecurityContext;
-import org.apache.flink.runtime.testutils.CommonTestUtils;
 import org.apache.flink.test.util.SecureTestEnvironment;
 import org.apache.flink.test.util.TestingSecurityContext;
 import org.apache.flink.yarn.configuration.YarnConfigOptions;
@@ -47,6 +47,8 @@ import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.time.Duration;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -156,12 +158,9 @@ class YARNSessionFIFOSecuredITCase extends YARNSessionFIFOITCase {
                                 SecurityOptions.KERBEROS_LOGIN_PRINCIPAL.key(),
                                 SecureTestEnvironment.getHadoopServicePrincipal());
                     }
-                    runDetachedModeTest(
-                            securityProperties,
-                            VIEW_ACLS,
-                            MODIFY_ACLS,
-                            YARNSessionFIFOSecuredITCase::verifyKerberosKeytabInLogs);
-                    verifyTokenAndAclsInContainers(VIEW_ACLS, MODIFY_ACLS);
+                    final ApplicationId applicationId =
+                            runDetachedModeTest(securityProperties, VIEW_ACLS, MODIFY_ACLS);
+                    verifyResultContainsKerberosKeytab(applicationId, VIEW_ACLS, MODIFY_ACLS);
                 });
     }
 
@@ -181,38 +180,40 @@ class YARNSessionFIFOSecuredITCase extends YARNSessionFIFOITCase {
                                 SecurityOptions.KERBEROS_LOGIN_PRINCIPAL.key(),
                                 SecureTestEnvironment.getHadoopServicePrincipal());
                     }
-                    runDetachedModeTest(
-                            securityProperties,
-                            VIEW_ACLS,
-                            MODIFY_ACLS,
-                            YARNSessionFIFOSecuredITCase::verifyKerberosKeytabInLogs);
-                    verifyTokenAndAclsInContainers(VIEW_ACLS, MODIFY_ACLS);
-                    runDetachedModeTest(
-                            securityProperties,
-                            VIEW_ACLS_WITH_WILDCARD,
-                            MODIFY_ACLS_WITH_WILDCARD,
-                            YARNSessionFIFOSecuredITCase::verifyKerberosKeytabInLogs);
-                    verifyTokenAndAclsInContainers(WILDCARD, WILDCARD);
+                    final ApplicationId applicationId =
+                            runDetachedModeTest(securityProperties, VIEW_ACLS, MODIFY_ACLS);
+                    verifyResultContainsKerberosKeytab(applicationId, VIEW_ACLS, MODIFY_ACLS);
+                    final ApplicationId applicationIdWithWildcard =
+                            runDetachedModeTest(
+                                    securityProperties,
+                                    VIEW_ACLS_WITH_WILDCARD,
+                                    MODIFY_ACLS_WITH_WILDCARD);
+                    verifyResultContainsKerberosKeytab(
+                            applicationIdWithWildcard, WILDCARD, WILDCARD);
                 });
     }
 
-    /**
-     * Verifies that both the JobManager and TaskManager logged a Kerberos keytab login. The
-     * container log files are polled rather than read once, and this must run while the containers
-     * are still alive so the logs are complete. A short-lived TaskManager can otherwise be torn
-     * down before its startup log becomes durably readable.
-     */
-    private static void verifyKerberosKeytabInLogs(ApplicationId applicationId) throws Exception {
+    private static void verifyResultContainsKerberosKeytab(
+            ApplicationId applicationId, String viewAcls, String modifyAcls) throws Exception {
         final String[] mustHave = {"Login successful for user", "using keytab file"};
+        // The application has been killed by now, so all container output is flushed. A
+        // short-lived TaskManager's startup login line can still be briefly unreadable right
+        // after teardown (FLINK-17662), so poll each log instead of reading it once.
         for (final String logFile : new String[] {"jobmanager.log", "taskmanager.log"}) {
             log.info("Waiting until {} contains the Kerberos keytab login", logFile);
-            CommonTestUtils.waitUntilCondition(
-                    () -> verifyStringsInNamedLogFiles(mustHave, applicationId, logFile), 500);
+            CommonTestUtils.waitUtil(
+                    () -> verifyStringsInNamedLogFiles(mustHave, applicationId, logFile),
+                    Duration.ofSeconds(60),
+                    Duration.ofMillis(500),
+                    "Kerberos keytab login "
+                            + Arrays.toString(mustHave)
+                            + " not found in "
+                            + logFile
+                            + " for application "
+                            + applicationId
+                            + " within the timeout; inspect the uploaded container logs.");
         }
-    }
 
-    private static void verifyTokenAndAclsInContainers(String viewAcls, String modifyAcls)
-            throws Exception {
         final List<String> amRMTokens =
                 Lists.newArrayList(AMRMTokenIdentifier.KIND_NAME.toString());
         final String jobmanagerContainerId = getContainerIdByLogName("jobmanager.log");


### PR DESCRIPTION
## What is the purpose of the change

`YARNSessionFIFOSecuredITCase.testDetachedMode` is flaky on `master` since FLINK-40099, failing with `FlinkException: Exhausted retry attempts.` (e.g. [GHA run 29005398820](https://github.com/apache/flink/actions/runs/29005398820/job/86077406039), module `misc`).

FLINK-40099 moved the Kerberos keytab log verification into a callback that runs after the job reaches FINISHED but **before the application is killed**, polling `waitUntilCondition(condition, 500)`. Two problems:

1. The `500` `int` literal binds to the `waitUntilCondition(condition, int retryAttempts)` overload (500 attempts × 100ms, then `"Exhausted retry attempts."`) rather than the intended millisecond interval.
2. More fundamentally, reading the JobManager log while the application is still alive is racy. The in-scope `jobmanager.log` does not reliably contain the keytab login line before teardown: the bootstrap output that carries the login line and the running-JobManager output land in different files, and the pre-kill content is not durably readable. The keytab line **is** present once the application has been torn down and its logs flushed.

The original FLINK-17662 concern (a short-lived TaskManager's startup login line being briefly unreadable shortly after teardown) is real, but the fix for it should be a bounded post-kill poll, not relocating the check to before the kill.

## Brief change log

  - Revert FLINK-40099's pre-kill verification callback in `YARNSessionFIFOITCase.runDetachedModeTest` (remove the `ThrowingConsumer` overload); the base test is unchanged.
  - In `YARNSessionFIFOSecuredITCase`, verify the keytab logs after the application is killed (as before FLINK-40099), but replace the original single read with a bounded `CommonTestUtils.waitUtil(...)` poll that fails with a message naming the log file and the expected strings. This absorbs the FLINK-17662 durability lag without the pre-kill race.

## Verifying this change

This change is already covered by the existing `YARNSessionFIFOSecuredITCase`. A genuine regression still fails: if the keytab login strings never appear, the bounded poll times out with a message naming the log file and strings, and the uploaded container logs allow diagnosing whether the file was absent or the string was missing.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: Claude Opus 4.8 (1M context)
