### PR TITLE
[FLINK-40086][runtime] Adds error handling to newly added preCompletionAction

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
@@ -1708,7 +1708,11 @@ public class Execution
                 initializingOrRunningFuture.complete(null);
             } else if (targetState.isTerminal()) {
                 if (preCompletionAction != null) {
-                    preCompletionAction.run();
+                    try {
+                        preCompletionAction.run();
+                    } catch (Exception e) {
+                        LOG.error("Error while executing pre-completion action.", e);
+                    }
                 }
                 // complete the terminal state future
                 terminalStateFuture.complete(targetState);


### PR DESCRIPTION
## What is the purpose of the change

FLINK-40076 introduced a slight refactoring to Execution where the accumulators and ioMetrics are updated before completing the `Execution`. This introduced a slight inconsistency, where (theoretically) the `preCompletionAction` can fail and leave the `Execution` in an inconsistent state with the state being terminal but the `terminalFuture` not being completed.

This PR fixes the inconsistency. That said - the issue doesn't exist in the current code base because the only existing `preCompletionAction` only consists of field setters. 

## Brief change log

* Adds a try/catch around the `preCompletionAction` execution

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change the checkbox below to `[X]` followed by the name of the tool, and uncomment the
"Generated-by" line. See the ASF Generative Tooling Guidance for details:
https://www.apache.org/legal/generative-tooling.html

You are responsible for the quality and correctness of every change in this PR
regardless of the tooling used. Low-effort AI-generated PRs will be closed. See
AGENTS.md for the full guidance.
-->

- [X] Yes (please specify the tool below)

Issue was identified by claude. Code change was done manually.