### PR TITLE
[FLINK-40112][table] Report changelog mode mismatch instead of a generic planning error

### DIFF
--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/optimize/program/FlinkChangelogModeInferenceProgram.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/optimize/program/FlinkChangelogModeInferenceProgram.scala
@@ -141,7 +141,9 @@ class FlinkChangelogModeInferenceProgram extends FlinkOptimizeProgram[StreamOpti
         "The conflict is at:\n" + conflict
     } else {
       val plan = FlinkRelOptUtil.toString(rootWithModifyKindSet, withChangelogTraits = true)
-      "Can't generate a valid execution plan for the given query:\n" + plan
+      "Can't generate a valid execution plan for the given query because of a changelog mismatch: " +
+        "an operator cannot produce the changelog its consumer requires. Review the changelog " +
+        "modes of the operators in the plan below:\n" + plan
     }
   }
 

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/stream/sql/ProcessTableFunctionTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/stream/sql/ProcessTableFunctionTest.java
@@ -544,14 +544,16 @@ class ProcessTableFunctionTest extends TableTestBase {
                         UpdatingUpsertFunction.class,
                         "SELECT name, SUM(`count`) OVER (PARTITION BY name ORDER BY name) "
                                 + "FROM f(r => TABLE t_updating PARTITION BY name)",
-                        "Can't generate a valid execution plan for the given query:\n"),
+                        "Can't generate a valid execution plan for the given query because of a "
+                                + "changelog mismatch"),
                 ErrorSpec.ofSelect(
                         // t_upsert produces an upsert changelog.
                         // the table argument for f requires a retract changelog
                         "retract requirement on an upsert table arg",
                         SetSemanticTableRetractArgFunction.class,
                         "SELECT * FROM f(r => TABLE t_upsert PARTITION BY name)",
-                        "Can't generate a valid execution plan for the given query:\n"),
+                        "Can't generate a valid execution plan for the given query because of a "
+                                + "changelog mismatch"),
                 ErrorSpec.ofInsertInto(
                         "upsert conflict buried below a calc",
                         UpdatingUpsertFunction.class,


### PR DESCRIPTION
## What is the purpose of the change

When changelog mode inference cannot satisfy an operator's required changelog and the failure is not at a sink, the planner threw a generic "Can't generate a valid execution plan for the given query" error. This tells the user the failure is a changelog mode mismatch and points at the operators' changelog modes in the annotated plan.

## Brief change log

- Report a changelog mode mismatch in the non-sink branch of createTargetedErrorMessage, keeping the annotated plan output.
- Update ProcessTableFunctionTest error specs to the new message.

## Verifying this change

- ProcessTableFunctionTest

## Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): (no)
- The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
- The serializers: (no)
- The runtime per-record code paths (performance sensitive): (no)
- Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
- The S3 file system connector: (no)

## Documentation

- Does this pull request introduce a new feature? (no)
- If yes, how is the feature documented? (not applicable)

---

##### Was generative AI tooling used to co-author this PR?

- [x] Yes (please specify the tool below)

2.1.196 (Claude Code) with Opus 4.8