### PR TITLE
[FLINK-40116][state] Support more predicates for filter pushdown during savepoint scan

### DIFF
--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/filter/RangeKeyFilter.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/filter/RangeKeyFilter.java
@@ -20,37 +20,41 @@ package org.apache.flink.state.api.filter;
 
 import javax.annotation.Nullable;
 
-import java.util.Set;
-
 /** A filter based on a range with an injected comparator. */
 final class RangeKeyFilter<K> implements SavepointKeyFilter<K> {
 
     private static final long serialVersionUID = 3L;
 
     private final SerializableComparator<K> comparator;
-    @Nullable private final BoundInfo<K> lower;
-    @Nullable private final BoundInfo<K> upper;
+    @Nullable private final K lower;
+    private final boolean isLowerInclusive;
+    @Nullable private final K upper;
+    private final boolean isUpperInclusive;
 
     RangeKeyFilter(
             SerializableComparator<K> comparator,
-            @Nullable BoundInfo<K> lower,
-            @Nullable BoundInfo<K> upper) {
+            @Nullable K lower,
+            boolean isLowerInclusive,
+            @Nullable K upper,
+            boolean isUpperInclusive) {
         this.comparator = comparator;
         this.lower = lower;
+        this.isLowerInclusive = isLowerInclusive;
         this.upper = upper;
+        this.isUpperInclusive = isUpperInclusive;
     }
 
     @Override
     public boolean test(K key) {
         if (lower != null) {
-            int cmp = comparator.compare(lower.getValue(), key);
-            if (cmp > 0 || (cmp == 0 && !lower.isInclusive())) {
+            int cmp = comparator.compare(lower, key);
+            if (cmp > 0 || (cmp == 0 && !isLowerInclusive)) {
                 return false;
             }
         }
         if (upper != null) {
-            int cmp = comparator.compare(upper.getValue(), key);
-            if (cmp < 0 || (cmp == 0 && !upper.isInclusive())) {
+            int cmp = comparator.compare(upper, key);
+            if (cmp < 0 || (cmp == 0 && !isUpperInclusive)) {
                 return false;
             }
         }
@@ -58,67 +62,9 @@ final class RangeKeyFilter<K> implements SavepointKeyFilter<K> {
     }
 
     @Override
-    public BoundInfo<K> getLowerBound() {
-        return lower;
-    }
-
-    @Override
-    public BoundInfo<K> getUpperBound() {
-        return upper;
-    }
-
-    @Override
-    public SavepointKeyFilter<K> intersect(SavepointKeyFilter<K> other) {
-        if (other.isEmpty()) {
-            return other;
-        }
-        final Set<K> otherExactKeys = other.getExactKeys();
-        if (otherExactKeys != null) {
-            return SavepointKeyFilter.filterKeys(otherExactKeys, this);
-        }
-        return intersectRange(other.getLowerBound(), other.getUpperBound());
-    }
-
-    private SavepointKeyFilter<K> intersectRange(
-            @Nullable BoundInfo<K> otherLower, @Nullable BoundInfo<K> otherUpper) {
-        BoundInfo<K> newLower = tighter(lower, otherLower, true);
-        BoundInfo<K> newUpper = tighter(upper, otherUpper, false);
-
-        if (newLower != null && newUpper != null) {
-            int cmp = comparator.compare(newLower.getValue(), newUpper.getValue());
-            if (cmp > 0) {
-                return SavepointKeyFilter.empty();
-            }
-            if (cmp == 0 && (!newLower.isInclusive() || !newUpper.isInclusive())) {
-                return SavepointKeyFilter.empty();
-            }
-        }
-        return new RangeKeyFilter<>(comparator, newLower, newUpper);
-    }
-
-    @Nullable
-    private BoundInfo<K> tighter(
-            @Nullable BoundInfo<K> a, @Nullable BoundInfo<K> b, boolean preferHigher) {
-        if (a == null) {
-            return b;
-        }
-        if (b == null) {
-            return a;
-        }
-        int c = comparator.compare(a.getValue(), b.getValue());
-        if (c == 0) {
-            return new BoundInfo<>(a.getValue(), a.isInclusive() && b.isInclusive());
-        }
-        boolean aWins = preferHigher ? c > 0 : c < 0;
-        return aWins ? a : b;
-    }
-
-    @Override
     public String toString() {
-        String lowerStr =
-                lower == null ? "(-∞" : (lower.isInclusive() ? "[" : "(") + lower.getValue();
-        String upperStr =
-                upper == null ? "+∞)" : upper.getValue() + (upper.isInclusive() ? "]" : ")");
+        String lowerStr = lower == null ? "(-∞" : (isLowerInclusive ? "[" : "(") + lower;
+        String upperStr = upper == null ? "+∞)" : upper + (isUpperInclusive ? "]" : ")");
         return "RangeKeyFilter" + lowerStr + ", " + upperStr;
     }
 }

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/filter/SavepointKeyFilter.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/filter/SavepointKeyFilter.java
@@ -23,7 +23,6 @@ import org.apache.flink.annotation.Experimental;
 import javax.annotation.Nullable;
 
 import java.io.Serializable;
-import java.util.HashSet;
 import java.util.Set;
 
 /**
@@ -38,15 +37,6 @@ public interface SavepointKeyFilter<K> extends Serializable {
     boolean test(K key);
 
     /**
-     * Returns {@code true} if this filter rejects every key.
-     *
-     * <p>Used only while combining filters during push-down translation, not during the scan.
-     */
-    default boolean isEmpty() {
-        return false;
-    }
-
-    /**
      * Returns the finite set of keys this filter matches, or {@code null} if the filter does not
      * resolve to a finite key set.
      */
@@ -55,58 +45,12 @@ public interface SavepointKeyFilter<K> extends Serializable {
         return null;
     }
 
-    /**
-     * Returns the lower bound of this filter's range, or {@code null} if the filter does not define
-     * a lower bound.
-     *
-     * <p>Used only while combining filters during push-down translation, not during the scan.
-     */
-    @Nullable
-    default BoundInfo<K> getLowerBound() {
-        return null;
-    }
-
-    /**
-     * Returns the upper bound of this filter's range, or {@code null} if the filter does not define
-     * an upper bound.
-     *
-     * <p>Used only while combining filters during push-down translation, not during the scan.
-     */
-    @Nullable
-    default BoundInfo<K> getUpperBound() {
-        return null;
-    }
-
-    /**
-     * Returns a filter that accepts a key if and only if both {@code this} and {@code other} accept
-     * it.
-     *
-     * <p>Used only while combining filters during push-down translation, not during the scan.
-     */
-    default SavepointKeyFilter<K> intersect(SavepointKeyFilter<K> other) {
-        throw new UnsupportedOperationException(
-                getClass().getSimpleName() + " does not support intersect()");
-    }
-
-    static <K> SavepointKeyFilter<K> filterKeys(Set<K> keys, SavepointKeyFilter<K> predicate) {
-        final Set<K> retained = new HashSet<>();
-        for (K key : keys) {
-            if (predicate.test(key)) {
-                retained.add(key);
-            }
-        }
-        return exact(retained);
-    }
-
     static <K> SavepointKeyFilter<K> exact(Set<K> keys) {
-        if (keys.isEmpty()) {
-            return EmptyKeyFilter.instance();
-        }
         return new ExactKeyFilter<>(keys);
     }
 
     static <K> SavepointKeyFilter<K> exact(K value) {
-        return new ExactKeyFilter<>(Set.of(value));
+        return exact(Set.of(value));
     }
 
     static <K extends Comparable<K>> SavepointKeyFilter<K> range(
@@ -120,13 +64,7 @@ public interface SavepointKeyFilter<K> extends Serializable {
             @Nullable K upper,
             boolean upperInclusive,
             SerializableComparator<K> comparator) {
-        BoundInfo<K> lowerBoundInfo = lower != null ? new BoundInfo<>(lower, lowerInclusive) : null;
-        BoundInfo<K> upperBoundInfo = upper != null ? new BoundInfo<>(upper, upperInclusive) : null;
-        return new RangeKeyFilter<>(comparator, lowerBoundInfo, upperBoundInfo);
-    }
-
-    static <K> SavepointKeyFilter<K> empty() {
-        return EmptyKeyFilter.instance();
+        return new RangeKeyFilter<>(comparator, lower, lowerInclusive, upper, upperInclusive);
     }
 
     final class NaturalOrderComparator<K extends Comparable<K>>

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/table/SavepointFilterTranslator.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/table/SavepointFilterTranslator.java
@@ -52,23 +52,37 @@ class SavepointFilterTranslator {
                     FunctionDefinition,
                     BiFunction<SavepointFilterTranslator, CallExpression, SavepointKeyFilterPlan>>
             FILTERS =
-                    Map.of(
-                            BuiltInFunctionDefinitions.EQUALS,
-                            SavepointFilterTranslator::fromEquals,
-                            BuiltInFunctionDefinitions.OR,
-                            SavepointFilterTranslator::fromOr,
-                            BuiltInFunctionDefinitions.AND,
-                            SavepointFilterTranslator::fromAnd,
-                            BuiltInFunctionDefinitions.BETWEEN,
-                            SavepointFilterTranslator::fromBetween,
-                            BuiltInFunctionDefinitions.GREATER_THAN,
-                            SavepointFilterTranslator::fromGreaterThan,
-                            BuiltInFunctionDefinitions.GREATER_THAN_OR_EQUAL,
-                            SavepointFilterTranslator::fromGreaterThanOrEqual,
-                            BuiltInFunctionDefinitions.LESS_THAN,
-                            SavepointFilterTranslator::fromLessThan,
-                            BuiltInFunctionDefinitions.LESS_THAN_OR_EQUAL,
-                            SavepointFilterTranslator::fromLessThanOrEqual);
+                    Map.ofEntries(
+                            Map.entry(
+                                    BuiltInFunctionDefinitions.EQUALS,
+                                    SavepointFilterTranslator::fromEquals),
+                            Map.entry(
+                                    BuiltInFunctionDefinitions.NOT_EQUALS,
+                                    SavepointFilterTranslator::fromNotEquals),
+                            Map.entry(
+                                    BuiltInFunctionDefinitions.NOT,
+                                    SavepointFilterTranslator::fromNot),
+                            Map.entry(
+                                    BuiltInFunctionDefinitions.OR,
+                                    SavepointFilterTranslator::fromOr),
+                            Map.entry(
+                                    BuiltInFunctionDefinitions.AND,
+                                    SavepointFilterTranslator::fromAnd),
+                            Map.entry(
+                                    BuiltInFunctionDefinitions.BETWEEN,
+                                    SavepointFilterTranslator::fromBetween),
+                            Map.entry(
+                                    BuiltInFunctionDefinitions.GREATER_THAN,
+                                    SavepointFilterTranslator::fromGreaterThan),
+                            Map.entry(
+                                    BuiltInFunctionDefinitions.GREATER_THAN_OR_EQUAL,
+                                    SavepointFilterTranslator::fromGreaterThanOrEqual),
+                            Map.entry(
+                                    BuiltInFunctionDefinitions.LESS_THAN,
+                                    SavepointFilterTranslator::fromLessThan),
+                            Map.entry(
+                                    BuiltInFunctionDefinitions.LESS_THAN_OR_EQUAL,
+                                    SavepointFilterTranslator::fromLessThanOrEqual));
 
     private final int keyColumnIndex;
     private final DataType keyColumnType;
@@ -137,6 +151,49 @@ class SavepointFilterTranslator {
         return SavepointKeyFilterPlan.exact(value);
     }
 
+    // -------------------------------------------------------------------------
+    //  Negation / membership
+    // -------------------------------------------------------------------------
+
+    @Nullable
+    private SavepointKeyFilterPlan fromNotEquals(CallExpression call) {
+        if (!isBinaryValid(call)) {
+            return null;
+        }
+        ResolvedExpression left = call.getResolvedChildren().get(0);
+        ResolvedExpression right = call.getResolvedChildren().get(1);
+
+        Object value = null;
+        if (isKeyField(left)) {
+            value = extractValue(right);
+        } else if (isKeyField(right)) {
+            value = extractValue(left);
+        }
+
+        if (value == null) {
+            return null;
+        }
+        return SavepointKeyFilterPlan.exclude(value);
+    }
+
+    @Nullable
+    private SavepointKeyFilterPlan fromNot(CallExpression call) {
+        if (call.getResolvedChildren().size() != 1) {
+            return null;
+        }
+        SavepointKeyFilterPlan inner = extractFilter(call.getResolvedChildren().get(0));
+        if (inner == null) {
+            return null;
+        }
+        Set<Object> keys = inner.getExactKeys();
+        // Only NOT of a finite key set is an exclusion; NOT of a range is not pushed
+        // (will be supported in a future commit).
+        if (keys == null) {
+            return null;
+        }
+        return SavepointKeyFilterPlan.exclude(keys);
+    }
+
     @Nullable
     private SavepointKeyFilterPlan fromOr(CallExpression call) {
         Set<Object> keys = new HashSet<>();
@@ -164,8 +221,8 @@ class SavepointFilterTranslator {
         SavepointKeyFilterPlan merged = null;
         for (ResolvedExpression arg : call.getResolvedChildren()) {
             SavepointKeyFilterPlan sub = extractFilter(arg);
-            // AND only absorbs range filters; exact (or null) children break pushdown.
-            if (sub == null || sub.getExactKeys() != null) {
+            // A non-pushable child breaks pushdown of the whole AND.
+            if (sub == null) {
                 return null;
             }
             merged = (merged == null) ? sub : merged.intersect(sub);

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/table/SavepointFilterTranslator.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/table/SavepointFilterTranslator.java
@@ -18,7 +18,7 @@
 
 package org.apache.flink.state.table;
 
-import org.apache.flink.state.api.filter.SavepointKeyFilter;
+import org.apache.flink.state.table.filter.SavepointKeyFilterPlan;
 import org.apache.flink.table.expressions.CallExpression;
 import org.apache.flink.table.expressions.FieldReferenceExpression;
 import org.apache.flink.table.expressions.ResolvedExpression;
@@ -40,7 +40,7 @@ import java.util.Set;
 import java.util.function.BiFunction;
 
 /**
- * Converts {@link ResolvedExpression} key filter predicates into {@link SavepointKeyFilter}
+ * Converts {@link ResolvedExpression} key filter predicates into {@link SavepointKeyFilterPlan}
  * instances that can be used to prune key groups and key iterations during savepoint reads.
  */
 @SuppressWarnings({"rawtypes", "unchecked"})
@@ -50,7 +50,7 @@ class SavepointFilterTranslator {
 
     private static final Map<
                     FunctionDefinition,
-                    BiFunction<SavepointFilterTranslator, CallExpression, SavepointKeyFilter>>
+                    BiFunction<SavepointFilterTranslator, CallExpression, SavepointKeyFilterPlan>>
             FILTERS =
                     Map.of(
                             BuiltInFunctionDefinitions.EQUALS,
@@ -82,9 +82,9 @@ class SavepointFilterTranslator {
         final List<ResolvedExpression> accepted = new ArrayList<>();
         final List<ResolvedExpression> remaining = new ArrayList<>();
 
-        SavepointKeyFilter keyFilter = null;
+        SavepointKeyFilterPlan keyFilter = null;
         for (ResolvedExpression filter : filters) {
-            SavepointKeyFilter extracted = extractFilter(filter);
+            SavepointKeyFilterPlan extracted = extractFilter(filter);
             if (extracted == null) {
                 remaining.add(filter);
                 continue;
@@ -98,11 +98,12 @@ class SavepointFilterTranslator {
     }
 
     @Nullable
-    private SavepointKeyFilter extractFilter(ResolvedExpression expr) {
-        final BiFunction<SavepointFilterTranslator, CallExpression, SavepointKeyFilter> extractor =
-                expr instanceof CallExpression
-                        ? FILTERS.get(((CallExpression) expr).getFunctionDefinition())
-                        : null;
+    private SavepointKeyFilterPlan extractFilter(ResolvedExpression expr) {
+        final BiFunction<SavepointFilterTranslator, CallExpression, SavepointKeyFilterPlan>
+                extractor =
+                        expr instanceof CallExpression
+                                ? FILTERS.get(((CallExpression) expr).getFunctionDefinition())
+                                : null;
         if (extractor == null) {
             LOG.debug(
                     "Unsupported predicate [{}] cannot be pushed into savepoint key filter.", expr);
@@ -116,7 +117,7 @@ class SavepointFilterTranslator {
     // -------------------------------------------------------------------------
 
     @Nullable
-    private SavepointKeyFilter fromEquals(CallExpression call) {
+    private SavepointKeyFilterPlan fromEquals(CallExpression call) {
         if (!isBinaryValid(call)) {
             return null;
         }
@@ -133,14 +134,14 @@ class SavepointFilterTranslator {
         if (value == null) {
             return null;
         }
-        return SavepointKeyFilter.exact(value);
+        return SavepointKeyFilterPlan.exact(value);
     }
 
     @Nullable
-    private SavepointKeyFilter fromOr(CallExpression call) {
+    private SavepointKeyFilterPlan fromOr(CallExpression call) {
         Set<Object> keys = new HashSet<>();
         for (ResolvedExpression arg : call.getResolvedChildren()) {
-            SavepointKeyFilter sub = extractFilter(arg);
+            SavepointKeyFilterPlan sub = extractFilter(arg);
             if (sub == null) {
                 return null;
             }
@@ -151,7 +152,7 @@ class SavepointFilterTranslator {
             }
             keys.addAll(subKeys);
         }
-        return SavepointKeyFilter.exact(keys);
+        return SavepointKeyFilterPlan.exact(keys);
     }
 
     // -------------------------------------------------------------------------
@@ -159,10 +160,10 @@ class SavepointFilterTranslator {
     // -------------------------------------------------------------------------
 
     @Nullable
-    private SavepointKeyFilter fromAnd(CallExpression call) {
-        SavepointKeyFilter merged = null;
+    private SavepointKeyFilterPlan fromAnd(CallExpression call) {
+        SavepointKeyFilterPlan merged = null;
         for (ResolvedExpression arg : call.getResolvedChildren()) {
-            SavepointKeyFilter sub = extractFilter(arg);
+            SavepointKeyFilterPlan sub = extractFilter(arg);
             // AND only absorbs range filters; exact (or null) children break pushdown.
             if (sub == null || sub.getExactKeys() != null) {
                 return null;
@@ -176,7 +177,7 @@ class SavepointFilterTranslator {
     }
 
     @Nullable
-    private SavepointKeyFilter fromBetween(CallExpression call) {
+    private SavepointKeyFilterPlan fromBetween(CallExpression call) {
         List<ResolvedExpression> args = call.getResolvedChildren();
         if (args.size() != 3) {
             return null;
@@ -200,33 +201,33 @@ class SavepointFilterTranslator {
                     lower.getClass().getName());
             return null;
         }
-        return SavepointKeyFilter.range(
+        return SavepointKeyFilterPlan.range(
                 (Comparable) lower, true,
                 (Comparable) upper, true);
     }
 
     @Nullable
-    private SavepointKeyFilter fromGreaterThan(CallExpression call) {
+    private SavepointKeyFilterPlan fromGreaterThan(CallExpression call) {
         return fromComparison(call, Comparison.GT);
     }
 
     @Nullable
-    private SavepointKeyFilter fromGreaterThanOrEqual(CallExpression call) {
+    private SavepointKeyFilterPlan fromGreaterThanOrEqual(CallExpression call) {
         return fromComparison(call, Comparison.GTE);
     }
 
     @Nullable
-    private SavepointKeyFilter fromLessThan(CallExpression call) {
+    private SavepointKeyFilterPlan fromLessThan(CallExpression call) {
         return fromComparison(call, Comparison.LT);
     }
 
     @Nullable
-    private SavepointKeyFilter fromLessThanOrEqual(CallExpression call) {
+    private SavepointKeyFilterPlan fromLessThanOrEqual(CallExpression call) {
         return fromComparison(call, Comparison.LTE);
     }
 
     @Nullable
-    private SavepointKeyFilter fromComparison(CallExpression call, Comparison cmp) {
+    private SavepointKeyFilterPlan fromComparison(CallExpression call, Comparison cmp) {
         if (!isBinaryValid(call)) {
             return null;
         }
@@ -252,13 +253,13 @@ class SavepointFilterTranslator {
         Comparison keyLeftCmp = keyOnLeft ? cmp : cmp.flip();
         switch (keyLeftCmp) {
             case GT:
-                return SavepointKeyFilter.range(b, false, null, true);
+                return SavepointKeyFilterPlan.range(b, false, null, true);
             case GTE:
-                return SavepointKeyFilter.range(b, true, null, true);
+                return SavepointKeyFilterPlan.range(b, true, null, true);
             case LT:
-                return SavepointKeyFilter.range(null, true, b, false);
+                return SavepointKeyFilterPlan.range(null, true, b, false);
             case LTE:
-                return SavepointKeyFilter.range(null, true, b, true);
+                return SavepointKeyFilterPlan.range(null, true, b, true);
             default:
                 throw new IllegalStateException("Unknown Comparison: " + keyLeftCmp);
         }
@@ -323,12 +324,12 @@ class SavepointFilterTranslator {
     static final class Result {
         private final List<ResolvedExpression> accepted;
         private final List<ResolvedExpression> remaining;
-        @Nullable private final SavepointKeyFilter keyFilter;
+        @Nullable private final SavepointKeyFilterPlan keyFilter;
 
         private Result(
                 List<ResolvedExpression> accepted,
                 List<ResolvedExpression> remaining,
-                @Nullable SavepointKeyFilter keyFilter) {
+                @Nullable SavepointKeyFilterPlan keyFilter) {
             this.accepted = accepted;
             this.remaining = remaining;
             this.keyFilter = keyFilter;
@@ -343,7 +344,7 @@ class SavepointFilterTranslator {
         }
 
         @Nullable
-        SavepointKeyFilter keyFilter() {
+        SavepointKeyFilterPlan keyFilter() {
             return keyFilter;
         }
     }

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/table/filter/BoundInfo.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/table/filter/BoundInfo.java
@@ -16,15 +16,12 @@
  * limitations under the License.
  */
 
-package org.apache.flink.state.api.filter;
-
-import org.apache.flink.annotation.Experimental;
+package org.apache.flink.state.table.filter;
 
 import java.io.Serializable;
 
 /** Information about a bound in a range filter. */
-@Experimental
-public final class BoundInfo<K> implements Serializable {
+final class BoundInfo<K> implements Serializable {
     private static final long serialVersionUID = 4L;
 
     private final K value;

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/table/filter/ConjunctionKeyFilterPlan.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/table/filter/ConjunctionKeyFilterPlan.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.state.table.filter;
+
+import javax.annotation.Nullable;
+
+import java.util.List;
+import java.util.Set;
+
+/**
+ * A filter that accepts a key only if every branch accepts it (logical AND).
+ *
+ * <p>Used as the fallback for filter pairs that cannot be simplified into a single {@link
+ * ExactKeyFilterPlan} or {@link RangeKeyFilterPlan}, for example a range intersected with an
+ * exclusion.
+ */
+final class ConjunctionKeyFilterPlan<K> implements SavepointKeyFilterPlan<K> {
+
+    private static final long serialVersionUID = 7L;
+
+    private final List<SavepointKeyFilterPlan<K>> branches;
+
+    ConjunctionKeyFilterPlan(List<SavepointKeyFilterPlan<K>> branches) {
+        this.branches = List.copyOf(branches);
+    }
+
+    @Override
+    public List<SavepointKeyFilterPlan<K>> getConjunctionBranches() {
+        return branches;
+    }
+
+    @Override
+    public boolean test(K key) {
+        for (SavepointKeyFilterPlan<K> branch : branches) {
+            if (!branch.test(key)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    @Override
+    @Nullable
+    public Set<K> getExactKeys() {
+        // If any branch is a finite key set, the conjunction is at most that set narrowed by the
+        // other branches — still finite, so key groups can be pruned.
+        for (SavepointKeyFilterPlan<K> branch : branches) {
+            final Set<K> keys = branch.getExactKeys();
+            if (keys != null) {
+                return SavepointKeyFilterPlan.filterKeys(keys, this).getExactKeys();
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public SavepointKeyFilterPlan<K> intersect(SavepointKeyFilterPlan<K> other) {
+        if (other.isEmpty()) {
+            return other;
+        }
+        final Set<K> otherKeys = other.getExactKeys();
+        if (otherKeys != null) {
+            return SavepointKeyFilterPlan.filterKeys(otherKeys, this);
+        }
+        return SavepointKeyFilterPlan.conjunction(this, other);
+    }
+
+    @Override
+    public String toString() {
+        return "ConjunctionKeyFilterPlan" + branches;
+    }
+}

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/table/filter/EmptyKeyFilterPlan.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/table/filter/EmptyKeyFilterPlan.java
@@ -16,33 +16,52 @@
  * limitations under the License.
  */
 
-package org.apache.flink.state.api.filter;
+package org.apache.flink.state.table.filter;
 
+import java.util.Collections;
 import java.util.Set;
 
-/** A filter that accepts a finite set of keys. */
-final class ExactKeyFilter<K> implements SavepointKeyFilter<K> {
+/** A filter that rejects every key. */
+final class EmptyKeyFilterPlan<K> implements SavepointKeyFilterPlan<K> {
 
-    private static final long serialVersionUID = 2L;
+    private static final long serialVersionUID = 1L;
 
-    private final Set<K> keys;
+    @SuppressWarnings("rawtypes")
+    private static final EmptyKeyFilterPlan INSTANCE = new EmptyKeyFilterPlan<>();
 
-    ExactKeyFilter(Set<K> keys) {
-        this.keys = Set.copyOf(keys);
+    private EmptyKeyFilterPlan() {}
+
+    @SuppressWarnings("unchecked")
+    static <K> EmptyKeyFilterPlan<K> instance() {
+        return (EmptyKeyFilterPlan<K>) INSTANCE;
     }
 
     @Override
     public boolean test(K key) {
-        return keys.contains(key);
+        return false;
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return true;
     }
 
     @Override
     public Set<K> getExactKeys() {
-        return keys;
+        return Collections.emptySet();
+    }
+
+    @Override
+    public SavepointKeyFilterPlan<K> intersect(SavepointKeyFilterPlan<K> other) {
+        return this;
+    }
+
+    private Object readResolve() {
+        return INSTANCE;
     }
 
     @Override
     public String toString() {
-        return "ExactKeyFilter" + keys;
+        return "EmptyKeyFilterPlan";
     }
 }

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/table/filter/ExactKeyFilterPlan.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/table/filter/ExactKeyFilterPlan.java
@@ -16,52 +16,48 @@
  * limitations under the License.
  */
 
-package org.apache.flink.state.api.filter;
+package org.apache.flink.state.table.filter;
 
-import java.util.Collections;
+import java.util.HashSet;
 import java.util.Set;
 
-/** A filter that rejects every key. */
-final class EmptyKeyFilter<K> implements SavepointKeyFilter<K> {
+/** A filter that accepts a finite set of keys. */
+final class ExactKeyFilterPlan<K> implements SavepointKeyFilterPlan<K> {
 
-    private static final long serialVersionUID = 1L;
+    private static final long serialVersionUID = 2L;
 
-    @SuppressWarnings("rawtypes")
-    private static final EmptyKeyFilter INSTANCE = new EmptyKeyFilter<>();
+    private final Set<K> keys;
 
-    private EmptyKeyFilter() {}
-
-    @SuppressWarnings("unchecked")
-    static <K> EmptyKeyFilter<K> instance() {
-        return (EmptyKeyFilter<K>) INSTANCE;
+    ExactKeyFilterPlan(Set<K> keys) {
+        this.keys = Set.copyOf(keys);
     }
 
     @Override
     public boolean test(K key) {
-        return false;
-    }
-
-    @Override
-    public boolean isEmpty() {
-        return true;
+        return keys.contains(key);
     }
 
     @Override
     public Set<K> getExactKeys() {
-        return Collections.emptySet();
+        return keys;
     }
 
     @Override
-    public SavepointKeyFilter<K> intersect(SavepointKeyFilter<K> other) {
-        return this;
-    }
-
-    private Object readResolve() {
-        return INSTANCE;
+    public SavepointKeyFilterPlan<K> intersect(SavepointKeyFilterPlan<K> other) {
+        if (other.isEmpty()) {
+            return other;
+        }
+        final Set<K> otherKeys = other.getExactKeys();
+        if (otherKeys != null) {
+            final Set<K> intersection = new HashSet<>(keys);
+            intersection.retainAll(otherKeys);
+            return SavepointKeyFilterPlan.exact(intersection);
+        }
+        return SavepointKeyFilterPlan.filterKeys(keys, other);
     }
 
     @Override
     public String toString() {
-        return "EmptyKeyFilter";
+        return "ExactKeyFilterPlan" + keys;
     }
 }

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/table/filter/ExclusionKeyFilterPlan.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/table/filter/ExclusionKeyFilterPlan.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.state.table.filter;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * A filter that rejects a finite set of keys and accepts everything else (logical NOT of a finite
+ * set, e.g. {@code key <> v} or {@code key NOT IN (..)}).
+ */
+final class ExclusionKeyFilterPlan<K> implements SavepointKeyFilterPlan<K> {
+
+    private static final long serialVersionUID = 6L;
+
+    private final Set<K> excluded;
+
+    ExclusionKeyFilterPlan(Set<K> excluded) {
+        this.excluded = Set.copyOf(excluded);
+    }
+
+    @Override
+    public boolean test(K key) {
+        return !excluded.contains(key);
+    }
+
+    @Override
+    public Set<K> getExcludedKeys() {
+        return excluded;
+    }
+
+    @Override
+    public SavepointKeyFilterPlan<K> intersect(SavepointKeyFilterPlan<K> other) {
+        if (other.isEmpty()) {
+            return other;
+        }
+        final Set<K> otherKeys = other.getExactKeys();
+        if (otherKeys != null) {
+            final Set<K> retained = new HashSet<>(otherKeys);
+            retained.removeAll(excluded);
+            return SavepointKeyFilterPlan.exact(retained);
+        }
+        final Set<K> otherExcluded = other.getExcludedKeys();
+        if (otherExcluded != null) {
+            // NOT a AND NOT b = NOT (a OR b).
+            final Set<K> merged = new HashSet<>(excluded);
+            merged.addAll(otherExcluded);
+            return new ExclusionKeyFilterPlan<>(merged);
+        }
+        // A range (or any other predicate) minus a finite set is not a single filter, so keep both
+        // constraints as a precise per-key conjunction.
+        return SavepointKeyFilterPlan.conjunction(this, other);
+    }
+
+    @Override
+    public String toString() {
+        return "ExclusionKeyFilterPlan!" + excluded;
+    }
+}

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/table/filter/RangeKeyFilterPlan.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/table/filter/RangeKeyFilterPlan.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.state.table.filter;
+
+import org.apache.flink.state.api.filter.SerializableComparator;
+
+import javax.annotation.Nullable;
+
+import java.util.Set;
+
+/** A filter based on a range with an injected comparator. */
+final class RangeKeyFilterPlan<K> implements SavepointKeyFilterPlan<K> {
+
+    private static final long serialVersionUID = 3L;
+
+    private final SerializableComparator<K> comparator;
+    @Nullable private final BoundInfo<K> lower;
+    @Nullable private final BoundInfo<K> upper;
+
+    RangeKeyFilterPlan(
+            SerializableComparator<K> comparator,
+            @Nullable BoundInfo<K> lower,
+            @Nullable BoundInfo<K> upper) {
+        this.comparator = comparator;
+        this.lower = lower;
+        this.upper = upper;
+    }
+
+    @Override
+    public boolean test(K key) {
+        if (lower != null) {
+            int cmp = comparator.compare(lower.getValue(), key);
+            if (cmp > 0 || (cmp == 0 && !lower.isInclusive())) {
+                return false;
+            }
+        }
+        if (upper != null) {
+            int cmp = comparator.compare(upper.getValue(), key);
+            if (cmp < 0 || (cmp == 0 && !upper.isInclusive())) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    @Override
+    public BoundInfo<K> getLowerBound() {
+        return lower;
+    }
+
+    @Override
+    public BoundInfo<K> getUpperBound() {
+        return upper;
+    }
+
+    @Override
+    public SavepointKeyFilterPlan<K> intersect(SavepointKeyFilterPlan<K> other) {
+        if (other.isEmpty()) {
+            return other;
+        }
+        final Set<K> otherExactKeys = other.getExactKeys();
+        if (otherExactKeys != null) {
+            return SavepointKeyFilterPlan.filterKeys(otherExactKeys, this);
+        }
+        return intersectRange(other.getLowerBound(), other.getUpperBound());
+    }
+
+    private SavepointKeyFilterPlan<K> intersectRange(
+            @Nullable BoundInfo<K> otherLower, @Nullable BoundInfo<K> otherUpper) {
+        BoundInfo<K> newLower = tighter(lower, otherLower, true);
+        BoundInfo<K> newUpper = tighter(upper, otherUpper, false);
+
+        if (newLower != null && newUpper != null) {
+            int cmp = comparator.compare(newLower.getValue(), newUpper.getValue());
+            if (cmp > 0) {
+                return SavepointKeyFilterPlan.empty();
+            }
+            if (cmp == 0 && (!newLower.isInclusive() || !newUpper.isInclusive())) {
+                return SavepointKeyFilterPlan.empty();
+            }
+        }
+        return new RangeKeyFilterPlan<>(comparator, newLower, newUpper);
+    }
+
+    @Nullable
+    private BoundInfo<K> tighter(
+            @Nullable BoundInfo<K> a, @Nullable BoundInfo<K> b, boolean preferHigher) {
+        if (a == null) {
+            return b;
+        }
+        if (b == null) {
+            return a;
+        }
+        int c = comparator.compare(a.getValue(), b.getValue());
+        if (c == 0) {
+            return new BoundInfo<>(a.getValue(), a.isInclusive() && b.isInclusive());
+        }
+        boolean aWins = preferHigher ? c > 0 : c < 0;
+        return aWins ? a : b;
+    }
+
+    @Override
+    public String toString() {
+        String lowerStr =
+                lower == null ? "(-∞" : (lower.isInclusive() ? "[" : "(") + lower.getValue();
+        String upperStr =
+                upper == null ? "+∞)" : upper.getValue() + (upper.isInclusive() ? "]" : ")");
+        return "RangeKeyFilterPlan" + lowerStr + ", " + upperStr;
+    }
+}

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/table/filter/RangeKeyFilterPlan.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/table/filter/RangeKeyFilterPlan.java
@@ -70,6 +70,11 @@ final class RangeKeyFilterPlan<K> implements SavepointKeyFilterPlan<K> {
     }
 
     @Override
+    public boolean isRange() {
+        return true;
+    }
+
+    @Override
     public SavepointKeyFilterPlan<K> intersect(SavepointKeyFilterPlan<K> other) {
         if (other.isEmpty()) {
             return other;
@@ -78,7 +83,12 @@ final class RangeKeyFilterPlan<K> implements SavepointKeyFilterPlan<K> {
         if (otherExactKeys != null) {
             return SavepointKeyFilterPlan.filterKeys(otherExactKeys, this);
         }
-        return intersectRange(other.getLowerBound(), other.getUpperBound());
+        if (other.isRange()) {
+            return intersectRange(other.getLowerBound(), other.getUpperBound());
+        }
+        // Anything else (e.g. an exclusion) intersected with a range is not a single range, so keep
+        // both constraints as a precise per-key conjunction.
+        return SavepointKeyFilterPlan.conjunction(this, other);
     }
 
     private SavepointKeyFilterPlan<K> intersectRange(

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/table/filter/SavepointKeyFilterPlan.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/table/filter/SavepointKeyFilterPlan.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.state.table.filter;
+
+import org.apache.flink.annotation.Experimental;
+import org.apache.flink.state.api.filter.SavepointKeyFilter;
+import org.apache.flink.state.api.filter.SerializableComparator;
+
+import javax.annotation.Nullable;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * The internal, richer view of a {@link SavepointKeyFilter} used while combining and analyzing
+ * filters during push-down translation.
+ */
+@Experimental
+public interface SavepointKeyFilterPlan<K> extends SavepointKeyFilter<K> {
+
+    /** Returns {@code true} if this filter rejects every key. */
+    default boolean isEmpty() {
+        return false;
+    }
+
+    /** Returns the lower bound of this filter's range, or {@code null} if there is none. */
+    @Nullable
+    default BoundInfo<K> getLowerBound() {
+        return null;
+    }
+
+    /** Returns the upper bound of this filter's range, or {@code null} if there is none. */
+    @Nullable
+    default BoundInfo<K> getUpperBound() {
+        return null;
+    }
+
+    /**
+     * Returns a filter that accepts a key if and only if both {@code this} and {@code other} accept
+     * it.
+     */
+    SavepointKeyFilterPlan<K> intersect(SavepointKeyFilterPlan<K> other);
+
+    static <K> SavepointKeyFilterPlan<K> filterKeys(Set<K> keys, SavepointKeyFilter<K> predicate) {
+        final Set<K> retained = new HashSet<>();
+        for (K key : keys) {
+            if (predicate.test(key)) {
+                retained.add(key);
+            }
+        }
+        return exact(retained);
+    }
+
+    static <K> SavepointKeyFilterPlan<K> exact(Set<K> keys) {
+        if (keys.isEmpty()) {
+            return EmptyKeyFilterPlan.instance();
+        }
+        return new ExactKeyFilterPlan<>(keys);
+    }
+
+    static <K> SavepointKeyFilterPlan<K> exact(K value) {
+        return new ExactKeyFilterPlan<>(Set.of(value));
+    }
+
+    static <K extends Comparable<K>> SavepointKeyFilterPlan<K> range(
+            @Nullable K lower, boolean lowerInclusive, @Nullable K upper, boolean upperInclusive) {
+        return range(lower, lowerInclusive, upper, upperInclusive, new NaturalOrderComparator<>());
+    }
+
+    static <K> SavepointKeyFilterPlan<K> range(
+            @Nullable K lower,
+            boolean lowerInclusive,
+            @Nullable K upper,
+            boolean upperInclusive,
+            SerializableComparator<K> comparator) {
+        BoundInfo<K> lowerBoundInfo = lower != null ? new BoundInfo<>(lower, lowerInclusive) : null;
+        BoundInfo<K> upperBoundInfo = upper != null ? new BoundInfo<>(upper, upperInclusive) : null;
+        return new RangeKeyFilterPlan<>(comparator, lowerBoundInfo, upperBoundInfo);
+    }
+
+    static <K> SavepointKeyFilterPlan<K> empty() {
+        return EmptyKeyFilterPlan.instance();
+    }
+}

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/table/filter/SavepointKeyFilterPlan.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/table/filter/SavepointKeyFilterPlan.java
@@ -24,7 +24,10 @@ import org.apache.flink.state.api.filter.SerializableComparator;
 
 import javax.annotation.Nullable;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 /**
@@ -49,6 +52,28 @@ public interface SavepointKeyFilterPlan<K> extends SavepointKeyFilter<K> {
     @Nullable
     default BoundInfo<K> getUpperBound() {
         return null;
+    }
+
+    /** Returns {@code true} if this filter is a single range, reporting its bounds. */
+    default boolean isRange() {
+        return false;
+    }
+
+    /**
+     * Returns the finite set of keys this filter rejects while accepting every other key, or {@code
+     * null} if this filter is not a pure exclusion.
+     */
+    @Nullable
+    default Set<K> getExcludedKeys() {
+        return null;
+    }
+
+    /**
+     * Decomposes this filter into its top-level conjunctive (AND) branches; a non-conjunction
+     * filter is a single branch.
+     */
+    default List<SavepointKeyFilterPlan<K>> getConjunctionBranches() {
+        return Collections.singletonList(this);
     }
 
     /**
@@ -96,5 +121,34 @@ public interface SavepointKeyFilterPlan<K> extends SavepointKeyFilter<K> {
 
     static <K> SavepointKeyFilterPlan<K> empty() {
         return EmptyKeyFilterPlan.instance();
+    }
+
+    /**
+     * Returns a filter accepting a key if and only if it is <em>not</em> one of the excluded keys
+     * ({@code key <> v} or {@code key NOT IN (..)}), or {@code null} if nothing is excluded.
+     */
+    @Nullable
+    static <K> SavepointKeyFilterPlan<K> exclude(Set<K> excluded) {
+        if (excluded.isEmpty()) {
+            return null;
+        }
+        return new ExclusionKeyFilterPlan<>(excluded);
+    }
+
+    /** Returns a filter accepting a key if and only if it is <em>not</em> the excluded key. */
+    static <K> SavepointKeyFilterPlan<K> exclude(K value) {
+        return new ExclusionKeyFilterPlan<>(Set.of(value));
+    }
+
+    /** Returns a filter accepting a key if and only if both {@code a} and {@code b} accept it. */
+    static <K> SavepointKeyFilterPlan<K> conjunction(
+            SavepointKeyFilterPlan<K> a, SavepointKeyFilterPlan<K> b) {
+        if (a.isEmpty() || b.isEmpty()) {
+            return empty();
+        }
+        final List<SavepointKeyFilterPlan<K>> branches = new ArrayList<>();
+        branches.addAll(a.getConjunctionBranches());
+        branches.addAll(b.getConjunctionBranches());
+        return new ConjunctionKeyFilterPlan<>(branches);
     }
 }

--- a/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/api/SavepointReaderKeyedStateITCase.java
+++ b/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/api/SavepointReaderKeyedStateITCase.java
@@ -31,6 +31,7 @@ import org.apache.flink.state.api.filter.SavepointKeyFilter;
 import org.apache.flink.state.api.functions.KeyedStateReaderFunction;
 import org.apache.flink.state.api.utils.JobResultRetriever;
 import org.apache.flink.state.api.utils.SavepointTestBase;
+import org.apache.flink.state.table.filter.SavepointKeyFilterPlan;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.KeyedProcessFunction;
@@ -220,7 +221,7 @@ public abstract class SavepointReaderKeyedStateITCase<B extends StateBackend>
 
         SavepointReader savepoint = SavepointReader.read(env, savepointPath, backendTuple.f1);
         CountingReadResult result =
-                readKeyedStateWithCountingReader(savepoint, SavepointKeyFilter.empty());
+                readKeyedStateWithCountingReader(savepoint, SavepointKeyFilterPlan.empty());
         // No key reaches the reader, so no state is read.
         assertThat(result.values).isEmpty();
         assertThat(result.counter).isZero();

--- a/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/api/input/KeyedStateInputFormatTest.java
+++ b/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/api/input/KeyedStateInputFormatTest.java
@@ -145,29 +145,6 @@ class KeyedStateInputFormatTest {
 
     @ParameterizedTest(name = "Enable async state = {0}")
     @ValueSource(booleans = {false, true})
-    void testEmptyFilterProducesNoInputSplits(boolean asyncState) throws Exception {
-        OperatorID operatorID = OperatorIDGenerator.fromUid("uid");
-
-        OperatorSubtaskState state =
-                createOperatorSubtaskState(createFlatMap(asyncState), asyncState);
-        OperatorState operatorState = new OperatorState(null, null, operatorID, 1, 128);
-        operatorState.putState(0, state);
-
-        KeyedStateInputFormat<?, ?, ?> format =
-                new KeyedStateInputFormat<>(
-                        operatorState,
-                        new HashMapStateBackend(),
-                        new Configuration(),
-                        new KeyedStateReaderOperator<>(new ReaderFunction(), Types.INT),
-                        new ExecutionConfig(),
-                        SavepointKeyFilter.empty());
-        KeyGroupRangeInputSplit[] splits = format.createInputSplits(10);
-
-        assertThat(splits).isEmpty();
-    }
-
-    @ParameterizedTest(name = "Enable async state = {0}")
-    @ValueSource(booleans = {false, true})
     void testRangeFilterDoesNotPruneInputSplits(boolean asyncState) throws Exception {
         OperatorID operatorID = OperatorIDGenerator.fromUid("uid");
 

--- a/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/table/SavepointFilterTranslatorTest.java
+++ b/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/table/SavepointFilterTranslatorTest.java
@@ -221,10 +221,12 @@ class SavepointFilterTranslatorTest {
     }
 
     @Test
-    void andWithExactKeyChildIsNotPushable() {
-        // AND requires all children to be range filters; exact filter breaks pushdown
+    void andOfExactAndRangeNarrowsToExactSubset() {
+        // key = 5 AND key > 3 -> {5}
         CallExpression expr = and(eq(longKeyRef(), longLit(5L)), gt(longKeyRef(), longLit(3L)));
-        assertThat(keyFilterOf(expr)).isNull();
+        SavepointKeyFilterPlan<Object> filter = keyFilterOf(expr);
+        assertNotNull(filter);
+        assertThat(filter.getExactKeys()).containsExactly(5L);
     }
 
     // -------------------------------------------------------------------------

--- a/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/table/SavepointFilterTranslatorTest.java
+++ b/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/table/SavepointFilterTranslatorTest.java
@@ -19,6 +19,7 @@
 package org.apache.flink.state.table;
 
 import org.apache.flink.state.api.filter.SavepointKeyFilter;
+import org.apache.flink.state.table.filter.SavepointKeyFilterPlan;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.expressions.CallExpression;
 import org.apache.flink.table.expressions.FieldReferenceExpression;
@@ -53,7 +54,7 @@ class SavepointFilterTranslatorTest {
 
     @Test
     void equalsKeyOnLeft() {
-        SavepointKeyFilter<Object> filter = keyFilterOf(eq(longKeyRef(), longLit(42L)));
+        SavepointKeyFilterPlan<Object> filter = keyFilterOf(eq(longKeyRef(), longLit(42L)));
         assertNotNull(filter);
         assertThat(filter.getExactKeys()).containsExactly(42L);
         assertThat(filter.test(42L)).isTrue();
@@ -62,7 +63,7 @@ class SavepointFilterTranslatorTest {
 
     @Test
     void equalsKeyOnRight() {
-        SavepointKeyFilter<Object> filter = keyFilterOf(eq(longLit(42L), longKeyRef()));
+        SavepointKeyFilterPlan<Object> filter = keyFilterOf(eq(longLit(42L), longKeyRef()));
         assertNotNull(filter);
         assertThat(filter.getExactKeys()).containsExactly(42L);
         assertThat(filter.test(42L)).isTrue();
@@ -71,13 +72,13 @@ class SavepointFilterTranslatorTest {
 
     @Test
     void equalsNeitherSideIsKeyColumn_returnsNull() {
-        SavepointKeyFilter<Object> filter = keyFilterOf(eq(otherRef(), longLit(42L)));
+        SavepointKeyFilterPlan<Object> filter = keyFilterOf(eq(otherRef(), longLit(42L)));
         assertThat(filter).isNull();
     }
 
     @Test
     void equalsNeitherSideIsLiteral_returnsNull() {
-        SavepointKeyFilter<Object> filter = keyFilterOf(eq(longKeyRef(), otherRef()));
+        SavepointKeyFilterPlan<Object> filter = keyFilterOf(eq(longKeyRef(), otherRef()));
         assertThat(filter).isNull();
     }
 
@@ -93,7 +94,7 @@ class SavepointFilterTranslatorTest {
                         eq(longKeyRef(), longLit(2L)),
                         eq(longLit(3L), longKeyRef()));
 
-        SavepointKeyFilter<Object> filter = keyFilterOf(expr);
+        SavepointKeyFilterPlan<Object> filter = keyFilterOf(expr);
         assertNotNull(filter);
         assertThat(filter.getExactKeys()).containsExactlyInAnyOrder(1L, 2L, 3L);
         assertThat(filter.test(4L)).isFalse();
@@ -112,7 +113,7 @@ class SavepointFilterTranslatorTest {
 
     @Test
     void betweenProducesInclusiveRange() {
-        SavepointKeyFilter<Object> filter =
+        SavepointKeyFilterPlan<Object> filter =
                 keyFilterOf(between(longKeyRef(), longLit(10L), longLit(20L)));
 
         assertNotNull(filter);
@@ -126,7 +127,7 @@ class SavepointFilterTranslatorTest {
 
     @Test
     void betweenWithNonKeyField_returnsNull() {
-        SavepointKeyFilter<Object> filter =
+        SavepointKeyFilterPlan<Object> filter =
                 keyFilterOf(between(otherRef(), longLit(1L), longLit(10L)));
         assertThat(filter).isNull();
     }
@@ -137,7 +138,7 @@ class SavepointFilterTranslatorTest {
 
     @Test
     void greaterThanProducesExclusiveLowerBound() {
-        SavepointKeyFilter<Object> filter = keyFilterOf(gt(longKeyRef(), longLit(5L)));
+        SavepointKeyFilterPlan<Object> filter = keyFilterOf(gt(longKeyRef(), longLit(5L)));
         assertNotNull(filter);
         assertThat(filter.getExactKeys()).isNull();
         assertThat(filter.test(5L)).isFalse();
@@ -146,7 +147,7 @@ class SavepointFilterTranslatorTest {
 
     @Test
     void greaterThanOrEqualProducesInclusiveLowerBound() {
-        SavepointKeyFilter<Object> filter = keyFilterOf(gte(longKeyRef(), longLit(5L)));
+        SavepointKeyFilterPlan<Object> filter = keyFilterOf(gte(longKeyRef(), longLit(5L)));
         assertNotNull(filter);
         assertThat(filter.getExactKeys()).isNull();
         assertThat(filter.test(4L)).isFalse();
@@ -156,7 +157,7 @@ class SavepointFilterTranslatorTest {
 
     @Test
     void lessThanProducesExclusiveUpperBound() {
-        SavepointKeyFilter<Object> filter = keyFilterOf(lt(longKeyRef(), longLit(10L)));
+        SavepointKeyFilterPlan<Object> filter = keyFilterOf(lt(longKeyRef(), longLit(10L)));
         assertNotNull(filter);
         assertThat(filter.getExactKeys()).isNull();
         assertThat(filter.test(9L)).isTrue();
@@ -165,7 +166,7 @@ class SavepointFilterTranslatorTest {
 
     @Test
     void lessThanOrEqualProducesInclusiveUpperBound() {
-        SavepointKeyFilter<Object> filter = keyFilterOf(lte(longKeyRef(), longLit(10L)));
+        SavepointKeyFilterPlan<Object> filter = keyFilterOf(lte(longKeyRef(), longLit(10L)));
         assertNotNull(filter);
         assertThat(filter.getExactKeys()).isNull();
         assertThat(filter.test(10L)).isTrue();
@@ -175,7 +176,7 @@ class SavepointFilterTranslatorTest {
     @Test
     void comparisonWithLiteralOnLeft_flipsDirection() {
         // literal > key  →  key < literal  →  upper bound (exclusive)
-        SavepointKeyFilter<Object> filter = keyFilterOf(gt(longLit(10L), longKeyRef()));
+        SavepointKeyFilterPlan<Object> filter = keyFilterOf(gt(longLit(10L), longKeyRef()));
         assertNotNull(filter);
         assertThat(filter.getExactKeys()).isNull();
         assertThat(filter.test(9L)).isTrue();
@@ -185,7 +186,7 @@ class SavepointFilterTranslatorTest {
     @Test
     void comparisonWithLiteralOnLeft_lte_flipsDirection() {
         // literal <= key  →  key >= literal  →  lower bound (inclusive)
-        SavepointKeyFilter<Object> filter = keyFilterOf(lte(longLit(5L), longKeyRef()));
+        SavepointKeyFilterPlan<Object> filter = keyFilterOf(lte(longLit(5L), longKeyRef()));
         assertThat(filter.getExactKeys()).isNull();
         assertThat(filter.test(4L)).isFalse();
         assertThat(filter.test(5L)).isTrue();
@@ -199,7 +200,7 @@ class SavepointFilterTranslatorTest {
     void andOfTwoRangesProducesIntersection() {
         // key >= 5 AND key <= 10
         CallExpression expr = and(gte(longKeyRef(), longLit(5L)), lte(longKeyRef(), longLit(10L)));
-        SavepointKeyFilter<Object> filter = keyFilterOf(expr);
+        SavepointKeyFilterPlan<Object> filter = keyFilterOf(expr);
 
         assertNotNull(filter);
         assertThat(filter.getExactKeys()).isNull();
@@ -213,7 +214,7 @@ class SavepointFilterTranslatorTest {
     void andWithProvablyEmptyIntersection_matchesNothing() {
         // key > 10 AND key < 5 — disjoint
         CallExpression expr = and(gt(longKeyRef(), longLit(10L)), lt(longKeyRef(), longLit(5L)));
-        SavepointKeyFilter<Object> filter = keyFilterOf(expr);
+        SavepointKeyFilterPlan<Object> filter = keyFilterOf(expr);
 
         assertNotNull(filter);
         assertThat(filter.isEmpty()).isTrue();
@@ -251,7 +252,7 @@ class SavepointFilterTranslatorTest {
 
     @Test
     void rangeFilterOnStringKey() {
-        SavepointKeyFilter<Object> filter =
+        SavepointKeyFilterPlan<Object> filter =
                 keyFilterOf(between(stringKeyRef(), stringLit("beta"), stringLit("delta")));
 
         assertNotNull(filter);
@@ -271,7 +272,8 @@ class SavepointFilterTranslatorTest {
         FieldReferenceExpression floatKey =
                 new FieldReferenceExpression("key", DataTypes.FLOAT().notNull(), 0, KEY_COL);
 
-        SavepointKeyFilter<Object> filter = keyFilterOf(between(floatKey, floatLower, floatUpper));
+        SavepointKeyFilterPlan<Object> filter =
+                keyFilterOf(between(floatKey, floatLower, floatUpper));
 
         assertNotNull(filter);
         assertThat(filter.test(1.5f)).isTrue();
@@ -288,9 +290,9 @@ class SavepointFilterTranslatorTest {
     @Test
     void intersectNarrowsBounds() {
         // [5, ∞) ∩ (-∞, 10] = [5, 10]
-        SavepointKeyFilter<Long> lower = SavepointKeyFilter.range(5L, true, null, true);
-        SavepointKeyFilter<Long> upper = SavepointKeyFilter.range(null, true, 10L, true);
-        SavepointKeyFilter<Long> result = lower.intersect(upper);
+        SavepointKeyFilterPlan<Long> lower = SavepointKeyFilterPlan.range(5L, true, null, true);
+        SavepointKeyFilterPlan<Long> upper = SavepointKeyFilterPlan.range(null, true, 10L, true);
+        SavepointKeyFilterPlan<Long> result = lower.intersect(upper);
 
         assertThat(result.isEmpty()).isFalse();
         assertThat(result.getExactKeys()).isNull();
@@ -303,17 +305,17 @@ class SavepointFilterTranslatorTest {
     @Test
     void intersectDisjointRangesReturnsEmpty() {
         // [10, ∞) ∩ (-∞, 5] — disjoint
-        SavepointKeyFilter<Long> a = SavepointKeyFilter.range(10L, true, null, true);
-        SavepointKeyFilter<Long> b = SavepointKeyFilter.range(null, true, 5L, true);
+        SavepointKeyFilterPlan<Long> a = SavepointKeyFilterPlan.range(10L, true, null, true);
+        SavepointKeyFilterPlan<Long> b = SavepointKeyFilterPlan.range(null, true, 5L, true);
         assertThat(a.intersect(b).isEmpty()).isTrue();
     }
 
     @Test
     void intersectEqualBoundsInclusiveIsNonEmpty() {
         // [7, ∞) ∩ (-∞, 7] = [7, 7]
-        SavepointKeyFilter<Long> a = SavepointKeyFilter.range(7L, true, null, true);
-        SavepointKeyFilter<Long> b = SavepointKeyFilter.range(null, true, 7L, true);
-        SavepointKeyFilter<Long> result = a.intersect(b);
+        SavepointKeyFilterPlan<Long> a = SavepointKeyFilterPlan.range(7L, true, null, true);
+        SavepointKeyFilterPlan<Long> b = SavepointKeyFilterPlan.range(null, true, 7L, true);
+        SavepointKeyFilterPlan<Long> result = a.intersect(b);
         assertThat(result.isEmpty()).isFalse();
         assertThat(result.test(7L)).isTrue();
         assertThat(result.test(6L)).isFalse();
@@ -323,8 +325,8 @@ class SavepointFilterTranslatorTest {
     @Test
     void intersectEqualBoundsOneExclusiveIsEmpty() {
         // (7, ∞) ∩ (-∞, 7] — empty because lower is exclusive
-        SavepointKeyFilter<Long> a = SavepointKeyFilter.range(7L, false, null, true);
-        SavepointKeyFilter<Long> b = SavepointKeyFilter.range(null, true, 7L, true);
+        SavepointKeyFilterPlan<Long> a = SavepointKeyFilterPlan.range(7L, false, null, true);
+        SavepointKeyFilterPlan<Long> b = SavepointKeyFilterPlan.range(null, true, 7L, true);
         assertThat(a.intersect(b).isEmpty()).isTrue();
     }
 
@@ -336,7 +338,7 @@ class SavepointFilterTranslatorTest {
     void rangeWithCustomComparatorIsUsed() {
         // Orders strings by length — clearly not the natural String order.
         SavepointKeyFilter<String> filter =
-                SavepointKeyFilter.range(
+                SavepointKeyFilterPlan.range(
                         "aa",
                         true,
                         "cccc",
@@ -359,7 +361,7 @@ class SavepointFilterTranslatorTest {
                 apply(
                         List.of(gte(longKeyRef(), longLit(3L)), lte(longKeyRef(), longLit(8L))),
                         LONG_KEY_TYPE);
-        SavepointKeyFilter<Object> result = applied.keyFilter();
+        SavepointKeyFilterPlan<Object> result = applied.keyFilter();
         assertNotNull(result);
 
         assertThat(applied.accepted()).hasSize(2);
@@ -384,7 +386,7 @@ class SavepointFilterTranslatorTest {
                                         eq(longKeyRef(), longLit(3L)),
                                         eq(longKeyRef(), longLit(4L)))),
                         LONG_KEY_TYPE);
-        SavepointKeyFilter<Object> result = applied.keyFilter();
+        SavepointKeyFilterPlan<Object> result = applied.keyFilter();
 
         assertNotNull(result);
         assertThat(applied.accepted()).hasSize(2);
@@ -398,7 +400,7 @@ class SavepointFilterTranslatorTest {
                 apply(
                         List.of(eq(longKeyRef(), longLit(1L)), eq(longKeyRef(), longLit(2L))),
                         LONG_KEY_TYPE);
-        SavepointKeyFilter<Object> result = applied.keyFilter();
+        SavepointKeyFilterPlan<Object> result = applied.keyFilter();
 
         assertNotNull(result);
         assertThat(applied.accepted()).hasSize(2);
@@ -418,7 +420,7 @@ class SavepointFilterTranslatorTest {
                                         eq(longKeyRef(), longLit(15L))),
                                 between(longKeyRef(), longLit(4L), longLit(12L))),
                         LONG_KEY_TYPE);
-        SavepointKeyFilter<Object> result = applied.keyFilter();
+        SavepointKeyFilterPlan<Object> result = applied.keyFilter();
 
         assertNotNull(result);
         assertThat(applied.accepted()).hasSize(2);
@@ -438,7 +440,7 @@ class SavepointFilterTranslatorTest {
                                         eq(longKeyRef(), longLit(10L)),
                                         eq(longKeyRef(), longLit(15L)))),
                         LONG_KEY_TYPE);
-        SavepointKeyFilter<Object> result = applied.keyFilter();
+        SavepointKeyFilterPlan<Object> result = applied.keyFilter();
 
         assertNotNull(result);
         assertThat(applied.accepted()).hasSize(2);
@@ -452,7 +454,7 @@ class SavepointFilterTranslatorTest {
 
     @Test
     void emptyKeyFilter_rejectsEverything() {
-        SavepointKeyFilter<Object> empty = SavepointKeyFilter.empty();
+        SavepointKeyFilterPlan<Object> empty = SavepointKeyFilterPlan.empty();
         assertThat(empty.isEmpty()).isTrue();
         assertThat(empty.getExactKeys()).isEmpty();
         assertThat(empty.test(42L)).isFalse();
@@ -461,13 +463,14 @@ class SavepointFilterTranslatorTest {
 
     @Test
     void exactWithEmptySetReturnsEmptyKeyFilter() {
-        SavepointKeyFilter<Object> filter = SavepointKeyFilter.exact(Collections.emptySet());
+        SavepointKeyFilterPlan<Object> filter =
+                SavepointKeyFilterPlan.exact(Collections.emptySet());
         assertThat(filter.isEmpty()).isTrue();
     }
 
     @Test
     void emptyKeyFilterSingletonPreservedAcrossSerialization() throws Exception {
-        SavepointKeyFilter<Object> original = SavepointKeyFilter.empty();
+        SavepointKeyFilterPlan<Object> original = SavepointKeyFilterPlan.empty();
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         try (ObjectOutputStream oos = new ObjectOutputStream(baos)) {
             oos.writeObject(original);
@@ -477,7 +480,7 @@ class SavepointFilterTranslatorTest {
                 new ObjectInputStream(new ByteArrayInputStream(baos.toByteArray()))) {
             deserialized = ois.readObject();
         }
-        assertThat(deserialized).isSameAs(SavepointKeyFilter.empty());
+        assertThat(deserialized).isSameAs(SavepointKeyFilterPlan.empty());
     }
 
     // -------------------------------------------------------------------------
@@ -504,7 +507,7 @@ class SavepointFilterTranslatorTest {
                         gte(longKeyRef(), longLit(3L)),
                         lte(longKeyRef(), longLit(20L)),
                         lt(longKeyRef(), longLit(10L)));
-        SavepointKeyFilter<Object> filter = keyFilterOf(expr);
+        SavepointKeyFilterPlan<Object> filter = keyFilterOf(expr);
 
         assertNotNull(filter);
         assertThat(filter.getExactKeys()).isNull();
@@ -522,7 +525,7 @@ class SavepointFilterTranslatorTest {
     @Test
     void orWithSingleChild_returnsExactFilter() {
         CallExpression expr = or(eq(longKeyRef(), longLit(7L)));
-        SavepointKeyFilter<Object> filter = keyFilterOf(expr);
+        SavepointKeyFilterPlan<Object> filter = keyFilterOf(expr);
 
         assertNotNull(filter);
         assertThat(filter.getExactKeys()).containsExactly(7L);
@@ -550,7 +553,7 @@ class SavepointFilterTranslatorTest {
                                 and(gt(longKeyRef(), longLit(10L)), lt(longKeyRef(), longLit(5L))),
                                 lte(longKeyRef(), longLit(10L))),
                         LONG_KEY_TYPE);
-        SavepointKeyFilter<Object> result = applied.keyFilter();
+        SavepointKeyFilterPlan<Object> result = applied.keyFilter();
 
         assertNotNull(result);
         assertThat(applied.accepted()).hasSize(2);
@@ -566,7 +569,7 @@ class SavepointFilterTranslatorTest {
                                 lte(longKeyRef(), longLit(10L)),
                                 and(gt(longKeyRef(), longLit(10L)), lt(longKeyRef(), longLit(5L)))),
                         LONG_KEY_TYPE);
-        SavepointKeyFilter<Object> result = applied.keyFilter();
+        SavepointKeyFilterPlan<Object> result = applied.keyFilter();
 
         assertNotNull(result);
         assertThat(applied.accepted()).hasSize(2);
@@ -582,7 +585,7 @@ class SavepointFilterTranslatorTest {
                                 and(gt(longKeyRef(), longLit(10L)), lt(longKeyRef(), longLit(5L))),
                                 eq(longKeyRef(), longLit(1L))),
                         LONG_KEY_TYPE);
-        SavepointKeyFilter<Object> result = applied.keyFilter();
+        SavepointKeyFilterPlan<Object> result = applied.keyFilter();
 
         assertNotNull(result);
         assertThat(applied.accepted()).hasSize(2);
@@ -596,7 +599,7 @@ class SavepointFilterTranslatorTest {
                 apply(
                         List.of(eq(longKeyRef(), longLit(1L)), eq(longKeyRef(), longLit(2L))),
                         LONG_KEY_TYPE);
-        SavepointKeyFilter<Object> result = applied.keyFilter();
+        SavepointKeyFilterPlan<Object> result = applied.keyFilter();
 
         assertNotNull(result);
         assertThat(applied.accepted()).hasSize(2);
@@ -662,7 +665,7 @@ class SavepointFilterTranslatorTest {
     @Test
     void equalsWithIntLiteralIsWidenedToBigintKeyAndPushed() {
         ValueLiteralExpression intLit = new ValueLiteralExpression(5, DataTypes.INT().notNull());
-        SavepointKeyFilter<Object> filter = keyFilterOf(eq(longKeyRef(), intLit));
+        SavepointKeyFilterPlan<Object> filter = keyFilterOf(eq(longKeyRef(), intLit));
 
         assertNotNull(filter);
         assertThat(filter.getExactKeys()).containsExactly(5L);
@@ -674,7 +677,7 @@ class SavepointFilterTranslatorTest {
     void betweenWithIntLiteralBoundsIsWidenedToBigintKeyAndPushed() {
         ValueLiteralExpression lower = new ValueLiteralExpression(1, DataTypes.INT().notNull());
         ValueLiteralExpression upper = new ValueLiteralExpression(10, DataTypes.INT().notNull());
-        SavepointKeyFilter<Object> filter = keyFilterOf(between(longKeyRef(), lower, upper));
+        SavepointKeyFilterPlan<Object> filter = keyFilterOf(between(longKeyRef(), lower, upper));
 
         assertNotNull(filter);
         assertThat(filter.getExactKeys()).isNull();
@@ -690,7 +693,7 @@ class SavepointFilterTranslatorTest {
                 new FieldReferenceExpression("key", DataTypes.DOUBLE().notNull(), 0, KEY_COL);
         ValueLiteralExpression intLit = new ValueLiteralExpression(5, DataTypes.INT().notNull());
 
-        SavepointKeyFilter<Object> filter = keyFilterOf(eq(doubleKey, intLit));
+        SavepointKeyFilterPlan<Object> filter = keyFilterOf(eq(doubleKey, intLit));
 
         assertNotNull(filter);
         assertThat(filter.getExactKeys()).containsExactly(5.0d);
@@ -718,7 +721,7 @@ class SavepointFilterTranslatorTest {
                 new ValueLiteralExpression(
                         new BigDecimal("5.00"), DataTypes.DECIMAL(10, 2).notNull());
 
-        SavepointKeyFilter<Object> filter = keyFilterOf(eq(decKey, lit));
+        SavepointKeyFilterPlan<Object> filter = keyFilterOf(eq(decKey, lit));
 
         assertNotNull(filter);
         // Literal scale is preserved, so exact matching is scale sensitive: 5.00 matches, 5.0 not.
@@ -731,7 +734,7 @@ class SavepointFilterTranslatorTest {
     //  Expression helpers
     // -------------------------------------------------------------------------
 
-    private static SavepointKeyFilter<Object> keyFilterOf(ResolvedExpression expr) {
+    private static SavepointKeyFilterPlan<Object> keyFilterOf(ResolvedExpression expr) {
         DataType keyType = findKeyType(expr);
         return apply(Collections.singletonList(expr), keyType).keyFilter();
     }


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

This pull request hides predicate pushdown Table API-only internals and improves filter pushdown logic in the `savepoint` Table API connector by supporting more predicates:

- exclusion (WHERE k <> 5 / k NOT IN (3, 7) / k NOT BETWEEN 10 AND 20)
- union of exact and range (k = 1 OR k > 5)

Currently filters live in the package `org.apache.flink.state.api.filter`. Users of DataStream API can import `SavepointKeyFilter` and create a new filter with `SavepointKeyFilter.exact()`, `SavepointKeyFilter.range()`, or implement their own filter. `savepoint` connector in the Table API also uses these filters to prune input splits and / or optimize state reading by excluding reading state for the keys the user didn't request.

Inside `SavepointKeyFilter`, only `.test()` and `.getExactKeys()` methods are used during the execution phase of the job. The rest of the methods, such as `getLowerBound()`, `getUpperBound()` and `intersect()` are only used during the planning phase.

In the future, more planning-stage-only methods will be added to this interface. It is a better design if we only leave user-facing methods inside this interface (`.test()` and `.getExactKeys()`), since those are the only ones needed for the runtime.

## Brief change log

- Methods related to key filter pruning are moved to the interface `SavepointKeyFilterPlan implements SavepointKeyFilter` inside the new package `org.apache.flink.state.table.filter`, which is used only by the Table API. It contains all the methods needed for filter resolution: `intersect()`, `getLowerBound()`, `getUpperBound()`. When we want to support more filters, we will add methods to `SavepointKeyFilterPlan` instead of the user-facing `SavepointKeyFilter`.
- `SavepointKeyFilter` becomes simple, no need to explain in the docs that some methods are only used internally by the table api
- Remove `SavepointKeyFilter.empty()`, since it will no longer make sense
- filters `ExactKeyFilter` and `RangeKeyFilter` become common predefined filters to be used with the DataStream API, Table API no longer depends on them
- `RangeKeyFilter` no longer needs `getUpperBound` and `getLowerBound`, so `BoundInfo` class becomes internal to the Table API.

## Verifying this change

This change is coveted by existing and new tests: TODO

<!--

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Added test that validates that TaskInfo is transferred only once across recoveries*
  - *Manually verified the change by running a 4 node cluster with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*
-->

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? docs / JavaDoc

---

##### Was generative AI tooling used to co-author this PR

- [ X] Yes (please specify the tool below)

Generated-by: Claude
