### PR TITLE
[FLINK-40118][runtime-web] Use REST endpoint field instead of removed host field

### DIFF
--- a/flink-runtime-web/web-dashboard/src/app/interfaces/job-accumulators.ts
+++ b/flink-runtime-web/web-dashboard/src/app/interfaces/job-accumulators.ts
@@ -32,6 +32,6 @@ export interface SubTaskAccumulators {
   type: string;
   value: string;
   subtask: number;
-  host: string;
+  endpoint: string;
   attempt: number;
 }

--- a/flink-runtime-web/web-dashboard/src/app/interfaces/job-timeline.ts
+++ b/flink-runtime-web/web-dashboard/src/app/interfaces/job-timeline.ts
@@ -22,7 +22,7 @@ export interface JobSubTaskTime {
   now: number;
   subtasks: Array<{
     subtask: number;
-    host: string;
+    endpoint: string;
     duration: number;
     timestamps: {
       CREATED: number;

--- a/flink-runtime-web/web-dashboard/src/app/pages/job/overview/accumulators/job-overview-drawer-accumulators.component.html
+++ b/flink-runtime-web/web-dashboard/src/app/pages/job/overview/accumulators/job-overview-drawer-accumulators.component.html
@@ -76,7 +76,7 @@
           <ng-container *ngIf="narrowSubTaskAccumulators(data) as subTaskAccumulator">
             <tr>
               <td nzLeft>
-                ({{ subTaskAccumulator['subtask'] }}) {{ subTaskAccumulator.host }}, attempt:
+                ({{ subTaskAccumulator['subtask'] }}) {{ subTaskAccumulator.endpoint }}, attempt:
                 {{ subTaskAccumulator.attempt + 1 }}
               </td>
               <td>{{ subTaskAccumulator.name }}</td>

--- a/flink-runtime-web/web-dashboard/src/app/pages/job/timeline/job-timeline.component.ts
+++ b/flink-runtime-web/web-dashboard/src/app/pages/job/timeline/job-timeline.component.ts
@@ -132,13 +132,13 @@ export class JobTimelineComponent implements AfterViewInit, OnDestroy {
           listOfTimeLine.forEach((item, index) => {
             if (index === listOfTimeLine.length - 1) {
               this.listOfSubTaskTimeLine.push({
-                name: `${task.subtask} - ${task.host}`,
+                name: `${task.subtask} - ${task.endpoint}`,
                 status: item.status,
                 range: [item.startTime, task.duration + listOfTimeLine[0].startTime]
               });
             } else {
               this.listOfSubTaskTimeLine.push({
-                name: `${task.subtask} - ${task.host}`,
+                name: `${task.subtask} - ${task.endpoint}`,
                 status: item.status,
                 range: [item.startTime, listOfTimeLine[index + 1].startTime]
               });


### PR DESCRIPTION
## What is the purpose of the change

The job Timeline tab's SubTask view and the SubTask Accumulators table both render `N - undefined` instead of the TaskManager location for each subtask.

## Brief change log

- FLINK-36355 removed the deprecated `host` field from the REST API's subtask-level responses (`SubtasksTimesInfo`, `SubtaskExecutionAttemptDetailsInfo`, `SubtasksAllAccumulatorsInfo`), keeping only `endpoint`. That PR (apache/flink#25436) touched only backend Java classes; the web-dashboard frontend was never updated to match, so `task.host` has read `undefined` since Flink 2.0.
- Update `JobSubTaskTime` (`job-timeline.ts`) and `SubTaskAccumulators` (`job-accumulators.ts`) to declare `endpoint` instead of `host`.
- Update the two consumers — `job-timeline.component.ts` (SubTask TimeLine chart labels) and `job-overview-drawer-accumulators.component.html` (SubTask Accumulators table) — to read `task.endpoint` / `subTaskAccumulator.endpoint`.

## Verifying this change

- `npm run lint` and `npm run build` pass.
- Verified against a real running JobManager (local standalone cluster + StateMachineExample): before the fix, the Timeline tab's SubTask view showed `0 - undefined`; after the fix, it shows `0 - localhost:<port>`.

Before:
<img width="2870" height="1062" alt="image" src="https://github.com/user-attachments/assets/d5e8471f-55cd-4148-a700-b2c9fc80204b" />
After: 
<img width="1435" height="457" alt="image" src="https://github.com/user-attachments/assets/85ca56e1-be40-43e1-b88a-1d039d5750a5" />

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no (bug fix)
  - If yes, how is the feature documented? not applicable

## AI Usage Disclosure

- [x] Claude Code