### PR TITLE
[FLINK-40124][ci] Do not store cache on every run if no dependency changed

### DIFF
--- a/.github/actions/job_init/action.yml
+++ b/.github/actions/job_init/action.yml
@@ -38,6 +38,13 @@ inputs:
     description: "Runs tools/azure-pipelines/free_disk_space.sh to remove unneeded pre-installed software from the runner (only works for jobs that run directly on the host, not in a container)."
     required: false
     default: "false"
+outputs:
+  maven-cache-hit:
+    description: "Whether the Maven package cache was restored via an exact key match. Callers should only save a new cache when this is not 'true'."
+    value: ${{ steps.maven-cache-restore.outputs.cache-hit }}
+  maven-cache-key:
+    description: "The cache key computed for the Maven package cache, for use by a caller's own explicit save step (placed after Maven has actually run)."
+    value: ${{ steps.maven-cache-key.outputs.key }}
 runs:
   using: "composite"
   steps:
@@ -105,14 +112,20 @@ runs:
         echo "namespace=${ns}" >> "${GITHUB_OUTPUT}"
         echo "Cache namespace: ${ns}"
 
-    - name: "Setup Maven package cache"
+    - name: "Compute Maven package cache key"
       if: ${{ inputs.maven_repo_folder != '' }}
-      uses: actions/cache@v5
+      id: maven-cache-key
+      shell: bash
+      run: echo "key=${{ runner.os }}-ns-${{ steps.cache-ns.outputs.namespace }}-maven-${{ hashFiles('**/pom.xml') }}" >> "${GITHUB_OUTPUT}"
+
+    - name: "Restore Maven package cache"
+      if: ${{ inputs.maven_repo_folder != '' }}
+      id: maven-cache-restore
+      uses: actions/cache/restore@v6
       with:
         path: ${{ inputs.maven_repo_folder }}
-        key: ${{ runner.os }}-ns-${{ steps.cache-ns.outputs.namespace }}-maven-${{ hashFiles('**/pom.xml') }}-${{ github.run_id }}
+        key: ${{ steps.maven-cache-key.outputs.key }}
         restore-keys: |
-          ${{ runner.os }}-ns-${{ steps.cache-ns.outputs.namespace }}-maven-${{ hashFiles('**/pom.xml') }}-
           ${{ runner.os }}-ns-${{ steps.cache-ns.outputs.namespace }}-maven-
           ${{ runner.os }}-maven-
 

--- a/.github/workflows/template.flink-ci.yml
+++ b/.github/workflows/template.flink-ci.yml
@@ -88,6 +88,7 @@ jobs:
           persist-credentials: false
 
       - name: "Initialize job"
+        id: job-init
         uses: "./.github/actions/job_init"
         with:
           jdk_version: ${{ inputs.jdk_version }}
@@ -123,6 +124,15 @@ jobs:
           # use minimum here because we only need these artifacts to speed up the build
           retention-days: 1
 
+      # Only saves when the restore in job_init wasn't an exact hit, i.e. pom.xml actually
+      # changed since the last save for this namespace - avoids re-uploading an unchanged cache.
+      - name: "Save Maven package cache"
+        if: ${{ !cancelled() && steps.job-init.outputs.maven-cache-hit != 'true' }}
+        uses: actions/cache/save@v6
+        with:
+          path: ${{ env.MAVEN_REPO_FOLDER }}
+          key: ${{ steps.job-init.outputs.maven-cache-key }}
+
   packaging:
     name: "Test packaging/licensing"
     needs: compile
@@ -145,6 +155,7 @@ jobs:
             tools
 
       - name: "Initialize job"
+        id: job-init
         uses: "./.github/actions/job_init"
         with:
           jdk_version: ${{ inputs.jdk_version }}
@@ -167,6 +178,13 @@ jobs:
         working-directory: ${{ env.CONTAINER_LOCAL_WORKING_DIR }}
         run: |
           ${{ inputs.environment }} ./tools/ci/compile_ci.sh || exit $?
+
+      - name: "Save Maven package cache"
+        if: ${{ !cancelled() && steps.job-init.outputs.maven-cache-hit != 'true' }}
+        uses: actions/cache/save@v6
+        with:
+          path: ${{ env.MAVEN_REPO_FOLDER }}
+          key: ${{ steps.job-init.outputs.maven-cache-key }}
 
   test:
     name: "Test (module: ${{ matrix.module }})"
@@ -212,6 +230,7 @@ jobs:
             tools
 
       - name: "Initialize job"
+        id: job-init
         uses: "./.github/actions/job_init"
         with:
           jdk_version: ${{ inputs.jdk_version }}
@@ -315,6 +334,13 @@ jobs:
         if: ${{ !cancelled() && (failure() || steps.docker-cache.outputs.cache-hit != 'true') }}
         run: ./tools/azure-pipelines/cache_docker_images.sh save
 
+      - name: "Save Maven package cache"
+        if: ${{ !cancelled() && steps.job-init.outputs.maven-cache-hit != 'true' }}
+        uses: actions/cache/save@v6
+        with:
+          path: ${{ env.MAVEN_REPO_FOLDER }}
+          key: ${{ steps.job-init.outputs.maven-cache-key }}
+
   e2e:
     name: "E2E (group ${{ matrix.group }})"
     needs: compile
@@ -353,6 +379,7 @@ jobs:
             tools
 
       - name: "Initialize job"
+        id: job-init
         uses: "./.github/actions/job_init"
         with:
           jdk_version: ${{ inputs.jdk_version }}
@@ -446,3 +473,10 @@ jobs:
       - name: "Save Docker images to Cache"
         if: ${{ !cancelled() && (failure() || steps.docker-cache.outputs.cache-hit != 'true') }}
         run: ./tools/azure-pipelines/cache_docker_images.sh save
+
+      - name: "Save Maven package cache"
+        if: ${{ !cancelled() && steps.job-init.outputs.maven-cache-hit != 'true' }}
+        uses: actions/cache/save@v6
+        with:
+          path: ${{ env.MAVEN_REPO_FOLDER }}
+          key: ${{ steps.job-init.outputs.maven-cache-key }}


### PR DESCRIPTION


## What is the purpose of the change

The problem with current GHA is that it stores cache on every GHA job run even if the cache content was not changed (no dependency changed). The PR is going to fix this.
This can be observed by looking into logs (see into jira issue description for examples)

## Brief change log

GHA


## Verifying this change

GHA

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change the checkbox below to `[X]` followed by the name of the tool, and uncomment the
"Generated-by" line. See the ASF Generative Tooling Guidance for details:
https://www.apache.org/legal/generative-tooling.html

You are responsible for the quality and correctness of every change in this PR
regardless of the tooling used. Low-effort AI-generated PRs will be closed. See
AGENTS.md for the full guidance.
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name and Version]
-->
