### PR TITLE
[hotfix][runtime-web] Fix savepointPath query parameter in JarService.runJob()

### DIFF
--- a/flink-runtime-web/web-dashboard/src/app/services/jar.service.ts
+++ b/flink-runtime-web/web-dashboard/src/app/services/jar.service.ts
@@ -76,7 +76,7 @@ export class JarService {
       params = params.append('program-args', programArgs);
     }
     if (savepointPath) {
-      params = params.append('savepointPath', programArgs);
+      params = params.append('savepointPath', savepointPath);
     }
     if (allowNonRestoredState) {
       params = params.append('allowNonRestoredState', allowNonRestoredState);


### PR DESCRIPTION
## What is the purpose of the change

`JarService.runJob()` was appending the `programArgs` value under the `savepointPath` query parameter key instead of `savepointPath` itself. This has had no observable effect because the backend (`JarRunHandler`) always prefers the value already present in the POST body over the query parameter, but the query parameter itself was wrong and misleading.

## Brief change log

  - Fix `jar.service.ts` to append `savepointPath` (not `programArgs`) under the `savepointPath` query key in `runJob()`.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: Claude Code