### PR TITLE
[FLINK-38727][test][BP-2.2]: fix flaky EventTimeWindowCheckpointingITCase / LocalRecoveryITCase via REQUIREMENTS_CHECK_DELAY

### DIFF
--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/EventTimeWindowCheckpointingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/EventTimeWindowCheckpointingITCase.java
@@ -29,6 +29,7 @@ import org.apache.flink.configuration.CheckpointingOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.HighAvailabilityOptions;
 import org.apache.flink.configuration.MemorySize;
+import org.apache.flink.configuration.ResourceManagerOptions;
 import org.apache.flink.configuration.RpcOptions;
 import org.apache.flink.configuration.StateBackendOptions;
 import org.apache.flink.configuration.TaskManagerOptions;
@@ -269,6 +270,12 @@ public class EventTimeWindowCheckpointingITCase extends TestLogger {
 
         Configuration config = new Configuration();
         config.set(RpcOptions.FRAMESIZE, String.valueOf(MAX_MEM_STATE_SIZE) + "b");
+
+        // FLINK-38727: Increase requirement-check delay to reduce slot manager polling frequency
+        // under CI load, preventing premature NoResourceAvailableException while TaskManagers
+        // are registering. SLOT_REQUEST_TIMEOUT (5 min default) already serves as the startup
+        // grace period via getStandaloneClusterStartupPeriodTime() fallback.
+        config.set(ResourceManagerOptions.REQUIREMENTS_CHECK_DELAY, Duration.ofSeconds(30));
 
         if (zkServer != null) {
             config.set(HighAvailabilityOptions.HA_MODE, "ZOOKEEPER");


### PR DESCRIPTION
Backport of #27659 to `release-2.2`.

Sets `ResourceManagerOptions.REQUIREMENTS_CHECK_DELAY = 30s` for `EventTimeWindowCheckpointingITCase`'s test cluster to fix the flaky `LocalRecoveryITCase[ROCKSDB_FULL, ...]` failure on `release-2.2` 
