### PR TITLE
[FLINK-34423][ci] Make `tools/ci/compile_ci.sh` not necessarily rely on clean phase

### DIFF
--- a/.github/workflows/template.flink-ci.yml
+++ b/.github/workflows/template.flink-ci.yml
@@ -166,7 +166,7 @@ jobs:
       - name: "Test"
         working-directory: ${{ env.CONTAINER_LOCAL_WORKING_DIR }}
         run: |
-          ${{ inputs.environment }} ./tools/ci/compile_ci.sh || exit $?
+          ${{ inputs.environment }} ./tools/ci/compile_ci.sh -Dmaven.clean.skip=true || exit $?
 
   test:
     name: "Test (module: ${{ matrix.module }})"

--- a/tools/ci/compile_ci.sh
+++ b/tools/ci/compile_ci.sh
@@ -24,6 +24,6 @@
 CI_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
 source "${CI_DIR}/maven-utils.sh"
 
-MVN=run_mvn "${CI_DIR}/compile.sh"
+MVN=run_mvn "${CI_DIR}/compile.sh" "${@}"
 
 exit $?


### PR DESCRIPTION
## What is the purpose of the change

There is packaging/licensing job in GHA ci which does not need for clean phase
The PR is to skip this step in that job

## Brief change log

GHA

## Verifying this change

GHA
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change the checkbox below to `[X]` followed by the name of the tool, and uncomment the
"Generated-by" line. See the ASF Generative Tooling Guidance for details:
https://www.apache.org/legal/generative-tooling.html

You are responsible for the quality and correctness of every change in this PR
regardless of the tooling used. Low-effort AI-generated PRs will be closed. See
AGENTS.md for the full guidance.
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name and Version]
-->
