### PR TITLE
[FLINK-31931] Return 404 for a gone TaskManager and stop the Web UI from re-polling it

### DIFF
--- a/flink-runtime-web/web-dashboard/src/app/app.interceptor.spec.ts
+++ b/flink-runtime-web/web-dashboard/src/app/app.interceptor.spec.ts
@@ -16,10 +16,17 @@
  * limitations under the License.
  */
 
-import { HttpErrorResponse, HttpHandler, HttpHeaders, HttpRequest, HttpResponse } from '@angular/common/http';
+import {
+  HttpContext,
+  HttpErrorResponse,
+  HttpHandler,
+  HttpHeaders,
+  HttpRequest,
+  HttpResponse
+} from '@angular/common/http';
 import { of, Subject, throwError } from 'rxjs';
 
-import { StatusService } from '@flink-runtime-web/services';
+import { EXPECTED_NOT_FOUND, StatusService } from '@flink-runtime-web/services';
 import { NzNotificationService } from 'ng-zorro-antd/notification';
 import { type Mock, afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -159,6 +166,56 @@ describe('AppInterceptor', () => {
 
     expect(statusService.listOfErrorMessage).toEqual([]);
     expect(notificationService.info).not.toHaveBeenCalled();
+  });
+
+  it('surfaces a 404 with an error body by default', () => {
+    const error = new HttpErrorResponse({
+      status: 404,
+      url: '/taskmanagers/tm-1',
+      error: { errors: ['RestHandlerException: Could not find TaskExecutor tm-1.'] }
+    });
+    handle.mockReturnValue(throwError(() => error));
+
+    interceptor.intercept(new HttpRequest('GET', '/taskmanagers/tm-1'), handler).subscribe({ error: () => {} });
+
+    expect(statusService.listOfErrorMessage).toHaveLength(1);
+    expect(notificationService.info).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not surface an expected 404 but still re-throws it to the caller', () => {
+    const error = new HttpErrorResponse({
+      status: 404,
+      url: '/taskmanagers/tm-1',
+      error: { errors: ['RestHandlerException: Could not find TaskExecutor tm-1.'] }
+    });
+    handle.mockReturnValue(throwError(() => error));
+    const request = new HttpRequest('GET', '/taskmanagers/tm-1', {
+      context: new HttpContext().set(EXPECTED_NOT_FOUND, true)
+    });
+
+    let caught: unknown;
+    interceptor.intercept(request, handler).subscribe({ error: err => (caught = err) });
+
+    expect(caught).toBe(error);
+    expect(statusService.listOfErrorMessage).toEqual([]);
+    expect(notificationService.info).not.toHaveBeenCalled();
+  });
+
+  it('still surfaces other errors on a request that expects a 404', () => {
+    const error = new HttpErrorResponse({
+      status: 500,
+      url: '/taskmanagers/tm-1',
+      error: { errors: ['Internal server error.'] }
+    });
+    handle.mockReturnValue(throwError(() => error));
+    const request = new HttpRequest('GET', '/taskmanagers/tm-1', {
+      context: new HttpContext().set(EXPECTED_NOT_FOUND, true)
+    });
+
+    interceptor.intercept(request, handler).subscribe({ error: () => {} });
+
+    expect(statusService.listOfErrorMessage).toEqual(['Internal server error.']);
+    expect(notificationService.info).toHaveBeenCalledTimes(1);
   });
 
   it.each([0, 500, 503])(

--- a/flink-runtime-web/web-dashboard/src/app/app.interceptor.ts
+++ b/flink-runtime-web/web-dashboard/src/app/app.interceptor.ts
@@ -29,7 +29,7 @@ import { Injectable } from '@angular/core';
 import { Observable, throwError } from 'rxjs';
 import { catchError, tap } from 'rxjs/operators';
 
-import { StatusService } from '@flink-runtime-web/services';
+import { EXPECTED_NOT_FOUND, StatusService } from '@flink-runtime-web/services';
 import { NzNotificationService, NzNotificationDataOptions } from 'ng-zorro-antd/notification';
 
 @Injectable()
@@ -71,8 +71,10 @@ export class AppInterceptor implements HttpInterceptor {
         }
 
         const errorMessage = res && res.error && res.error.errors && res.error.errors[0];
+        const expectedNotFound = res.status === HttpStatusCode.NotFound && req.context.get(EXPECTED_NOT_FOUND);
         if (
           errorMessage &&
+          !expectedNotFound &&
           ignoreErrorUrlEndsList.every(url => !res.url.endsWith(url)) &&
           ignoreErrorMessage.every(message => errorMessage !== message)
         ) {

--- a/flink-runtime-web/web-dashboard/src/app/pages/task-manager/metrics/task-manager-metrics.component.html
+++ b/flink-runtime-web/web-dashboard/src/app/pages/task-manager/metrics/task-manager-metrics.component.html
@@ -16,7 +16,7 @@
   ~ limitations under the License.
   -->
 
-<nz-card nzTitle="Memory" nzSize="small" class="flink-memory-model">
+<nz-card *ngIf="taskManagerDetail" nzTitle="Memory" nzSize="small" class="flink-memory-model">
   <nz-table
     nzBordered
     *ngIf="metrics"
@@ -164,7 +164,7 @@
     </tbody>
   </nz-table>
 </nz-card>
-<nz-card nzTitle="Advanced" nzSize="small" class="flink-memory-model">
+<nz-card *ngIf="taskManagerDetail" nzTitle="Advanced" nzSize="small" class="flink-memory-model">
   <div nz-row [nzGutter]="16">
     <div nz-col [nzSpan]="12">
       <nz-table
@@ -318,7 +318,7 @@
   </tr>
 </ng-template>
 
-<nz-card nzTitle="Resources" nzSize="small" class="flink-memory-model">
+<nz-card *ngIf="taskManagerDetail" nzTitle="Resources" nzSize="small" class="flink-memory-model">
   <nz-table
     nzBordered
     nzTitle="Unassigned resources"

--- a/flink-runtime-web/web-dashboard/src/app/pages/task-manager/metrics/task-manager-metrics.component.spec.ts
+++ b/flink-runtime-web/web-dashboard/src/app/pages/task-manager/metrics/task-manager-metrics.component.spec.ts
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { HttpErrorResponse } from '@angular/common/http';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ActivatedRoute } from '@angular/router';
+import { of, throwError } from 'rxjs';
+
+import { TaskManagerDetail } from '@flink-runtime-web/interfaces';
+import { StatusService, TaskManagerService } from '@flink-runtime-web/services';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { TaskManagerMetricsComponent } from './task-manager-metrics.component';
+
+const mockDetail = { id: 'tm-container-7' } as unknown as TaskManagerDetail;
+
+describe('TaskManagerMetricsComponent', () => {
+  let fixture: ComponentFixture<TaskManagerMetricsComponent>;
+  let element: HTMLElement;
+  const loadManager = vi.fn();
+  const loadMetrics = vi.fn();
+
+  beforeEach(async () => {
+    loadManager.mockReset().mockReturnValue(of(mockDetail));
+    loadMetrics.mockReset().mockReturnValue(of({ 'Status.JVM.Memory.Heap.Used': 1, 'Status.JVM.Memory.Heap.Max': 2 }));
+    await TestBed.configureTestingModule({
+      imports: [TaskManagerMetricsComponent],
+      providers: [
+        { provide: StatusService, useValue: { refresh$: of(true) } },
+        { provide: TaskManagerService, useValue: { loadManager, loadMetrics } },
+        { provide: ActivatedRoute, useValue: { parent: { snapshot: { params: { taskManagerId: 'tm-container-7' } } } } }
+      ]
+    }).compileComponents();
+    fixture = TestBed.createComponent(TaskManagerMetricsComponent);
+    element = fixture.nativeElement as HTMLElement;
+  });
+
+  it('loads the metrics when the TaskManager is available', () => {
+    // Drive the load path without a full DOM render: the metric cards bind
+    // taskManagerDetail.metrics.*, so rendering needs a complete metrics fixture
+    // (the production build covers that). Here we assert the wiring.
+    fixture.componentInstance.ngOnInit();
+
+    expect(fixture.componentInstance.taskManagerDetail).toBe(mockDetail);
+    expect(loadMetrics).toHaveBeenCalled();
+  });
+
+  it('hides the metric cards (no NaN) when the TaskManager is gone (404)', () => {
+    loadManager.mockReturnValue(throwError(() => new HttpErrorResponse({ status: 404 })));
+
+    fixture.detectChanges();
+
+    expect(fixture.componentInstance.taskManagerDetail).toBeUndefined();
+    expect(element.textContent).not.toContain('Flink Memory Model');
+    expect(element.textContent).not.toContain('Advanced');
+    expect(element.textContent).not.toContain('NaN');
+    expect(loadMetrics).not.toHaveBeenCalled();
+  });
+});

--- a/flink-runtime-web/web-dashboard/src/app/pages/task-manager/metrics/task-manager-metrics.component.spec.ts
+++ b/flink-runtime-web/web-dashboard/src/app/pages/task-manager/metrics/task-manager-metrics.component.spec.ts
@@ -16,6 +16,7 @@
  * limitations under the License.
  */
 
+import { HttpErrorResponse } from '@angular/common/http';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ActivatedRoute } from '@angular/router';
 import { of, throwError } from 'rxjs';
@@ -113,5 +114,18 @@ describe('TaskManagerMetricsComponent', () => {
 
     expect(fixture.componentInstance.taskManagerDetail).toBeUndefined();
     expect(loadMetrics).not.toHaveBeenCalled();
+  });
+
+  it('hides the metric cards (no NaN) when the TaskManager is gone (404)', () => {
+    loadManager.mockReturnValue(throwError(() => new HttpErrorResponse({ status: 404 })));
+
+    fixture.detectChanges();
+
+    expect(fixture.componentInstance.taskManagerDetail).toBeUndefined();
+    expect(loadMetrics).not.toHaveBeenCalled();
+    const text = element.textContent ?? '';
+    expect(text).not.toContain('Flink Memory Model');
+    expect(text).not.toContain('Advanced');
+    expect(text).not.toContain('NaN');
   });
 });

--- a/flink-runtime-web/web-dashboard/src/app/pages/task-manager/metrics/task-manager-metrics.component.ts
+++ b/flink-runtime-web/web-dashboard/src/app/pages/task-manager/metrics/task-manager-metrics.component.ts
@@ -20,7 +20,7 @@ import { DecimalPipe, NgForOf, NgIf, NgTemplateOutlet } from '@angular/common';
 import { ChangeDetectionStrategy, ChangeDetectorRef, Component, OnDestroy, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { of, Subject } from 'rxjs';
-import { catchError, mergeMap, startWith, takeUntil } from 'rxjs/operators';
+import { catchError, takeUntil } from 'rxjs/operators';
 
 import { HumanizeBytesPipe } from '@flink-runtime-web/components/humanize-bytes.pipe';
 import { MetricMap, TaskManagerDetail } from '@flink-runtime-web/interfaces';
@@ -31,6 +31,8 @@ import { NzIconModule } from 'ng-zorro-antd/icon';
 import { NzProgressModule } from 'ng-zorro-antd/progress';
 import { NzTableModule } from 'ng-zorro-antd/table';
 import { NzTooltipModule } from 'ng-zorro-antd/tooltip';
+
+import { pollTaskManagerDetail } from '../task-manager-detail-poll';
 
 @Component({
   selector: 'flink-task-manager-metrics',
@@ -66,17 +68,13 @@ export class TaskManagerMetricsComponent implements OnInit, OnDestroy {
 
   public ngOnInit(): void {
     const taskManagerId = this.activatedRoute.parent!.snapshot.params.taskManagerId;
-    this.statusService.refresh$
-      .pipe(
-        startWith(true),
-        mergeMap(() => this.taskManagerService.loadManager(taskManagerId).pipe(catchError(() => of(undefined)))),
-        takeUntil(this.destroy$)
-      )
-      .subscribe(data => {
-        if (data) {
-          this.reload(data.id);
+    pollTaskManagerDetail(this.statusService.refresh$, () => this.taskManagerService.loadManager(taskManagerId))
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(({ detail }) => {
+        if (detail) {
+          this.reload(detail.id);
         }
-        this.taskManagerDetail = data;
+        this.taskManagerDetail = detail;
         this.cdr.markForCheck();
       });
   }

--- a/flink-runtime-web/web-dashboard/src/app/pages/task-manager/status/task-manager-status.component.html
+++ b/flink-runtime-web/web-dashboard/src/app/pages/task-manager/status/task-manager-status.component.html
@@ -17,40 +17,49 @@
   -->
 
 <ng-container *ngIf="!loading; else loadingContent">
-  <div class="title-wrapper" [attr.title]="taskManagerDetail?.id">
-    <span class="title">{{ taskManagerDetail?.id }}</span>
-    <flink-blocked-badge *ngIf="taskManagerDetail?.blocked"></flink-blocked-badge>
-  </div>
-  <nz-descriptions *ngIf="taskManagerDetail" nzBordered nzSize="small">
-    <nz-descriptions-item [nzSpan]="1" nzTitle="Path">
-      {{ taskManagerDetail.path }}
-    </nz-descriptions-item>
-    <nz-descriptions-item [nzSpan]="1" nzTitle="Free/All Slots">
-      {{ taskManagerDetail.freeSlots }} / {{ taskManagerDetail.slotsNumber }}
-    </nz-descriptions-item>
-    <nz-descriptions-item [nzSpan]="1" nzTitle="Assigned Tasks">
-      {{ taskManagerDetail.assignedTasks }}
-    </nz-descriptions-item>
-    <nz-descriptions-item [nzSpan]="1" nzTitle="Last Heartbeat">
-      {{ taskManagerDetail.timeSinceLastHeartbeat | date: 'yyyy-MM-dd HH:mm:ss' }}
-    </nz-descriptions-item>
-    <nz-descriptions-item [nzSpan]="1" nzTitle="Data Port">
-      {{ taskManagerDetail.dataPort }}
-    </nz-descriptions-item>
-    <nz-descriptions-item [nzSpan]="1" nzTitle="CPU Cores">
-      {{ taskManagerDetail.hardware.cpuCores }}
-    </nz-descriptions-item>
-    <nz-descriptions-item [nzSpan]="1" nzTitle="Physical Memory">
-      {{ taskManagerDetail.hardware.physicalMemory | humanizeBytes }}
-    </nz-descriptions-item>
-    <nz-descriptions-item [nzSpan]="1" nzTitle="JVM Heap Size">
-      {{ taskManagerDetail.hardware.freeMemory | humanizeBytes }}
-    </nz-descriptions-item>
-    <nz-descriptions-item [nzSpan]="1" nzTitle="Flink Managed Memory">
-      {{ taskManagerDetail.hardware.managedMemory | humanizeBytes }}
-    </nz-descriptions-item>
-  </nz-descriptions>
-  <flink-navigation [listOfNavigation]="listOfNavigation"></flink-navigation>
+  <nz-alert
+    *ngIf="notFound; else detailContent"
+    nzType="warning"
+    nzShowIcon
+    nzMessage="TaskManager not available"
+    nzDescription="This TaskManager is no longer registered. It may have been shut down or lost."
+  ></nz-alert>
+  <ng-template #detailContent>
+    <div class="title-wrapper" [attr.title]="taskManagerDetail?.id">
+      <span class="title">{{ taskManagerDetail?.id }}</span>
+      <flink-blocked-badge *ngIf="taskManagerDetail?.blocked"></flink-blocked-badge>
+    </div>
+    <nz-descriptions *ngIf="taskManagerDetail" nzBordered nzSize="small">
+      <nz-descriptions-item [nzSpan]="1" nzTitle="Path">
+        {{ taskManagerDetail.path }}
+      </nz-descriptions-item>
+      <nz-descriptions-item [nzSpan]="1" nzTitle="Free/All Slots">
+        {{ taskManagerDetail.freeSlots }} / {{ taskManagerDetail.slotsNumber }}
+      </nz-descriptions-item>
+      <nz-descriptions-item [nzSpan]="1" nzTitle="Assigned Tasks">
+        {{ taskManagerDetail.assignedTasks }}
+      </nz-descriptions-item>
+      <nz-descriptions-item [nzSpan]="1" nzTitle="Last Heartbeat">
+        {{ taskManagerDetail.timeSinceLastHeartbeat | date: 'yyyy-MM-dd HH:mm:ss' }}
+      </nz-descriptions-item>
+      <nz-descriptions-item [nzSpan]="1" nzTitle="Data Port">
+        {{ taskManagerDetail.dataPort }}
+      </nz-descriptions-item>
+      <nz-descriptions-item [nzSpan]="1" nzTitle="CPU Cores">
+        {{ taskManagerDetail.hardware.cpuCores }}
+      </nz-descriptions-item>
+      <nz-descriptions-item [nzSpan]="1" nzTitle="Physical Memory">
+        {{ taskManagerDetail.hardware.physicalMemory | humanizeBytes }}
+      </nz-descriptions-item>
+      <nz-descriptions-item [nzSpan]="1" nzTitle="JVM Heap Size">
+        {{ taskManagerDetail.hardware.freeMemory | humanizeBytes }}
+      </nz-descriptions-item>
+      <nz-descriptions-item [nzSpan]="1" nzTitle="Flink Managed Memory">
+        {{ taskManagerDetail.hardware.managedMemory | humanizeBytes }}
+      </nz-descriptions-item>
+    </nz-descriptions>
+    <flink-navigation [listOfNavigation]="listOfNavigation"></flink-navigation>
+  </ng-template>
 </ng-container>
 
 <ng-template #loadingContent>

--- a/flink-runtime-web/web-dashboard/src/app/pages/task-manager/status/task-manager-status.component.spec.ts
+++ b/flink-runtime-web/web-dashboard/src/app/pages/task-manager/status/task-manager-status.component.spec.ts
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { HttpErrorResponse } from '@angular/common/http';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ActivatedRoute } from '@angular/router';
+import { of, throwError } from 'rxjs';
+
+import { TaskManagerDetail } from '@flink-runtime-web/interfaces';
+import { StatusService, TaskManagerService } from '@flink-runtime-web/services';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { TaskManagerStatusComponent } from './task-manager-status.component';
+
+const mockDetail = {
+  id: 'tm-container-7',
+  path: 'pekko.tcp://flink@10.0.0.7:6122/user/rpc/taskmanager',
+  dataPort: 43210,
+  timeSinceLastHeartbeat: 1_781_000_000_000,
+  slotsNumber: 4,
+  freeSlots: 2,
+  assignedTasks: 2,
+  hardware: { cpuCores: 8, physicalMemory: 16_000_000_000, freeMemory: 8_000_000_000, managedMemory: 4_000_000_000 },
+  blocked: false
+} as unknown as TaskManagerDetail;
+
+describe('TaskManagerStatusComponent', () => {
+  let fixture: ComponentFixture<TaskManagerStatusComponent>;
+  let element: HTMLElement;
+  const loadManager = vi.fn();
+
+  beforeEach(async () => {
+    loadManager.mockReset().mockReturnValue(of(mockDetail));
+    await TestBed.configureTestingModule({
+      imports: [TaskManagerStatusComponent],
+      providers: [
+        { provide: StatusService, useValue: { refresh$: of(true) } },
+        { provide: TaskManagerService, useValue: { loadManager } },
+        { provide: ActivatedRoute, useValue: { snapshot: { params: { taskManagerId: 'tm-container-7' } } } }
+      ]
+    }).compileComponents();
+    fixture = TestBed.createComponent(TaskManagerStatusComponent);
+    element = fixture.nativeElement as HTMLElement;
+  });
+
+  it('renders the TaskManager detail when it is available', () => {
+    fixture.detectChanges();
+
+    expect(fixture.componentInstance.notFound).toBe(false);
+    expect(element.textContent).toContain('tm-container-7');
+    expect(element.textContent).toContain('43210');
+    expect(element.textContent).not.toContain('no longer registered');
+  });
+
+  it('shows a not-available notice when the TaskManager is gone (404)', () => {
+    loadManager.mockReturnValue(throwError(() => new HttpErrorResponse({ status: 404 })));
+
+    fixture.detectChanges();
+
+    expect(fixture.componentInstance.notFound).toBe(true);
+    expect(fixture.componentInstance.taskManagerDetail).toBeUndefined();
+    expect(element.textContent).toContain('TaskManager not available');
+  });
+});

--- a/flink-runtime-web/web-dashboard/src/app/pages/task-manager/status/task-manager-status.component.ts
+++ b/flink-runtime-web/web-dashboard/src/app/pages/task-manager/status/task-manager-status.component.ts
@@ -19,16 +19,19 @@
 import { DatePipe, NgIf } from '@angular/common';
 import { ChangeDetectionStrategy, ChangeDetectorRef, Component, OnDestroy, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
-import { of, Subject } from 'rxjs';
-import { catchError, mergeMap, takeUntil } from 'rxjs/operators';
+import { Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
 
 import { BlockedBadgeComponent } from '@flink-runtime-web/components/blocked-badge/blocked-badge.component';
 import { HumanizeBytesPipe } from '@flink-runtime-web/components/humanize-bytes.pipe';
 import { NavigationComponent } from '@flink-runtime-web/components/navigation/navigation.component';
 import { TaskManagerDetail } from '@flink-runtime-web/interfaces';
 import { StatusService, TaskManagerService } from '@flink-runtime-web/services';
+import { NzAlertModule } from 'ng-zorro-antd/alert';
 import { NzDescriptionsModule } from 'ng-zorro-antd/descriptions';
 import { NzSkeletonModule } from 'ng-zorro-antd/skeleton';
+
+import { pollTaskManagerDetail } from '../task-manager-detail-poll';
 
 @Component({
   selector: 'flink-task-manager-status',
@@ -38,6 +41,7 @@ import { NzSkeletonModule } from 'ng-zorro-antd/skeleton';
   imports: [
     NgIf,
     BlockedBadgeComponent,
+    NzAlertModule,
     NzDescriptionsModule,
     DatePipe,
     HumanizeBytesPipe,
@@ -56,6 +60,7 @@ export class TaskManagerStatusComponent implements OnInit, OnDestroy {
   ];
   public taskManagerDetail?: TaskManagerDetail;
   public loading = true;
+  public notFound = false;
 
   private readonly destroy$ = new Subject<void>();
 
@@ -67,17 +72,13 @@ export class TaskManagerStatusComponent implements OnInit, OnDestroy {
   ) {}
 
   public ngOnInit(): void {
-    this.statusService.refresh$
-      .pipe(
-        mergeMap(() =>
-          this.taskManagerService
-            .loadManager(this.activatedRoute.snapshot.params.taskManagerId)
-            .pipe(catchError(() => of(undefined)))
-        ),
-        takeUntil(this.destroy$)
-      )
-      .subscribe(data => {
-        this.taskManagerDetail = data;
+    pollTaskManagerDetail(this.statusService.refresh$, () =>
+      this.taskManagerService.loadManager(this.activatedRoute.snapshot.params.taskManagerId)
+    )
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(({ detail, notFound }) => {
+        this.taskManagerDetail = detail;
+        this.notFound = notFound;
         this.loading = false;
         this.cdr.markForCheck();
       });

--- a/flink-runtime-web/web-dashboard/src/app/pages/task-manager/task-manager-detail-poll.spec.ts
+++ b/flink-runtime-web/web-dashboard/src/app/pages/task-manager/task-manager-detail-poll.spec.ts
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { HttpErrorResponse } from '@angular/common/http';
+import { Subject, of, throwError } from 'rxjs';
+
+import { TaskManagerDetail } from '@flink-runtime-web/interfaces';
+import { describe, expect, it, vi } from 'vitest';
+
+import { pollTaskManagerDetail, TaskManagerDetailResult } from './task-manager-detail-poll';
+
+const detail = { id: 'tm-1' } as unknown as TaskManagerDetail;
+
+describe('pollTaskManagerDetail', () => {
+  it('emits the detail on every successful tick', () => {
+    const tick$ = new Subject<void>();
+    const results: TaskManagerDetailResult[] = [];
+    pollTaskManagerDetail(tick$, () => of(detail)).subscribe(result => results.push(result));
+
+    tick$.next();
+    tick$.next();
+
+    expect(results).toEqual([
+      { detail, notFound: false },
+      { detail, notFound: false }
+    ]);
+  });
+
+  it('reports notFound and stops polling once the TaskManager is gone (404)', () => {
+    const tick$ = new Subject<void>();
+    const load = vi.fn(() => throwError(() => new HttpErrorResponse({ status: 404 })));
+    const results: TaskManagerDetailResult[] = [];
+    let completed = false;
+    pollTaskManagerDetail(tick$, load).subscribe({
+      next: result => results.push(result),
+      complete: () => (completed = true)
+    });
+
+    tick$.next();
+    tick$.next();
+
+    expect(results).toEqual([{ detail: undefined, notFound: true }]);
+    expect(load).toHaveBeenCalledTimes(1);
+    expect(completed).toBe(true);
+  });
+
+  it('ignores a transient (non-404) error and keeps polling', () => {
+    const tick$ = new Subject<void>();
+    const load = vi
+      .fn()
+      .mockReturnValueOnce(throwError(() => new HttpErrorResponse({ status: 503 })))
+      .mockReturnValueOnce(of(detail));
+    const results: TaskManagerDetailResult[] = [];
+    pollTaskManagerDetail(tick$, load).subscribe(result => results.push(result));
+
+    tick$.next();
+    tick$.next();
+
+    expect(results).toEqual([{ detail, notFound: false }]);
+    expect(load).toHaveBeenCalledTimes(2);
+  });
+});

--- a/flink-runtime-web/web-dashboard/src/app/pages/task-manager/task-manager-detail-poll.ts
+++ b/flink-runtime-web/web-dashboard/src/app/pages/task-manager/task-manager-detail-poll.ts
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { HttpErrorResponse } from '@angular/common/http';
+import { defer, EMPTY, Observable, of } from 'rxjs';
+import { catchError, map, switchMap, takeWhile } from 'rxjs/operators';
+
+import { TaskManagerDetail } from '@flink-runtime-web/interfaces';
+
+/** Outcome of polling a single TaskManager's detail. */
+export interface TaskManagerDetailResult {
+  detail?: TaskManagerDetail;
+  notFound: boolean;
+}
+
+/**
+ * Loads a single TaskManager's detail on every tick, stopping for good once the backend reports
+ * the TaskManager is gone (404). A gone TaskManager never comes back (its id is unique per
+ * registration), so re-polling it is futile; transient errors are ignored and keep polling.
+ */
+export function pollTaskManagerDetail(
+  tick$: Observable<unknown>,
+  load: () => Observable<TaskManagerDetail>
+): Observable<TaskManagerDetailResult> {
+  return defer(() => {
+    let notFound = false;
+    return tick$.pipe(
+      takeWhile(() => !notFound),
+      switchMap(() =>
+        load().pipe(
+          map(detail => ({ detail, notFound: false })),
+          catchError((error: unknown) => {
+            if (error instanceof HttpErrorResponse && error.status === 404) {
+              notFound = true;
+              return of({ detail: undefined, notFound: true });
+            }
+            return EMPTY;
+          })
+        )
+      )
+    );
+  });
+}

--- a/flink-runtime-web/web-dashboard/src/app/services/http-context.ts
+++ b/flink-runtime-web/web-dashboard/src/app/services/http-context.ts
@@ -16,13 +16,11 @@
  * limitations under the License.
  */
 
-export * from './status.service';
-export * from './http-context';
-export * from './overview.service';
-export * from './job.service';
-export * from './jar.service';
-export * from './job-manager.service';
-export * from './task-manager.service';
-export * from './metrics.service';
-export * from './config.service';
-export * from './application.service';
+import { HttpContextToken } from '@angular/common/http';
+
+/**
+ * Marks a request for which a 404 is an expected outcome that the caller handles itself, so the
+ * global interceptor does not surface it as a server error notification. Any other error is
+ * still surfaced as usual.
+ */
+export const EXPECTED_NOT_FOUND = new HttpContextToken<boolean>(() => false);

--- a/flink-runtime-web/web-dashboard/src/app/services/task-manager.service.spec.ts
+++ b/flink-runtime-web/web-dashboard/src/app/services/task-manager.service.spec.ts
@@ -16,13 +16,14 @@
  * limitations under the License.
  */
 
-import { HttpClient } from '@angular/common/http';
-import { firstValueFrom, of, throwError, toArray } from 'rxjs';
+import { HttpClient, HttpContext } from '@angular/common/http';
+import { firstValueFrom, of, throwError } from 'rxjs';
 
 import { TaskManagerDetail, TaskManagersItem } from '@flink-runtime-web/interfaces';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { ConfigService } from './config.service';
+import { EXPECTED_NOT_FOUND } from './http-context';
 import { TaskManagerService } from './task-manager.service';
 
 describe('TaskManagerService', () => {
@@ -71,12 +72,20 @@ describe('TaskManagerService', () => {
       expect(result).toBe(detail);
     });
 
-    it('swallows request errors into an empty stream, unlike loadManagers which falls back to []', async () => {
-      httpClient.get.mockReturnValue(throwError(() => new Error('cluster unreachable')));
+    it('propagates request errors so callers can react to a gone TaskManager, unlike loadManagers', async () => {
+      const error = new Error('cluster unreachable');
+      httpClient.get.mockReturnValue(throwError(() => error));
 
-      const emissions = await firstValueFrom(service.loadManager('tm-1').pipe(toArray()));
+      await expect(firstValueFrom(service.loadManager('tm-1'))).rejects.toBe(error);
+    });
 
-      expect(emissions).toEqual([]);
+    it('marks the request as expecting a 404 so the interceptor does not surface it', () => {
+      httpClient.get.mockReturnValue(of({ id: 'tm-1' }));
+
+      service.loadManager('tm-1');
+
+      const [, options] = httpClient.get.mock.calls[0] as [string, { context: HttpContext }];
+      expect(options.context.get(EXPECTED_NOT_FOUND)).toBe(true);
     });
   });
 });

--- a/flink-runtime-web/web-dashboard/src/app/services/task-manager.service.ts
+++ b/flink-runtime-web/web-dashboard/src/app/services/task-manager.service.ts
@@ -18,7 +18,7 @@
 
 import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { EMPTY, Observable, of } from 'rxjs';
+import { Observable, of } from 'rxjs';
 import { catchError, map } from 'rxjs/operators';
 
 import {
@@ -49,9 +49,8 @@ export class TaskManagerService {
   }
 
   loadManager(taskManagerId: string): Observable<TaskManagerDetail> {
-    return this.httpClient
-      .get<TaskManagerDetail>(`${this.configService.BASE_URL}/taskmanagers/${taskManagerId}`)
-      .pipe(catchError(() => EMPTY));
+    // Let errors propagate (e.g. a 404 for a gone TaskManager) so callers can react to them.
+    return this.httpClient.get<TaskManagerDetail>(`${this.configService.BASE_URL}/taskmanagers/${taskManagerId}`);
   }
 
   loadLogList(taskManagerId: string): Observable<TaskManagerLogItem[]> {

--- a/flink-runtime-web/web-dashboard/src/app/services/task-manager.service.ts
+++ b/flink-runtime-web/web-dashboard/src/app/services/task-manager.service.ts
@@ -16,9 +16,9 @@
  * limitations under the License.
  */
 
-import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { HttpClient, HttpContext, HttpHeaders } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { EMPTY, Observable, of } from 'rxjs';
+import { Observable, of } from 'rxjs';
 import { catchError, map } from 'rxjs/operators';
 
 import {
@@ -34,6 +34,7 @@ import {
 import { ProfilingDetail, ProfilingList } from '@flink-runtime-web/interfaces/job-profiler';
 
 import { ConfigService } from './config.service';
+import { EXPECTED_NOT_FOUND } from './http-context';
 
 @Injectable({
   providedIn: 'root'
@@ -52,9 +53,11 @@ export class TaskManagerService {
   }
 
   loadManager(taskManagerId: string): Observable<TaskManagerDetail> {
-    return this.httpClient
-      .get<TaskManagerDetail>(`${this.configService.BASE_URL}/taskmanagers/${taskManagerId}`)
-      .pipe(catchError(() => EMPTY));
+    // Let errors propagate (e.g. a 404 for a gone TaskManager) so callers can react to them. The 404
+    // is expected and handled by the callers, so it is not surfaced as a server error notification.
+    return this.httpClient.get<TaskManagerDetail>(`${this.configService.BASE_URL}/taskmanagers/${taskManagerId}`, {
+      context: new HttpContext().set(EXPECTED_NOT_FOUND, true)
+    });
   }
 
   loadLogList(taskManagerId: string): Observable<TaskManagerLogItem[]> {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/taskmanager/TaskManagerDetailsHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/taskmanager/TaskManagerDetailsHandler.java
@@ -119,7 +119,7 @@ public class TaskManagerDetailsHandler
                 .exceptionally(
                         (Throwable throwable) -> {
                             final Throwable strippedThrowable =
-                                    ExceptionUtils.stripExecutionException(throwable);
+                                    ExceptionUtils.stripCompletionException(throwable);
 
                             if (strippedThrowable instanceof UnknownTaskExecutorException) {
                                 throw new CompletionException(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/taskmanager/TaskManagerDetailsHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/taskmanager/TaskManagerDetailsHandlerTest.java
@@ -24,6 +24,7 @@ import org.apache.flink.runtime.instance.HardwareDescription;
 import org.apache.flink.runtime.metrics.dump.MetricDump;
 import org.apache.flink.runtime.metrics.dump.QueryScopeInfo;
 import org.apache.flink.runtime.resourcemanager.TaskManagerInfoWithSlots;
+import org.apache.flink.runtime.resourcemanager.exceptions.UnknownTaskExecutorException;
 import org.apache.flink.runtime.resourcemanager.utils.TestingResourceManagerGateway;
 import org.apache.flink.runtime.rest.handler.HandlerRequest;
 import org.apache.flink.runtime.rest.handler.HandlerRequestException;
@@ -39,10 +40,12 @@ import org.apache.flink.runtime.rest.messages.taskmanager.TaskManagerInfo;
 import org.apache.flink.runtime.rest.messages.taskmanager.TaskManagerMetricsInfo;
 import org.apache.flink.runtime.taskexecutor.TaskExecutorMemoryConfiguration;
 import org.apache.flink.testutils.TestingUtils;
+import org.apache.flink.util.concurrent.FutureUtils;
 import org.apache.flink.util.jackson.JacksonMapperFactory;
 
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonProcessingException;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseStatus;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -55,6 +58,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Tests the {@link TaskManagerDetailsHandler} implementation. */
 class TaskManagerDetailsHandlerTest {
@@ -127,6 +131,29 @@ class TaskManagerDetailsHandlerTest {
         String expectedJson = objectMapper.writeValueAsString(expected);
 
         assertThat(actualJson).isEqualTo(expectedJson);
+    }
+
+    @Test
+    void testUnknownTaskExecutorLeadsToNotFound() {
+        resourceManagerGateway.setRequestTaskManagerDetailsInfoFunction(
+                taskManagerId ->
+                        FutureUtils.completedExceptionally(
+                                new UnknownTaskExecutorException(taskManagerId)));
+
+        assertThatThrownBy(
+                        () ->
+                                testInstance
+                                        .handleRequest(createRequest(), resourceManagerGateway)
+                                        .get())
+                .cause()
+                .isInstanceOfSatisfying(
+                        RestHandlerException.class,
+                        restHandlerException -> {
+                            assertThat(restHandlerException.getHttpResponseStatus())
+                                    .isEqualTo(HttpResponseStatus.NOT_FOUND);
+                            assertThat(restHandlerException.getMessage())
+                                    .contains("Could not find TaskExecutor " + TASK_MANAGER_ID);
+                        });
     }
 
     private static void initializeMetricStore(MetricStore metricStore) {


### PR DESCRIPTION
## What is the purpose of the change

Requesting `/taskmanagers/:taskmanagerid` for a TaskManager that is no longer registered (for example after a TaskManager is lost while the Web UI's TaskManager page keeps polling it, or when following a link from a job's exception history) returned HTTP 500 with an `Unhandled exception` ERROR log on the JobManager, and the Web UI kept re-requesting it indefinitely.

This returns a proper 404 for a gone TaskManager and stops the futile polling, showing a clear "TaskManager not available" notice instead of an endless skeleton.

This supersedes #22542 (thanks @JunRuiLee for the original investigation). That PR addressed FLINK-31931 by preventing the exception-history page from linking to a gone TaskManager. Handling the not-found at the destination instead is more robust: it also covers deep-links and a TaskManager dying while its page is open, it is not racy (a TaskManager can disappear right after the link is rendered), and it keeps the link informative for the common case where the exception's TaskManager is already gone by the time the history is viewed.

## Brief change log

- **[runtime/rest]** `TaskManagerDetailsHandler` strips the failure with `stripCompletionException` (not `stripExecutionException`), so the `UnknownTaskExecutorException` to `NOT_FOUND` mapping actually fires; this matches the sibling TaskManager handlers. Previously a gone TaskManager produced a 500 plus a repeated `Unhandled exception` ERROR log.
- **[runtime-web]** `loadManager` no longer swallows errors; a shared poll helper stops polling once the backend reports the TaskManager is gone (404), while transient errors keep retrying. The TaskManager status view shows a "TaskManager not available" notice and the metric cards are hidden instead of rendering blank tables.
- **[runtime-web]** The global HTTP interceptor no longer pops up a "Server Response Message" (with the server stack trace) for the now-expected 404: `loadManager` marks its request with an `EXPECTED_NOT_FOUND` `HttpContext` token and the interceptor skips the notification for a 404 on such a request. Other errors are surfaced as before.

## Verifying this change

- New unit test `TaskManagerDetailsHandlerTest#testUnknownTaskExecutorLeadsToNotFound` asserts a 404 for an unknown TaskManager id.
- New Vitest specs cover the poll helper (stops on 404, keeps retrying on transient errors) and the status/metrics components (notice shown / cards hidden on 404).
- New Vitest spec `app.interceptor.spec.ts`: a 404 is surfaced by default, an expected 404 is not surfaced but still propagates to the caller, and other errors on an expected-404 request are still surfaced.
- Manually verified on standalone clusters built from this branch and from master. Killing a TaskManager now yields one 404 per view that stops repeating, a "TaskManager not available" notice, no notification popup, and no `Unhandled exception` ERROR log on the JobManager. On master the same scenario produces a 500 per refresh tick and an `Unhandled exception` ERROR each time.

### Before / after

Before (master), TaskManager page open while the TaskManager is killed: the page freezes on stale data, the message counter climbs, `/taskmanagers/<id>` returns 500 on every refresh tick and the JobManager logs `Unhandled exception` for each.

<img width="1552" height="784" alt="before-02-tm-gone-page-open" src="https://github.com/user-attachments/assets/654437b6-ecbc-44c7-b3d4-c94a9c24b67f" />

Before (master), fresh load of the URL of a gone TaskManager (deep-link or exception history link): skeleton and empty metric tables forever, "Internal server error." popups.

<img width="1552" height="784" alt="before-03-tm-gone-deeplink" src="https://github.com/user-attachments/assets/e83c616e-ef75-4798-b7cf-c3d2e3ba60ca" />

After, both scenarios: one 404 per view, polling stops, no popup, no `Unhandled exception` in the JobManager log.

<img width="1552" height="784" alt="after-02-tm-gone-page-open" src="https://github.com/user-attachments/assets/e7f396aa-ec7f-4d68-89c6-388eab5aa48d" />

<img width="1552" height="784" alt="after-03-tm-gone-deeplink" src="https://github.com/user-attachments/assets/517081c8-b45e-468b-8fd3-475488034eb9" />

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable

## AI Usage Disclosure

- [x] Claude Code


