### PR TITLE
[FLINK-36298][table-planner] Re-establish Calcite metadata provider on foreign threads

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/metadata/FlinkRelMetadataQuery.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/metadata/FlinkRelMetadataQuery.java
@@ -28,6 +28,7 @@ import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.core.Exchange;
 import org.apache.calcite.rel.metadata.JaninoRelMetadataProvider;
 import org.apache.calcite.rel.metadata.RelMetadataQuery;
+import org.apache.calcite.rel.metadata.RelMetadataQueryBase;
 import org.apache.calcite.util.ImmutableBitSet;
 
 import java.util.Arrays;
@@ -57,6 +58,14 @@ public class FlinkRelMetadataQuery extends RelMetadataQuery {
      * computing metadata.
      */
     public static FlinkRelMetadataQuery instance() {
+        // The metadata handler provider lives in Calcite's RelMetadataQueryBase.THREAD_PROVIDERS
+        // thread-local, seeded only on the thread that built the (cached, shared) RelOptCluster. On
+        // a foreign thread (e.g. a PyFlink py4j gateway thread) it is unset and handlers NPE
+        // (FLINK-36298), so re-seed it with the provider FlinkRelOptClusterFactory installs.
+        if (RelMetadataQueryBase.THREAD_PROVIDERS.get() == null) {
+            RelMetadataQueryBase.THREAD_PROVIDERS.set(
+                    JaninoRelMetadataProvider.of(FlinkDefaultRelMetadataProvider.INSTANCE()));
+        }
         return new FlinkRelMetadataQuery();
     }
 

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/calcite/FlinkRelOptClusterFactory.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/calcite/FlinkRelOptClusterFactory.scala
@@ -34,6 +34,9 @@ object FlinkRelOptClusterFactory {
 
   def create(planner: RelOptPlanner, rexBuilder: RexBuilder): RelOptCluster = {
     val cluster = RelOptCluster.create(planner, rexBuilder)
+    // Installs the metadata provider (and seeds RelMetadataQueryBase.THREAD_PROVIDERS on this
+    // thread). FlinkRelMetadataQuery.instance() re-seeds the same provider on foreign threads
+    // (FLINK-36298); keep the two in sync if this provider ever changes.
     cluster.setMetadataProvider(FlinkDefaultRelMetadataProvider.INSTANCE)
     cluster.setMetadataQuerySupplier(new Supplier[RelMetadataQuery]() {
       def get: FlinkRelMetadataQuery = FlinkRelMetadataQuery.instance()

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/metadata/FlinkRelMetadataQueryThreadLocalTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/metadata/FlinkRelMetadataQueryThreadLocalTest.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.metadata;
+
+import org.apache.flink.table.planner.plan.trait.RelModifiedMonotonicity;
+
+import org.apache.calcite.rel.metadata.RelMetadataQuery;
+import org.apache.calcite.rel.metadata.RelMetadataQueryBase;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests that metadata queries survive being issued on a thread other than the one that built the
+ * {@link org.apache.calcite.plan.RelOptCluster} (FLINK-36298).
+ *
+ * <p>The metadata handler provider is a thread-local seeded only on the cluster-building thread, so
+ * PyFlink optimizing on a py4j gateway thread hits an unset provider. The test reproduces that
+ * invariant deterministically: build the cluster on the main thread, run the metadata query on a
+ * fresh worker thread.
+ */
+class FlinkRelMetadataQueryThreadLocalTest extends FlinkRelMdHandlerTestBase {
+
+    @Test
+    void testMetadataQueryOnForeignThread() throws Exception {
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        try {
+            Future<RelModifiedMonotonicity> future =
+                    executor.submit(
+                            () -> {
+                                // Fresh thread with the provider cleared, as with a py4j gateway
+                                // thread.
+                                RelMetadataQueryBase.THREAD_PROVIDERS.remove();
+                                // Rebuild the shared cluster's metadata query on this thread (the
+                                // transformTo path).
+                                cluster().invalidateMetadataQuery();
+                                RelMetadataQuery mq = cluster().getMetadataQuery();
+                                return FlinkRelMetadataQuery.reuseOrCreate(mq)
+                                        .getRelModifiedMonotonicity(studentLogicalScan());
+                            });
+            // Before the fix this fails with NullPointerException("metadataHandlerProvider");
+            // after the fix the query resolves normally.
+            assertThat(future.get()).isNotNull();
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

Fixes the intermittent `NullPointerException: metadataHandlerProvider` (Calcite `RelMetadataQueryBase`) that has recurred for years, only in flink-python (e.g. `StreamPandasConversionTests`).

Root cause: Calcite keeps the metadata handler provider in a thread-local (`RelMetadataQueryBase.THREAD_PROVIDERS`), seeded only on the thread that builds the cached, shared `RelOptCluster` (`FlinkRelOptClusterFactory`). PyFlink runs optimization (`to_pandas()` -> `ArrowUtils.collectAsPandasDataFrame` -> `table.execute().collect()`) on a py4j gateway thread that can differ from the cluster-building thread, where the thread-local is unset, so the first metadata-handler lookup NPEs. The nondeterministic py4j thread assignment is why it is intermittent and PyFlink-only.

The fix re-seeds the thread-local in `FlinkRelMetadataQuery.instance()`, the single funnel through which all metadata queries are obtained (directly, via `reuseOrCreate`, and via the cluster's metadata-query supplier), using the same provider `FlinkRelOptClusterFactory` installs.

Notes for reviewers:
- Scope: this addresses the sequential cross-thread case (the observed failures). Concurrent optimization on multiple threads against the same shared, non-thread-safe `RelMetadataQuery` is a separate, pre-existing concern that this change neither introduces nor fixes.
- The thread-local is set and not cleared on foreign (pooled py4j) threads, by parity with Calcite's own `RelOptCluster.setMetadataProvider` seeding; the value is the stateless `FlinkDefaultRelMetadataProvider` singleton chain.
- Design choice: healing the `instance()` funnel is provider-agnostic and robust to any foreign-thread caller, versus seeding at the PyFlink entry point, which is more invasive and PyFlink-specific.

Likely duplicates of the same NPE: FLINK-33531, FLINK-38392.

## Brief change log

  - Guard `FlinkRelMetadataQuery.instance()` to re-seed `RelMetadataQueryBase.THREAD_PROVIDERS` when unset on the current thread
  - Cross-reference comment in `FlinkRelOptClusterFactory` documenting the single provider both sites rely on
  - Add `FlinkRelMetadataQueryThreadLocalTest`, a deterministic red/green reproduction of the cross-thread NPE

## Verifying this change

This change added tests and can be verified as follows:

  - `FlinkRelMetadataQueryThreadLocalTest` builds the cluster on the main thread and issues a metadata query on a fresh worker thread; it fails with `NullPointerException: metadataHandlerProvider` without the fix and passes with it
  - `mvn test -Dtest=FlinkRelMd*` in `flink-table-planner` passes (315 tests)

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (Claude Code with Claude Opus 4.8)

Generated-by: Claude Opus 4.8 (1M context)
