### PR TITLE
[hotfix][table] Fix compilation with jdk11

### DIFF
--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/join/snapshot/LateralSnapshotJoinOperatorTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/join/snapshot/LateralSnapshotJoinOperatorTest.java
@@ -57,6 +57,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.apache.flink.table.runtime.operators.join.snapshot.LateralSnapshotJoinOperator.BUILD_CHANGE_BUFFER_STATE_NAME;
@@ -491,7 +492,7 @@ class LateralSnapshotJoinOperatorTest {
             List<Long> emittedProbeIds =
                     h.getOutput().stream()
                             .map(o -> ((RowData) ((StreamRecord<?>) o).getValue()).getLong(0))
-                            .toList();
+                            .collect(Collectors.toList());
             assertThat(emittedProbeIds).containsExactly(1L, 2L, 3L, 4L, 5L);
             JOINED_ASSERTOR.shouldEmitAll(
                     h,
@@ -536,7 +537,7 @@ class LateralSnapshotJoinOperatorTest {
             List<Long> emittedProbeIds =
                     h.getOutput().stream()
                             .map(o -> ((RowData) ((StreamRecord<?>) o).getValue()).getLong(0))
-                            .toList();
+                            .collect(Collectors.toList());
             assertThat(emittedProbeIds).containsExactly(1L, 2L);
             JOINED_ASSERTOR.shouldEmitAll(
                     h, row(1L, "k1", "p1", "k1", "v1", 1L), row(2L, "k1", "p2", "k1", "v1", 1L));
@@ -1518,7 +1519,7 @@ class LateralSnapshotJoinOperatorTest {
             List<Long> emittedProbeIds =
                     h.getOutput().stream()
                             .map(o -> ((RowData) ((StreamRecord<?>) o).getValue()).getLong(0))
-                            .toList();
+                            .collect(Collectors.toList());
             assertThat(emittedProbeIds).containsExactly(1L, 2L, 3L);
             JOINED_ASSERTOR.shouldEmitAll(
                     h,
@@ -1739,7 +1740,7 @@ class LateralSnapshotJoinOperatorTest {
             List<Long> emittedIds =
                     h.getOutput().stream()
                             .map(o -> ((RowData) ((StreamRecord<?>) o).getValue()).getLong(0))
-                            .toList();
+                            .collect(Collectors.toList());
             assertThat(emittedIds).containsExactly(1L, 2L);
             JOINED_ASSERTOR.shouldEmitAll(
                     h, row(1L, "k1", "p1", "k1", "v1", 1L), row(2L, "k1", "p2", "k1", "v1", 1L));
@@ -2048,7 +2049,7 @@ class LateralSnapshotJoinOperatorTest {
                 .getKeys(BUILD_TABLE_STATE_NAME, VoidNamespace.INSTANCE)
                 .map(r -> ((BinaryRowData) r).getString(0).toString())
                 .sorted()
-                .toList();
+                .collect(Collectors.toList());
     }
 
     private static List<String> probeBufferKeys(
@@ -2059,7 +2060,7 @@ class LateralSnapshotJoinOperatorTest {
                 .getKeys(PROBE_BUFFER_STATE_NAME, VoidNamespace.INSTANCE)
                 .map(r -> ((BinaryRowData) r).getString(0).toString())
                 .sorted()
-                .toList();
+                .collect(Collectors.toList());
     }
 
     /**
@@ -2156,7 +2157,10 @@ class LateralSnapshotJoinOperatorTest {
     }
 
     private static List<Watermark> extractWatermarks(ConcurrentLinkedQueue<Object> output) {
-        return output.stream().filter(o -> o instanceof Watermark).map(w -> (Watermark) w).toList();
+        return output.stream()
+                .filter(o -> o instanceof Watermark)
+                .map(w -> (Watermark) w)
+                .collect(Collectors.toList());
     }
 
     /**
@@ -2180,6 +2184,6 @@ class LateralSnapshotJoinOperatorTest {
         return output.stream()
                 .filter(o -> o instanceof WatermarkStatus)
                 .map(w -> (WatermarkStatus) w)
-                .toList();
+                .collect(Collectors.toList());
     }
 }


### PR DESCRIPTION


## What is the purpose of the change

The PR to fix compilation with jdk11
see example of build failure in nightly https://github.com/apache/flink/actions/runs/29385342301

## Brief change log
`.toList` -> `.collect(Collectors.toList())`

## Verifying this change

run with jdk11

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no )
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: ( no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change the checkbox below to `[X]` followed by the name of the tool, and uncomment the
"Generated-by" line. See the ASF Generative Tooling Guidance for details:
https://www.apache.org/legal/generative-tooling.html

You are responsible for the quality and correctness of every change in this PR
regardless of the tooling used. Low-effort AI-generated PRs will be closed. See
AGENTS.md for the full guidance.
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name and Version]
-->
