### PR TITLE
[FLINK-35324][formats] Avro format can not perform projection pushdown for specific fields

### DIFF
--- a/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/AvroDeserializationSchema.java
+++ b/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/AvroDeserializationSchema.java
@@ -56,7 +56,21 @@ public class AvroDeserializationSchema<T> implements DeserializationSchema<T> {
      * @return deserialized record in form of {@link GenericRecord}
      */
     public static AvroDeserializationSchema<GenericRecord> forGeneric(Schema schema) {
-        return new AvroDeserializationSchema<>(GenericRecord.class, schema);
+        return forGeneric(schema, null);
+    }
+
+    /**
+     * Creates {@link AvroDeserializationSchema} that produces {@link GenericRecord} using the
+     * provided reader schema and resolves the input against the given writer schema.
+     *
+     * @param schema reader schema of produced records
+     * @param writer writer schema the input was serialized with, or {@code null} to reuse the
+     *     reader schema
+     * @return deserialized record in form of {@link GenericRecord}
+     */
+    public static AvroDeserializationSchema<GenericRecord> forGeneric(
+            Schema schema, @Nullable Schema writer) {
+        return new AvroDeserializationSchema<>(GenericRecord.class, schema, writer);
     }
 
     /**
@@ -79,6 +93,9 @@ public class AvroDeserializationSchema<T> implements DeserializationSchema<T> {
     /** Schema in case of GenericRecord for serialization purpose. */
     private final String schemaString;
 
+    /** Writer schema the input was serialized with, or {@code null} to reuse the reader schema. */
+    private final String writerSchemaString;
+
     /** Reader that deserializes byte array into a record. */
     private transient GenericDatumReader<T> datumReader;
 
@@ -91,6 +108,9 @@ public class AvroDeserializationSchema<T> implements DeserializationSchema<T> {
     /** Avro schema for the reader. */
     private transient Schema reader;
 
+    /** Avro schema for the writer. */
+    private transient Schema writer;
+
     /**
      * Creates a Avro deserialization schema.
      *
@@ -100,14 +120,27 @@ public class AvroDeserializationSchema<T> implements DeserializationSchema<T> {
      *     GenericRecord}
      */
     AvroDeserializationSchema(Class<T> recordClazz, @Nullable Schema reader) {
+        this(recordClazz, reader, null);
+    }
+
+    /**
+     * Creates a Avro deserialization schema.
+     *
+     * @param recordClazz class to which deserialize. Should be one of: {@link
+     *     org.apache.avro.specific.SpecificRecord}, {@link org.apache.avro.generic.GenericRecord}.
+     * @param reader reader's Avro schema. Should be provided if recordClazz is {@link
+     *     GenericRecord}
+     * @param writer writer's Avro schema the input was serialized with. Used to resolve the input
+     *     against the reader schema, e.g. to read a subset of the written fields.
+     */
+    AvroDeserializationSchema(
+            Class<T> recordClazz, @Nullable Schema reader, @Nullable Schema writer) {
         Preconditions.checkNotNull(recordClazz, "Avro record class must not be null.");
         this.recordClazz = recordClazz;
         this.reader = reader;
-        if (reader != null) {
-            this.schemaString = reader.toString();
-        } else {
-            this.schemaString = null;
-        }
+        this.schemaString = reader != null ? reader.toString() : null;
+        this.writer = writer;
+        this.writerSchemaString = writer != null ? writer.toString() : null;
     }
 
     GenericDatumReader<T> getDatumReader() {
@@ -116,6 +149,11 @@ public class AvroDeserializationSchema<T> implements DeserializationSchema<T> {
 
     Schema getReaderSchema() {
         return reader;
+    }
+
+    @Nullable
+    Schema getWriterSchema() {
+        return writer;
     }
 
     MutableByteArrayInputStream getInputStream() {
@@ -135,9 +173,15 @@ public class AvroDeserializationSchema<T> implements DeserializationSchema<T> {
         checkAvroInitialized();
         inputStream.setBuffer(message);
         Schema readerSchema = getReaderSchema();
+        Schema writerSchema = getWriterSchema();
         GenericDatumReader<T> datumReader = getDatumReader();
 
-        datumReader.setSchema(readerSchema);
+        if (writerSchema != null) {
+            datumReader.setSchema(writerSchema);
+            datumReader.setExpected(readerSchema);
+        } else {
+            datumReader.setSchema(readerSchema);
+        }
 
         return datumReader.read(null, decoder);
     }
@@ -157,6 +201,9 @@ public class AvroDeserializationSchema<T> implements DeserializationSchema<T> {
             this.reader = AvroFactory.extractAvroSpecificSchema(recordClazz, specificData);
         } else {
             this.reader = new Schema.Parser().parse(schemaString);
+            if (writerSchemaString != null) {
+                this.writer = new Schema.Parser().parse(writerSchemaString);
+            }
             GenericData genericData = new GenericData(cl);
             this.datumReader = new GenericDatumReader<>(null, this.reader, genericData);
         }
@@ -189,11 +236,13 @@ public class AvroDeserializationSchema<T> implements DeserializationSchema<T> {
             return false;
         }
         AvroDeserializationSchema<?> that = (AvroDeserializationSchema<?>) o;
-        return recordClazz.equals(that.recordClazz) && Objects.equals(reader, that.reader);
+        return recordClazz.equals(that.recordClazz)
+                && Objects.equals(reader, that.reader)
+                && Objects.equals(writer, that.writer);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(recordClazz, reader);
+        return Objects.hash(recordClazz, reader, writer);
     }
 }

--- a/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/AvroFormatFactory.java
+++ b/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/AvroFormatFactory.java
@@ -24,6 +24,7 @@ import org.apache.flink.api.common.serialization.SerializationSchema;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.ReadableConfig;
+import org.apache.flink.formats.avro.typeutils.AvroSchemaConverter;
 import org.apache.flink.table.connector.ChangelogMode;
 import org.apache.flink.table.connector.Projection;
 import org.apache.flink.table.connector.format.DecodingFormat;
@@ -64,10 +65,16 @@ public class AvroFormatFactory implements DeserializationFormatFactory, Serializ
                     int[][] projections) {
                 final DataType producedDataType =
                         Projection.of(projections).project(physicalDataType);
-                final RowType rowType = (RowType) producedDataType.getLogicalType();
+                final RowType producedRowType = (RowType) producedDataType.getLogicalType();
+                final RowType physicalRowType = (RowType) physicalDataType.getLogicalType();
                 final TypeInformation<RowData> rowDataTypeInfo =
                         context.createTypeInformation(producedDataType);
-                return new AvroRowDataDeserializationSchema(rowType, rowDataTypeInfo);
+                return new AvroRowDataDeserializationSchema(
+                        AvroDeserializationSchema.forGeneric(
+                                AvroSchemaConverter.convertToSchema(producedRowType),
+                                AvroSchemaConverter.convertToSchema(physicalRowType)),
+                        AvroToRowDataConverters.createRowConverter(producedRowType),
+                        rowDataTypeInfo);
             }
 
             @Override

--- a/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/AvroRowDataDeSerializationSchemaTest.java
+++ b/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/AvroRowDataDeSerializationSchemaTest.java
@@ -275,8 +275,7 @@ class AvroRowDataDeSerializationSchemaTest {
         final Schema schema =
                 AvroSchemaConverter.convertToSchema(physicalDataType.getLogicalType());
 
-        final GenericRecord nested =
-                new GenericData.Record(schema.getField("nested").schema());
+        final GenericRecord nested = new GenericData.Record(schema.getField("nested").schema());
         nested.put(0, 7);
         nested.put(1, "inner");
         final GenericRecord record = new GenericData.Record(schema);

--- a/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/AvroRowDataDeSerializationSchemaTest.java
+++ b/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/AvroRowDataDeSerializationSchemaTest.java
@@ -21,6 +21,7 @@ package org.apache.flink.formats.avro;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.formats.avro.generated.LogicalTimeRecord;
 import org.apache.flink.formats.avro.typeutils.AvroSchemaConverter;
+import org.apache.flink.table.connector.Projection;
 import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.util.DataFormatConverters;
@@ -229,6 +230,97 @@ class AvroRowDataDeSerializationSchemaTest {
                 .isInstanceOf(RuntimeException.class)
                 .hasMessageContaining("Failed to serialize row.")
                 .hasStackTraceContaining("Fail to serialize at field: f1");
+    }
+
+    @Test
+    void testDeserializeWithNonZeroStartingProjection() throws Exception {
+        final DataType physicalDataType =
+                ROW(
+                                FIELD("user_id", BIGINT()),
+                                FIELD("name", STRING()),
+                                FIELD("event_id", BIGINT()),
+                                FIELD("payload", STRING().notNull()))
+                        .notNull();
+        final Schema schema =
+                AvroSchemaConverter.convertToSchema(physicalDataType.getLogicalType());
+
+        final GenericRecord record = new GenericData.Record(schema);
+        record.put(0, 3L);
+        record.put(1, "name 3");
+        record.put(2, 102L);
+        record.put(3, "payload 3");
+        final byte[] input = writeRecord(record, schema);
+
+        // projection does not start at 0: reads only {name, event_id}
+        final RowData rowData =
+                createProjectedDeserializationSchema(physicalDataType, new int[][] {{1}, {2}})
+                        .deserialize(input);
+
+        assertThat(rowData.getArity()).isEqualTo(2);
+        assertThat(rowData.getString(0).toString()).isEqualTo("name 3");
+        assertThat(rowData.getLong(1)).isEqualTo(102L);
+    }
+
+    @Test
+    void testDeserializeProjectionWithNestedRow() throws Exception {
+        final DataType physicalDataType =
+                ROW(
+                                FIELD("id", BIGINT()),
+                                FIELD("name", STRING()),
+                                FIELD(
+                                        "nested",
+                                        ROW(FIELD("a", INT().notNull()), FIELD("b", STRING()))
+                                                .notNull()))
+                        .notNull();
+        final Schema schema =
+                AvroSchemaConverter.convertToSchema(physicalDataType.getLogicalType());
+
+        final GenericRecord nested =
+                new GenericData.Record(schema.getField("nested").schema());
+        nested.put(0, 7);
+        nested.put(1, "inner");
+        final GenericRecord record = new GenericData.Record(schema);
+        record.put(0, 1L);
+        record.put(1, "outer");
+        record.put(2, nested);
+        final byte[] input = writeRecord(record, schema);
+
+        // project {name, nested}, i.e. a non-zero starting projection including a nested row
+        final RowData rowData =
+                createProjectedDeserializationSchema(physicalDataType, new int[][] {{1}, {2}})
+                        .deserialize(input);
+
+        assertThat(rowData.getArity()).isEqualTo(2);
+        assertThat(rowData.getString(0).toString()).isEqualTo("outer");
+        final RowData nestedOut = rowData.getRow(1, 2);
+        assertThat(nestedOut.getInt(0)).isEqualTo(7);
+        assertThat(nestedOut.getString(1).toString()).isEqualTo("inner");
+    }
+
+    private static byte[] writeRecord(GenericRecord record, Schema schema) throws Exception {
+        final ByteArrayOutputStream out = new ByteArrayOutputStream();
+        final GenericDatumWriter<IndexedRecord> datumWriter = new GenericDatumWriter<>(schema);
+        final Encoder encoder = EncoderFactory.get().binaryEncoder(out, null);
+        datumWriter.write(record, encoder);
+        encoder.flush();
+        return out.toByteArray();
+    }
+
+    private AvroRowDataDeserializationSchema createProjectedDeserializationSchema(
+            DataType physicalDataType, int[][] projections) throws Exception {
+        final DataType producedDataType = Projection.of(projections).project(physicalDataType);
+        final RowType producedRowType = (RowType) producedDataType.getLogicalType();
+        final RowType physicalRowType = (RowType) physicalDataType.getLogicalType();
+
+        AvroRowDataDeserializationSchema deserializationSchema =
+                new AvroRowDataDeserializationSchema(
+                        AvroDeserializationSchema.forGeneric(
+                                AvroSchemaConverter.convertToSchema(producedRowType),
+                                AvroSchemaConverter.convertToSchema(physicalRowType)),
+                        AvroToRowDataConverters.createRowConverter(producedRowType),
+                        InternalTypeInfo.of(producedRowType));
+        deserializationSchema.open(null);
+        return deserializationSchema;
     }
 
     private AvroRowDataSerializationSchema createSerializationSchema(DataType dataType)


### PR DESCRIPTION
**What is the purpose of the change**

The avro format returns a ProjectableDecodingFormat, but projection pushdown only works when the projected fields start at index 0; a projection such as [[1], [2]] fails with ArrayIndexOutOfBoundsException. The deserializer used the projected schema as both the writer and reader schema, so the positional Avro decoding reads the wrong fields. This passes the full physical schema as the writer schema and the projected schema as the reader schema, so Avro schema resolution reads only the projected fields.

**Brief change log**

- AvroDeserializationSchema: support an optional writer schema and resolve the input with setSchema(writer) + setExpected(reader); add a forGeneric(Schema reader, Schema writer) overload.
- AvroFormatFactory#createRuntimeDecoder: use the projected schema as the reader schema and the full physical schema as the writer schema.

**Verifying this change**

- AvroRowDataDeSerializationSchemaTest

**Does this pull request potentially affect one of the following parts:**

- Dependencies (does it add or upgrade a dependency): no
- The public API, i.e., is any changed class annotated with @Public(Evolving): no
- The serializers: no
- The runtime per-record code paths (performance sensitive): yes
- Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
- The S3 file system connector: no

**Documentation**

- Does this pull request introduce a new feature? no
- If yes, how is the feature documented? not applicable