### PR TITLE
[FLINK-36512][runtime] Ignore non-rescale-relevant checkpoint failure reasons in adaptive rescale trigger

### DIFF
--- a/docs/layouts/shortcodes/generated/all_jobmanager_section.html
+++ b/docs/layouts/shortcodes/generated/all_jobmanager_section.html
@@ -60,7 +60,7 @@
             <td><h5>jobmanager.adaptive-scheduler.rescale-trigger.max-checkpoint-failures</h5></td>
             <td style="word-wrap: break-word;">2</td>
             <td>Integer</td>
-            <td>The number of consecutive failed checkpoints that will trigger rescaling even in the absence of a completed checkpoint.</td>
+            <td>The number of consecutive failed checkpoints that will trigger rescaling even in the absence of a completed checkpoint. Only failures that count against the tolerable checkpoint-failure threshold (e.g. IO errors, async failures, expirations, declines, finalization errors) advance this counter; other failures such as tasks not being fully running, coordinator shutdown, or checkpoint subsumption are ignored to avoid spurious rescales during startup or recovery.</td>
         </tr>
         <tr>
             <td><h5>jobmanager.adaptive-scheduler.rescale-trigger.max-delay</h5></td>

--- a/docs/layouts/shortcodes/generated/expert_scheduling_section.html
+++ b/docs/layouts/shortcodes/generated/expert_scheduling_section.html
@@ -114,7 +114,7 @@
             <td><h5>jobmanager.adaptive-scheduler.rescale-trigger.max-checkpoint-failures</h5></td>
             <td style="word-wrap: break-word;">2</td>
             <td>Integer</td>
-            <td>The number of consecutive failed checkpoints that will trigger rescaling even in the absence of a completed checkpoint.</td>
+            <td>The number of consecutive failed checkpoints that will trigger rescaling even in the absence of a completed checkpoint. Only failures that count against the tolerable checkpoint-failure threshold (e.g. IO errors, async failures, expirations, declines, finalization errors) advance this counter; other failures such as tasks not being fully running, coordinator shutdown, or checkpoint subsumption are ignored to avoid spurious rescales during startup or recovery.</td>
         </tr>
         <tr>
             <td><h5>jobmanager.adaptive-scheduler.rescale-trigger.max-delay</h5></td>

--- a/docs/layouts/shortcodes/generated/job_manager_configuration.html
+++ b/docs/layouts/shortcodes/generated/job_manager_configuration.html
@@ -60,7 +60,7 @@
             <td><h5>jobmanager.adaptive-scheduler.rescale-trigger.max-checkpoint-failures</h5></td>
             <td style="word-wrap: break-word;">2</td>
             <td>Integer</td>
-            <td>The number of consecutive failed checkpoints that will trigger rescaling even in the absence of a completed checkpoint.</td>
+            <td>The number of consecutive failed checkpoints that will trigger rescaling even in the absence of a completed checkpoint. Only failures that count against the tolerable checkpoint-failure threshold (e.g. IO errors, async failures, expirations, declines, finalization errors) advance this counter; other failures such as tasks not being fully running, coordinator shutdown, or checkpoint subsumption are ignored to avoid spurious rescales during startup or recovery.</td>
         </tr>
         <tr>
             <td><h5>jobmanager.adaptive-scheduler.rescale-trigger.max-delay</h5></td>

--- a/flink-core/src/main/java/org/apache/flink/configuration/JobManagerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/JobManagerOptions.java
@@ -724,7 +724,9 @@ public class JobManagerOptions {
                     .withDescription(
                             Description.builder()
                                     .text(
-                                            "The number of consecutive failed checkpoints that will trigger rescaling even in the absence of a completed checkpoint.")
+                                            "The number of consecutive failed checkpoints that will trigger rescaling even in the absence of a completed checkpoint. "
+                                                    + "Only failures that count against the tolerable checkpoint-failure threshold (e.g. IO errors, async failures, expirations, declines, finalization errors) advance this counter; "
+                                                    + "other failures such as tasks not being fully running, coordinator shutdown, or checkpoint subsumption are ignored to avoid spurious rescales during startup or recovery.")
                                     .build());
 
     @Documentation.Section({

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointFailureManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointFailureManager.java
@@ -141,7 +141,8 @@ public class CheckpointFailureManager {
             statsTracker.reportFailedCheckpoint(
                     pendingCheckpointStats.toFailedCheckpoint(failureTimestamp, exception));
         } else {
-            statsTracker.reportFailedCheckpointsWithoutInProgress();
+            statsTracker.reportFailedCheckpointsWithoutInProgress(
+                    exception.getCheckpointFailureReason());
         }
     }
 
@@ -219,49 +220,11 @@ public class CheckpointFailureManager {
             return;
         }
 
-        CheckpointFailureReason reason = exception.getCheckpointFailureReason();
-        switch (reason) {
-            case PERIODIC_SCHEDULER_SHUTDOWN:
-            case TOO_MANY_CHECKPOINT_REQUESTS:
-            case MINIMUM_TIME_BETWEEN_CHECKPOINTS:
-            case NOT_ALL_REQUIRED_TASKS_RUNNING:
-            case CHECKPOINT_SUBSUMED:
-            case CHECKPOINT_COORDINATOR_SUSPEND:
-            case CHECKPOINT_COORDINATOR_SHUTDOWN:
-            case CHANNEL_STATE_SHARED_STREAM_EXCEPTION:
-            case JOB_FAILOVER_REGION:
-            // for compatibility purposes with user job behavior
-            case CHECKPOINT_DECLINED_TASK_NOT_READY:
-            case CHECKPOINT_DECLINED_TASK_CLOSING:
-            case CHECKPOINT_DECLINED_ON_CANCELLATION_BARRIER:
-            case CHECKPOINT_DECLINED_SUBSUMED:
-            case CHECKPOINT_DECLINED_INPUT_END_OF_STREAM:
-
-            case TASK_FAILURE:
-            case TASK_CHECKPOINT_FAILURE:
-            case UNKNOWN_TASK_CHECKPOINT_NOTIFICATION_FAILURE:
-            // there are some edge cases shouldn't be counted as a failure, e.g. shutdown
-            case TRIGGER_CHECKPOINT_FAILURE:
-            case BLOCKING_OUTPUT_EXIST:
-                // ignore
-                break;
-
-            case IO_EXCEPTION:
-            case CHECKPOINT_ASYNC_EXCEPTION:
-            case CHECKPOINT_DECLINED:
-            case CHECKPOINT_EXPIRED:
-            case FINALIZE_CHECKPOINT_FAILURE:
-                // we should make sure one checkpoint only be counted once
-                if (checkpointId == UNKNOWN_CHECKPOINT_ID
-                        || countedCheckpointIds.add(checkpointId)) {
-                    continuousFailureCounter.incrementAndGet();
-                }
-
-                break;
-
-            default:
-                throw new FlinkRuntimeException(
-                        "Unknown checkpoint failure reason : " + reason.name());
+        if (exception.getCheckpointFailureReason().isCountedAgainstFailureThreshold()) {
+            // we should make sure one checkpoint only be counted once
+            if (checkpointId == UNKNOWN_CHECKPOINT_ID || countedCheckpointIds.add(checkpointId)) {
+                continuousFailureCounter.incrementAndGet();
+            }
         }
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointFailureReason.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointFailureReason.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.runtime.checkpoint;
 
+import org.apache.flink.util.FlinkRuntimeException;
+
 /** Various reasons why a checkpoint was failure. */
 public enum CheckpointFailureReason {
     PERIODIC_SCHEDULER_SHUTDOWN(true, "Periodic checkpoint scheduler is shut down."),
@@ -98,5 +100,51 @@ public enum CheckpointFailureReason {
      */
     public boolean isPreFlight() {
         return preFlight;
+    }
+
+    /**
+     * Whether a checkpoint failure with this reason counts toward the continuous checkpoint-failure
+     * threshold. This is the single source of truth shared by {@link
+     * CheckpointFailureManager#checkFailureCounter} (which fails the job once the tolerable failure
+     * number is exceeded) and the adaptive scheduler's rescale-on-failed-checkpoints countdown, so
+     * the two mechanisms cannot drift apart. Reasons such as tasks not yet running, coordinator
+     * shutdown, or checkpoint subsumption are not counted.
+     */
+    public boolean isCountedAgainstFailureThreshold() {
+        switch (this) {
+            case PERIODIC_SCHEDULER_SHUTDOWN:
+            case TOO_MANY_CHECKPOINT_REQUESTS:
+            case MINIMUM_TIME_BETWEEN_CHECKPOINTS:
+            case NOT_ALL_REQUIRED_TASKS_RUNNING:
+            case CHECKPOINT_SUBSUMED:
+            case CHECKPOINT_COORDINATOR_SUSPEND:
+            case CHECKPOINT_COORDINATOR_SHUTDOWN:
+            case CHANNEL_STATE_SHARED_STREAM_EXCEPTION:
+            case JOB_FAILOVER_REGION:
+            // for compatibility purposes with user job behavior
+            case CHECKPOINT_DECLINED_TASK_NOT_READY:
+            case CHECKPOINT_DECLINED_TASK_CLOSING:
+            case CHECKPOINT_DECLINED_ON_CANCELLATION_BARRIER:
+            case CHECKPOINT_DECLINED_SUBSUMED:
+            case CHECKPOINT_DECLINED_INPUT_END_OF_STREAM:
+
+            case TASK_FAILURE:
+            case TASK_CHECKPOINT_FAILURE:
+            case UNKNOWN_TASK_CHECKPOINT_NOTIFICATION_FAILURE:
+            // there are some edge cases shouldn't be counted as a failure, e.g. shutdown
+            case TRIGGER_CHECKPOINT_FAILURE:
+            case BLOCKING_OUTPUT_EXIST:
+                return false;
+
+            case IO_EXCEPTION:
+            case CHECKPOINT_ASYNC_EXCEPTION:
+            case CHECKPOINT_DECLINED:
+            case CHECKPOINT_EXPIRED:
+            case FINALIZE_CHECKPOINT_FAILURE:
+                return true;
+
+            default:
+                throw new FlinkRuntimeException("Unknown checkpoint failure reason : " + name());
+        }
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointStatsListener.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointStatsListener.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.runtime.checkpoint;
 
+import javax.annotation.Nullable;
+
 /** An interface that allows listening on the checkpoint lifecycle. */
 public interface CheckpointStatsListener {
 
@@ -26,8 +28,13 @@ public interface CheckpointStatsListener {
         // No-op.
     }
 
-    /** Called when a checkpoint failed. */
-    default void onFailedCheckpoint() {
+    /**
+     * Called when a checkpoint failed.
+     *
+     * @param reason the {@link CheckpointFailureReason} categorizing the failure, or {@code null}
+     *     if the cause could not be classified (e.g. a non-{@link CheckpointException} cause).
+     */
+    default void onFailedCheckpoint(@Nullable CheckpointFailureReason reason) {
         // No-op.
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointStatsTracker.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointStatsTracker.java
@@ -92,8 +92,11 @@ public interface CheckpointStatsTracker {
     /**
      * Callback when a checkpoint failure without in progress checkpoint. For example, it should be
      * callback when triggering checkpoint failure before creating PendingCheckpoint.
+     *
+     * @param reason the {@link CheckpointFailureReason} categorizing the failure, or {@code null}
+     *     if unknown.
      */
-    void reportFailedCheckpointsWithoutInProgress();
+    void reportFailedCheckpointsWithoutInProgress(@Nullable CheckpointFailureReason reason);
 
     /**
      * Creates a new snapshot of the available stats.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/DefaultCheckpointStatsTracker.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/DefaultCheckpointStatsTracker.java
@@ -334,7 +334,7 @@ public class DefaultCheckpointStatsTracker implements CheckpointStatsTracker {
             logCheckpointStatistics(failed);
 
             if (checkpointStatsListener != null) {
-                checkpointStatsListener.onFailedCheckpoint();
+                checkpointStatsListener.onFailedCheckpoint(failed.getFailureReason());
             }
         } finally {
             statsReadWriteLock.unlock();
@@ -519,7 +519,7 @@ public class DefaultCheckpointStatsTracker implements CheckpointStatsTracker {
     }
 
     @Override
-    public void reportFailedCheckpointsWithoutInProgress() {
+    public void reportFailedCheckpointsWithoutInProgress(@Nullable CheckpointFailureReason reason) {
         statsReadWriteLock.lock();
         try {
             counts.incrementFailedCheckpointsWithoutInProgress();
@@ -527,7 +527,7 @@ public class DefaultCheckpointStatsTracker implements CheckpointStatsTracker {
             dirty = true;
 
             if (checkpointStatsListener != null) {
-                checkpointStatsListener.onFailedCheckpoint();
+                checkpointStatsListener.onFailedCheckpoint(reason);
             }
         } finally {
             statsReadWriteLock.unlock();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/FailedCheckpointStats.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/FailedCheckpointStats.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.checkpoint;
 
 import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.util.ExceptionUtils;
 
 import javax.annotation.Nullable;
 
@@ -41,6 +42,8 @@ public class FailedCheckpointStats extends PendingCheckpointStats {
     /** Optional failure message. */
     @Nullable private final String failureMsg;
 
+    @Nullable private final CheckpointFailureReason failureReason;
+
     /**
      * Creates a tracker for a failed checkpoint.
      *
@@ -58,7 +61,9 @@ public class FailedCheckpointStats extends PendingCheckpointStats {
      * @param unalignedCheckpoint Whether the checkpoint is unaligned.
      * @param failureTimestamp Timestamp when this checkpoint failed.
      * @param latestAcknowledgedSubtask The latest acknowledged subtask stats or <code>null</code>.
-     * @param cause Cause of the checkpoint failure or <code>null</code>.
+     * @param cause Cause of the checkpoint failure or <code>null</code>. If a {@link
+     *     CheckpointException} is found in its cause chain, that exception's {@link
+     *     CheckpointFailureReason} is captured.
      */
     FailedCheckpointStats(
             long checkpointId,
@@ -92,6 +97,10 @@ public class FailedCheckpointStats extends PendingCheckpointStats {
         checkArgument(numAcknowledgedSubtasks >= 0, "Negative number of ACKs");
         this.failureTimestamp = failureTimestamp;
         this.failureMsg = cause != null ? cause.getMessage() : null;
+        this.failureReason =
+                ExceptionUtils.findThrowable(cause, CheckpointException.class)
+                        .map(CheckpointException::getCheckpointFailureReason)
+                        .orElse(null);
     }
 
     @Override
@@ -122,5 +131,15 @@ public class FailedCheckpointStats extends PendingCheckpointStats {
     @Nullable
     public String getFailureMessage() {
         return failureMsg;
+    }
+
+    /**
+     * Returns the structured failure reason captured from a {@link CheckpointException} in the
+     * cause chain, or <code>null</code> if the cause was unknown or contained no {@code
+     * CheckpointException}.
+     */
+    @Nullable
+    public CheckpointFailureReason getFailureReason() {
+        return failureReason;
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/NoOpCheckpointStatsTracker.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/NoOpCheckpointStatsTracker.java
@@ -72,7 +72,8 @@ public enum NoOpCheckpointStatsTracker implements CheckpointStatsTracker {
     public void reportFailedCheckpoint(FailedCheckpointStats failed) {}
 
     @Override
-    public void reportFailedCheckpointsWithoutInProgress() {}
+    public void reportFailedCheckpointsWithoutInProgress(
+            @Nullable CheckpointFailureReason reason) {}
 
     @Override
     public CheckpointStatsSnapshot createSnapshot() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveScheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveScheduler.java
@@ -1827,8 +1827,9 @@ public class AdaptiveScheduler
         return new CheckpointStatsListener() {
 
             @Override
-            public void onFailedCheckpoint() {
-                runIfSupported(CheckpointStatsListener::onFailedCheckpoint, "onFailedCheckpoint");
+            public void onFailedCheckpoint(@Nullable CheckpointFailureReason reason) {
+                runIfSupported(
+                        listener -> listener.onFailedCheckpoint(reason), "onFailedCheckpoint");
             }
 
             @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/Executing.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/Executing.java
@@ -23,6 +23,7 @@ import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.core.execution.SavepointFormatType;
 import org.apache.flink.runtime.JobException;
 import org.apache.flink.runtime.checkpoint.CheckpointCoordinator;
+import org.apache.flink.runtime.checkpoint.CheckpointFailureReason;
 import org.apache.flink.runtime.checkpoint.CheckpointScheduling;
 import org.apache.flink.runtime.checkpoint.CheckpointStatsListener;
 import org.apache.flink.runtime.checkpoint.CompletedCheckpoint;
@@ -389,11 +390,33 @@ class Executing extends StateWithExecutionGraph
     }
 
     @Override
-    public void onFailedCheckpoint() {
+    public void onFailedCheckpoint(@Nullable CheckpointFailureReason reason) {
+        if (!isRescaleRelevantFailure(reason)) {
+            return;
+        }
+        // The countdown advances once per counted failure notification; unlike
+        // CheckpointFailureManager it does not dedup by checkpoint id. This is acceptable because
+        // the countdown is reset (to null) on the next completed checkpoint or rescale trigger, so
+        // at most one spurious decrement could ever accumulate within a single countdown window.
         if (this.failedCheckpointCountdown != null
                 && this.failedCheckpointCountdown.decrementAndGet() <= 0) {
             triggerPotentialRescale();
         }
+    }
+
+    /**
+     * Whether a failed checkpoint with the given reason should advance the
+     * rescale-on-failed-checkpoints countdown. Delegates to {@link
+     * CheckpointFailureReason#isCountedAgainstFailureThreshold()} — the single source of truth
+     * shared with {@link
+     * org.apache.flink.runtime.checkpoint.CheckpointFailureManager#checkFailureCounter} — so the
+     * countdown stays consistent with the job-level failure counter. A {@code null} reason carries
+     * no such classification and is ignored; no production notification path yields a countable
+     * {@code null} reason, as a failure with an in-progress checkpoint always originates from a
+     * {@link org.apache.flink.runtime.checkpoint.CheckpointException}.
+     */
+    private static boolean isRescaleRelevantFailure(@Nullable CheckpointFailureReason reason) {
+        return reason != null && reason.isCountedAgainstFailureThreshold();
     }
 
     private void triggerPotentialRescale() {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTest.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.checkpoint;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.configuration.TraceOptions;
 import org.apache.flink.core.execution.RecoveryClaimMode;
 import org.apache.flink.core.execution.SavepointFormatType;
 import org.apache.flink.core.fs.FSDataInputStream;
@@ -455,6 +456,142 @@ class CheckpointCoordinatorTest {
         assertThat(checkpointCoordinator.getNumberOfRetainedSuccessfulCheckpoints()).isZero();
 
         checkpointCoordinator.shutdown();
+    }
+
+    // ------------------------------------------------------------------------
+    //  Checkpoint failure reason delivery to the CheckpointStatsListener.
+    //
+    //  Integration coverage for FLINK-36512: the adaptive scheduler's
+    //  rescale-on-failed-checkpoints countdown consumes the reason handed to
+    //  CheckpointStatsListener#onFailedCheckpoint and must only advance for
+    //  reasons attributable to in-flight checkpoint execution. These tests
+    //  drive a real CheckpointCoordinator so the reason under assertion is the
+    //  one production code actually generates (rather than a hand-supplied one),
+    //  covering both listener paths: reportFailedCheckpointsWithoutInProgress
+    //  (pre-flight / IO trigger failures) and reportFailedCheckpoint (declines).
+    // ------------------------------------------------------------------------
+
+    @Test
+    void testPreFlightFailureReasonDeliveredToStatsListenerIsNotRescaleRelevant() throws Exception {
+        // A checkpoint triggered while not all tasks are running fails before any
+        // PendingCheckpoint exists and must surface NOT_ALL_REQUIRED_TASKS_RUNNING, which the
+        // adaptive scheduler ignores for rescaling.
+        ExecutionGraph graph =
+                new CheckpointCoordinatorTestingUtils.CheckpointExecutionGraphBuilder()
+                        .addJobVertex(new JobVertexID())
+                        .setTransitToRunning(false)
+                        .build(EXECUTOR_RESOURCE.getExecutor());
+
+        List<CheckpointFailureReason> observedFailureReasons = new ArrayList<>();
+        CheckpointCoordinator coordinator =
+                createCoordinatorWithFailureReasonListener(graph, null, observedFailureReasons);
+
+        CompletableFuture<CompletedCheckpoint> future = coordinator.triggerCheckpoint(false);
+        manuallyTriggeredScheduledExecutor.triggerAll();
+
+        assertThat(future).isCompletedExceptionally();
+        assertThat(observedFailureReasons)
+                .containsExactly(CheckpointFailureReason.NOT_ALL_REQUIRED_TASKS_RUNNING);
+        assertThat(
+                        CheckpointFailureReason.NOT_ALL_REQUIRED_TASKS_RUNNING
+                                .isCountedAgainstFailureThreshold())
+                .as("Pre-flight failures must not advance the adaptive rescale countdown.")
+                .isFalse();
+
+        coordinator.shutdown();
+    }
+
+    @Test
+    void testIOExceptionFailureReasonDeliveredToStatsListenerIsRescaleRelevant() throws Exception {
+        ExecutionGraph graph =
+                new CheckpointCoordinatorTestingUtils.CheckpointExecutionGraphBuilder()
+                        .addJobVertex(new JobVertexID())
+                        .build(EXECUTOR_RESOURCE.getExecutor());
+
+        List<CheckpointFailureReason> observedFailureReasons = new ArrayList<>();
+        CheckpointCoordinator coordinator =
+                createCoordinatorWithFailureReasonListener(
+                        graph, new IOExceptionCheckpointStorage(), observedFailureReasons);
+
+        CompletableFuture<CompletedCheckpoint> future = coordinator.triggerCheckpoint(false);
+        manuallyTriggeredScheduledExecutor.triggerAll();
+
+        assertThat(future).isCompletedExceptionally();
+        assertThat(observedFailureReasons).containsExactly(IO_EXCEPTION);
+        assertThat(IO_EXCEPTION.isCountedAgainstFailureThreshold())
+                .as("In-flight IO failures must advance the adaptive rescale countdown.")
+                .isTrue();
+
+        coordinator.shutdown();
+    }
+
+    @Test
+    void testDeclineFailureReasonDeliveredToStatsListenerIsRescaleRelevant() throws Exception {
+        JobVertexID jobVertexID = new JobVertexID();
+        ExecutionGraph graph =
+                new CheckpointCoordinatorTestingUtils.CheckpointExecutionGraphBuilder()
+                        .addJobVertex(jobVertexID)
+                        .build(EXECUTOR_RESOURCE.getExecutor());
+        ExecutionAttemptID attemptID =
+                graph.getJobVertex(jobVertexID)
+                        .getTaskVertices()[0]
+                        .getCurrentExecutionAttempt()
+                        .getAttemptId();
+
+        List<CheckpointFailureReason> observedFailureReasons = new ArrayList<>();
+        CheckpointCoordinator coordinator =
+                createCoordinatorWithFailureReasonListener(graph, null, observedFailureReasons);
+
+        // A declined in-flight checkpoint reaches the listener via the reportFailedCheckpoint
+        // path (a PendingCheckpoint exists).
+        CompletableFuture<CompletedCheckpoint> future = coordinator.triggerCheckpoint(false);
+        manuallyTriggeredScheduledExecutor.triggerAll();
+        FutureUtils.throwIfCompletedExceptionally(future);
+
+        long checkpointId =
+                coordinator.getPendingCheckpoints().entrySet().iterator().next().getKey();
+        coordinator.receiveDeclineMessage(
+                new DeclineCheckpoint(
+                        graph.getJobID(),
+                        attemptID,
+                        checkpointId,
+                        new CheckpointException(CHECKPOINT_DECLINED)),
+                TASK_MANAGER_LOCATION_INFO);
+
+        assertThat(observedFailureReasons).containsExactly(CHECKPOINT_DECLINED);
+        assertThat(CHECKPOINT_DECLINED.isCountedAgainstFailureThreshold())
+                .as("Declined checkpoints must advance the adaptive rescale countdown.")
+                .isTrue();
+
+        coordinator.shutdown();
+    }
+
+    private CheckpointCoordinator createCoordinatorWithFailureReasonListener(
+            ExecutionGraph graph,
+            @Nullable CheckpointStorage checkpointStorage,
+            List<CheckpointFailureReason> observedFailureReasons)
+            throws Exception {
+        CheckpointStatsListener listener =
+                new CheckpointStatsListener() {
+                    @Override
+                    public void onFailedCheckpoint(@Nullable CheckpointFailureReason reason) {
+                        observedFailureReasons.add(reason);
+                    }
+                };
+        DefaultCheckpointStatsTracker statsTracker =
+                new DefaultCheckpointStatsTracker(
+                        Integer.MAX_VALUE,
+                        UnregisteredMetricGroups.createUnregisteredJobManagerJobMetricGroup(),
+                        TraceOptions.CheckpointSpanDetailLevel.SPAN_PER_CHECKPOINT,
+                        listener);
+        CheckpointCoordinatorBuilder builder =
+                new CheckpointCoordinatorBuilder()
+                        .setTimer(manuallyTriggeredScheduledExecutor)
+                        .setCheckpointStatsTracker(statsTracker);
+        if (checkpointStorage != null) {
+            builder.setCheckpointStorage(checkpointStorage);
+        }
+        return builder.build(graph);
     }
 
     @Test

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/DefaultCheckpointStatsTrackerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/DefaultCheckpointStatsTrackerTest.java
@@ -40,6 +40,8 @@ import org.apache.flink.shaded.guava33.com.google.common.collect.Iterables;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+import javax.annotation.Nullable;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -194,7 +196,7 @@ class DefaultCheckpointStatsTrackerTest {
         assertThat(counts.getNumberOfCompletedCheckpoints()).isEqualTo(2);
         assertThat(counts.getNumberOfFailedCheckpoints()).isOne();
 
-        tracker.reportFailedCheckpointsWithoutInProgress();
+        tracker.reportFailedCheckpointsWithoutInProgress(null);
 
         CheckpointStatsSnapshot snapshot1 = tracker.createSnapshot();
         counts = snapshot1.getCounts();
@@ -280,7 +282,7 @@ class DefaultCheckpointStatsTrackerTest {
                     }
 
                     @Override
-                    public void onFailedCheckpoint() {
+                    public void onFailedCheckpoint(@Nullable CheckpointFailureReason reason) {
                         onFailedCheckpointCount.incrementAndGet();
                     }
                 };

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/FailedCheckpointStatsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/FailedCheckpointStatsTest.java
@@ -23,6 +23,8 @@ import org.apache.flink.runtime.jobgraph.JobVertexID;
 
 import org.junit.jupiter.api.Test;
 
+import javax.annotation.Nullable;
+
 import java.io.NotSerializableException;
 import java.util.HashMap;
 import java.util.Map;
@@ -110,5 +112,64 @@ public class FailedCheckpointStatsTest {
                 .isEqualTo(failed.getLatestAcknowledgedSubtaskStats());
         assertThat(copy.getStatus()).isEqualTo(failed.getStatus());
         assertThat(copy.getFailureMessage()).isEqualTo(failed.getFailureMessage());
+    }
+
+    @Test
+    void testFailureReasonExtractedFromCheckpointException() {
+        FailedCheckpointStats failed =
+                newFailedCheckpointStats(
+                        new CheckpointException(CheckpointFailureReason.IO_EXCEPTION));
+
+        assertThat(failed.getFailureReason()).isEqualTo(CheckpointFailureReason.IO_EXCEPTION);
+    }
+
+    @Test
+    void testFailureReasonExtractedFromWrappedCheckpointException() {
+        FailedCheckpointStats failed =
+                newFailedCheckpointStats(
+                        new RuntimeException(
+                                "wrapper",
+                                new CheckpointException(
+                                        CheckpointFailureReason.CHECKPOINT_EXPIRED)));
+
+        assertThat(failed.getFailureReason()).isEqualTo(CheckpointFailureReason.CHECKPOINT_EXPIRED);
+    }
+
+    @Test
+    void testFailureReasonNullForNonCheckpointExceptionCause() {
+        FailedCheckpointStats failed =
+                newFailedCheckpointStats(new RuntimeException("some other failure"));
+
+        assertThat(failed.getFailureReason()).isNull();
+    }
+
+    @Test
+    void testFailureReasonNullForNullCause() {
+        FailedCheckpointStats failed = newFailedCheckpointStats(null);
+
+        assertThat(failed.getFailureReason()).isNull();
+    }
+
+    private static FailedCheckpointStats newFailedCheckpointStats(@Nullable Throwable cause) {
+        Map<JobVertexID, TaskStateStats> taskStats = new HashMap<>();
+        JobVertexID jobVertexId = new JobVertexID();
+        taskStats.put(jobVertexId, new TaskStateStats(jobVertexId, 1));
+
+        return new FailedCheckpointStats(
+                0,
+                10123L,
+                CheckpointProperties.forCheckpoint(
+                        CheckpointRetentionPolicy.NEVER_RETAIN_AFTER_TERMINATION),
+                1,
+                taskStats,
+                0,
+                0,
+                0,
+                0,
+                0,
+                false,
+                10123L,
+                null,
+                cause);
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/TestingCheckpointStatsTracker.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/TestingCheckpointStatsTracker.java
@@ -21,6 +21,8 @@ package org.apache.flink.runtime.checkpoint;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 
+import javax.annotation.Nullable;
+
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
@@ -39,7 +41,7 @@ public class TestingCheckpointStatsTracker implements CheckpointStatsTracker {
                     Collections.singletonMap(new JobVertexID(), 1));
 
     @Override
-    public void reportFailedCheckpointsWithoutInProgress() {
+    public void reportFailedCheckpointsWithoutInProgress(@Nullable CheckpointFailureReason reason) {
         numFailedCheckpoints.incrementAndGet();
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherTest.java
@@ -802,8 +802,8 @@ public class DispatcherTest extends AbstractDispatcherTest {
         CheckpointStatsTracker checkpointStatsTracker =
                 new DefaultCheckpointStatsTracker(
                         10, UnregisteredMetricGroups.createUnregisteredJobManagerJobMetricGroup());
-        checkpointStatsTracker.reportFailedCheckpointsWithoutInProgress();
-        checkpointStatsTracker.reportFailedCheckpointsWithoutInProgress();
+        checkpointStatsTracker.reportFailedCheckpointsWithoutInProgress(null);
+        checkpointStatsTracker.reportFailedCheckpointsWithoutInProgress(null);
         return checkpointStatsTracker.createSnapshot();
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveSchedulerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveSchedulerTest.java
@@ -2306,7 +2306,9 @@ public class AdaptiveSchedulerTest extends AdaptiveSchedulerTestBase {
     @Test
     void testOnFailedCheckpointIsHandledInMainThread() throws Exception {
         testCheckpointStatsEventBeingExecutedInTheMainThread(
-                CheckpointStatsListener::onFailedCheckpoint, 2, 2);
+                listener -> listener.onFailedCheckpoint(CheckpointFailureReason.IO_EXCEPTION),
+                2,
+                2);
     }
 
     private void testCheckpointStatsEventBeingExecutedInTheMainThread(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/ExecutingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/ExecutingTest.java
@@ -26,6 +26,7 @@ import org.apache.flink.runtime.blob.BlobWriter;
 import org.apache.flink.runtime.blob.PermanentBlobKey;
 import org.apache.flink.runtime.checkpoint.CheckpointCoordinator;
 import org.apache.flink.runtime.checkpoint.CheckpointCoordinatorTestingUtils;
+import org.apache.flink.runtime.checkpoint.CheckpointFailureReason;
 import org.apache.flink.runtime.checkpoint.CheckpointScheduling;
 import org.apache.flink.runtime.client.JobExecutionException;
 import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
@@ -83,6 +84,7 @@ import org.apache.flink.util.concurrent.ManuallyTriggeredScheduledExecutor;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -242,7 +244,7 @@ class ExecutingTest {
 
                 // trigger an initial failed checkpoint event to show that the counting only starts
                 // with the subsequent change event
-                testInstance.onFailedCheckpoint();
+                testInstance.onFailedCheckpoint(CheckpointFailureReason.IO_EXCEPTION);
 
                 // trigger change
                 testInstance.onNewResourceRequirements();
@@ -253,7 +255,7 @@ class ExecutingTest {
                                     "No rescale operation should have been triggered for iteration #%d, yet.",
                                     rescaleIteration)
                             .hasValue(rescaleIteration - 1);
-                    testInstance.onFailedCheckpoint();
+                    testInstance.onFailedCheckpoint(CheckpointFailureReason.IO_EXCEPTION);
                 }
 
                 assertThat(rescaleTriggerCount)
@@ -284,13 +286,16 @@ class ExecutingTest {
 
             // trigger an initial failed checkpoint event to show that the counting only starts with
             // the subsequent change event
-            testInstance.onFailedCheckpoint();
+            testInstance.onFailedCheckpoint(CheckpointFailureReason.IO_EXCEPTION);
 
             // trigger change
             testInstance.onNewResourcesAvailable();
 
             IntStream.range(0, rescaleOnFailedCheckpointsCount - 1)
-                    .forEach(ignored -> testInstance.onFailedCheckpoint());
+                    .forEach(
+                            ignored ->
+                                    testInstance.onFailedCheckpoint(
+                                            CheckpointFailureReason.IO_EXCEPTION));
 
             assertThat(rescaleTriggeredCount)
                     .as("No rescaling should have been trigger, yet.")
@@ -306,18 +311,113 @@ class ExecutingTest {
                     .hasValue(1);
 
             IntStream.range(0, rescaleOnFailedCheckpointsCount - 1)
-                    .forEach(ignored -> testInstance.onFailedCheckpoint());
+                    .forEach(
+                            ignored ->
+                                    testInstance.onFailedCheckpoint(
+                                            CheckpointFailureReason.IO_EXCEPTION));
 
             assertThat(rescaleTriggeredCount)
                     .as(
                             "No additional rescaling should have been trigger by any subsequent failed checkpoint, yet.")
                     .hasValue(1);
 
-            testInstance.onFailedCheckpoint();
+            testInstance.onFailedCheckpoint(CheckpointFailureReason.IO_EXCEPTION);
 
             assertThat(rescaleTriggeredCount)
                     .as("The previous failed checkpoint should have triggered the rescale.")
                     .hasValue(2);
+        }
+    }
+
+    @Test
+    public void testIgnoredFailureReasonDoesNotTriggerRescale() throws Exception {
+        runRescaleTriggerCheckForReason(CheckpointFailureReason.NOT_ALL_REQUIRED_TASKS_RUNNING, 0);
+    }
+
+    @Test
+    public void testNullFailureReasonDoesNotTriggerRescale() throws Exception {
+        runRescaleTriggerCheckForReason(null, 0);
+    }
+
+    /**
+     * Guards that the rescale countdown honors exactly the set of failure reasons classified as
+     * counted by {@link CheckpointFailureReason#isCountedAgainstFailureThreshold()} — the same
+     * predicate used by {@code CheckpointFailureManager} — for every reason, so the two mechanisms
+     * cannot silently drift apart when a new reason is added.
+     */
+    @ParameterizedTest
+    @EnumSource(CheckpointFailureReason.class)
+    public void testRescaleCountdownHonorsFailureThresholdClassification(
+            CheckpointFailureReason reason) throws Exception {
+        runRescaleTriggerCheckForReason(reason, reason.isCountedAgainstFailureThreshold() ? 1 : 0);
+    }
+
+    @Test
+    public void testMixedFailureReasonsOnlyCountRelevant() throws Exception {
+        final AtomicInteger rescaleTriggerCount = new AtomicInteger();
+        final Function<StateTransitionManager.Context, StateTransitionManager>
+                stateTransitionManagerFactory =
+                        context ->
+                                TestingStateTransitionManager.withOnTriggerEventOnly(
+                                        rescaleTriggerCount::incrementAndGet);
+
+        final int rescaleOnFailedCheckpointsCount = 2;
+        try (MockExecutingContext ctx = new MockExecutingContext()) {
+            final Executing testInstance =
+                    new ExecutingStateBuilder()
+                            .setStateTransitionManagerFactory(stateTransitionManagerFactory)
+                            .setRescaleOnFailedCheckpointCount(rescaleOnFailedCheckpointsCount)
+                            .build(ctx);
+
+            testInstance.onNewResourceRequirements();
+
+            // ignored failures interspersed with a single relevant failure must not advance the
+            // countdown enough to trigger a rescale
+            testInstance.onFailedCheckpoint(CheckpointFailureReason.NOT_ALL_REQUIRED_TASKS_RUNNING);
+            testInstance.onFailedCheckpoint(CheckpointFailureReason.IO_EXCEPTION);
+            testInstance.onFailedCheckpoint(CheckpointFailureReason.CHECKPOINT_SUBSUMED);
+            testInstance.onFailedCheckpoint(null);
+
+            assertThat(rescaleTriggerCount)
+                    .as("Only one relevant failure has been observed so far.")
+                    .hasValue(0);
+
+            testInstance.onFailedCheckpoint(CheckpointFailureReason.CHECKPOINT_EXPIRED);
+
+            assertThat(rescaleTriggerCount)
+                    .as("Two relevant failures should have triggered the rescale.")
+                    .hasValue(1);
+        }
+    }
+
+    private void runRescaleTriggerCheckForReason(
+            @Nullable CheckpointFailureReason reason, int expectedRescaleCount) throws Exception {
+        final AtomicInteger rescaleTriggerCount = new AtomicInteger();
+        final Function<StateTransitionManager.Context, StateTransitionManager>
+                stateTransitionManagerFactory =
+                        context ->
+                                TestingStateTransitionManager.withOnTriggerEventOnly(
+                                        rescaleTriggerCount::incrementAndGet);
+
+        final int rescaleOnFailedCheckpointsCount = 2;
+        try (MockExecutingContext ctx = new MockExecutingContext()) {
+            final Executing testInstance =
+                    new ExecutingStateBuilder()
+                            .setStateTransitionManagerFactory(stateTransitionManagerFactory)
+                            .setRescaleOnFailedCheckpointCount(rescaleOnFailedCheckpointsCount)
+                            .build(ctx);
+
+            testInstance.onNewResourceRequirements();
+
+            for (int i = 0; i < rescaleOnFailedCheckpointsCount * 2; i++) {
+                testInstance.onFailedCheckpoint(reason);
+            }
+
+            assertThat(rescaleTriggerCount)
+                    .as(
+                            "Failures with reason %s should have triggered %d rescale(s).",
+                            reason, expectedRescaleCount)
+                    .hasValue(expectedRescaleCount);
         }
     }
 


### PR DESCRIPTION
## What is the purpose of the change

The Adaptive Scheduler can trigger a rescale after a configurable number of consecutive failed checkpoints (`jobmanager.adaptive-scheduler.rescale-trigger.max-checkpoint-failures`). The countdown was decremented on *every* failed-checkpoint notification, including failures that do not count against the tolerable checkpoint-failure threshold — e.g. checkpoints triggered before all tasks are running during startup/recovery (`NOT_ALL_REQUIRED_TASKS_RUNNING`), coordinator shutdown, or checkpoint subsumption.

As a result, transient pre-flight failures during startup/recovery could drive the countdown to zero and cause a spurious, premature rescale even though no checkpoint ever actually ran and failed.

This change makes the rescale trigger count only the failure reasons that count against the tolerable checkpoint-failure threshold — the exact same set that `CheckpointFailureManager` enforces at the job level — so the two failure-counting mechanisms stay consistent.

## Brief change log

  - Added `CheckpointFailureReason#isCountedAgainstFailureThreshold()` as the single source of truth for which reasons count toward a failure threshold; `CheckpointFailureManager#checkFailureCounter` and the Adaptive Scheduler rescale countdown now both consult it (previously the classification was duplicated).
  - Threaded the `CheckpointFailureReason` through the checkpoint-stats failure notification path: `CheckpointStatsListener#onFailedCheckpoint`, `CheckpointStatsTracker#reportFailedCheckpointsWithoutInProgress`, and `FailedCheckpointStats` (extracted from the `CheckpointException` cause chain).
  - `Executing#onFailedCheckpoint` now ignores non-counted reasons, so pre-flight failures no longer advance the rescale countdown.
  - Tightened the description of `SCHEDULER_RESCALE_TRIGGER_MAX_CHECKPOINT_FAILURES` to reflect the above.

## Verifying this change

This change added tests and can be verified as follows:

  - `ExecutingTest`: parameterized over **all** `CheckpointFailureReason` values, asserting the rescale countdown advances iff the reason is counted; plus null-reason and mixed relevant/irrelevant interleaving cases.
  - `CheckpointFailureManagerTest`: existing tests confirm the refactor to the shared predicate is behavior-preserving.
  - `FailedCheckpointStatsTest`: reason extraction from a direct `CheckpointException`, a wrapped `CheckpointException` in the cause chain, a non-`CheckpointException` cause, and a null cause.
  - `CheckpointCoordinatorTest` (integration): new cases drive a real `CheckpointCoordinator` → `CheckpointFailureManager` → `DefaultCheckpointStatsTracker` → `CheckpointStatsListener` and assert the exact reason delivered for a pre-flight failure (`NOT_ALL_REQUIRED_TASKS_RUNNING`), an IO failure, and a declined checkpoint — covering both listener paths (`reportFailedCheckpointsWithoutInProgress` and `reportFailedCheckpoint`).

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: **yes** — changes checkpoint-failure classification and the Adaptive Scheduler's rescale-on-failed-checkpoints behavior. No changes to checkpoint format, wire protocol, or public API.
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no** (bug fix to existing behavior)
  - If yes, how is the feature documented? **not applicable** (the description of the existing `rescale-trigger.max-checkpoint-failures` config option was updated to reflect the corrected semantics)

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (Claude Code — Claude Opus 4.8)

<!--
Generated-by: Claude Code (Claude Opus 4.8)
-->
