### PR TITLE
[FLINK-40154][formats] Upgrade Parquet to 1.16.0

### DIFF
--- a/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/protobuf/PatchedProtoWriteSupport.java
+++ b/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/protobuf/PatchedProtoWriteSupport.java
@@ -78,7 +78,7 @@ import static org.apache.parquet.proto.ProtoConstants.METADATA_ENUM_PREFIX;
  * https://github.com/apache/parquet-java/issues/3175.
  *
  * <p>The original source can be found here:
- * https://github.com/apache/parquet-java/blob/apache-parquet-1.15.2/parquet-protobuf/src/main/java/org/apache/parquet/proto/ProtoWriteSupport.java
+ * https://github.com/apache/parquet-java/blob/apache-parquet-1.16.0/parquet-protobuf/src/main/java/org/apache/parquet/proto/ProtoWriteSupport.java
  *
  * <p>Patched code is marked with BEGIN PATCH / END PATCH comments in the source.
  */

--- a/flink-formats/flink-sql-parquet/src/main/resources/META-INF/NOTICE
+++ b/flink-formats/flink-sql-parquet/src/main/resources/META-INF/NOTICE
@@ -6,11 +6,11 @@ The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0. (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-- org.apache.parquet:parquet-avro:1.15.2
-- org.apache.parquet:parquet-hadoop:1.15.2
-- org.apache.parquet:parquet-column:1.15.2
-- org.apache.parquet:parquet-common:1.15.2
-- org.apache.parquet:parquet-encoding:1.15.2
-- org.apache.parquet:parquet-format-structures:1.15.2
-- org.apache.parquet:parquet-jackson:1.15.2
+- org.apache.parquet:parquet-avro:1.16.0
+- org.apache.parquet:parquet-hadoop:1.16.0
+- org.apache.parquet:parquet-column:1.16.0
+- org.apache.parquet:parquet-common:1.16.0
+- org.apache.parquet:parquet-encoding:1.16.0
+- org.apache.parquet:parquet-format-structures:1.16.0
+- org.apache.parquet:parquet-jackson:1.16.0
 - commons-pool:commons-pool:1.6

--- a/flink-formats/pom.xml
+++ b/flink-formats/pom.xml
@@ -30,7 +30,7 @@ under the License.
 	</parent>
 
 	<properties>
-		<flink.format.parquet.version>1.15.2</flink.format.parquet.version>
+		<flink.format.parquet.version>1.16.0</flink.format.parquet.version>
 	</properties>
 
 	<artifactId>flink-formats</artifactId>
@@ -92,3 +92,4 @@ under the License.
 	</profiles>
 
 </project>
+


### PR DESCRIPTION
## Title

[FLINK-xxxxx][Formats][Parquet] Upgrade Parquet dependency to 1.16.0

## Description

## What is the purpose of the change

This pull request upgrades the Apache Parquet dependency from 1.15.2 to 1.16.0.

## Brief change log

* Upgraded `org.apache.parquet:parquet-bom` from `1.15.2` to `1.16.0`.

## Related changes

This PR is kept as a draft until the Hadoop 3.4.x upgrade in #27026 is finalized.

The Parquet upgrade itself is intentionally kept separate from the Hadoop upgrade. Once #27026 is merged, or its final dependency layout is settled, this PR should be rebased and verified against that baseline.

## Verifying this change

This change is covered by the existing Parquet format test coverage.

It can be verified by running:

```bash
./mvnw -pl flink-formats/flink-parquet -am test
```

## Does this pull request potentially affect one of the following parts:

* Dependencies: yes
* The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
* The serializers: no
* The runtime per-record code paths: no
* Anything that affects deployment or recovery: no
* The S3 file system connector: no

## Documentation

* Does this pull request introduce a new feature? no
* If yes, how is the feature documented? not applicable