### PR TITLE
[FLINK-40114][runtime] Don't erase leader information while a confirmation is pending

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/DefaultLeaderElectionService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/DefaultLeaderElectionService.java
@@ -517,10 +517,17 @@ public class DefaultLeaderElectionService extends DefaultLeaderElection.ParentSe
         }
 
         if (confirmedLeaderInformation.isEmpty()) {
+            // No confirmed leader information for this component yet (e.g. leadership was
+            // (re-)acquired but the asynchronous confirmation hasn't completed). Leave the external
+            // storage untouched instead of deleting it: a pending confirmation will overwrite any
+            // stale value, whereas deleting here would drop the leader information permanently if
+            // the confirmation never completes.
             LOG.trace(
-                    "Leader information changed while there's no confirmation available by the contender for component '{}', yet. Changed leader information {} will be reset.",
+                    "Leader information for component '{}' changed while no confirmation is available yet (issued leader session ID: {}). Leaving the external storage untouched. Changed leader information: {}.",
                     componentId,
+                    issuedLeaderSessionID,
                     LeaderElectionUtils.convertToString(externallyChangedLeaderInformation));
+            return;
         } else if (externallyChangedLeaderInformation.isEmpty()) {
             LOG.debug(
                     "Re-writing leader information ({}) for component '{}' to overwrite the empty leader information in the external storage.",

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/DefaultLeaderElectionServiceTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/DefaultLeaderElectionServiceTest.java
@@ -1105,6 +1105,138 @@ class DefaultLeaderElectionServiceTest {
         };
     }
 
+    /**
+     * A leader-information change event (e.g. a Kubernetes ConfigMap watch event) that arrives
+     * while a granted session's confirmation is still in flight must not erase the component's
+     * leader information from the external storage. {@code confirmLeadershipAsync} runs
+     * asynchronously on the {@code leadershipOperationExecutor} while {@code
+     * onLeaderInformationChange} is handled synchronously, so the change handler can observe an
+     * empty {@code confirmedLeaderInformation} and reset a stale external entry to empty before the
+     * confirmation has had a chance to run.
+     */
+    @Test
+    void testLeaderInformationChangeDoesNotEraseComponentWithInflightConfirmation()
+            throws Exception {
+        final AtomicReference<LeaderInformationRegister> storedLeaderInformation =
+                new AtomicReference<>();
+        new Context(storedLeaderInformation) {
+            {
+                runTestWithManuallyTriggeredEvents(
+                        executor -> {
+                            final String componentId = contenderContext0.componentId;
+                            final UUID staleSessionId = UUID.randomUUID();
+                            final UUID currentSessionId = UUID.randomUUID();
+
+                            // Acquire leadership for the current session but keep the confirmation
+                            // in flight: the grant runnable runs, the auto-queued confirm does not.
+                            grantLeadership(currentSessionId);
+                            executor.trigger();
+
+                            // The external storage still holds a stale entry from a previous
+                            // session that wasn't cleaned up (e.g. during an API-server outage).
+                            final LeaderInformation staleLeaderInformation =
+                                    LeaderInformation.known(staleSessionId, "stale-address");
+                            storedLeaderInformation.set(
+                                    LeaderInformationRegister.of(
+                                            componentId, staleLeaderInformation));
+
+                            // A watch event delivers the stale entry while the confirmation for the
+                            // current session is still queued on the leadershipOperationExecutor.
+                            leaderElectionService.onLeaderInformationChange(
+                                    LeaderInformationRegister.of(
+                                            componentId, staleLeaderInformation));
+
+                            assertThat(
+                                            storedLeaderInformation
+                                                    .get()
+                                                    .hasLeaderInformation(componentId))
+                                    .as(
+                                            "The leader information for a component we lead must not be "
+                                                    + "erased from the external storage while its confirmation "
+                                                    + "is still in flight.")
+                                    .isTrue();
+
+                            // Once the pending confirmation runs, the external storage converges to
+                            // the current session's leader information.
+                            executor.triggerAll();
+                            assertThat(storedLeaderInformation.get().forComponentId(componentId))
+                                    .hasValue(
+                                            LeaderInformation.known(
+                                                    currentSessionId, contenderContext0.address));
+                        });
+            }
+        };
+    }
+
+    /**
+     * After leadership is lost and re-acquired with a new session, the previous session's
+     * still-present external entry must not be erased while the new session's confirmation is in
+     * flight. A component confirms one session, gets revoked (which clears the local confirmation
+     * but leaves the external entry in place), and is re-granted a new session whose confirmation
+     * is still pending when a change event replays the stale entry.
+     */
+    @Test
+    void testLeaderInformationChangeDoesNotEraseComponentAfterReacquisition() throws Exception {
+        final AtomicReference<LeaderInformationRegister> storedLeaderInformation =
+                new AtomicReference<>();
+        new Context(storedLeaderInformation) {
+            {
+                runTestWithManuallyTriggeredEvents(
+                        executor -> {
+                            final String componentId = contenderContext0.componentId;
+                            final UUID firstSessionId = UUID.randomUUID();
+                            final UUID secondSessionId = UUID.randomUUID();
+
+                            // First reign: grant and let the confirmation land so the external
+                            // storage holds the first session's leader information.
+                            grantLeadership(firstSessionId);
+                            executor.triggerAll();
+                            assertThat(
+                                            storedLeaderInformation
+                                                    .get()
+                                                    .hasLeaderInformation(componentId))
+                                    .as("precondition: the first session's entry was written")
+                                    .isTrue();
+
+                            // Leadership is lost: the local confirmation is cleared but the
+                            // external
+                            // storage keeps the stale entry (not cleaned up during the outage).
+                            revokeLeadership();
+                            executor.triggerAll();
+
+                            // Leadership is re-acquired with a new session; the confirmation for
+                            // the
+                            // new session is queued but kept in flight.
+                            grantLeadership(secondSessionId);
+                            executor.trigger();
+
+                            // A watch event replays the stale (first-session) entry while the new
+                            // session's confirmation is still pending.
+                            leaderElectionService.onLeaderInformationChange(
+                                    storedLeaderInformation.get());
+
+                            assertThat(
+                                            storedLeaderInformation
+                                                    .get()
+                                                    .hasLeaderInformation(componentId))
+                                    .as(
+                                            "The leader information must not be erased after "
+                                                    + "re-acquisition while the new session's confirmation "
+                                                    + "is still in flight.")
+                                    .isTrue();
+
+                            // Once the pending confirmation runs, the external storage converges to
+                            // the new session's leader information.
+                            executor.triggerAll();
+                            assertThat(storedLeaderInformation.get().forComponentId(componentId))
+                                    .hasValue(
+                                            LeaderInformation.known(
+                                                    secondSessionId, contenderContext0.address));
+                        });
+            }
+        };
+    }
+
     @Test
     void testErrorForwarding() throws Exception {
         new Context() {
@@ -1201,9 +1333,13 @@ class DefaultLeaderElectionServiceTest {
                                     contenderContext0.componentId,
                                     storedLeaderInformation.get());
 
-                            assertThat(storedLeaderInformation.get().hasNoLeaderInformation())
+                            assertThat(
+                                            storedLeaderInformation
+                                                    .get()
+                                                    .hasLeaderInformation(
+                                                            contenderContext0.componentId))
                                     .as(
-                                            "The blocked leadership grant event shouldn't have blocked the processing of the LeaderInformation change event.")
+                                            "A queued leadership grant event shouldn't block the LeaderInformation change event; while the grant is pending (no confirmation available yet) the change handler must not erase the still-unconfirmed leader information.")
                                     .isTrue();
                         });
             }


### PR DESCRIPTION
## What is the purpose of the change

Fixes a regression from [FLINK-36451](https://issues.apache.org/jira/browse/FLINK-36451) that can permanently erase a component's leader information from the HA backend after a leadership loss and re-acquisition.

Mechanism: leadership is granted once per process (a single `issuedLeaderSessionID`), but each component (restserver, dispatcher, jobmanager, resourcemanager) confirms its own leader information asynchronously on `leadershipOperationExecutor`, while leader-information change events are handled synchronously in `notifyLeaderInformationChangeInternal`. After re-acquiring leadership a component is granted but not yet confirmed, so its `confirmedLeaderInformation` is empty. A change event in that window takes the `confirmedLeaderInformation.isEmpty()` branch and publishes empty, which on Kubernetes removes the component's key. The self-correcting rewrite only runs once a confirmation exists, so the erased entry is not restored until a subsequent confirmation succeeds, and remains erased if none does.

The change event is typically self-inflicted: all components share one ConfigMap, so when one component confirms (e.g. the dispatcher), that write fires a watch event evaluated against every other component, including one whose confirmation hasn't landed yet and whose stale prior-session entry is then reset to empty.

Impact: the JobManager keeps running as a healthy leader while its external entry is gone. The REST endpoint cannot be resolved (restserver), or job submission and TaskManager registration fail (dispatcher/jobmanager), with no self-recovery.

## Brief change log

- `DefaultLeaderElectionService#notifyLeaderInformationChangeInternal`: the `confirmedLeaderInformation.isEmpty()` branch now returns instead of publishing empty. That branch reset the external value on the assumption that `confirmed == empty` means "not leader", which only held under synchronous confirmation; with async confirmation it also means "leader, but not yet confirmed", so deleting acts on a transient state and destroys still-valid information. Returning is safe: if we hold the lock a pending (session-fenced) confirmation overwrites any stale value, and if we do not, the write would no-op anyway. Intentional cleanup is unchanged (`remove` -> `deleteLeaderInformation`).

## Verifying this change

Added tests that use `ManuallyTriggeredScheduledExecutorService` to hold a confirmation while a change event is injected; they fail without the fix and pass with it:

- `testLeaderInformationChangeDoesNotEraseComponentWithInflightConfirmation`: a change event during an outstanding confirmation must not erase the entry; it self-heals once the confirmation runs.
- `testLeaderInformationChangeDoesNotEraseComponentAfterReacquisition`: loss and re-acquisition with a new session; the prior session's entry must not be erased and self-heals to the new session.
- Repurposed `testGrantDoesNotBlockNotifyLeaderInformationChange` and `...AllKnownLeaderInformation` to assert non-erasure for both `onLeaderInformationChange` overloads.
- Also verified against the leaderelection / leaderretrieval / highavailability suites (including ZooKeeper and `LeaderChangeClusterComponentsTest`) and the `flink-kubernetes` HA unit tests.

## Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): no
- The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
- The serializers: no
- The runtime per-record code paths (performance sensitive): no
- Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: yes, fixes HA leader-election behavior affecting JobManager recovery on Kubernetes and ZooKeeper.
- The S3 file system connector: no

## Documentation

- Does this pull request introduce a new feature? no
- If yes, how is the feature documented? not applicable

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (Claude Code / Claude Opus 4.8)

Generated-by: Claude Code (Claude Opus 4.8)
