### PR TITLE
[FLINK-40153][table] Fix resolving inherited metadata columns used by watermarks in LIKE clause

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/MergeTableLikeUtil.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/MergeTableLikeUtil.java
@@ -282,6 +282,12 @@ public class MergeTableLikeUtil {
                 } else if (sourceColumn instanceof UnresolvedMetadataColumn) {
                     if (mergingStrategies.get(FeatureOption.METADATA)
                             != MergingStrategy.EXCLUDING) {
+                        UnresolvedMetadataColumn metadataColumn =
+                                (UnresolvedMetadataColumn) sourceColumn;
+                        LogicalType columnType = getLogicalType(dataTypeFactory, metadataColumn);
+                        metadataFieldNamesToTypes.put(
+                                sourceColumn.getName(),
+                                typeFactory.createFieldTypeFromLogicalType(columnType));
                         columns.put(sourceColumn.getName(), sourceColumn);
                     }
                 }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/converters/MergeTableLikeUtilTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/converters/MergeTableLikeUtilTest.java
@@ -508,6 +508,39 @@ class MergeTableLikeUtilTest {
     }
 
     @Test
+    void mergeWatermarkReferencingInheritedMetadataColumn() {
+        Schema sourceSchema =
+                Schema.newBuilder()
+                        .column("timestamp", DataTypes.TIMESTAMP(3))
+                        .columnByMetadata("opts", DataTypes.TIMESTAMP(3), true)
+                        .watermark("timestamp", "timestamp")
+                        .build();
+
+        List<SqlWatermark> derivedWatermarkSpecs =
+                List.of(
+                        new SqlWatermark(
+                                SqlParserPos.ZERO,
+                                identifier("opts"),
+                                boundedStrategy("opts", "5")));
+
+        Map<FeatureOption, MergingStrategy> mergingStrategies = getDefaultMergingStrategies();
+        mergingStrategies.put(FeatureOption.WATERMARKS, MergingStrategy.EXCLUDING);
+
+        Schema mergedSchema =
+                util.mergeTables(
+                        mergingStrategies, sourceSchema, List.of(), derivedWatermarkSpecs, null);
+
+        Schema expectedSchema =
+                Schema.newBuilder()
+                        .column("timestamp", DataTypes.TIMESTAMP(3))
+                        .columnByMetadata("opts", DataTypes.TIMESTAMP(3), true)
+                        .watermark("opts", "`opts` - INTERVAL '5' SECOND")
+                        .build();
+
+        assertThat(mergedSchema).isEqualTo(expectedSchema);
+    }
+
+    @Test
     void mergeIncludingWatermarksFailsOnDuplicate() {
         Schema sourceSchema =
                 Schema.newBuilder()

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/TableScanTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/TableScanTest.xml
@@ -105,6 +105,28 @@ Calc(select=[a, b, c], changelogMode=[I,UA,D])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testCreateTableLikeWithWatermarkReferencingMetadataColumn">
+    <Resource name="sql">
+      <![CDATA[INSERT INTO SinkTable SELECT `ts`, `opts` FROM LikeSourceWithWatermark]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.SinkTable], fields=[ts, opts])
++- LogicalProject(ts=[$0], opts=[$1])
+   +- LogicalWatermarkAssigner(rowtime=[opts], watermark=[-($1, 5000:INTERVAL SECOND)])
+      +- LogicalProject(ts=[$0], opts=[CAST($1):TIMESTAMP(3) *ROWTIME*])
+         +- LogicalTableScan(table=[[default_catalog, default_database, LikeSourceWithWatermark, metadata=[opts]]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.SinkTable], fields=[ts, opts])
++- WatermarkAssigner(rowtime=[opts], watermark=[(opts - 5000:INTERVAL SECOND)])
+   +- Calc(select=[ts, CAST(opts AS TIMESTAMP(3) *ROWTIME*) AS opts])
+      +- TableSourceScan(table=[[default_catalog, default_database, LikeSourceWithWatermark, metadata=[opts]]], fields=[ts, opts])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testDDLTableScan">
     <Resource name="sql">
       <![CDATA[SELECT * FROM src WHERE a > 1]]>

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/TableScanTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/TableScanTest.scala
@@ -147,6 +147,42 @@ class TableScanTest extends TableTestBase {
   }
 
   @Test
+  def testCreateTableLikeWithWatermarkReferencingMetadataColumn(): Unit = {
+    util.tableEnv.executeSql("""
+                               |CREATE TABLE LikeSourceTable (
+                               |  `ts` TIMESTAMP(3),
+                               |  `opts` TIMESTAMP(3) METADATA VIRTUAL,
+                               |  WATERMARK FOR `ts` AS `ts`
+                               |) WITH (
+                               |  'connector' = 'values',
+                               |  'readable-metadata' = 'opts:TIMESTAMP(3)'
+                               |)
+                               |""".stripMargin)
+
+    util.tableEnv.executeSql("""
+                               |CREATE TABLE LikeSourceWithWatermark (
+                               |  WATERMARK FOR `opts`
+                               |    AS `opts` - INTERVAL '5' SECOND
+                               |) LIKE LikeSourceTable (
+                               |  EXCLUDING WATERMARKS
+                               |)
+                               |""".stripMargin)
+
+    util.tableEnv.executeSql("""
+                               |CREATE TABLE SinkTable (
+                               |  `ts` TIMESTAMP(3),
+                               |  `opts` TIMESTAMP(3)
+                               |) WITH (
+                               |  'connector' = 'values'
+                               |)
+                               |""".stripMargin)
+
+    util.verifyExecPlanInsert(
+      "INSERT INTO SinkTable " +
+        "SELECT `ts`, `opts` FROM LikeSourceWithWatermark")
+  }
+
+  @Test
   def testDDLWithWatermarkComputedColumn(): Unit = {
     // Create table with field as atom expression.
     util.addTemporarySystemFunction("my_udf", Func0)


### PR DESCRIPTION
## What is the purpose of the change

This pull request fixes an issue where CREATE TABLE ... LIKE cannot resolve an inherited metadata column when validating a newly declared watermark.

MergeTableLikeUtil adds inherited metadata columns to the merged schema but does not register their types in the field mapping used to validate watermark definitions. As a result, declaring a watermark on an
  inherited metadata timestamp fails because the rowtime field cannot be resolved.

## Brief change log
- Register the types of inherited metadata columns when building the merged table schema.
- Add unit coverage for declaring a watermark on an inherited metadata column.
- Add a stream plan test covering CREATE TABLE ... LIKE with EXCLUDING WATERMARKS and a new watermark defined as:
WATERMARK FOR `opts` AS `opts` - INTERVAL '5' SECOND

## Verifying this change
This change added tests and can be verified as follows:
- Added MergeTableLikeUtilTest#mergeWatermarkReferencingInheritedMetadataColumn to verify that inherited metadata columns are available during watermark validation.
- Added TableScanTest#testCreateTableLikeWithWatermarkReferencingMetadataColumn to verify the complete DDL-to-plan flow and confirm that opts becomes the rowtime attribute.

## Does this pull request potentially affect one of the following parts:
  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with @Public(Evolving): (no)
  - The serializers: (no )
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)