### PR TITLE
[FLINK-35324][formats] Avro format can not perform projection pushdown for specific fields

### DIFF
--- a/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/AvroDeserializationSchema.java
+++ b/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/AvroDeserializationSchema.java
@@ -71,7 +71,22 @@ public class AvroDeserializationSchema<T> implements DeserializationSchema<T> {
      */
     public static AvroDeserializationSchema<GenericRecord> forGeneric(
             Schema schema, AvroEncoding encoding) {
-        return new AvroDeserializationSchema<>(GenericRecord.class, schema, encoding);
+        return forGeneric(schema, null, encoding);
+    }
+
+    /**
+     * Creates {@link AvroDeserializationSchema} that produces {@link GenericRecord} using the
+     * provided reader schema and resolves the input against the given writer schema.
+     *
+     * @param schema reader schema of produced records
+     * @param writer writer schema the input was serialized with, or {@code null} to reuse the
+     *     reader schema
+     * @param encoding Avro serialization approach to use for decoding
+     * @return deserialized record in form of {@link GenericRecord}
+     */
+    public static AvroDeserializationSchema<GenericRecord> forGeneric(
+            Schema schema, @Nullable Schema writer, AvroEncoding encoding) {
+        return new AvroDeserializationSchema<>(GenericRecord.class, schema, writer, encoding);
     }
 
     /**
@@ -107,6 +122,9 @@ public class AvroDeserializationSchema<T> implements DeserializationSchema<T> {
     /** Schema in case of GenericRecord for serialization purpose. */
     private final String schemaString;
 
+    /** Writer schema the input was serialized with, or {@code null} to reuse the reader schema. */
+    private final String writerSchemaString;
+
     /** Reader that deserializes byte array into a record. */
     private transient GenericDatumReader<T> datumReader;
 
@@ -122,6 +140,9 @@ public class AvroDeserializationSchema<T> implements DeserializationSchema<T> {
     /** Avro schema for the reader. */
     private transient Schema reader;
 
+    /** Avro schema for the writer. */
+    private transient Schema writer;
+
     /**
      * Creates a Avro deserialization schema.
      *
@@ -133,14 +154,31 @@ public class AvroDeserializationSchema<T> implements DeserializationSchema<T> {
      */
     AvroDeserializationSchema(
             Class<T> recordClazz, @Nullable Schema reader, AvroEncoding encoding) {
+        this(recordClazz, reader, null, encoding);
+    }
+
+    /**
+     * Creates a Avro deserialization schema.
+     *
+     * @param recordClazz class to which deserialize. Should be one of: {@link
+     *     org.apache.avro.specific.SpecificRecord}, {@link org.apache.avro.generic.GenericRecord}.
+     * @param reader reader's Avro schema. Should be provided if recordClazz is {@link
+     *     GenericRecord}
+     * @param writer writer's Avro schema the input was serialized with. Used to resolve the input
+     *     against the reader schema, e.g. to read a subset of the written fields.
+     * @param encoding encoding approach to use. Identifies the Avro decoder class to use.
+     */
+    AvroDeserializationSchema(
+            Class<T> recordClazz,
+            @Nullable Schema reader,
+            @Nullable Schema writer,
+            AvroEncoding encoding) {
         Preconditions.checkNotNull(recordClazz, "Avro record class must not be null.");
         this.recordClazz = recordClazz;
         this.reader = reader;
-        if (reader != null) {
-            this.schemaString = reader.toString();
-        } else {
-            this.schemaString = null;
-        }
+        this.schemaString = reader != null ? reader.toString() : null;
+        this.writer = writer;
+        this.writerSchemaString = writer != null ? writer.toString() : null;
         this.encoding = encoding;
     }
 
@@ -150,6 +188,11 @@ public class AvroDeserializationSchema<T> implements DeserializationSchema<T> {
 
     Schema getReaderSchema() {
         return reader;
+    }
+
+    @Nullable
+    Schema getWriterSchema() {
+        return writer;
     }
 
     MutableByteArrayInputStream getInputStream() {
@@ -173,9 +216,15 @@ public class AvroDeserializationSchema<T> implements DeserializationSchema<T> {
         checkAvroInitialized();
         inputStream.setBuffer(message);
         Schema readerSchema = getReaderSchema();
+        Schema writerSchema = getWriterSchema();
         GenericDatumReader<T> datumReader = getDatumReader();
 
-        datumReader.setSchema(readerSchema);
+        if (writerSchema != null) {
+            datumReader.setSchema(writerSchema);
+            datumReader.setExpected(readerSchema);
+        } else {
+            datumReader.setSchema(readerSchema);
+        }
 
         if (encoding == AvroEncoding.JSON) {
             ((JsonDecoder) this.decoder).configure(inputStream);
@@ -199,6 +248,9 @@ public class AvroDeserializationSchema<T> implements DeserializationSchema<T> {
             this.reader = AvroFactory.extractAvroSpecificSchema(recordClazz, specificData);
         } else {
             this.reader = new Schema.Parser().parse(schemaString);
+            if (writerSchemaString != null) {
+                this.writer = new Schema.Parser().parse(writerSchemaString);
+            }
             GenericData genericData = new GenericData(cl);
             this.datumReader = new GenericDatumReader<>(null, this.reader, genericData);
         }
@@ -236,11 +288,13 @@ public class AvroDeserializationSchema<T> implements DeserializationSchema<T> {
             return false;
         }
         AvroDeserializationSchema<?> that = (AvroDeserializationSchema<?>) o;
-        return recordClazz.equals(that.recordClazz) && Objects.equals(reader, that.reader);
+        return recordClazz.equals(that.recordClazz)
+                && Objects.equals(reader, that.reader)
+                && Objects.equals(writer, that.writer);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(recordClazz, reader);
+        return Objects.hash(recordClazz, reader, writer);
     }
 }

--- a/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/AvroDeserializationSchema.java
+++ b/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/AvroDeserializationSchema.java
@@ -78,15 +78,15 @@ public class AvroDeserializationSchema<T> implements DeserializationSchema<T> {
      * Creates {@link AvroDeserializationSchema} that produces {@link GenericRecord} using the
      * provided reader schema and resolves the input against the given writer schema.
      *
-     * @param schema reader schema of produced records
+     * @param reader reader schema of produced records
      * @param writer writer schema the input was serialized with, or {@code null} to reuse the
      *     reader schema
      * @param encoding Avro serialization approach to use for decoding
      * @return deserialized record in form of {@link GenericRecord}
      */
-    public static AvroDeserializationSchema<GenericRecord> forGeneric(
-            Schema schema, @Nullable Schema writer, AvroEncoding encoding) {
-        return new AvroDeserializationSchema<>(GenericRecord.class, schema, writer, encoding);
+    static AvroDeserializationSchema<GenericRecord> forGeneric(
+            Schema reader, @Nullable Schema writer, AvroEncoding encoding) {
+        return new AvroDeserializationSchema<>(GenericRecord.class, reader, writer, encoding);
     }
 
     /**
@@ -258,7 +258,9 @@ public class AvroDeserializationSchema<T> implements DeserializationSchema<T> {
         this.inputStream = new MutableByteArrayInputStream();
 
         if (encoding == AvroEncoding.JSON) {
-            this.decoder = DecoderFactory.get().jsonDecoder(getReaderSchema(), inputStream);
+            final Schema writerSchema = getWriterSchema();
+            final Schema decoderSchema = writerSchema == null ? getReaderSchema() : writerSchema;
+            this.decoder = DecoderFactory.get().jsonDecoder(decoderSchema, inputStream);
         } else {
             this.decoder = DecoderFactory.get().binaryDecoder(inputStream, null);
         }

--- a/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/AvroFormatFactory.java
+++ b/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/AvroFormatFactory.java
@@ -25,6 +25,7 @@ import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.formats.avro.AvroFormatOptions.AvroEncoding;
+import org.apache.flink.formats.avro.typeutils.AvroSchemaConverter;
 import org.apache.flink.table.connector.ChangelogMode;
 import org.apache.flink.table.connector.Projection;
 import org.apache.flink.table.connector.format.DecodingFormat;
@@ -72,11 +73,22 @@ public class AvroFormatFactory implements DeserializationFormatFactory, Serializ
                     int[][] projections) {
                 final DataType producedDataType =
                         Projection.of(projections).project(physicalDataType);
-                final RowType rowType = (RowType) producedDataType.getLogicalType();
+                final RowType producedRowType = (RowType) producedDataType.getLogicalType();
+                final RowType physicalRowType = (RowType) physicalDataType.getLogicalType();
                 final TypeInformation<RowData> rowDataTypeInfo =
                         context.createTypeInformation(producedDataType);
                 return new AvroRowDataDeserializationSchema(
-                        rowType, rowDataTypeInfo, encoding, legacyTimestampMapping);
+                        AvroDeserializationSchema.forGeneric(
+                                AvroSchemaConverter.convertToSchema(
+                                        producedRowType, legacyTimestampMapping),
+                                producedRowType.equals(physicalRowType)
+                                        ? null
+                                        : AvroSchemaConverter.convertToSchema(
+                                                physicalRowType, legacyTimestampMapping),
+                                encoding),
+                        AvroToRowDataConverters.createRowConverter(
+                                producedRowType, legacyTimestampMapping),
+                        rowDataTypeInfo);
             }
 
             @Override

--- a/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/AvroFormatFactoryTest.java
+++ b/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/AvroFormatFactoryTest.java
@@ -21,9 +21,11 @@ package org.apache.flink.formats.avro;
 import org.apache.flink.api.common.serialization.DeserializationSchema;
 import org.apache.flink.api.common.serialization.SerializationSchema;
 import org.apache.flink.formats.avro.AvroFormatOptions.AvroEncoding;
+import org.apache.flink.formats.avro.typeutils.AvroSchemaConverter;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.catalog.Column;
 import org.apache.flink.table.catalog.ResolvedSchema;
+import org.apache.flink.table.connector.format.ProjectableDecodingFormat;
 import org.apache.flink.table.connector.sink.DynamicTableSink;
 import org.apache.flink.table.connector.source.DynamicTableSource;
 import org.apache.flink.table.data.RowData;
@@ -31,13 +33,21 @@ import org.apache.flink.table.factories.TestDynamicTableFactory;
 import org.apache.flink.table.factories.utils.FactoryMocks;
 import org.apache.flink.table.runtime.connector.source.ScanRuntimeProviderContext;
 import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
+import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.RowType;
 
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericDatumWriter;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.io.Encoder;
+import org.apache.avro.io.EncoderFactory;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
+import java.io.ByteArrayOutputStream;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -53,6 +63,13 @@ class AvroFormatFactoryTest {
                     Column.physical("b", DataTypes.INT()),
                     Column.physical("c", DataTypes.BOOLEAN()),
                     Column.physical("d", DataTypes.TIMESTAMP(3)));
+
+    private static final ResolvedSchema PROJECTION_SCHEMA =
+            ResolvedSchema.of(
+                    Column.physical("user_id", DataTypes.BIGINT().notNull()),
+                    Column.physical("name", DataTypes.STRING().notNull()),
+                    Column.physical("event_id", DataTypes.BIGINT().notNull()),
+                    Column.physical("payload", DataTypes.STRING().notNull()));
 
     private static final ResolvedSchema NEW_SCHEMA =
             ResolvedSchema.of(
@@ -77,7 +94,7 @@ class AvroFormatFactoryTest {
                 new AvroRowDataDeserializationSchema(
                         ROW_TYPE, InternalTypeInfo.of(ROW_TYPE), encoding);
 
-        final Map<String, String> options = getAllOptions(true);
+        final Map<String, String> options = getAllOptions(true, encoding);
 
         final DynamicTableSource actualSource = FactoryMocks.createTableSource(SCHEMA, options);
         assertThat(actualSource).isInstanceOf(TestDynamicTableFactory.DynamicTableSourceMock.class);
@@ -102,6 +119,51 @@ class AvroFormatFactoryTest {
                 sinkMock.valueFormat.createRuntimeEncoder(null, SCHEMA.toPhysicalRowDataType());
 
         assertThat(actualSer).isEqualTo(expectedSer);
+    }
+
+    @ParameterizedTest
+    @EnumSource(AvroEncoding.class)
+    void testProjectionPushDown(AvroEncoding encoding) throws Exception {
+        final Map<String, String> options = getAllOptions(true, encoding);
+        final DynamicTableSource actualSource =
+                FactoryMocks.createTableSource(PROJECTION_SCHEMA, options);
+        assertThat(actualSource).isInstanceOf(TestDynamicTableFactory.DynamicTableSourceMock.class);
+        final TestDynamicTableFactory.DynamicTableSourceMock scanSourceMock =
+                (TestDynamicTableFactory.DynamicTableSourceMock) actualSource;
+        assertThat(scanSourceMock.valueFormat).isInstanceOf(ProjectableDecodingFormat.class);
+
+        final ProjectableDecodingFormat<DeserializationSchema<RowData>> projectableFormat =
+                (ProjectableDecodingFormat<DeserializationSchema<RowData>>)
+                        scanSourceMock.valueFormat;
+        final DataType physicalDataType = PROJECTION_SCHEMA.toPhysicalRowDataType();
+        final DeserializationSchema<RowData> deserializationSchema =
+                projectableFormat.createRuntimeDecoder(
+                        ScanRuntimeProviderContext.INSTANCE,
+                        physicalDataType,
+                        new int[][] {{1}, {2}});
+        deserializationSchema.open(null);
+
+        final Schema writerSchema =
+                AvroSchemaConverter.convertToSchema(physicalDataType.getLogicalType());
+        final GenericRecord record = new GenericData.Record(writerSchema);
+        record.put("user_id", 3L);
+        record.put("name", "name 3");
+        record.put("event_id", 102L);
+        record.put("payload", "payload 3");
+        final ByteArrayOutputStream output = new ByteArrayOutputStream();
+        final Encoder encoder;
+        if (encoding == AvroEncoding.BINARY) {
+            encoder = EncoderFactory.get().binaryEncoder(output, null);
+        } else {
+            encoder = EncoderFactory.get().jsonEncoder(writerSchema, output);
+        }
+        new GenericDatumWriter<GenericRecord>(writerSchema).write(record, encoder);
+        encoder.flush();
+
+        final RowData rowData = deserializationSchema.deserialize(output.toByteArray());
+        assertThat(rowData.getArity()).isEqualTo(2);
+        assertThat(rowData.getString(0).toString()).isEqualTo("name 3");
+        assertThat(rowData.getLong(1)).isEqualTo(102L);
     }
 
     @Test
@@ -186,6 +248,13 @@ class AvroFormatFactoryTest {
         }
 
         options.put("format", AvroFormatFactory.IDENTIFIER);
+        return options;
+    }
+
+    private Map<String, String> getAllOptions(
+            boolean legacyTimestampMapping, AvroEncoding encoding) {
+        final Map<String, String> options = getAllOptions(legacyTimestampMapping);
+        options.put("avro.encoding", encoding.toString());
         return options;
     }
 }

--- a/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/AvroRowDataDeSerializationSchemaTest.java
+++ b/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/AvroRowDataDeSerializationSchemaTest.java
@@ -25,6 +25,7 @@ import org.apache.flink.formats.avro.generated.LogicalTimeRecord;
 import org.apache.flink.formats.avro.generated.Timestamps;
 import org.apache.flink.formats.avro.typeutils.AvroSchemaConverter;
 import org.apache.flink.formats.avro.utils.AvroTestUtils;
+import org.apache.flink.table.connector.Projection;
 import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.util.DataFormatConverters;
@@ -400,6 +401,97 @@ class AvroRowDataDeSerializationSchemaTest {
                 .isEqualTo("2014-03-01T12:12:12.321");
         assertThat(rowData.getTimestamp(3, 6).toLocalDateTime().toString())
                 .isEqualTo("1970-01-01T00:02:03.456");
+    }
+
+    @Test
+    void testDeserializeWithNonZeroStartingProjection() throws Exception {
+        final DataType physicalDataType =
+                ROW(
+                                FIELD("user_id", BIGINT()),
+                                FIELD("name", STRING()),
+                                FIELD("event_id", BIGINT()),
+                                FIELD("payload", STRING().notNull()))
+                        .notNull();
+        final Schema schema =
+                AvroSchemaConverter.convertToSchema(physicalDataType.getLogicalType());
+
+        final GenericRecord record = new GenericData.Record(schema);
+        record.put(0, 3L);
+        record.put(1, "name 3");
+        record.put(2, 102L);
+        record.put(3, "payload 3");
+        final byte[] input = writeRecord(record, schema);
+
+        // projection does not start at 0: reads only {name, event_id}
+        final RowData rowData =
+                createProjectedDeserializationSchema(physicalDataType, new int[][] {{1}, {2}})
+                        .deserialize(input);
+
+        assertThat(rowData.getArity()).isEqualTo(2);
+        assertThat(rowData.getString(0).toString()).isEqualTo("name 3");
+        assertThat(rowData.getLong(1)).isEqualTo(102L);
+    }
+
+    @Test
+    void testDeserializeProjectionWithNestedRow() throws Exception {
+        final DataType physicalDataType =
+                ROW(
+                                FIELD("id", BIGINT()),
+                                FIELD("name", STRING()),
+                                FIELD(
+                                        "nested",
+                                        ROW(FIELD("a", INT().notNull()), FIELD("b", STRING()))
+                                                .notNull()))
+                        .notNull();
+        final Schema schema =
+                AvroSchemaConverter.convertToSchema(physicalDataType.getLogicalType());
+
+        final GenericRecord nested = new GenericData.Record(schema.getField("nested").schema());
+        nested.put(0, 7);
+        nested.put(1, "inner");
+        final GenericRecord record = new GenericData.Record(schema);
+        record.put(0, 1L);
+        record.put(1, "outer");
+        record.put(2, nested);
+        final byte[] input = writeRecord(record, schema);
+
+        // project {name, nested}, i.e. a non-zero starting projection including a nested row
+        final RowData rowData =
+                createProjectedDeserializationSchema(physicalDataType, new int[][] {{1}, {2}})
+                        .deserialize(input);
+
+        assertThat(rowData.getArity()).isEqualTo(2);
+        assertThat(rowData.getString(0).toString()).isEqualTo("outer");
+        final RowData nestedOut = rowData.getRow(1, 2);
+        assertThat(nestedOut.getInt(0)).isEqualTo(7);
+        assertThat(nestedOut.getString(1).toString()).isEqualTo("inner");
+    }
+
+    private static byte[] writeRecord(GenericRecord record, Schema schema) throws Exception {
+        final ByteArrayOutputStream out = new ByteArrayOutputStream();
+        final GenericDatumWriter<IndexedRecord> datumWriter = new GenericDatumWriter<>(schema);
+        final Encoder encoder = EncoderFactory.get().binaryEncoder(out, null);
+        datumWriter.write(record, encoder);
+        encoder.flush();
+        return out.toByteArray();
+    }
+
+    private AvroRowDataDeserializationSchema createProjectedDeserializationSchema(
+            DataType physicalDataType, int[][] projections) throws Exception {
+        final DataType producedDataType = Projection.of(projections).project(physicalDataType);
+        final RowType producedRowType = (RowType) producedDataType.getLogicalType();
+        final RowType physicalRowType = (RowType) physicalDataType.getLogicalType();
+
+        AvroRowDataDeserializationSchema deserializationSchema =
+                new AvroRowDataDeserializationSchema(
+                        AvroDeserializationSchema.forGeneric(
+                                AvroSchemaConverter.convertToSchema(producedRowType),
+                                AvroSchemaConverter.convertToSchema(physicalRowType),
+                                AvroEncoding.BINARY),
+                        AvroToRowDataConverters.createRowConverter(producedRowType),
+                        InternalTypeInfo.of(producedRowType));
+        deserializationSchema.open(null);
+        return deserializationSchema;
     }
 
     private AvroRowDataSerializationSchema createSerializationSchema(

--- a/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/AvroRowDataDeSerializationSchemaTest.java
+++ b/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/AvroRowDataDeSerializationSchemaTest.java
@@ -403,8 +403,9 @@ class AvroRowDataDeSerializationSchemaTest {
                 .isEqualTo("1970-01-01T00:02:03.456");
     }
 
-    @Test
-    void testDeserializeWithNonZeroStartingProjection() throws Exception {
+    @ParameterizedTest
+    @EnumSource(AvroEncoding.class)
+    void testDeserializeWithNonZeroStartingProjection(AvroEncoding encoding) throws Exception {
         final DataType physicalDataType =
                 ROW(
                                 FIELD("user_id", BIGINT()),
@@ -420,11 +421,12 @@ class AvroRowDataDeSerializationSchemaTest {
         record.put(1, "name 3");
         record.put(2, 102L);
         record.put(3, "payload 3");
-        final byte[] input = writeRecord(record, schema);
+        final byte[] input = writeRecord(record, schema, encoding);
 
         // projection does not start at 0: reads only {name, event_id}
         final RowData rowData =
-                createProjectedDeserializationSchema(physicalDataType, new int[][] {{1}, {2}})
+                createProjectedDeserializationSchema(
+                                physicalDataType, new int[][] {{1}, {2}}, encoding)
                         .deserialize(input);
 
         assertThat(rowData.getArity()).isEqualTo(2);
@@ -432,8 +434,9 @@ class AvroRowDataDeSerializationSchemaTest {
         assertThat(rowData.getLong(1)).isEqualTo(102L);
     }
 
-    @Test
-    void testDeserializeProjectionWithNestedRow() throws Exception {
+    @ParameterizedTest
+    @EnumSource(AvroEncoding.class)
+    void testDeserializeProjectionIncludingNestedRow(AvroEncoding encoding) throws Exception {
         final DataType physicalDataType =
                 ROW(
                                 FIELD("id", BIGINT()),
@@ -453,11 +456,12 @@ class AvroRowDataDeSerializationSchemaTest {
         record.put(0, 1L);
         record.put(1, "outer");
         record.put(2, nested);
-        final byte[] input = writeRecord(record, schema);
+        final byte[] input = writeRecord(record, schema, encoding);
 
         // project {name, nested}, i.e. a non-zero starting projection including a nested row
         final RowData rowData =
-                createProjectedDeserializationSchema(physicalDataType, new int[][] {{1}, {2}})
+                createProjectedDeserializationSchema(
+                                physicalDataType, new int[][] {{1}, {2}}, encoding)
                         .deserialize(input);
 
         assertThat(rowData.getArity()).isEqualTo(2);
@@ -467,17 +471,19 @@ class AvroRowDataDeSerializationSchemaTest {
         assertThat(nestedOut.getString(1).toString()).isEqualTo("inner");
     }
 
-    private static byte[] writeRecord(GenericRecord record, Schema schema) throws Exception {
+    private static byte[] writeRecord(GenericRecord record, Schema schema, AvroEncoding encoding)
+            throws Exception {
         final ByteArrayOutputStream out = new ByteArrayOutputStream();
         final GenericDatumWriter<IndexedRecord> datumWriter = new GenericDatumWriter<>(schema);
-        final Encoder encoder = EncoderFactory.get().binaryEncoder(out, null);
+        final Encoder encoder = createEncoder(encoding, schema, out);
         datumWriter.write(record, encoder);
         encoder.flush();
         return out.toByteArray();
     }
 
     private AvroRowDataDeserializationSchema createProjectedDeserializationSchema(
-            DataType physicalDataType, int[][] projections) throws Exception {
+            DataType physicalDataType, int[][] projections, AvroEncoding encoding)
+            throws Exception {
         final DataType producedDataType = Projection.of(projections).project(physicalDataType);
         final RowType producedRowType = (RowType) producedDataType.getLogicalType();
         final RowType physicalRowType = (RowType) physicalDataType.getLogicalType();
@@ -487,7 +493,7 @@ class AvroRowDataDeSerializationSchemaTest {
                         AvroDeserializationSchema.forGeneric(
                                 AvroSchemaConverter.convertToSchema(producedRowType),
                                 AvroSchemaConverter.convertToSchema(physicalRowType),
-                                AvroEncoding.BINARY),
+                                encoding),
                         AvroToRowDataConverters.createRowConverter(producedRowType),
                         InternalTypeInfo.of(producedRowType));
         deserializationSchema.open(null);


### PR DESCRIPTION
Supersedes #28746, which targeted `release-1.17`. This replacement targets `master` following @davidradl's review and can be backported separately if needed.

## What is the purpose of the change

The Avro format exposes a `ProjectableDecodingFormat`, but projection pushdown failed when projected fields did not start at index 0. For example, `[[1], [2]]` could decode fields against the wrong positions because the projected schema was used as both the writer and reader schema.

This change passes the full physical schema as the writer schema and the projected schema as the reader schema. Avro schema resolution can then read only the requested fields. For JSON encoding, the `JsonDecoder` is also created with the writer schema because it must parse the encoded physical record before reader-schema resolution is applied.

## Brief change log

- Allow the package-internal generic Avro deserializer path to carry separate reader and writer schemas.
- Make `AvroFormatFactory#createRuntimeDecoder` use the projected schema for output and the physical schema for decoding projected input.
- Create JSON decoders with the writer schema when one is present.
- Cover non-zero-starting and nested-row projections through both binary and JSON encodings, including the table-format factory path.

## Verifying this change

Maven 3.8.6 with JDK 21:

`mvn -pl flink-formats/flink-avro clean test -Dtest=AvroRowDataDeSerializationSchemaTest,AvroFormatFactoryTest -Djdk21 -Pjava21-target`

Result: 24 tests passed; Checkstyle reported 0 violations; Spotless reported 0 files requiring changes.

## Does this pull request potentially affect one of the following parts:

Dependencies (does it add or upgrade a dependency): no
The public API, i.e., is any changed class annotated with @Public(Evolving): no
The serializers: no
The runtime per-record code paths (performance sensitive): yes
Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
The S3 file system connector: no

## Documentation

Does this pull request introduce a new feature? no
If yes, how is the feature documented? not applicable

## Was generative AI tooling used to co-author this PR?

Yes. Claude Code was used for the original change (exact version unavailable); Codex CLI 0.146.0 was used for review, correction, and tests.

Generated-by: Claude Code
Generated-by: Codex CLI 0.146.0