### PR TITLE
[release-2.1] [BP-2.1][FLINK-40118][runtime-web] Use REST endpoint field instead of removed host field

### DIFF
--- a/flink-runtime-web/web-dashboard/src/app/interfaces/job-accumulators.ts
+++ b/flink-runtime-web/web-dashboard/src/app/interfaces/job-accumulators.ts
@@ -32,6 +32,6 @@ export interface SubTaskAccumulators {
   type: string;
   value: string;
   subtask: number;
-  host: string;
+  endpoint: string;
   attempt: number;
 }

--- a/flink-runtime-web/web-dashboard/src/app/interfaces/job-timeline.ts
+++ b/flink-runtime-web/web-dashboard/src/app/interfaces/job-timeline.ts
@@ -22,7 +22,7 @@ export interface JobSubTaskTime {
   now: number;
   subtasks: Array<{
     subtask: number;
-    host: string;
+    endpoint: string;
     duration: number;
     timestamps: {
       CREATED: number;

--- a/flink-runtime-web/web-dashboard/src/app/pages/job/overview/accumulators/job-overview-drawer-accumulators.component.html
+++ b/flink-runtime-web/web-dashboard/src/app/pages/job/overview/accumulators/job-overview-drawer-accumulators.component.html
@@ -76,7 +76,7 @@
           <ng-container *ngIf="narrowSubTaskAccumulators(data) as subTaskAccumulator">
             <tr>
               <td nzLeft>
-                ({{ subTaskAccumulator['subtask'] }}) {{ subTaskAccumulator.host }}, attempt:
+                ({{ subTaskAccumulator['subtask'] }}) {{ subTaskAccumulator.endpoint }}, attempt:
                 {{ subTaskAccumulator.attempt + 1 }}
               </td>
               <td>{{ subTaskAccumulator.name }}</td>

--- a/flink-runtime-web/web-dashboard/src/app/pages/job/timeline/job-timeline.component.ts
+++ b/flink-runtime-web/web-dashboard/src/app/pages/job/timeline/job-timeline.component.ts
@@ -133,13 +133,13 @@ export class JobTimelineComponent implements AfterViewInit, OnDestroy {
           listOfTimeLine.forEach((item, index) => {
             if (index === listOfTimeLine.length - 1) {
               this.listOfSubTaskTimeLine.push({
-                name: `${task.subtask} - ${task.host}`,
+                name: `${task.subtask} - ${task.endpoint}`,
                 status: item.status,
                 range: [item.startTime, task.duration + listOfTimeLine[0].startTime]
               });
             } else {
               this.listOfSubTaskTimeLine.push({
-                name: `${task.subtask} - ${task.host}`,
+                name: `${task.subtask} - ${task.endpoint}`,
                 status: item.status,
                 range: [item.startTime, listOfTimeLine[index + 1].startTime]
               });


### PR DESCRIPTION
Backport of #28712 (FLINK-40118) to release-2.1.