### PR TITLE
[FLINK-34620][formats][protobuf] Add serialize-side handling for recursive message schemas

### DIFF
--- a/docs/content/docs/connectors/table/formats/protobuf.md
+++ b/docs/content/docs/connectors/table/formats/protobuf.md
@@ -153,6 +153,7 @@ Format Options
           If the value is set to false, the format will generate null values if the data element does not exist in the binary protobuf message.
           With Flink's current protobuf version (4.32.1), field presence is properly supported for proto3, allowing null handling for non-primitive types.
           Please be aware that setting this to true will cause the deserialization performance to be much slower depending on schema complexity and message size.
+          Note: a recursive message type that declares <code>required</code> fields cannot be serialized when an absent recursive field is read with this set to true. The absent sub-message is materialized as empty bytes, which cannot be parsed back because its required fields are missing, so serialization fails with a runtime error. Use false for such messages, or ensure the recursive field is always present.
       </td>
     </tr>
     <tr>

--- a/flink-formats/flink-protobuf/src/main/java/org/apache/flink/formats/protobuf/deserialize/PbCodegenBytesDeserializer.java
+++ b/flink-formats/flink-protobuf/src/main/java/org/apache/flink/formats/protobuf/deserialize/PbCodegenBytesDeserializer.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.formats.protobuf.deserialize;
+
+import org.apache.flink.formats.protobuf.PbCodegenException;
+import org.apache.flink.formats.protobuf.util.PbCodegenAppender;
+
+import com.google.protobuf.Descriptors.FieldDescriptor;
+
+/**
+ * Deserializer that converts a protobuf message to its raw binary bytes. Used when a recursive
+ * message type is detected and represented as BYTES in the Flink schema, preserving the data for
+ * optional later unpacking via a UDF.
+ */
+public class PbCodegenBytesDeserializer implements PbCodegenDeserializer {
+    private final FieldDescriptor fd;
+
+    public PbCodegenBytesDeserializer(FieldDescriptor fd) {
+        this.fd = fd;
+    }
+
+    @Override
+    public String codegen(String resultVar, String pbObjectCode, int indent)
+            throws PbCodegenException {
+        PbCodegenAppender appender = new PbCodegenAppender(indent);
+        appender.appendLine(resultVar + " = " + pbObjectCode + ".toByteArray()");
+        return appender.code();
+    }
+}

--- a/flink-formats/flink-protobuf/src/main/java/org/apache/flink/formats/protobuf/deserialize/PbCodegenDeserializeFactory.java
+++ b/flink-formats/flink-protobuf/src/main/java/org/apache/flink/formats/protobuf/deserialize/PbCodegenDeserializeFactory.java
@@ -23,16 +23,25 @@ import org.apache.flink.formats.protobuf.PbFormatContext;
 import org.apache.flink.formats.protobuf.util.PbFormatUtils;
 import org.apache.flink.table.types.logical.ArrayType;
 import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.LogicalTypeRoot;
 import org.apache.flink.table.types.logical.MapType;
 import org.apache.flink.table.types.logical.RowType;
 
 import com.google.protobuf.Descriptors;
+import com.google.protobuf.Descriptors.FieldDescriptor.JavaType;
 
 /** Codegen factory class which return {@link PbCodegenDeserializer} of different data type. */
 public class PbCodegenDeserializeFactory {
     public static PbCodegenDeserializer getPbCodegenDes(
             Descriptors.FieldDescriptor fd, LogicalType type, PbFormatContext formatContext)
             throws PbCodegenException {
+        // Check for recursive message type represented as raw bytes:
+        // the proto field is a MESSAGE but the logical type has been resolved to VARBINARY
+        // by PbToRowTypeUtil's cycle detection.
+        if (fd.getJavaType() == JavaType.MESSAGE
+                && type.getTypeRoot() == LogicalTypeRoot.VARBINARY) {
+            return new PbCodegenBytesDeserializer(fd);
+        }
         // We do not use FieldDescriptor to check because there's no way to get
         // element field descriptor of array type.
         if (type instanceof RowType) {

--- a/flink-formats/flink-protobuf/src/main/java/org/apache/flink/formats/protobuf/deserialize/PbCodegenRowDeserializer.java
+++ b/flink-formats/flink-protobuf/src/main/java/org/apache/flink/formats/protobuf/deserialize/PbCodegenRowDeserializer.java
@@ -72,7 +72,11 @@ public class PbCodegenRowDeserializer implements PbCodegenDeserializer {
                     PbCodegenDeserializeFactory.getPbCodegenDes(elementFd, subType, formatContext);
             splitAppender.appendLine("Object " + flinkRowEleVar + " = null");
             boolean readDefaultValues = formatContext.getPbFormatConfig().isReadDefaultValues();
-            if (PbFormatUtils.isSimpleType(subType)) {
+            // A recursive message field is stored as VARBINARY, so it looks like a "simple type",
+            // but it is still a MESSAGE. Don't force the proto3 primitive default path on it, or an
+            // absent sub-message would round-trip back as a present (empty) one. See FLINK-34620.
+            if (PbFormatUtils.isSimpleType(subType)
+                    && elementFd.getJavaType() != FieldDescriptor.JavaType.MESSAGE) {
                 readDefaultValues = formatContext.getReadDefaultValuesForPrimitiveTypes();
             }
 

--- a/flink-formats/flink-protobuf/src/main/java/org/apache/flink/formats/protobuf/serialize/PbCodegenBytesSerializer.java
+++ b/flink-formats/flink-protobuf/src/main/java/org/apache/flink/formats/protobuf/serialize/PbCodegenBytesSerializer.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.formats.protobuf.serialize;
+
+import org.apache.flink.formats.protobuf.PbCodegenException;
+import org.apache.flink.formats.protobuf.util.PbCodegenAppender;
+import org.apache.flink.formats.protobuf.util.PbCodegenVarId;
+import org.apache.flink.formats.protobuf.util.PbFormatUtils;
+
+import com.google.protobuf.Descriptors.FieldDescriptor;
+
+/**
+ * Serializer for a recursive message field, which {@link
+ * org.apache.flink.formats.protobuf.util.PbToRowTypeUtil} represents as BYTES through its cycle
+ * detection. It is the inverse of {@link
+ * org.apache.flink.formats.protobuf.deserialize.PbCodegenBytesDeserializer}: the deserializer emits
+ * the sub-message as {@code message.toByteArray()}, and here we parse those bytes back into the
+ * message so the enclosing {@link PbCodegenRowSerializer} can set it on the builder.
+ */
+public class PbCodegenBytesSerializer implements PbCodegenSerializer {
+    private final FieldDescriptor fd;
+
+    public PbCodegenBytesSerializer(FieldDescriptor fd) {
+        this.fd = fd;
+    }
+
+    @Override
+    public String codegen(String resultVar, String flinkObjectCode, int indent)
+            throws PbCodegenException {
+        // flinkObjectCode is a non-null flink BYTES value holding a serialized protobuf message.
+        PbCodegenAppender appender = new PbCodegenAppender(indent);
+        int uid = PbCodegenVarId.getInstance().getAndIncrement();
+        String bytesVar = "recursiveBytes" + uid;
+        String messageTypeStr = PbFormatUtils.getFullJavaName(fd.getMessageType());
+
+        appender.appendLine("byte[] " + bytesVar + " = " + flinkObjectCode);
+        codegenRequiredFieldGuard(appender, bytesVar, messageTypeStr);
+        appender.begin("try{");
+        appender.appendLine(resultVar + " = " + messageTypeStr + ".parseFrom(" + bytesVar + ")");
+        appender.end("}");
+        appender.begin("catch(com.google.protobuf.InvalidProtocolBufferException e){");
+        appender.appendLine(
+                "throw new RuntimeException("
+                        + "\"failed to parse recursive protobuf bytes for field '"
+                        + fd.getName()
+                        + "'\", e)");
+        appender.end("}");
+        return appender.code();
+    }
+
+    // A recursive message type with required fields cannot round-trip an absent field read with
+    // read-default-values=true: it is materialized on read as byte[0], which parseFrom cannot
+    // rebuild. getDefaultInstance().isInitialized() is false only for such types, so this guard is
+    // a no-op for proto3 and for proto2 without required fields.
+    private void codegenRequiredFieldGuard(
+            PbCodegenAppender appender, String bytesVar, String messageTypeStr) {
+        appender.begin(
+                "if("
+                        + bytesVar
+                        + ".length == 0 && !"
+                        + messageTypeStr
+                        + ".getDefaultInstance().isInitialized()){");
+        appender.appendLine(
+                "throw new RuntimeException("
+                        + "\"cannot serialize field '"
+                        + fd.getName()
+                        + "': recursive proto2 message has required fields and was read with "
+                        + "read-default-values=true; set read-default-values=false, or ensure the "
+                        + "field is present\")");
+        appender.end("}");
+    }
+}

--- a/flink-formats/flink-protobuf/src/main/java/org/apache/flink/formats/protobuf/serialize/PbCodegenSerializeFactory.java
+++ b/flink-formats/flink-protobuf/src/main/java/org/apache/flink/formats/protobuf/serialize/PbCodegenSerializeFactory.java
@@ -23,16 +23,25 @@ import org.apache.flink.formats.protobuf.PbFormatContext;
 import org.apache.flink.formats.protobuf.util.PbFormatUtils;
 import org.apache.flink.table.types.logical.ArrayType;
 import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.LogicalTypeRoot;
 import org.apache.flink.table.types.logical.MapType;
 import org.apache.flink.table.types.logical.RowType;
 
 import com.google.protobuf.Descriptors;
+import com.google.protobuf.Descriptors.FieldDescriptor.JavaType;
 
 /** Codegen factory class which return {@link PbCodegenSerializer} of different data type. */
 public class PbCodegenSerializeFactory {
     public static PbCodegenSerializer getPbCodegenSer(
             Descriptors.FieldDescriptor fd, LogicalType type, PbFormatContext formatContext)
             throws PbCodegenException {
+        // Recursive message type represented as raw bytes: the proto field is a MESSAGE but the
+        // logical type was resolved to VARBINARY by PbToRowTypeUtil's cycle detection. Mirrors the
+        // matching branch in PbCodegenDeserializeFactory.
+        if (fd.getJavaType() == JavaType.MESSAGE
+                && type.getTypeRoot() == LogicalTypeRoot.VARBINARY) {
+            return new PbCodegenBytesSerializer(fd);
+        }
         if (type instanceof RowType) {
             return new PbCodegenRowSerializer(fd.getMessageType(), (RowType) type, formatContext);
         } else if (PbFormatUtils.isSimpleType(type)) {

--- a/flink-formats/flink-protobuf/src/main/java/org/apache/flink/formats/protobuf/util/PbSchemaValidationUtils.java
+++ b/flink-formats/flink-protobuf/src/main/java/org/apache/flink/formats/protobuf/util/PbSchemaValidationUtils.java
@@ -100,7 +100,11 @@ public class PbSchemaValidationUtils {
                 // simple type
                 validateSimpleType(fd, logicalType.getTypeRoot());
             } else {
-                // message type
+                // message type - may be RowType (normal) or VarBinaryType (recursive, as bytes)
+                if (logicalType.getTypeRoot() == LogicalTypeRoot.VARBINARY) {
+                    // Recursive message type represented as raw bytes - valid mapping
+                    return;
+                }
                 if (!(logicalType instanceof RowType)) {
                     throw new ValidationException(
                             "Unexpected LogicalType: " + logicalType + ". It should be RowType");
@@ -131,6 +135,10 @@ public class PbSchemaValidationUtils {
                 if (fd.getJavaType() == JavaType.MESSAGE) {
                     // array message type
                     LogicalType elementType = arrayType.getElementType();
+                    if (elementType.getTypeRoot() == LogicalTypeRoot.VARBINARY) {
+                        // Recursive message type as raw bytes - valid
+                        return;
+                    }
                     if (!(elementType instanceof RowType)) {
                         throw new ValidationException(
                                 "Unexpected logicalType: "

--- a/flink-formats/flink-protobuf/src/main/java/org/apache/flink/formats/protobuf/util/PbToRowTypeUtil.java
+++ b/flink-formats/flink-protobuf/src/main/java/org/apache/flink/formats/protobuf/util/PbToRowTypeUtil.java
@@ -36,6 +36,9 @@ import com.google.protobuf.Descriptors;
 import com.google.protobuf.Descriptors.FieldDescriptor;
 import com.google.protobuf.Descriptors.FieldDescriptor.JavaType;
 
+import java.util.HashSet;
+import java.util.Set;
+
 /** Generate Row type information according to pb descriptors. */
 public class PbToRowTypeUtil {
     public static RowType generateRowType(Descriptors.Descriptor root) {
@@ -43,20 +46,43 @@ public class PbToRowTypeUtil {
     }
 
     public static RowType generateRowType(Descriptors.Descriptor root, boolean enumAsInt) {
+        // Track message types currently being resolved in the ancestor chain to detect
+        // recursive references (e.g., A -> B -> A). Without this, recursive proto
+        // definitions cause infinite recursion and StackOverflowError.
+        Set<String> ancestors = new HashSet<>();
+        return generateRowTypeInternal(root, enumAsInt, ancestors);
+    }
+
+    /**
+     * @param ancestors message type full names currently being resolved in the call stack. Used to
+     *     detect cycles: if a field's message type is already in this set, it's a recursive
+     *     reference and gets emitted as BYTES instead of recursing infinitely.
+     */
+    private static RowType generateRowTypeInternal(
+            Descriptors.Descriptor root, boolean enumAsInt, Set<String> ancestors) {
         int size = root.getFields().size();
         LogicalType[] types = new LogicalType[size];
         String[] rowFieldNames = new String[size];
 
-        for (int i = 0; i < size; i++) {
-            FieldDescriptor field = root.getFields().get(i);
-            rowFieldNames[i] = field.getName();
-            types[i] = generateFieldTypeInformation(field, enumAsInt);
+        // Mark this type as "being resolved" before processing its fields
+        String fullName = root.getFullName();
+        ancestors.add(fullName);
+
+        try {
+            for (int i = 0; i < size; i++) {
+                FieldDescriptor field = root.getFields().get(i);
+                rowFieldNames[i] = field.getName();
+                types[i] = generateFieldTypeInformation(field, enumAsInt, ancestors);
+            }
+        } finally {
+            // Unmark when we're done - sibling branches shouldn't see this type as an ancestor
+            ancestors.remove(fullName);
         }
         return RowType.of(types, rowFieldNames);
     }
 
     private static LogicalType generateFieldTypeInformation(
-            FieldDescriptor field, boolean enumAsInt) {
+            FieldDescriptor field, boolean enumAsInt, Set<String> ancestors) {
         JavaType fieldType = field.getJavaType();
         LogicalType type;
         if (fieldType.equals(JavaType.MESSAGE)) {
@@ -66,16 +92,36 @@ public class PbToRowTypeUtil {
                                 generateFieldTypeInformation(
                                         field.getMessageType()
                                                 .findFieldByName(PbConstant.PB_MAP_KEY_NAME),
-                                        enumAsInt),
+                                        enumAsInt,
+                                        ancestors),
                                 generateFieldTypeInformation(
                                         field.getMessageType()
                                                 .findFieldByName(PbConstant.PB_MAP_VALUE_NAME),
-                                        enumAsInt));
+                                        enumAsInt,
+                                        ancestors));
                 return mapType;
-            } else if (field.isRepeated()) {
-                return new ArrayType(generateRowType(field.getMessageType()));
+            }
+
+            // Cycle detection: if this field's message type is already being resolved
+            // in the ancestor chain, we have a recursive proto definition
+            // (e.g., Node -> Child -> Node). Columnar schemas cannot represent
+            // infinite recursion, so we emit the field as raw BYTES. The protobuf
+            // binary is preserved and can be deserialized on demand if consumers
+            // need the recursive data.
+            String msgFullName = field.getMessageType().getFullName();
+            if (ancestors.contains(msgFullName)) {
+                LogicalType bytesType = new VarBinaryType(Integer.MAX_VALUE);
+                if (field.isRepeated()) {
+                    return new ArrayType(bytesType);
+                }
+                return bytesType;
+            }
+
+            if (field.isRepeated()) {
+                return new ArrayType(
+                        generateRowTypeInternal(field.getMessageType(), enumAsInt, ancestors));
             } else {
-                return generateRowType(field.getMessageType());
+                return generateRowTypeInternal(field.getMessageType(), enumAsInt, ancestors);
             }
         } else {
             if (fieldType.equals(JavaType.STRING)) {

--- a/flink-formats/flink-protobuf/src/test/java/org/apache/flink/formats/protobuf/RecursiveMessageProtoToRowTest.java
+++ b/flink-formats/flink-protobuf/src/test/java/org/apache/flink/formats/protobuf/RecursiveMessageProtoToRowTest.java
@@ -106,25 +106,37 @@ public class RecursiveMessageProtoToRowTest {
     }
 
     @Test
-    public void testProto3UnsetFieldReadsDefaultBytes() throws Exception {
-        // In proto3, the recursive field is treated as a primitive type (VARBINARY)
-        // by the codegen, so it always reads default values regardless of the
-        // readDefaultValues config. Both true and false produce the same result:
-        // empty bytes from .toByteArray() on the default message instance.
+    public void testProto3UnsetFieldIsNull() throws Exception {
+        // A recursive field is represented as VARBINARY (a "simple type") but is still a MESSAGE.
+        // With readDefaultValues=false an unset message field must be absent (null), not
+        // materialized as default bytes -- matching proto2 and non-recursive message fields. See
+        // FLINK-34620.
         RecursiveMessageTest message =
                 RecursiveMessageTest.newBuilder().setId(1).setName("leaf").build();
 
-        for (boolean readDefaults : new boolean[] {true, false}) {
-            RowData row = deserialize(PROTO3_CLASS, readDefaults, message.toByteArray());
-            assertNotNull(row);
-            assertEquals(1, row.getInt(0));
-            assertEquals("leaf", row.getString(1).toString());
-            byte[] parentBytes = row.getBinary(2);
-            assertNotNull("readDefaultValues=" + readDefaults, parentBytes);
-            RecursiveMessageTest parsed = RecursiveMessageTest.parseFrom(parentBytes);
-            assertEquals(0, parsed.getId());
-            assertEquals("", parsed.getName());
-        }
+        RowData row = deserialize(PROTO3_CLASS, false, message.toByteArray());
+        assertNotNull(row);
+        assertEquals(1, row.getInt(0));
+        assertEquals("leaf", row.getString(1).toString());
+        assertTrue("Proto3 unset recursive field should be null", row.isNullAt(2));
+    }
+
+    @Test
+    public void testProto3UnsetFieldWithReadDefaultValues() throws Exception {
+        // With readDefaultValues=true the unset recursive field is materialized as the default
+        // instance (empty message bytes) instead of null.
+        RecursiveMessageTest message =
+                RecursiveMessageTest.newBuilder().setId(1).setName("leaf").build();
+
+        RowData row = deserialize(PROTO3_CLASS, true, message.toByteArray());
+        assertNotNull(row);
+        assertEquals(1, row.getInt(0));
+        assertEquals("leaf", row.getString(1).toString());
+        byte[] parentBytes = row.getBinary(2);
+        assertNotNull(parentBytes);
+        RecursiveMessageTest parsed = RecursiveMessageTest.parseFrom(parentBytes);
+        assertEquals(0, parsed.getId());
+        assertEquals("", parsed.getName());
     }
 
     // --- proto2 deserialization ---

--- a/flink-formats/flink-protobuf/src/test/java/org/apache/flink/formats/protobuf/RecursiveMessageProtoToRowTest.java
+++ b/flink-formats/flink-protobuf/src/test/java/org/apache/flink/formats/protobuf/RecursiveMessageProtoToRowTest.java
@@ -1,0 +1,186 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.formats.protobuf;
+
+import org.apache.flink.formats.protobuf.deserialize.PbRowDataDeserializationSchema;
+import org.apache.flink.formats.protobuf.testproto.RecursiveMessageProto2Test;
+import org.apache.flink.formats.protobuf.testproto.RecursiveMessageTest;
+import org.apache.flink.formats.protobuf.util.PbFormatUtils;
+import org.apache.flink.formats.protobuf.util.PbToRowTypeUtil;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
+import org.apache.flink.table.types.logical.LogicalTypeRoot;
+import org.apache.flink.table.types.logical.RowType;
+
+import com.google.protobuf.Descriptors;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/** Test handling of recursive protobuf message types. */
+public class RecursiveMessageProtoToRowTest {
+
+    private static final String PROTO3_CLASS =
+            "org.apache.flink.formats.protobuf.testproto.RecursiveMessageTest";
+    private static final String PROTO2_CLASS =
+            "org.apache.flink.formats.protobuf.testproto.RecursiveMessageProto2Test";
+
+    /** Deserializes proto bytes through the full Flink codegen pipeline. */
+    private RowData deserialize(String className, boolean readDefaultValues, byte[] data)
+            throws Exception {
+        RowType rowType = PbToRowTypeUtil.generateRowType(PbFormatUtils.getDescriptor(className));
+        PbFormatConfig config = new PbFormatConfig(className, false, readDefaultValues, "");
+        PbRowDataDeserializationSchema schema =
+                new PbRowDataDeserializationSchema(rowType, InternalTypeInfo.of(rowType), config);
+        schema.open(null);
+        return schema.deserialize(data);
+    }
+
+    // --- schema generation ---
+
+    @Test
+    public void testCycleDetectionProducesBytes() {
+        Descriptors.Descriptor descriptor = RecursiveMessageTest.getDescriptor();
+        RowType rowType = PbToRowTypeUtil.generateRowType(descriptor);
+
+        assertEquals(3, rowType.getFieldCount());
+        assertEquals("id", rowType.getFieldNames().get(0));
+        assertEquals("name", rowType.getFieldNames().get(1));
+        assertEquals("parent", rowType.getFieldNames().get(2));
+        assertEquals(
+                "Recursive field should be VARBINARY",
+                LogicalTypeRoot.VARBINARY,
+                rowType.getTypeAt(2).getTypeRoot());
+    }
+
+    // --- proto3 deserialization ---
+
+    @Test
+    public void testProto3NestedDataPreservedAsBytes() throws Exception {
+        RecursiveMessageTest grandparent =
+                RecursiveMessageTest.newBuilder().setId(1).setName("grandparent").build();
+        RecursiveMessageTest parent =
+                RecursiveMessageTest.newBuilder()
+                        .setId(2)
+                        .setName("parent")
+                        .setParent(grandparent)
+                        .build();
+        RecursiveMessageTest message =
+                RecursiveMessageTest.newBuilder()
+                        .setId(3)
+                        .setName("child")
+                        .setParent(parent)
+                        .build();
+
+        RowData row = deserialize(PROTO3_CLASS, false, message.toByteArray());
+        assertNotNull(row);
+        assertEquals(3, row.getInt(0));
+        assertEquals("child", row.getString(1).toString());
+
+        // Parse the bytes back - should contain full parent including grandparent
+        byte[] parentBytes = row.getBinary(2);
+        RecursiveMessageTest parsedParent = RecursiveMessageTest.parseFrom(parentBytes);
+        assertEquals(2, parsedParent.getId());
+        assertEquals("parent", parsedParent.getName());
+        assertTrue(parsedParent.hasParent());
+        assertEquals(1, parsedParent.getParent().getId());
+        assertEquals("grandparent", parsedParent.getParent().getName());
+    }
+
+    @Test
+    public void testProto3UnsetFieldReadsDefaultBytes() throws Exception {
+        // In proto3, the recursive field is treated as a primitive type (VARBINARY)
+        // by the codegen, so it always reads default values regardless of the
+        // readDefaultValues config. Both true and false produce the same result:
+        // empty bytes from .toByteArray() on the default message instance.
+        RecursiveMessageTest message =
+                RecursiveMessageTest.newBuilder().setId(1).setName("leaf").build();
+
+        for (boolean readDefaults : new boolean[] {true, false}) {
+            RowData row = deserialize(PROTO3_CLASS, readDefaults, message.toByteArray());
+            assertNotNull(row);
+            assertEquals(1, row.getInt(0));
+            assertEquals("leaf", row.getString(1).toString());
+            byte[] parentBytes = row.getBinary(2);
+            assertNotNull("readDefaultValues=" + readDefaults, parentBytes);
+            RecursiveMessageTest parsed = RecursiveMessageTest.parseFrom(parentBytes);
+            assertEquals(0, parsed.getId());
+            assertEquals("", parsed.getName());
+        }
+    }
+
+    // --- proto2 deserialization ---
+
+    @Test
+    public void testProto2SetFieldPreservedAsBytes() throws Exception {
+        RecursiveMessageProto2Test parent =
+                RecursiveMessageProto2Test.newBuilder().setId(1).setName("parent").build();
+        RecursiveMessageProto2Test message =
+                RecursiveMessageProto2Test.newBuilder()
+                        .setId(2)
+                        .setName("child")
+                        .setParent(parent)
+                        .build();
+
+        RowData row = deserialize(PROTO2_CLASS, false, message.toByteArray());
+        assertNotNull(row);
+        assertEquals(2, row.getInt(0));
+        assertEquals("child", row.getString(1).toString());
+
+        byte[] parentBytes = row.getBinary(2);
+        assertNotNull(parentBytes);
+        RecursiveMessageProto2Test parsed = RecursiveMessageProto2Test.parseFrom(parentBytes);
+        assertEquals(1, parsed.getId());
+        assertEquals("parent", parsed.getName());
+    }
+
+    @Test
+    public void testProto2UnsetFieldIsNull() throws Exception {
+        // Proto2 has explicit field presence. With readDefaultValues=false,
+        // hasParent() returns false so the field is null.
+        RecursiveMessageProto2Test message =
+                RecursiveMessageProto2Test.newBuilder().setId(1).setName("leaf").build();
+
+        RowData row = deserialize(PROTO2_CLASS, false, message.toByteArray());
+        assertNotNull(row);
+        assertEquals(1, row.getInt(0));
+        assertEquals("leaf", row.getString(1).toString());
+        assertTrue("Proto2 unset recursive field should be null", row.isNullAt(2));
+    }
+
+    @Test
+    public void testProto2UnsetFieldWithReadDefaultValues() throws Exception {
+        // With readDefaultValues=true, proto2 returns the default instance as bytes
+        // instead of null.
+        RecursiveMessageProto2Test message =
+                RecursiveMessageProto2Test.newBuilder().setId(1).setName("leaf").build();
+
+        RowData row = deserialize(PROTO2_CLASS, true, message.toByteArray());
+        assertNotNull(row);
+        assertEquals(1, row.getInt(0));
+        assertEquals("leaf", row.getString(1).toString());
+        byte[] parentBytes = row.getBinary(2);
+        assertNotNull(parentBytes);
+        RecursiveMessageProto2Test parsed = RecursiveMessageProto2Test.parseFrom(parentBytes);
+        assertEquals(0, parsed.getId());
+        assertEquals("", parsed.getName());
+    }
+}

--- a/flink-formats/flink-protobuf/src/test/java/org/apache/flink/formats/protobuf/RecursiveMessageRowToProtoTest.java
+++ b/flink-formats/flink-protobuf/src/test/java/org/apache/flink/formats/protobuf/RecursiveMessageRowToProtoTest.java
@@ -1,0 +1,286 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.formats.protobuf;
+
+import org.apache.flink.formats.protobuf.deserialize.PbRowDataDeserializationSchema;
+import org.apache.flink.formats.protobuf.serialize.PbRowDataSerializationSchema;
+import org.apache.flink.formats.protobuf.testproto.RecursiveMessageProto2Test;
+import org.apache.flink.formats.protobuf.testproto.RecursiveMessageTest;
+import org.apache.flink.formats.protobuf.testproto.RecursiveRepeatedMessageTest;
+import org.apache.flink.formats.protobuf.testproto.RecursiveRequiredMessageProto2Test;
+import org.apache.flink.formats.protobuf.util.PbFormatUtils;
+import org.apache.flink.formats.protobuf.util.PbToRowTypeUtil;
+import org.apache.flink.table.data.GenericArrayData;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
+import org.apache.flink.table.types.logical.ArrayType;
+import org.apache.flink.table.types.logical.LogicalTypeRoot;
+import org.apache.flink.table.types.logical.RowType;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * Test serialization (row -&gt; proto) of recursive protobuf message types. Mirror of {@link
+ * RecursiveMessageProtoToRowTest}, exercising the serialize side added alongside the deserialize
+ * side in FLINK-34620.
+ */
+public class RecursiveMessageRowToProtoTest {
+
+    private static final String PROTO3_CLASS =
+            "org.apache.flink.formats.protobuf.testproto.RecursiveMessageTest";
+    private static final String PROTO2_CLASS =
+            "org.apache.flink.formats.protobuf.testproto.RecursiveMessageProto2Test";
+    private static final String REPEATED_RECURSIVE_CLASS =
+            "org.apache.flink.formats.protobuf.testproto.RecursiveRepeatedMessageTest";
+    private static final String PROTO2_REQUIRED_CLASS =
+            "org.apache.flink.formats.protobuf.testproto.RecursiveRequiredMessageProto2Test";
+
+    /** Serializes a flink row through the full codegen pipeline. */
+    private byte[] serialize(String className, RowData row) throws Exception {
+        RowType rowType = PbToRowTypeUtil.generateRowType(PbFormatUtils.getDescriptor(className));
+        PbFormatConfig config = new PbFormatConfig(className, false, false, "");
+        PbRowDataSerializationSchema schema = new PbRowDataSerializationSchema(rowType, config);
+        schema.open(null);
+        return schema.serialize(row);
+    }
+
+    /** Deserializes proto bytes through the full Flink codegen pipeline. */
+    private RowData deserialize(String className, boolean readDefaultValues, byte[] data)
+            throws Exception {
+        RowType rowType = PbToRowTypeUtil.generateRowType(PbFormatUtils.getDescriptor(className));
+        PbFormatConfig config = new PbFormatConfig(className, false, readDefaultValues, "");
+        PbRowDataDeserializationSchema schema =
+                new PbRowDataDeserializationSchema(rowType, InternalTypeInfo.of(rowType), config);
+        schema.open(null);
+        return schema.deserialize(data);
+    }
+
+    @Test
+    public void testProto3RecursiveFieldSerializedFromBytes() throws Exception {
+        // The recursive 'parent' field is represented as BYTES in the row, holding a serialized
+        // RecursiveMessageTest (mirrors how PbCodegenBytesDeserializer emits it on read).
+        RecursiveMessageTest grandparent =
+                RecursiveMessageTest.newBuilder().setId(1).setName("grandparent").build();
+        RecursiveMessageTest parent =
+                RecursiveMessageTest.newBuilder()
+                        .setId(2)
+                        .setName("parent")
+                        .setParent(grandparent)
+                        .build();
+
+        GenericRowData row =
+                GenericRowData.of(3, StringData.fromString("child"), parent.toByteArray());
+
+        RecursiveMessageTest result = RecursiveMessageTest.parseFrom(serialize(PROTO3_CLASS, row));
+
+        assertEquals(3, result.getId());
+        assertEquals("child", result.getName());
+        assertTrue(result.hasParent());
+        assertEquals(2, result.getParent().getId());
+        assertEquals("parent", result.getParent().getName());
+        assertTrue(result.getParent().hasParent());
+        assertEquals(1, result.getParent().getParent().getId());
+        assertEquals("grandparent", result.getParent().getParent().getName());
+    }
+
+    @Test
+    public void testProto3NullRecursiveFieldOmitted() throws Exception {
+        // The common case (e.g. signals): the recursive field is simply not populated.
+        GenericRowData row = GenericRowData.of(7, StringData.fromString("leaf"), null);
+
+        RecursiveMessageTest result = RecursiveMessageTest.parseFrom(serialize(PROTO3_CLASS, row));
+
+        assertEquals(7, result.getId());
+        assertEquals("leaf", result.getName());
+        // Unset recursive field -> default instance.
+        assertFalse(result.hasParent());
+        assertEquals(0, result.getParent().getId());
+        assertEquals("", result.getParent().getName());
+    }
+
+    @Test
+    public void testProto2RecursiveFieldSerializedFromBytes() throws Exception {
+        RecursiveMessageProto2Test parent =
+                RecursiveMessageProto2Test.newBuilder().setId(1).setName("parent").build();
+
+        GenericRowData row =
+                GenericRowData.of(2, StringData.fromString("child"), parent.toByteArray());
+
+        RecursiveMessageProto2Test result =
+                RecursiveMessageProto2Test.parseFrom(serialize(PROTO2_CLASS, row));
+
+        assertEquals(2, result.getId());
+        assertEquals("child", result.getName());
+        assertTrue(result.hasParent());
+        assertEquals(1, result.getParent().getId());
+        assertEquals("parent", result.getParent().getName());
+    }
+
+    @Test
+    public void testProto3RepeatedRecursiveFieldsSerializedFromBytes() throws Exception {
+        RowType rowType =
+                PbToRowTypeUtil.generateRowType(
+                        PbFormatUtils.getDescriptor(REPEATED_RECURSIVE_CLASS));
+        ArrayType parentsType = (ArrayType) rowType.getTypeAt(1);
+        ArrayType componentsType = (ArrayType) rowType.getTypeAt(2);
+        RowType componentRowType = (RowType) componentsType.getElementType();
+
+        assertEquals(LogicalTypeRoot.VARBINARY, parentsType.getElementType().getTypeRoot());
+        assertEquals(LogicalTypeRoot.VARBINARY, componentRowType.getTypeAt(1).getTypeRoot());
+
+        RecursiveRepeatedMessageTest parent =
+                RecursiveRepeatedMessageTest.newBuilder().setId(1).build();
+        RecursiveRepeatedMessageTest componentParent =
+                RecursiveRepeatedMessageTest.newBuilder().setId(2).build();
+
+        GenericArrayData parents = new GenericArrayData(new Object[] {parent.toByteArray()});
+        GenericArrayData components =
+                new GenericArrayData(
+                        new Object[] {
+                            GenericRowData.of(
+                                    StringData.fromString("component-a"),
+                                    componentParent.toByteArray()),
+                            GenericRowData.of(StringData.fromString("component-b"), null)
+                        });
+        GenericRowData row = GenericRowData.of(3, parents, components);
+
+        RecursiveRepeatedMessageTest result =
+                RecursiveRepeatedMessageTest.parseFrom(serialize(REPEATED_RECURSIVE_CLASS, row));
+
+        assertEquals(3, result.getId());
+        assertEquals(1, result.getParentsCount());
+        assertEquals(1, result.getParents(0).getId());
+        assertEquals(2, result.getComponentsCount());
+        assertEquals("component-a", result.getComponents(0).getName());
+        assertTrue(result.getComponents(0).hasComponentParent());
+        assertEquals(2, result.getComponents(0).getComponentParent().getId());
+        assertEquals("component-b", result.getComponents(1).getName());
+        assertFalse(result.getComponents(1).hasComponentParent());
+    }
+
+    // --- proto -> row -> proto round trips through the real (de)serialization schemas ---
+    // Unlike the tests above (which hand-build the row), the row here comes from
+    // PbRowDataDeserializationSchema, so an absent recursive field has already been converted to
+    // bytes/null exactly as it is in production. This is where the absent-recursive-field bug
+    // (FLINK-34620) surfaces: without the deserializer guard, an absent sub-message is materialized
+    // as empty bytes and round-trips back as a present default message.
+
+    @Test
+    public void testProto3AbsentRecursiveFieldRoundTripPreservesAbsence() throws Exception {
+        RecursiveMessageTest input =
+                RecursiveMessageTest.newBuilder().setId(7).setName("leaf").build();
+
+        RowData row = deserialize(PROTO3_CLASS, false, input.toByteArray());
+        RecursiveMessageTest result = RecursiveMessageTest.parseFrom(serialize(PROTO3_CLASS, row));
+
+        assertEquals(7, result.getId());
+        assertEquals("leaf", result.getName());
+        assertFalse(
+                "Absent recursive field should remain absent after a proto -> row -> proto round trip",
+                result.hasParent());
+    }
+
+    @Test
+    public void testProto2AbsentRecursiveFieldRoundTripPreservesAbsence() throws Exception {
+        // readDefaultValues=false: an absent proto2 message field must round-trip as absent. (With
+        // readDefaultValues=true the absent field is materialized as a default instance per the
+        // Flink protobuf format docs, so absence cannot be preserved in that mode.)
+        RecursiveMessageProto2Test input =
+                RecursiveMessageProto2Test.newBuilder().setId(7).setName("leaf").build();
+
+        RowData row = deserialize(PROTO2_CLASS, false, input.toByteArray());
+        RecursiveMessageProto2Test result =
+                RecursiveMessageProto2Test.parseFrom(serialize(PROTO2_CLASS, row));
+
+        assertEquals(7, result.getId());
+        assertEquals("leaf", result.getName());
+        assertFalse(
+                "Absent recursive field should remain absent after a proto -> row -> proto round trip",
+                result.hasParent());
+    }
+
+    @Test
+    public void testProto3PresentRecursiveChainRoundTrip() throws Exception {
+        // A populated recursive chain must survive proto -> row -> proto unchanged.
+        RecursiveMessageTest grandparent =
+                RecursiveMessageTest.newBuilder().setId(1).setName("grandparent").build();
+        RecursiveMessageTest parent =
+                RecursiveMessageTest.newBuilder()
+                        .setId(2)
+                        .setName("parent")
+                        .setParent(grandparent)
+                        .build();
+        RecursiveMessageTest input =
+                RecursiveMessageTest.newBuilder()
+                        .setId(3)
+                        .setName("child")
+                        .setParent(parent)
+                        .build();
+
+        RowData row = deserialize(PROTO3_CLASS, false, input.toByteArray());
+        RecursiveMessageTest result = RecursiveMessageTest.parseFrom(serialize(PROTO3_CLASS, row));
+
+        assertEquals(input, result);
+    }
+
+    @Test
+    public void testProto2RequiredRecursiveFieldWithReadDefaultsFailsClearly() throws Exception {
+        // Unsupported combination: proto2 + recursive message + a required field in that message +
+        // read-default-values=true. On read, the absent recursive field is materialized as byte[0]
+        // (toByteArray() does not enforce required fields). It cannot be re-serialized, since
+        // parseFrom() does enforce them. We surface a clear, actionable error rather than an opaque
+        // InvalidProtocolBufferException.
+        RecursiveRequiredMessageProto2Test input =
+                RecursiveRequiredMessageProto2Test.newBuilder().setId(7).setName("leaf").build();
+
+        // read-default-values=true -> the absent 'parent' becomes byte[0] in the row.
+        RowData row = deserialize(PROTO2_REQUIRED_CLASS, true, input.toByteArray());
+
+        try {
+            serialize(PROTO2_REQUIRED_CLASS, row);
+            fail("expected an exception for empty recursive bytes of a required message type");
+        } catch (Exception e) {
+            // The generated serializer runs via reflection, so our RuntimeException is wrapped
+            // (InvocationTargetException, etc.). Walk the cause chain and assert our actionable
+            // message appears somewhere in it.
+            StringBuilder chain = new StringBuilder();
+            boolean found = false;
+            for (Throwable t = e; t != null; t = t.getCause()) {
+                String m = t.getMessage();
+                if (m != null) {
+                    chain.append(m).append(" | ");
+                    if (m.contains("required fields") && m.contains("read-default-values")) {
+                        found = true;
+                    }
+                }
+            }
+            assertTrue(
+                    "error chain should explain the required-field / read-default-values cause, got: "
+                            + chain,
+                    found);
+        }
+    }
+}

--- a/flink-formats/flink-protobuf/src/test/proto/test_recursive_message.proto
+++ b/flink-formats/flink-protobuf/src/test/proto/test_recursive_message.proto
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+syntax = "proto3";
+package org.apache.flink.formats.protobuf.proto;
+option java_package = "org.apache.flink.formats.protobuf.testproto";
+option java_multiple_files = true;
+
+message RecursiveMessageTest {
+  int32 id = 1;
+  string name = 2;
+  RecursiveMessageTest parent = 3;
+}

--- a/flink-formats/flink-protobuf/src/test/proto/test_recursive_message_proto2.proto
+++ b/flink-formats/flink-protobuf/src/test/proto/test_recursive_message_proto2.proto
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+syntax = "proto2";
+package org.apache.flink.formats.protobuf.proto;
+option java_package = "org.apache.flink.formats.protobuf.testproto";
+option java_multiple_files = true;
+
+message RecursiveMessageProto2Test {
+  optional int32 id = 1;
+  optional string name = 2;
+  optional RecursiveMessageProto2Test parent = 3;
+}

--- a/flink-formats/flink-protobuf/src/test/proto/test_recursive_repeated_message.proto
+++ b/flink-formats/flink-protobuf/src/test/proto/test_recursive_repeated_message.proto
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+syntax = "proto3";
+package org.apache.flink.formats.protobuf.proto;
+option java_package = "org.apache.flink.formats.protobuf.testproto";
+option java_multiple_files = true;
+
+message RecursiveRepeatedMessageTest {
+  int32 id = 1;
+  repeated RecursiveRepeatedMessageTest parents = 2;
+  repeated RecursiveRepeatedMessageComponent components = 3;
+}
+
+message RecursiveRepeatedMessageComponent {
+  string name = 1;
+  RecursiveRepeatedMessageTest component_parent = 2;
+}

--- a/flink-formats/flink-protobuf/src/test/proto/test_recursive_required_message_proto2.proto
+++ b/flink-formats/flink-protobuf/src/test/proto/test_recursive_required_message_proto2.proto
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+syntax = "proto2";
+package org.apache.flink.formats.protobuf.proto;
+option java_package = "org.apache.flink.formats.protobuf.testproto";
+option java_multiple_files = true;
+
+// A recursive proto2 message whose type has a required field. An empty (default)
+// instance is NOT initialized, so it cannot be re-serialized from byte[0]. Used to
+// verify the clear runtime error for the read-default-values=true absent-field case.
+message RecursiveRequiredMessageProto2Test {
+  required int64 id = 1;
+  optional string name = 2;
+  optional RecursiveRequiredMessageProto2Test parent = 3;
+}


### PR DESCRIPTION
> **⚠️ Stacked on #28108** (`khaledh:handle-recursive-proto-fields`). #28108 adds the recursive-message **deserialize** support this builds on; it is not yet merged, so this PR's diff includes that commit as its base. **Please review only the top commit** (`[FLINK-34620][formats][protobuf] Add serialize-side handling...`) and merge this **after** #28108.

## What is the purpose of the change

Completes recursive-protobuf support for the `flink-protobuf` format (FLINK-34620). #28108 added the **deserialize** side — a message field whose type is (transitively) recursive is resolved to `VARBINARY` via cycle detection, and read back with `message.toByteArray()`. This PR adds the missing **serialize** side so that a `RowToProtoConverter` can be constructed for any proto whose descriptor transitively contains a recursive message, and fixes an absent-field round-trip bug that only surfaces once both paths exist.

Without this, building a serializer for such a proto fails at construction (job start), before any data:

```
PbCodegenException -> InvalidProgramException -> CompileException:
Assignment conversion not possible from "com.google.protobuf.ByteString" to "<recursive message type>"
```

Root cause: `PbToRowTypeUtil` resolves a recursive field to `VARBINARY`. On read, `PbCodegenDeserializeFactory` routes it to `PbCodegenBytesDeserializer`. On write, `PbCodegenSerializeFactory` had no matching branch, so `VARBINARY` fell through to `PbCodegenSimpleSerializer`, which emits `ByteString.copyFrom(...)` into a message-typed variable — which does not compile.

## Brief change log

  - `PbCodegenBytesSerializer` (new) — parses the `VARBINARY` bytes back into the message (`<MessageType>.parseFrom(bytes)`), the inverse of `PbCodegenBytesDeserializer`.
  - `PbCodegenSerializeFactory` — dispatches the `MESSAGE` + `VARBINARY` case to the new serializer, mirroring the branch already used in `PbCodegenDeserializeFactory`.
  - `PbCodegenRowDeserializer` — a recursive field is `VARBINARY` (a "simple type") but is still a `MESSAGE`; guard the proto3 primitive-default path with `getJavaType() != MESSAGE` so an absent sub-message stays absent instead of round-tripping back as a present (empty) one.
  - Docs — note that a proto2 recursive message declaring `required` fields cannot be serialized when an absent recursive field is read with `read-default-values=true`.

## Verifying this change

This change added tests and can be verified as follows:

  - `RecursiveMessageRowToProtoTest` (new) — serialize + round trips: proto3 nested recursive, null-field omission, proto2 round-trip, repeated recursive fields (`ARRAY<VARBINARY>`), absent-field round trips asserting absence is preserved.
  - `RecursiveMessageProtoToRowTest` (extended) — proto3 unset recursive field asserts `null` (`read-default-values=false`) / default bytes (`=true`), mirroring the proto2 pair.
  - `mvn -pl flink-formats/flink-protobuf test` → `Tests run: 61, Failures: 0, Errors: 0, Skipped: 0`; `checkstyle:check` and `spotless:check` clean.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **yes** (protobuf format codegen; serialize path for recursive message fields)
  - The runtime per-record code path (performance sensitive): **no**
  - Anything that affects deployment or recovery: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no** (completes an existing in-progress feature)
  - If yes, how is the feature documented? **docs** (protobuf format options note updated)
