### PR TITLE
[FLINK-40160] Fix casting 'NaN' to FLOAT or DOUBLE

### DIFF
--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/CodeGenUtils.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/CodeGenUtils.scala
@@ -233,12 +233,16 @@ object CodeGenUtils {
       value match {
         case JFloat.NEGATIVE_INFINITY => "java.lang.Float.NEGATIVE_INFINITY"
         case JFloat.POSITIVE_INFINITY => "java.lang.Float.POSITIVE_INFINITY"
+        // NaN is not equal to itself, so it can't be matched by value like the infinities above.
+        case f: JFloat if f.isNaN => "java.lang.Float.NaN"
         case _ => value.toString + "f"
       }
     case _: JDouble =>
       value match {
         case JDouble.NEGATIVE_INFINITY => "java.lang.Double.NEGATIVE_INFINITY"
         case JDouble.POSITIVE_INFINITY => "java.lang.Double.POSITIVE_INFINITY"
+        // NaN is not equal to itself, so it can't be matched by value like the infinities above.
+        case d: JDouble if d.isNaN => "java.lang.Double.NaN"
         case _ => value.toString + "d"
       }
     case sd: StringData =>

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CastFunctionITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CastFunctionITCase.java
@@ -1415,6 +1415,14 @@ public class CastFunctionITCase extends BuiltInFunctionTestBase {
                         .build(),
                 CastTestSpecBuilder.testCastTo(FLOAT())
                         .fromCase(DOUBLE(), -1.7976931348623157E308d, Float.NEGATIVE_INFINITY)
+                        .fromCase(STRING(), "NaN", Float.NaN)
+                        .fromCase(STRING(), "Infinity", Float.POSITIVE_INFINITY)
+                        .fromCase(STRING(), "-Infinity", Float.NEGATIVE_INFINITY)
+                        .build(),
+                CastTestSpecBuilder.testCastTo(DOUBLE())
+                        .fromCase(STRING(), "NaN", Double.NaN)
+                        .fromCase(STRING(), "Infinity", Double.POSITIVE_INFINITY)
+                        .fromCase(STRING(), "-Infinity", Double.NEGATIVE_INFINITY)
                         .build(),
                 CastTestSpecBuilder.testCastTo(DECIMAL(38, 0))
                         .fromCase(


### PR DESCRIPTION
## What is the purpose of the change

Casting NaN (Not A Number) to float or double is broken. When calling
```sql
SELECT CAST('NaN' AS FLOAT)
```
You will get
```
Caused by: org.codehaus.commons.compiler.CompileException Create breakpoint : Line 45, Column 36: Expression "NaNf" is not an rvalue
at org.codehaus.janino.UnitCompiler.compileError(UnitCompiler.java:13228)
at org.codehaus.janino.UnitCompiler.toRvalue0rCompileException(UnitCompiler.java:8073)
at org.codehaus.janino.UnitCompiler.getConstantValue2(UnitCompiler.java:6053)
at org.codehaus.janino.UnitCompiler.access$11000(UnitCompiler.java:240)
at org.codehaus.janino.UnitCompiler$19$1.visitAmbiguousName(UnitCompiler.java:6004)
at org.codehaus.janino.Java$AmbiguousName.accept(Java.java:4603)
at org.codehaus.janino.UnitCompiler$19.visitLvalve(UnitCompiler.java:6003)
at org.codehaus.janino.Java$Lvalue.accept(Java.java:4528) 
```

Same issue for `SELECT CAST('NaN' AS DOUBLE)`.

## Brief change log

- Updated the `CodeGenUtils` to accept `NaN`. Before it was taking the default branch and producing a string like `NaNf` or `NaNd`


## Verifying this change

Added `CastFucntionITCase` to back the logic for casting `NaN`, `-Infinity`, `Infinity`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change the checkbox below to `[X]` followed by the name of the tool, and uncomment the
"Generated-by" line. See the ASF Generative Tooling Guidance for details:
https://www.apache.org/legal/generative-tooling.html

You are responsible for the quality and correctness of every change in this PR
regardless of the tooling used. Low-effort AI-generated PRs will be closed. See
AGENTS.md for the full guidance.
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name and Version]
-->
