### PR TITLE
[hotfix][docs] Remove inconsistent parameter descriptions.

### DIFF
--- a/docs/content.zh/release-notes/flink-2.3.md
+++ b/docs/content.zh/release-notes/flink-2.3.md
@@ -90,17 +90,11 @@ CREATE FUNCTION my_func AS 'com.example.MyUdf'
 
 Flink 2.3 reworks how `SinkUpsertMaterializer` handles the case where a query's upsert key
 differs from the sink's primary key. Previously this required maintaining the full history of
-records and could blow up state. Two changes address this:
+records and could blow up state. A change partially addressed this issue:
 
 - A new `ON CONFLICT` clause with `DO NOTHING`, `DO ERROR` and `DO DEDUPLICATE` strategies makes
   the behavior on key conflict explicit. By default, planning now fails when the upsert and
   primary keys differ, requiring the user to choose a conflict strategy.
-- Watermark-based record compaction is introduced to fix internal changelog disorder. The
-  trigger and frequency of compaction are controlled by:
-  - `table.exec.sink.upserts.compaction-mode` (default: `WATERMARK`) — `WATERMARK` or
-    `CHECKPOINT`.
-  - `table.exec.sink.upserts.compaction-interval` — optional fallback interval for emitting
-    watermarks when none arrive naturally.
 
 #### Process Table Function enhancements
 

--- a/docs/content.zh/release-notes/flink-2.3.md
+++ b/docs/content.zh/release-notes/flink-2.3.md
@@ -90,7 +90,7 @@ CREATE FUNCTION my_func AS 'com.example.MyUdf'
 
 Flink 2.3 reworks how `SinkUpsertMaterializer` handles the case where a query's upsert key
 differs from the sink's primary key. Previously this required maintaining the full history of
-records and could blow up state. A change partially addressed this issue:
+records and could blow up state. An enhancement allows you to manage this situation:
 
 - A new `ON CONFLICT` clause with `DO NOTHING`, `DO ERROR` and `DO DEDUPLICATE` strategies makes
   the behavior on key conflict explicit. By default, planning now fails when the upsert and

--- a/docs/content/release-notes/flink-2.3.md
+++ b/docs/content/release-notes/flink-2.3.md
@@ -90,17 +90,11 @@ CREATE FUNCTION my_func AS 'com.example.MyUdf'
 
 Flink 2.3 reworks how `SinkUpsertMaterializer` handles the case where a query's upsert key
 differs from the sink's primary key. Previously this required maintaining the full history of
-records and could blow up state. Two changes address this:
+records and could blow up state. A change partially addressed this issue:
 
 - A new `ON CONFLICT` clause with `DO NOTHING`, `DO ERROR` and `DO DEDUPLICATE` strategies makes
   the behavior on key conflict explicit. By default, planning now fails when the upsert and
   primary keys differ, requiring the user to choose a conflict strategy.
-- Watermark-based record compaction is introduced to fix internal changelog disorder. The
-  trigger and frequency of compaction are controlled by:
-  - `table.exec.sink.upserts.compaction-mode` (default: `WATERMARK`) — `WATERMARK` or
-    `CHECKPOINT`.
-  - `table.exec.sink.upserts.compaction-interval` — optional fallback interval for emitting
-    watermarks when none arrive naturally.
 
 #### Process Table Function enhancements
 

--- a/docs/content/release-notes/flink-2.3.md
+++ b/docs/content/release-notes/flink-2.3.md
@@ -90,7 +90,7 @@ CREATE FUNCTION my_func AS 'com.example.MyUdf'
 
 Flink 2.3 reworks how `SinkUpsertMaterializer` handles the case where a query's upsert key
 differs from the sink's primary key. Previously this required maintaining the full history of
-records and could blow up state. A change partially addressed this issue:
+records and could blow up state. An enhancement allows you to manage this situation:
 
 - A new `ON CONFLICT` clause with `DO NOTHING`, `DO ERROR` and `DO DEDUPLICATE` strategies makes
   the behavior on key conflict explicit. By default, planning now fails when the upsert and


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

[hotfix][docs] Remove inconsistent parameter descriptions.


## Brief change log

[hotfix][docs] Remove inconsistent parameter descriptions.


## Verifying this change


N.A

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change the checkbox below to `[X]` followed by the name of the tool, and uncomment the
"Generated-by" line. See the ASF Generative Tooling Guidance for details:
https://www.apache.org/legal/generative-tooling.html

You are responsible for the quality and correctness of every change in this PR
regardless of the tooling used. Low-effort AI-generated PRs will be closed. See
AGENTS.md for the full guidance.
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name and Version]
-->
