### PR TITLE
[FLINK-40163] [ci] Add new baseline nightly build to Github Actions

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -43,6 +43,17 @@ jobs:
       s3_bucket: ${{ secrets.IT_CASE_S3_BUCKET }}
       s3_access_key: ${{ secrets.IT_CASE_S3_ACCESS_KEY }}
       s3_secret_key: ${{ secrets.IT_CASE_S3_SECRET_KEY }}
+  java17:
+    name: "Java 17 (default)"
+    uses: ./.github/workflows/template.flink-ci.yml
+    with:
+      workflow-caller-id: java17
+      environment: 'PROFILE="-Dflink.hadoop.version=2.10.2 -Djdk17 -Pjava17-target"'
+      jdk_version: 17
+    secrets:
+      s3_bucket: ${{ secrets.IT_CASE_S3_BUCKET }}
+      s3_access_key: ${{ secrets.IT_CASE_S3_ACCESS_KEY }}
+      s3_secret_key: ${{ secrets.IT_CASE_S3_SECRET_KEY }}
   java21:
     name: "Java 21"
     uses: ./.github/workflows/template.flink-ci.yml


### PR DESCRIPTION
## What is the purpose of the change

Azure's nightly stage in tools/azure-pipelines/build-apache-repo.yml has cron_azure as a default baseline build, but there is no equivalent build in the Github Actions scheduled nightly pipeline.

The goal of this commit is to update the GHA nightly release pipeline towards parity with the AZP implementation, treating it as a reference.


## Brief change log

Added new Java 17 job to the GHA nightly release pipeline

## Verifying this change

Manually triggered the Github Actions pipeline in my own fork. 

(see https://github.com/dalelane/flink/pull/3 )

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no 
  - The runtime per-record code paths (performance sensitive): no 
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable 

---

##### Was generative AI tooling used to co-author this PR?

no