### PR TITLE
[FLINK-40165][ci] Add docs check to Github Actions CI stage

### DIFF
--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -44,6 +44,9 @@ jobs:
         uses: actions/checkout@v5
         with:
           persist-credentials: false
+          sparse-checkout: |
+            docs
+            tools/ci/docs.sh
 
       - name: "Build docs and check for broken links"
         run: ./tools/ci/docs.sh

--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -1,0 +1,49 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Runs the Hugo docs build and checks for broken links. Triggered only when
+# docs/** files are changed, acting as a PR gate for documentation changes.
+#
+# This is the GHA equivalent of the docs_404_check job in the Azure Pipelines
+# ci stage (tools/azure-pipelines/build-apache-repo.yml). Azure gates the check
+# on pr_contains_docs_changes; here the workflow-level paths filter achieves the
+# same effect without needing a per-step skip condition.
+
+name: "Docs 404 check (beta)"
+
+on:
+  pull_request:
+    paths:
+      - 'docs/**'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+permissions: read-all
+
+jobs:
+  docs-check:
+    name: "Docs 404 check"
+    runs-on: ubuntu-24.04
+    steps:
+      - name: "Flink Checkout"
+        uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+
+      - name: "Build docs and check for broken links"
+        run: ./tools/ci/docs.sh

--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: "Flink Checkout"
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
           sparse-checkout: |

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -77,6 +77,18 @@ jobs:
       s3_access_key: ${{ secrets.IT_CASE_S3_ACCESS_KEY }}
       s3_secret_key: ${{ secrets.IT_CASE_S3_SECRET_KEY }}
 
+  docs_check:
+    name: "Docs 404 check"
+    runs-on: ubuntu-24.04
+    steps:
+      - name: "Flink Checkout"
+        uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+
+      - name: "Build docs and check for broken links"
+        run: ./tools/ci/docs.sh
+
   build_python_wheels:
     name: "Build Python Wheels on ${{ matrix.os_name }}"
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -85,6 +85,9 @@ jobs:
         uses: actions/checkout@v7
         with:
           persist-credentials: false
+          sparse-checkout: |
+            docs
+            tools/ci/docs.sh
 
       - name: "Build docs and check for broken links"
         run: ./tools/ci/docs.sh

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -82,7 +82,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: "Flink Checkout"
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
 


### PR DESCRIPTION
## What is the purpose of the change

Adding a new workflow to make sure docs aren't broken as part of the Github Actions CI pipeline for pull requests.

The goal is to achieve parity with the docs_404_check job that is included in the ci stage of the Azure Pipelines
azure-pipelines.yml which I'm treating as a reference implementation.

## Brief change log

Added a new docs check workflow, based on the Azure Pipelines equivalent.

## Verifying this change

Manually triggered the Github Actions pipeline in my own fork

(see https://github.com/dalelane/flink/pull/2)

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no 
  - The runtime per-record code paths (performance sensitive): no 
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no 
  - The S3 file system connector: no 

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable 

##### Was generative AI tooling used to co-author this PR?

no