### PR TITLE
[BP-2.2][FLINK-40157][state/ForSt] Fix MapState putAll value serialization

### DIFF
--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStDBBunchPutRequest.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStDBBunchPutRequest.java
@@ -19,10 +19,7 @@
 package org.apache.flink.state.forst;
 
 import org.apache.flink.annotation.VisibleForTesting;
-import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.core.asyncprocessing.InternalAsyncFuture;
-import org.apache.flink.core.memory.DataInputDeserializer;
-import org.apache.flink.core.memory.DataOutputSerializer;
 
 import org.forstdb.RocksDB;
 import org.forstdb.RocksDBException;
@@ -43,14 +40,7 @@ import static org.apache.flink.state.forst.ForStDBIterRequest.startWithKeyPrefix
  */
 public class ForStDBBunchPutRequest<K, N, UK, UV> extends ForStDBPutRequest<K, N, Map<UK, UV>> {
 
-    /** Serializer for the user values. */
-    final ThreadLocal<TypeSerializer<UV>> userValueSerializer;
-
-    /** The data outputStream used for value serializer, which should be thread-safe. */
-    final ThreadLocal<DataOutputSerializer> valueSerializerView;
-
-    /** The data inputStream used for value deserializer, which should be thread-safe. */
-    final ThreadLocal<DataInputDeserializer> valueDeserializerView;
+    private final ForStMapState<K, N, UK, UV> mapState;
 
     final int keyGroupPrefixBytes;
 
@@ -60,9 +50,7 @@ public class ForStDBBunchPutRequest<K, N, UK, UV> extends ForStDBPutRequest<K, N
             ForStMapState<K, N, UK, UV> table,
             InternalAsyncFuture<Void> future) {
         super(key, value, false, (ForStInnerTable<K, N, Map<UK, UV>>) table, future);
-        this.userValueSerializer = table.userValueSerializer;
-        this.valueSerializerView = table.valueSerializerView;
-        this.valueDeserializerView = table.valueDeserializerView;
+        this.mapState = table;
         this.keyGroupPrefixBytes = table.getKeyGroupPrefixBytes();
     }
 
@@ -98,10 +86,7 @@ public class ForStDBBunchPutRequest<K, N, UK, UV> extends ForStDBPutRequest<K, N
     }
 
     public byte[] buildSerializedValue(UV singleValue) throws IOException {
-        DataOutputSerializer outputView = valueSerializerView.get();
-        outputView.clear();
-        userValueSerializer.get().serialize(singleValue, outputView);
-        return outputView.getCopyOfBuffer();
+        return mapState.serializeValue(singleValue);
     }
 
     // --------------- For testing usage ---------------

--- a/flink-state-backends/flink-statebackend-forst/src/test/java/org/apache/flink/state/forst/ForStWriteBatchOperationTest.java
+++ b/flink-state-backends/flink-statebackend-forst/src/test/java/org/apache/flink/state/forst/ForStWriteBatchOperationTest.java
@@ -244,6 +244,7 @@ public class ForStWriteBatchOperationTest extends ForStDBOperationTestBase {
                     byte[] valueBytes = db.get(request.getColumnFamilyHandle(), keyBytes);
                     assertArrayEquals(
                             valueBytes, bunchPutRequest.buildSerializedValue(en.getValue()));
+                    assertThat(mapState1.deserializeValue(valueBytes)).isEqualTo(en.getValue());
                 }
             } else {
                 byte[] keyBytes = request.buildSerializedKey();


### PR DESCRIPTION
Backport of #28762 

## What is the purpose of the change

The ForSt's `asyncPutAll` uses the wrong serialized form without the null flag, so when reading it gives the wrong.

## Brief change log

 - Align `ForStDBBunchPutRequest.buildSerializedValue` with the `ForStDBPutRequest`'s.

## Verifying this change

  - Added new assertion to check the deserialized value equals the serialized one

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
