### PR TITLE
[FLINK-40181][ci] Make spotless checking changes since last green build in ci

### DIFF
--- a/.github/actions/last_workflow_run/action.yml
+++ b/.github/actions/last_workflow_run/action.yml
@@ -1,0 +1,65 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+name: "Finds the most recent run of a workflow on a branch"
+description: "Queries the GitHub Actions API for the most recent run of a given workflow on a given branch, optionally filtered by status, and exposes its head SHA and conclusion."
+inputs:
+  workflow_id:
+    description: "Workflow file name, e.g. ci.yml"
+    required: true
+  branch:
+    description: "Branch name to query"
+    required: true
+  status:
+    description: "Optional run status filter, e.g. success. Leave empty to match any status."
+    required: false
+    default: ""
+outputs:
+  sha:
+    description: "Head SHA of the matched run, or empty string if none found"
+    value: ${{ steps.resolve.outputs.sha }}
+  conclusion:
+    description: "Conclusion of the matched run, or empty string if none found"
+    value: ${{ steps.resolve.outputs.conclusion }}
+runs:
+  using: "composite"
+  steps:
+    - name: "Query workflow runs"
+      id: resolve
+      uses: actions/github-script@v7
+      with:
+        script: |
+          const workflowId = "${{ inputs.workflow_id }}";
+          const branch = "${{ inputs.branch }}";
+          const status = "${{ inputs.status }}";
+
+          const params = {
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            workflow_id: workflowId,
+            branch: branch,
+            per_page: 1
+          };
+          if (status) {
+            params.status = status;
+          }
+
+          const { data } = await github.rest.actions.listWorkflowRuns(params);
+          const run = data.workflow_runs[0];
+
+          core.setOutput('sha', run?.head_sha ?? '');
+          core.setOutput('conclusion', run?.conclusion ?? '');

--- a/.github/workflows/nightly-trigger.yml
+++ b/.github/workflows/nightly-trigger.yml
@@ -39,6 +39,13 @@ jobs:
           - release-1.20
     runs-on: ubuntu-latest
     steps:
+      - name: "Resolve last nightly run"
+        id: last-nightly
+        uses: "./.github/actions/last_workflow_run"
+        with:
+          workflow_id: "nightly.yml"
+          branch: ${{ matrix.branch }}
+
       - name: Trigger Workflow
         uses: actions/github-script@v7
         with:
@@ -55,17 +62,8 @@ jobs:
 
             // Compare SHA from last nightly against current
             // if it is same, then no need to run nightly for the same SHA again.
-            const { data: runsData } = await github.rest.actions.listWorkflowRuns({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              workflow_id: 'nightly.yml',
-              branch: branch,
-              per_page: 1
-            });
-            
-            const lastRun = runsData.workflow_runs[0];
-            const lastBuiltSha = lastRun?.head_sha;
-            const lastConclusion = lastRun?.conclusion;
+            const lastBuiltSha = '${{ steps.last-nightly.outputs.sha }}' || undefined;
+            const lastConclusion = '${{ steps.last-nightly.outputs.conclusion }}' || undefined;
 
             // Skip the scheduled run only if there are no new commits AND the
             // previous nightly was green. If the last run failed/was cancelled,

--- a/.github/workflows/template.pre-compile-checks.yml
+++ b/.github/workflows/template.pre-compile-checks.yml
@@ -59,16 +59,33 @@ jobs:
         with:
           jdk_version: ${{ inputs.jdk_version }}
 
-      - name: "Checkstyle"
-        uses: "./.github/actions/run_mvn"
+      - name: "Resolve last green commit for spotless ratchet"
+        id: last-green
+        uses: "./.github/actions/last_workflow_run"
         with:
-          maven-parameters: "checkstyle:check -T1C"
+          workflow_id: "ci.yml"
+          branch: ${{ github.ref_name }}
+          status: "success"
 
-      - name: "Spotless"
-        if: (success() || failure())
+      - name: "Fetch last green commit"
+        if: steps.last-green.outputs.sha != ''
+        shell: bash
+        run: |
+          sha="${{ steps.last-green.outputs.sha }}"
+          if git -c safe.directory='*' fetch --depth=1 origin "${sha}" \
+             && git -c safe.directory='*' cat-file -e "${sha}^{commit}"; then
+            echo "RATCHET_SHA=${sha}" >> "${GITHUB_ENV}"
+            echo "Ratcheting spotless from ${sha}"
+          else
+            echo "Could not fetch ${sha}; running full spotless check."
+          fi
+
+      - name: "Checkstyle & Spotless"
         uses: "./.github/actions/run_mvn"
         with:
-          maven-parameters: "spotless:check -T1C"
+          maven-parameters: >-
+            checkstyle:check spotless:check -T1C -fae
+            ${{ env.RATCHET_SHA && format('-Dspotless.ratchetFrom={0}', env.RATCHET_SHA) || '' }}
 
       - name: "License Headers"
         if: (success() || failure())

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@ under the License.
 -->
 <project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
 		 xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-<!-- test commit-->
+
 	<parent>
 		<groupId>org.apache</groupId>
 		<artifactId>apache</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@ under the License.
 -->
 <project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
 		 xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-
+<!-- test commit-->
 	<parent>
 		<groupId>org.apache</groupId>
 		<artifactId>apache</artifactId>
@@ -972,6 +972,27 @@ under the License.
 				     (which may bundled said classes). -->
 				<flink.markBundledAsOptional>false</flink.markBundledAsOptional>
 			</properties>
+		</profile>
+		<profile>
+			<id>spotless-ratchet</id>
+			<activation>
+				<property>
+					<name>spotless.ratchetFrom</name>
+				</property>
+			</activation>
+			<build>
+				<pluginManagement>
+					<plugins>
+						<plugin>
+							<groupId>com.diffplug.spotless</groupId>
+							<artifactId>spotless-maven-plugin</artifactId>
+							<configuration>
+								<ratchetFrom>${spotless.ratchetFrom}</ratchetFrom>
+							</configuration>
+						</plugin>
+					</plugins>
+				</pluginManagement>
+			</build>
 		</profile>
 		<profile>
 			<id>scala-2.12</id>


### PR DESCRIPTION

## What is the purpose of the change

The PR makes GHA running spotless against files changed since last successful build rather than for everything
also more details are at https://github.com/diffplug/spotless/issues/511

## Brief change log

GHA: check for last green branch and make spotless running for changes since that branch
## Verifying this change

GHA
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable)

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change the checkbox below to `[X]` followed by the name of the tool, and uncomment the
"Generated-by" line. See the ASF Generative Tooling Guidance for details:
https://www.apache.org/legal/generative-tooling.html

You are responsible for the quality and correctness of every change in this PR
regardless of the tooling used. Low-effort AI-generated PRs will be closed. See
AGENTS.md for the full guidance.
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name and Version]
-->
