### PR TITLE
FLINK-40245 Wire parquet.page.size.row.check.min/max conf keys in FlinkParquetBui…

### DIFF
--- a/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/row/ParquetRowDataBuilder.java
+++ b/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/row/ParquetRowDataBuilder.java
@@ -42,6 +42,8 @@ import static org.apache.parquet.hadoop.ParquetOutputFormat.MAX_PADDING_BYTES;
 import static org.apache.parquet.hadoop.ParquetOutputFormat.getBlockSize;
 import static org.apache.parquet.hadoop.ParquetOutputFormat.getDictionaryPageSize;
 import static org.apache.parquet.hadoop.ParquetOutputFormat.getEnableDictionary;
+import static org.apache.parquet.hadoop.ParquetOutputFormat.getMaxRowCountForPageSizeCheck;
+import static org.apache.parquet.hadoop.ParquetOutputFormat.getMinRowCountForPageSizeCheck;
 import static org.apache.parquet.hadoop.ParquetOutputFormat.getPageSize;
 import static org.apache.parquet.hadoop.ParquetOutputFormat.getValidation;
 import static org.apache.parquet.hadoop.ParquetOutputFormat.getWriterVersion;
@@ -143,6 +145,8 @@ public class ParquetRowDataBuilder extends ParquetWriter.Builder<RowData, Parque
                     .withDictionaryEncoding(getEnableDictionary(conf))
                     .withValidation(getValidation(conf))
                     .withWriterVersion(getWriterVersion(conf))
+                    .withMinRowCountForPageSizeCheck(getMinRowCountForPageSizeCheck(conf))
+                    .withMaxRowCountForPageSizeCheck(getMaxRowCountForPageSizeCheck(conf))
                     .withConf(conf)
                     .build();
         }

--- a/flink-formats/flink-parquet/src/test/java/org/apache/flink/formats/parquet/row/ParquetRowDataWriterTest.java
+++ b/flink-formats/flink-parquet/src/test/java/org/apache/flink/formats/parquet/row/ParquetRowDataWriterTest.java
@@ -483,4 +483,52 @@ class ParquetRowDataWriterTest {
         v = (v > 0 ? v : -v) % 1000;
         return LocalDateTime.now().plusNanos(v).plusSeconds(v);
     }
+
+    /**
+     * Verifies that {@code parquet.page.size.row.check.min} and {@code
+     * parquet.page.size.row.check.max} configuration keys are honoured by {@link
+     * ParquetRowDataBuilder}.
+     *
+     * <p>Before the fix, {@code FlinkParquetBuilder.createWriter()} never called {@code
+     * withMinRowCountForPageSizeCheck()} / {@code withMaxRowCountForPageSizeCheck()}, so these
+     * conf keys were silently ignored. A job writing rows with large binary fields could accumulate
+     * data across 100–10,000 rows (the defaults) before a page-size check, causing
+     * {@code java.lang.OutOfMemoryError: Size of data exceeded Integer.MAX_VALUE}.
+     */
+    @Test
+    void testRowCountForPageSizeCheckConfIsHonoured(@TempDir java.nio.file.Path folder)
+            throws IOException {
+        // Use a tiny page size (4 KB) and check after every row so the writer
+        // flushes frequently — this would OOM with the defaults on large payloads.
+        Configuration conf = new Configuration();
+        conf.setInt(ParquetOutputFormat.PAGE_SIZE, 4096);
+        conf.setInt(ParquetOutputFormat.MIN_ROW_COUNT_FOR_PAGE_SIZE_CHECK, 1);
+        conf.setInt(ParquetOutputFormat.MAX_ROW_COUNT_FOR_PAGE_SIZE_CHECK, 1);
+
+        RowType rowType =
+                RowType.of(new VarBinaryType(VarBinaryType.MAX_LENGTH));
+
+        Path path = new Path(folder.toString(), UUID.randomUUID().toString());
+        ParquetWriterFactory<RowData> factory =
+                ParquetRowDataBuilder.createWriterFactory(rowType, conf, true);
+        BulkWriter<RowData> writer =
+                factory.create(path.getFileSystem().create(path, FileSystem.WriteMode.OVERWRITE));
+
+        // Write rows with binary payloads larger than the page size.
+        // With row.check.min=1 the writer checks after every row and flushes before overflow.
+        byte[] largePayload = new byte[40_960]; // 40 KB — 10× the 4 KB page size
+        DataFormatConverters.DataFormatConverter<RowData, Row> converter =
+                (DataFormatConverters.DataFormatConverter<RowData, Row>)
+                        DataFormatConverters.getConverterForDataType(
+                                TypeConversions.fromLogicalToDataType(rowType));
+
+        // Write enough rows that the page buffer would overflow without frequent checks
+        RowData rowData = converter.toInternal(Row.of((Object) largePayload));
+        for (int i = 0; i < 100; i++) {
+            writer.addElement(rowData);
+        }
+        // Should complete without OutOfMemoryError
+        writer.flush();
+        writer.finish();
+    }
 }


### PR DESCRIPTION
…lder

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change
Fixes FLINK-40245.

`FlinkParquetBuilder.createWriter()` correctly reads `parquet.page.size` and 
`parquet.block.size` from conf via explicit method calls, but never calls 
`withMinRowCountForPageSizeCheck()` / `withMaxRowCountForPageSizeCheck()`.

This means `parquet.page.size.row.check.min` and `parquet.page.size.row.check.max` 
are silently ignored regardless of what values are configured.

Without frequent page size checks, a single row with a large binary field can 
accumulate beyond `Integer.MAX_VALUE` bytes in the Parquet page buffer, causing:
java.lang.OutOfMemoryError: Size of data exceeded Integer.MAX_VALUE at org.apache.parquet.bytes.CapacityByteArrayOutputStream.addSlab at org.apache.flink.formats.parquet.row.ParquetRowDataWriter$BinaryWriter.write

## Brief change log

- Add `withMinRowCountForPageSizeCheck(getMinRowCountForPageSizeCheck(conf))` 
  to `FlinkParquetBuilder.createWriter()`
- Add `withMaxRowCountForPageSizeCheck(getMaxRowCountForPageSizeCheck(conf))` 
  to `FlinkParquetBuilder.createWriter()`
- Add test `testRowCountForPageSizeCheckConfIsHonoured` in 
  `ParquetRowDataWriterTest` to verify the conf keys are honoured

## Verifying this change


Added `testRowCountForPageSizeCheckConfIsHonoured` in `ParquetRowDataWriterTest`:
- Creates a writer with `parquet.page.size.row.check.min=1` and 
  `parquet.page.size.row.check.max=1` and a small page size (4KB)
- Writes 100 rows each with a 40KB binary payload (10x the page size)
- Verifies no OOM occurs — Parquet flushes after every row instead of 
  accumulating 100-10000 rows worth of data



## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): No
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: No
  - The serializers: No
  - The runtime per-record code paths (performance sensitive): No
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: No
  - The S3 file system connector: No

## Documentation

  - Does this pull request introduce a new feature? No
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change the checkbox below to `[X]` followed by the name of the tool, and uncomment the
"Generated-by" line. See the ASF Generative Tooling Guidance for details:
https://www.apache.org/legal/generative-tooling.html

You are responsible for the quality and correctness of every change in this PR
regardless of the tooling used. Low-effort AI-generated PRs will be closed. See
AGENTS.md for the full guidance.
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name and Version]
-->
