### PR TITLE
[FLINK-38262][table] show create connection operation

### DIFF
--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/ShowCreateUtil.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/ShowCreateUtil.java
@@ -23,6 +23,7 @@ import org.apache.flink.configuration.GlobalConfiguration;
 import org.apache.flink.table.api.TableException;
 import org.apache.flink.table.catalog.CatalogBaseTable;
 import org.apache.flink.table.catalog.CatalogBaseTable.TableKind;
+import org.apache.flink.table.catalog.CatalogConnection;
 import org.apache.flink.table.catalog.CatalogDescriptor;
 import org.apache.flink.table.catalog.CatalogView;
 import org.apache.flink.table.catalog.Column;
@@ -64,6 +65,7 @@ public class ShowCreateUtil {
     private static final DateTimeFormatter TIMESTAMP_FORMATTER =
             DateTimeFormatter.ofPattern("uuuu-MM-dd HH:mm:ss");
     private static final String PRINT_INDENT = "  ";
+    private static final String CONNECTION_SECRET_REFERENCE_KEY = "__flink.encrypted-secret-key__";
 
     private ShowCreateUtil() {}
 
@@ -95,6 +97,29 @@ public class ShowCreateUtil {
                                                         "%s)%s",
                                                         System.lineSeparator(),
                                                         System.lineSeparator())));
+        return sb.toString();
+    }
+
+    public static String buildShowCreateConnectionRow(
+            CatalogConnection connection,
+            ObjectIdentifier connectionIdentifier,
+            boolean isTemporary,
+            List<String> additionalSensitiveKeys) {
+        StringBuilder sb =
+                new StringBuilder()
+                        .append(
+                                buildCreateFormattedPrefix(
+                                        "CONNECTION",
+                                        isTemporary,
+                                        connectionIdentifier,
+                                        false,
+                                        false));
+        extractComment(connection).ifPresent(c -> sb.append(formatComment(c)).append("\n"));
+        extractFormattedOptions(
+                        withoutConnectionInternalOptions(connection.getOptions()),
+                        PRINT_INDENT,
+                        additionalSensitiveKeys)
+                .ifPresent(v -> sb.append("WITH (\n").append(v).append("\n)\n"));
         return sb.toString();
     }
 
@@ -347,6 +372,18 @@ public class ShowCreateUtil {
         return StringUtils.isEmpty(model.getComment())
                 ? Optional.empty()
                 : Optional.of(model.getComment());
+    }
+
+    static Optional<String> extractComment(CatalogConnection connection) {
+        return StringUtils.isEmpty(connection.getComment())
+                ? Optional.empty()
+                : Optional.of(connection.getComment());
+    }
+
+    static Map<String, String> withoutConnectionInternalOptions(Map<String, String> options) {
+        return options.entrySet().stream()
+                .filter(entry -> !CONNECTION_SECRET_REFERENCE_KEY.equals(entry.getKey()))
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
     }
 
     static Optional<String> extractFormattedDistributedInfo(ResolvedCatalogTable catalogTable) {

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/ShowCreateUtil.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/ShowCreateUtil.java
@@ -65,6 +65,7 @@ public class ShowCreateUtil {
     private static final DateTimeFormatter TIMESTAMP_FORMATTER =
             DateTimeFormatter.ofPattern("uuuu-MM-dd HH:mm:ss");
     private static final String PRINT_INDENT = "  ";
+    // Internal secret-store metadata must not be emitted in recreated connection SQL.
     private static final String CONNECTION_SECRET_REFERENCE_KEY = "__flink.encrypted-secret-key__";
 
     private ShowCreateUtil() {}
@@ -380,7 +381,8 @@ public class ShowCreateUtil {
                 : Optional.of(connection.getComment());
     }
 
-    static Map<String, String> withoutConnectionInternalOptions(Map<String, String> options) {
+    private static Map<String, String> withoutConnectionInternalOptions(
+            Map<String, String> options) {
         return options.entrySet().stream()
                 .filter(entry -> !CONNECTION_SECRET_REFERENCE_KEY.equals(entry.getKey()))
                 .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/ShowCreateUtil.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/ShowCreateUtil.java
@@ -40,6 +40,7 @@ import org.apache.flink.table.catalog.StartMode;
 import org.apache.flink.table.catalog.TableDistribution;
 import org.apache.flink.table.catalog.UniqueConstraint;
 import org.apache.flink.table.expressions.SqlFactory;
+import org.apache.flink.table.factories.DefaultConnectionFactory;
 import org.apache.flink.table.factories.FactoryUtil;
 import org.apache.flink.table.utils.EncodingUtils;
 
@@ -66,8 +67,6 @@ public class ShowCreateUtil {
     private static final DateTimeFormatter TIMESTAMP_FORMATTER =
             DateTimeFormatter.ofPattern("uuuu-MM-dd HH:mm:ss");
     private static final String PRINT_INDENT = "  ";
-    // Internal secret-store metadata must not be emitted in recreated connection SQL.
-    private static final String CONNECTION_SECRET_REFERENCE_KEY = "__flink.encrypted-secret-key__";
 
     private ShowCreateUtil() {}
 
@@ -123,7 +122,9 @@ public class ShowCreateUtil {
                         connectionOptions.isEmpty()
                                         && connection
                                                 .getOptions()
-                                                .containsKey(CONNECTION_SECRET_REFERENCE_KEY)
+                                                .containsKey(
+                                                        DefaultConnectionFactory
+                                                                .SECRET_REFERENCE_KEY)
                                 ? Map.of(
                                         FactoryUtil.CONNECTION_TYPE.key(),
                                         FactoryUtil.CONNECTION_TYPE.defaultValue())
@@ -394,7 +395,10 @@ public class ShowCreateUtil {
     private static Map<String, String> withoutConnectionInternalOptions(
             Map<String, String> options) {
         return options.entrySet().stream()
-                .filter(entry -> !CONNECTION_SECRET_REFERENCE_KEY.equals(entry.getKey()))
+                .filter(
+                        entry ->
+                                !DefaultConnectionFactory.SECRET_REFERENCE_KEY.equals(
+                                        entry.getKey()))
                 .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
     }
 

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/ShowCreateUtil.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/ShowCreateUtil.java
@@ -40,6 +40,7 @@ import org.apache.flink.table.catalog.StartMode;
 import org.apache.flink.table.catalog.TableDistribution;
 import org.apache.flink.table.catalog.UniqueConstraint;
 import org.apache.flink.table.expressions.SqlFactory;
+import org.apache.flink.table.factories.FactoryUtil;
 import org.apache.flink.table.utils.EncodingUtils;
 
 import org.apache.commons.lang3.StringUtils;
@@ -116,8 +117,17 @@ public class ShowCreateUtil {
                                         false,
                                         false));
         extractComment(connection).ifPresent(c -> sb.append(formatComment(c)).append("\n"));
+        final Map<String, String> connectionOptions =
+                withoutConnectionInternalOptions(connection.getOptions());
         extractFormattedOptions(
-                        withoutConnectionInternalOptions(connection.getOptions()),
+                        connectionOptions.isEmpty()
+                                        && connection
+                                                .getOptions()
+                                                .containsKey(CONNECTION_SECRET_REFERENCE_KEY)
+                                ? Map.of(
+                                        FactoryUtil.CONNECTION_TYPE.key(),
+                                        FactoryUtil.CONNECTION_TYPE.defaultValue())
+                                : connectionOptions,
                         PRINT_INDENT,
                         additionalSensitiveKeys)
                 .ifPresent(v -> sb.append("WITH (\n").append(v).append("\n)\n"));

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogManager.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogManager.java
@@ -1925,6 +1925,36 @@ public final class CatalogManager implements CatalogRegistry, AutoCloseable {
     }
 
     /**
+     * Get a connection from the catalog with contextual metadata.
+     *
+     * @param objectIdentifier The fully qualified path of the connection.
+     * @return The requested connection wrapped in Optional.
+     */
+    public Optional<ContextResolvedConnection> getResolvedConnection(
+            ObjectIdentifier objectIdentifier) {
+        CatalogConnection temporaryConnection = temporaryConnections.get(objectIdentifier);
+        if (temporaryConnection != null) {
+            return Optional.of(
+                    ContextResolvedConnection.of(objectIdentifier, temporaryConnection, true));
+        }
+
+        Optional<Catalog> catalog = getCatalog(objectIdentifier.getCatalogName());
+        if (catalog.isPresent()) {
+            try {
+                return Optional.of(
+                        ContextResolvedConnection.of(
+                                objectIdentifier,
+                                catalog.get().getConnection(objectIdentifier.toObjectPath()),
+                                false));
+            } catch (ConnectionNotExistException | UnsupportedOperationException e) {
+                return Optional.empty();
+            }
+        } else {
+            return Optional.empty();
+        }
+    }
+
+    /**
      * List all connections in the given catalog and database.
      *
      * @param catalogName The name of the catalog.

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogManager.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogManager.java
@@ -1911,6 +1911,36 @@ public final class CatalogManager implements CatalogRegistry, AutoCloseable {
     }
 
     /**
+     * Get a connection from the catalog with contextual metadata.
+     *
+     * @param objectIdentifier The fully qualified path of the connection.
+     * @return The requested connection wrapped in Optional.
+     */
+    public Optional<ContextResolvedConnection> getResolvedConnection(
+            ObjectIdentifier objectIdentifier) {
+        CatalogConnection temporaryConnection = temporaryConnections.get(objectIdentifier);
+        if (temporaryConnection != null) {
+            return Optional.of(
+                    ContextResolvedConnection.of(objectIdentifier, temporaryConnection, true));
+        }
+
+        Optional<Catalog> catalog = getCatalog(objectIdentifier.getCatalogName());
+        if (catalog.isPresent()) {
+            try {
+                return Optional.of(
+                        ContextResolvedConnection.of(
+                                objectIdentifier,
+                                catalog.get().getConnection(objectIdentifier.toObjectPath()),
+                                false));
+            } catch (ConnectionNotExistException | UnsupportedOperationException e) {
+                return Optional.empty();
+            }
+        } else {
+            return Optional.empty();
+        }
+    }
+
+    /**
      * List all connections in the given catalog and database.
      *
      * @param catalogName The name of the catalog.

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogManager.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogManager.java
@@ -1949,9 +1949,8 @@ public final class CatalogManager implements CatalogRegistry, AutoCloseable {
             } catch (ConnectionNotExistException | UnsupportedOperationException e) {
                 return Optional.empty();
             }
-        } else {
-            return Optional.empty();
         }
+        return Optional.empty();
     }
 
     /**

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogManager.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogManager.java
@@ -1912,9 +1912,6 @@ public final class CatalogManager implements CatalogRegistry, AutoCloseable {
 
     /**
      * Get a connection from the catalog with contextual metadata.
-     *
-     * @param objectIdentifier The fully qualified path of the connection.
-     * @return The requested connection wrapped in Optional.
      */
     public Optional<ContextResolvedConnection> getResolvedConnection(
             ObjectIdentifier objectIdentifier) {

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogManager.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogManager.java
@@ -1926,9 +1926,6 @@ public final class CatalogManager implements CatalogRegistry, AutoCloseable {
 
     /**
      * Get a connection from the catalog with contextual metadata.
-     *
-     * @param objectIdentifier The fully qualified path of the connection.
-     * @return The requested connection wrapped in Optional.
      */
     public Optional<ContextResolvedConnection> getResolvedConnection(
             ObjectIdentifier objectIdentifier) {

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogManager.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogManager.java
@@ -1935,9 +1935,8 @@ public final class CatalogManager implements CatalogRegistry, AutoCloseable {
             } catch (ConnectionNotExistException | UnsupportedOperationException e) {
                 return Optional.empty();
             }
-        } else {
-            return Optional.empty();
         }
+        return Optional.empty();
     }
 
     /**

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogManager.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogManager.java
@@ -1924,9 +1924,7 @@ public final class CatalogManager implements CatalogRegistry, AutoCloseable {
         }
     }
 
-    /**
-     * Get a connection from the catalog with contextual metadata.
-     */
+    /** Get a connection from the catalog with contextual metadata. */
     public Optional<ContextResolvedConnection> getResolvedConnection(
             ObjectIdentifier objectIdentifier) {
         CatalogConnection temporaryConnection = temporaryConnections.get(objectIdentifier);

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/ContextResolvedConnection.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/ContextResolvedConnection.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.catalog;
+
+import org.apache.flink.annotation.Internal;
+
+/** Contextual metadata for a resolved connection. */
+@Internal
+public final class ContextResolvedConnection {
+
+    private final ObjectIdentifier identifier;
+    private final CatalogConnection connection;
+    private final boolean temporary;
+
+    private ContextResolvedConnection(
+            ObjectIdentifier identifier, CatalogConnection connection, boolean temporary) {
+        this.identifier = identifier;
+        this.connection = connection;
+        this.temporary = temporary;
+    }
+
+    public static ContextResolvedConnection of(
+            ObjectIdentifier identifier, CatalogConnection connection, boolean temporary) {
+        return new ContextResolvedConnection(identifier, connection, temporary);
+    }
+
+    public ObjectIdentifier getIdentifier() {
+        return identifier;
+    }
+
+    public CatalogConnection getConnection() {
+        return connection;
+    }
+
+    public boolean isTemporary() {
+        return temporary;
+    }
+}

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ShowCreateConnectionOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ShowCreateConnectionOperation.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.operations;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.configuration.SecurityOptions;
+import org.apache.flink.table.api.internal.ShowCreateUtil;
+import org.apache.flink.table.api.internal.TableResultInternal;
+import org.apache.flink.table.catalog.CatalogConnection;
+import org.apache.flink.table.catalog.ObjectIdentifier;
+
+import static org.apache.flink.table.api.internal.TableResultUtils.buildStringArrayResult;
+
+/** Operation to describe a SHOW CREATE CONNECTION statement. */
+@Internal
+public class ShowCreateConnectionOperation implements ShowOperation {
+
+    private final ObjectIdentifier connectionIdentifier;
+    private final CatalogConnection connection;
+    private final boolean isTemporary;
+
+    public ShowCreateConnectionOperation(
+            ObjectIdentifier connectionIdentifier,
+            CatalogConnection connection,
+            boolean isTemporary) {
+        this.connectionIdentifier = connectionIdentifier;
+        this.connection = connection;
+        this.isTemporary = isTemporary;
+    }
+
+    public ObjectIdentifier getConnectionIdentifier() {
+        return connectionIdentifier;
+    }
+
+    public CatalogConnection getConnection() {
+        return connection;
+    }
+
+    public boolean isTemporary() {
+        return isTemporary;
+    }
+
+    @Override
+    public String asSummaryString() {
+        return String.format("SHOW CREATE CONNECTION %s", connectionIdentifier.asSummaryString());
+    }
+
+    @Override
+    public TableResultInternal execute(Context ctx) {
+        String resultRow =
+                ShowCreateUtil.buildShowCreateConnectionRow(
+                        connection,
+                        connectionIdentifier,
+                        isTemporary,
+                        ctx.getTableConfig().get(SecurityOptions.ADDITIONAL_SENSITIVE_KEYS));
+        return buildStringArrayResult("result", new String[] {resultRow});
+    }
+}

--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/api/internal/ShowCreateUtilTest.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/api/internal/ShowCreateUtilTest.java
@@ -22,6 +22,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.Schema;
 import org.apache.flink.table.catalog.CatalogBaseTable;
+import org.apache.flink.table.catalog.CatalogConnection;
 import org.apache.flink.table.catalog.CatalogDescriptor;
 import org.apache.flink.table.catalog.CatalogMaterializedTable;
 import org.apache.flink.table.catalog.CatalogMaterializedTable.LogicalRefreshMode;
@@ -69,6 +70,8 @@ class ShowCreateUtilTest {
             ObjectIdentifier.of("catalogName", "dbName", "tableName");
     private static final ObjectIdentifier VIEW_IDENTIFIER =
             ObjectIdentifier.of("catalogName", "dbName", "viewName");
+    private static final ObjectIdentifier CONNECTION_IDENTIFIER =
+            ObjectIdentifier.of("catalogName", "dbName", "connectionName");
     private static final ObjectIdentifier MATERIALIZED_TABLE_IDENTIFIER =
             ObjectIdentifier.of("catalogName", "dbName", "materializedTableName");
 
@@ -201,6 +204,69 @@ class ShowCreateUtilTest {
         final String createCatalogString =
                 ShowCreateUtil.buildShowCreateCatalogRow(catalogDescriptor, List.of());
         assertThat(createCatalogString).isEqualTo(expected);
+    }
+
+    @ParameterizedTest(name = "{index}: {3}")
+    @MethodSource("argsForShowCreateConnection")
+    void showCreateConnection(
+            CatalogConnection catalogConnection,
+            boolean isTemporary,
+            List<String> additionalSensitiveKeys,
+            String expected) {
+        final String createConnectionString =
+                ShowCreateUtil.buildShowCreateConnectionRow(
+                        catalogConnection,
+                        CONNECTION_IDENTIFIER,
+                        isTemporary,
+                        additionalSensitiveKeys);
+        assertThat(createConnectionString).isEqualTo(expected);
+    }
+
+    private static Collection<Arguments> argsForShowCreateConnection() {
+        final Collection<Arguments> argList = new ArrayList<>();
+
+        final Map<String, String> options = new HashMap<>();
+        options.put("url", "jdbc:mysql://localhost:3306/db");
+        options.put("type", "default");
+        addTemporaryAndPermanent(
+                argList,
+                CatalogConnection.of(options, null),
+                List.of(),
+                "CREATE %sCONNECTION `catalogName`.`dbName`.`connectionName`\n"
+                        + "WITH (\n"
+                        + "  'type' = 'default',\n"
+                        + "  'url' = 'jdbc:mysql://localhost:3306/db'\n"
+                        + ")\n");
+
+        final Map<String, String> commentedOptions = new HashMap<>();
+        commentedOptions.put("connector", "jdbc");
+        addTemporaryAndPermanent(
+                argList,
+                CatalogConnection.of(commentedOptions, "Connection's comment"),
+                List.of(),
+                "CREATE %sCONNECTION `catalogName`.`dbName`.`connectionName`\n"
+                        + "COMMENT 'Connection''s comment'\n"
+                        + "WITH (\n"
+                        + "  'connector' = 'jdbc'\n"
+                        + ")\n");
+
+        final Map<String, String> sensitiveOptions = new HashMap<>();
+        sensitiveOptions.put("__flink.encrypted-secret-key__", "secret-id");
+        sensitiveOptions.put("endpoint", "service");
+        sensitiveOptions.put("my.custom.cred", "supersecret");
+        sensitiveOptions.put("password", "topsecret");
+        addTemporaryAndPermanent(
+                argList,
+                CatalogConnection.of(sensitiveOptions, null),
+                List.of("custom.cred"),
+                "CREATE %sCONNECTION `catalogName`.`dbName`.`connectionName`\n"
+                        + "WITH (\n"
+                        + "  'endpoint' = 'service',\n"
+                        + "  'my.custom.cred' = '******',\n"
+                        + "  'password' = '******'\n"
+                        + ")\n");
+
+        return argList;
     }
 
     private static Collection<Arguments> argsForShowCreateCatalog() {
@@ -559,6 +625,22 @@ class ShowCreateUtilTest {
             Collection<Arguments> argList, CatalogBaseTable catalogBaseTable, String sql) {
         argList.add(Arguments.of(catalogBaseTable, false, String.format(sql, "")));
         argList.add(Arguments.of(catalogBaseTable, true, String.format(sql, "TEMPORARY ")));
+    }
+
+    private static void addTemporaryAndPermanent(
+            Collection<Arguments> argList,
+            CatalogConnection catalogConnection,
+            List<String> additionalSensitiveKeys,
+            String sql) {
+        argList.add(
+                Arguments.of(
+                        catalogConnection, false, additionalSensitiveKeys, String.format(sql, "")));
+        argList.add(
+                Arguments.of(
+                        catalogConnection,
+                        true,
+                        additionalSensitiveKeys,
+                        String.format(sql, "TEMPORARY ")));
     }
 
     private static void addCreateAndCreateOrAlter(

--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/api/internal/ShowCreateUtilTest.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/api/internal/ShowCreateUtilTest.java
@@ -45,6 +45,7 @@ import org.apache.flink.table.catalog.StartMode.StartModeKind;
 import org.apache.flink.table.catalog.TableDistribution;
 import org.apache.flink.table.catalog.UniqueConstraint;
 import org.apache.flink.table.expressions.DefaultSqlFactory;
+import org.apache.flink.table.factories.DefaultConnectionFactory;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -251,7 +252,7 @@ class ShowCreateUtilTest {
                         + ")\n");
 
         final Map<String, String> sensitiveOptions = new HashMap<>();
-        sensitiveOptions.put("__flink.encrypted-secret-key__", "secret-id");
+        sensitiveOptions.put(DefaultConnectionFactory.SECRET_REFERENCE_KEY, "secret-id");
         sensitiveOptions.put("endpoint", "service");
         sensitiveOptions.put("my.custom.cred", "supersecret");
         sensitiveOptions.put("password", "topsecret");

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/DefaultConnectionFactory.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/DefaultConnectionFactory.java
@@ -64,7 +64,7 @@ public class DefaultConnectionFactory implements ConnectionFactory {
      * surrounding double underscores make collision with user-supplied option names unlikely; user
      * options containing this key will be rejected at create-time.
      */
-    static final String SECRET_REFERENCE_KEY = "__flink.encrypted-secret-key__";
+    public static final String SECRET_REFERENCE_KEY = "__flink.encrypted-secret-key__";
 
     /**
      * Default whitelist of option keys treated as sensitive. Seeded from {@link

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/SqlNodeConverters.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/SqlNodeConverters.java
@@ -141,6 +141,7 @@ public class SqlNodeConverters {
 
     private static void registerConnectionConverters() {
         register(new SqlCreateConnectionConverter());
+        register(new SqlShowCreateConnectionConverter());
     }
 
     private static void registerMaterializedTableConverters() {

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/SqlShowCreateConnectionConverter.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/SqlShowCreateConnectionConverter.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.operations.converters;
+
+import org.apache.flink.sql.parser.dql.SqlShowCreateConnection;
+import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.catalog.ContextResolvedConnection;
+import org.apache.flink.table.catalog.ObjectIdentifier;
+import org.apache.flink.table.catalog.UnresolvedIdentifier;
+import org.apache.flink.table.operations.Operation;
+import org.apache.flink.table.operations.ShowCreateConnectionOperation;
+
+import java.util.Optional;
+
+/** A converter for {@link SqlShowCreateConnection}. */
+public class SqlShowCreateConnectionConverter implements SqlNodeConverter<SqlShowCreateConnection> {
+
+    @Override
+    public Operation convertSqlNode(
+            SqlShowCreateConnection showCreateConnection, ConvertContext context) {
+        UnresolvedIdentifier unresolvedIdentifier =
+                UnresolvedIdentifier.of(showCreateConnection.getConnectionName().names);
+        ObjectIdentifier identifier =
+                context.getCatalogManager().qualifyIdentifier(unresolvedIdentifier);
+        Optional<ContextResolvedConnection> connection =
+                context.getCatalogManager().getResolvedConnection(identifier);
+
+        if (connection.isEmpty()) {
+            throw new ValidationException(
+                    String.format(
+                            "Could not execute SHOW CREATE CONNECTION. Connection with identifier %s does not exist.",
+                            identifier.asSerializableString()));
+        }
+
+        ContextResolvedConnection resolvedConnection = connection.get();
+        return new ShowCreateConnectionOperation(
+                identifier, resolvedConnection.getConnection(), resolvedConnection.isTemporary());
+    }
+}

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlConnectionOperationConverterTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlConnectionOperationConverterTest.java
@@ -20,9 +20,11 @@ package org.apache.flink.table.planner.operations;
 
 import org.apache.flink.sql.parser.error.SqlValidateException;
 import org.apache.flink.table.api.SqlParserException;
+import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.catalog.ObjectIdentifier;
 import org.apache.flink.table.catalog.SensitiveConnection;
 import org.apache.flink.table.operations.Operation;
+import org.apache.flink.table.operations.ShowCreateConnectionOperation;
 import org.apache.flink.table.operations.ddl.CreateConnectionOperation;
 
 import org.junit.jupiter.api.Test;
@@ -120,5 +122,51 @@ class SqlConnectionOperationConverterTest extends SqlNodeToOperationConversionTe
         assertThatThrownBy(() -> parse("CREATE CONNECTION my_conn WITH ()"))
                 .isInstanceOf(SqlValidateException.class)
                 .hasMessageContaining("Connection property list can not be empty.");
+    }
+
+    @Test
+    void testShowCreateConnection() {
+        createTemporaryConnection("my_conn");
+
+        Operation operation = parse("SHOW CREATE CONNECTION my_conn");
+        assertThat(operation).isInstanceOf(ShowCreateConnectionOperation.class);
+        ShowCreateConnectionOperation op = (ShowCreateConnectionOperation) operation;
+
+        assertThat(op.getConnectionIdentifier())
+                .isEqualTo(ObjectIdentifier.of("builtin", "default", "my_conn"));
+        assertThat(op.getConnection().getOptions()).containsEntry("k", "v");
+        assertThat(op.getConnection().getOptions()).doesNotContainKey("password");
+        assertThat(op.isTemporary()).isTrue();
+    }
+
+    @Test
+    void testShowCreateConnectionWithFullyQualifiedName() {
+        createTemporaryConnection("my_conn");
+
+        Operation operation = parse("SHOW CREATE CONNECTION `builtin`.`default`.`my_conn`");
+        ShowCreateConnectionOperation op = (ShowCreateConnectionOperation) operation;
+
+        assertThat(op.getConnectionIdentifier())
+                .isEqualTo(ObjectIdentifier.of("builtin", "default", "my_conn"));
+    }
+
+    @Test
+    void testShowCreateConnectionMissingConnectionRejected() {
+        assertThatThrownBy(() -> parse("SHOW CREATE CONNECTION missing_conn"))
+                .isInstanceOf(ValidationException.class)
+                .hasMessageContaining(
+                        "Could not execute SHOW CREATE CONNECTION. Connection with identifier");
+    }
+
+    private void createTemporaryConnection(String connectionName) {
+        catalogManager.createTemporaryConnection(
+                SensitiveConnection.of(
+                        Map.of("type", "default", "k", "v", "password", "super-secret"),
+                        "hi there"),
+                ObjectIdentifier.of(
+                        catalogManager.getCurrentCatalog(),
+                        catalogManager.getCurrentDatabase(),
+                        connectionName),
+                false);
     }
 }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/batch/sql/CreateConnectionITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/batch/sql/CreateConnectionITCase.java
@@ -18,13 +18,18 @@
 
 package org.apache.flink.table.planner.runtime.batch.sql;
 
+import org.apache.flink.table.api.TableResult;
 import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.api.internal.TableEnvironmentInternal;
 import org.apache.flink.table.catalog.CatalogManager;
 import org.apache.flink.table.catalog.ObjectIdentifier;
 import org.apache.flink.table.planner.runtime.utils.BatchTestBase;
+import org.apache.flink.types.Row;
+import org.apache.flink.util.CollectionUtil;
 
 import org.junit.jupiter.api.Test;
+
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -71,6 +76,32 @@ class CreateConnectionITCase extends BatchTestBase {
         assertThatThrownBy(() -> tEnv().executeSql("CREATE CONNECTION my_conn WITH ('k' = 'v')"))
                 .isInstanceOf(ValidationException.class)
                 .hasMessageContaining("WritableSecretStore must be configured");
+    }
+
+    @Test
+    void testShowCreateTemporaryConnection() {
+        tEnv().executeSql(
+                        "CREATE TEMPORARY CONNECTION my_conn COMMENT 'hi there' "
+                                + "WITH ('type' = 'default', 'k' = 'v', 'password' = 'super-secret')");
+
+        List<Row> rows = collectRows("SHOW CREATE CONNECTION my_conn");
+
+        assertThat(rows).hasSize(1);
+        String showCreate = (String) rows.get(0).getField(0);
+        assertThat(showCreate)
+                .contains("CREATE TEMPORARY CONNECTION")
+                .contains("`my_conn`")
+                .contains("COMMENT 'hi there'")
+                .contains("'k' = 'v'")
+                .contains("'type' = 'default'")
+                .doesNotContain("super-secret")
+                .doesNotContain("password")
+                .doesNotContain("__flink.encrypted-secret-key__");
+    }
+
+    private List<Row> collectRows(String sql) {
+        TableResult result = tEnv().executeSql(sql);
+        return CollectionUtil.iteratorToList(result.collect());
     }
 
     private CatalogManager catalogManager() {

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/batch/sql/CreateConnectionITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/batch/sql/CreateConnectionITCase.java
@@ -38,6 +38,8 @@ import static org.assertj.core.api.Assertions.entry;
 /** IT case for CREATE CONNECTION statement. */
 class CreateConnectionITCase extends BatchTestBase {
 
+    private static final String CONNECTION_SECRET_REFERENCE_KEY = "__flink.encrypted-secret-key__";
+
     @Test
     void testCreateTemporaryConnection() {
         tEnv().executeSql(
@@ -84,6 +86,13 @@ class CreateConnectionITCase extends BatchTestBase {
                         "CREATE TEMPORARY CONNECTION my_conn COMMENT 'hi there' "
                                 + "WITH ('type' = 'default', 'k' = 'v', 'password' = 'super-secret')");
 
+        assertThat(catalogManager().getConnection(connectionIdentifier("my_conn")))
+                .hasValueSatisfying(
+                        connection ->
+                                assertThat(connection.getOptions())
+                                        .containsKeys("k", "type", CONNECTION_SECRET_REFERENCE_KEY)
+                                        .doesNotContainKey("password"));
+
         List<Row> rows = collectRows("SHOW CREATE CONNECTION my_conn");
 
         assertThat(rows).hasSize(1);
@@ -96,7 +105,7 @@ class CreateConnectionITCase extends BatchTestBase {
                 .contains("'type' = 'default'")
                 .doesNotContain("super-secret")
                 .doesNotContain("password")
-                .doesNotContain("__flink.encrypted-secret-key__");
+                .doesNotContain(CONNECTION_SECRET_REFERENCE_KEY);
     }
 
     private List<Row> collectRows(String sql) {

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/batch/sql/CreateConnectionITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/batch/sql/CreateConnectionITCase.java
@@ -108,6 +108,31 @@ class CreateConnectionITCase extends BatchTestBase {
                 .doesNotContain(CONNECTION_SECRET_REFERENCE_KEY);
     }
 
+    @Test
+    void testShowCreateSecretOnlyTemporaryConnection() {
+        tEnv().executeSql("CREATE TEMPORARY CONNECTION my_conn WITH ('password' = 'super-secret')");
+
+        List<Row> rows = collectRows("SHOW CREATE CONNECTION my_conn");
+
+        assertThat(rows).hasSize(1);
+        String showCreate = (String) rows.get(0).getField(0);
+        assertThat(showCreate)
+                .contains("CREATE TEMPORARY CONNECTION")
+                .contains("WITH (\n  'type' = 'default'\n)\n")
+                .doesNotContain("password")
+                .doesNotContain("super-secret")
+                .doesNotContain(CONNECTION_SECRET_REFERENCE_KEY);
+
+        catalogManager().dropTemporaryConnection(connectionIdentifier("my_conn"), false);
+        tEnv().executeSql(showCreate);
+
+        assertThat(catalogManager().getConnection(connectionIdentifier("my_conn")))
+                .hasValueSatisfying(
+                        connection ->
+                                assertThat(connection.getOptions())
+                                        .containsOnly(entry("type", "default")));
+    }
+
     private List<Row> collectRows(String sql) {
         TableResult result = tEnv().executeSql(sql);
         return CollectionUtil.iteratorToList(result.collect());

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/batch/sql/CreateConnectionITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/batch/sql/CreateConnectionITCase.java
@@ -23,6 +23,7 @@ import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.api.internal.TableEnvironmentInternal;
 import org.apache.flink.table.catalog.CatalogManager;
 import org.apache.flink.table.catalog.ObjectIdentifier;
+import org.apache.flink.table.factories.DefaultConnectionFactory;
 import org.apache.flink.table.planner.runtime.utils.BatchTestBase;
 import org.apache.flink.types.Row;
 import org.apache.flink.util.CollectionUtil;
@@ -37,8 +38,6 @@ import static org.assertj.core.api.Assertions.entry;
 
 /** IT case for CREATE CONNECTION statement. */
 class CreateConnectionITCase extends BatchTestBase {
-
-    private static final String CONNECTION_SECRET_REFERENCE_KEY = "__flink.encrypted-secret-key__";
 
     @Test
     void testCreateTemporaryConnection() {
@@ -90,7 +89,10 @@ class CreateConnectionITCase extends BatchTestBase {
                 .hasValueSatisfying(
                         connection ->
                                 assertThat(connection.getOptions())
-                                        .containsKeys("k", "type", CONNECTION_SECRET_REFERENCE_KEY)
+                                        .containsKeys(
+                                                "k",
+                                                "type",
+                                                DefaultConnectionFactory.SECRET_REFERENCE_KEY)
                                         .doesNotContainKey("password"));
 
         List<Row> rows = collectRows("SHOW CREATE CONNECTION my_conn");
@@ -105,7 +107,7 @@ class CreateConnectionITCase extends BatchTestBase {
                 .contains("'type' = 'default'")
                 .doesNotContain("super-secret")
                 .doesNotContain("password")
-                .doesNotContain(CONNECTION_SECRET_REFERENCE_KEY);
+                .doesNotContain(DefaultConnectionFactory.SECRET_REFERENCE_KEY);
     }
 
     @Test
@@ -121,7 +123,7 @@ class CreateConnectionITCase extends BatchTestBase {
                 .contains("WITH (\n  'type' = 'default'\n)\n")
                 .doesNotContain("password")
                 .doesNotContain("super-secret")
-                .doesNotContain(CONNECTION_SECRET_REFERENCE_KEY);
+                .doesNotContain(DefaultConnectionFactory.SECRET_REFERENCE_KEY);
 
         catalogManager().dropTemporaryConnection(connectionIdentifier("my_conn"), false);
         tEnv().executeSql(showCreate);


### PR DESCRIPTION

## What is the purpose of the change

Adds resolved connection lookup and SHOW CREATE CONNECTION support, formatting connection DDL while filtering internal/sensitive options.


## Brief change log

Add SHOW CREATE CONNECTION operation

## Verifying this change

Unit tests and IT

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no) no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no) no
  - The serializers: (yes / no / don't know) no
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know) no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know) no
  - The S3 file system connector: (yes / no / don't know) no

## Documentation

  - Does this pull request introduce a new feature? (yes / no) yes
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)

---

##### Was generative AI tooling used to co-author this PR?


- [x] Yes 


