### PR TITLE
[FLINK-38262][table]  alter connection rename operation

### DIFF
--- a/flink-python/pyflink/table/tests/test_catalog_completeness.py
+++ b/flink-python/pyflink/table/tests/test_catalog_completeness.py
@@ -52,6 +52,7 @@ class CatalogAPICompletenessTests(PythonAPICompletenessTestCase, PyFlinkTestCase
             'listConnections',
             'createConnection',
             'alterConnection',
+            'renameConnection',
             'convertTableToMaterializedTable'}
 
 

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogManager.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogManager.java
@@ -2112,6 +2112,62 @@ public final class CatalogManager implements CatalogRegistry, AutoCloseable {
     }
 
     /**
+     * Rename a connection in the given fully qualified path.
+     *
+     * @param objectIdentifier The fully qualified path of the connection to rename.
+     * @param newConnectionName The new connection name.
+     * @param ignoreIfNotExists If false exception will be thrown if the connection to be renamed
+     *     does not exist.
+     */
+    public void renameConnection(
+            ObjectIdentifier objectIdentifier,
+            String newConnectionName,
+            boolean ignoreIfNotExists) {
+        checkArgument(!StringUtils.isNullOrWhitespaceOnly(newConnectionName));
+        ObjectIdentifier newIdentifier =
+                ObjectIdentifier.of(
+                        objectIdentifier.getCatalogName(),
+                        objectIdentifier.getDatabaseName(),
+                        newConnectionName);
+        CatalogConnection temporaryConnection = temporaryConnections.get(objectIdentifier);
+        if (temporaryConnection != null) {
+            if (getConnection(newIdentifier).isPresent()) {
+                throw new ValidationException(
+                        String.format(
+                                "Connection with identifier '%s' already exists.",
+                                newIdentifier.asSummaryString()));
+            }
+            temporaryConnections.remove(objectIdentifier);
+            temporaryConnections.put(newIdentifier, temporaryConnection);
+            return;
+        }
+
+        Optional<CatalogConnection> existingOpt = getConnection(objectIdentifier);
+        if (!existingOpt.isPresent()) {
+            if (ignoreIfNotExists) {
+                return;
+            }
+            throw new ValidationException(
+                    String.format(
+                            "Connection with identifier '%s' does not exist.",
+                            objectIdentifier.asSummaryString()));
+        }
+        if (getConnection(newIdentifier).isPresent()) {
+            throw new ValidationException(
+                    String.format(
+                            "Connection with identifier '%s' already exists.",
+                            newIdentifier.asSummaryString()));
+        }
+
+        execute(
+                (catalog, path) ->
+                        catalog.renameConnection(path, newConnectionName, ignoreIfNotExists),
+                objectIdentifier,
+                ignoreIfNotExists,
+                "RenameConnection");
+    }
+
+    /**
      * Drop a permanent connection from the given fully qualified path.
      *
      * @param objectIdentifier The fully qualified path of the connection to be dropped.

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogManager.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogManager.java
@@ -2130,8 +2130,7 @@ public final class CatalogManager implements CatalogRegistry, AutoCloseable {
                         objectIdentifier.getDatabaseName(),
                         newConnectionName);
         CatalogConnection temporaryConnection = temporaryConnections.get(objectIdentifier);
-        if (temporaryConnection != null) {
-            if (getConnection(newIdentifier).isPresent()) {
+        if (temporaryConnection != null && getConnection(newIdentifier).isPresent()) {
                 throw new ValidationException(
                         String.format(
                                 "Connection with identifier '%s' already exists.",

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogManager.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogManager.java
@@ -2130,12 +2130,8 @@ public final class CatalogManager implements CatalogRegistry, AutoCloseable {
                         objectIdentifier.getDatabaseName(),
                         newConnectionName);
         CatalogConnection temporaryConnection = temporaryConnections.get(objectIdentifier);
-        if (temporaryConnection != null && getConnection(newIdentifier).isPresent()) {
-                throw new ValidationException(
-                        String.format(
-                                "Connection with identifier '%s' already exists.",
-                                newIdentifier.asSummaryString()));
-            }
+        if (temporaryConnection != null) {
+            checkConnectionNotExists(newIdentifier);
             temporaryConnections.remove(objectIdentifier);
             temporaryConnections.put(newIdentifier, temporaryConnection);
             return;
@@ -2150,12 +2146,7 @@ public final class CatalogManager implements CatalogRegistry, AutoCloseable {
                             "Connection with identifier '%s' does not exist.",
                             objectIdentifier.asSummaryString()));
         }
-        if (getConnection(newIdentifier).isPresent()) {
-            throw new ValidationException(
-                    String.format(
-                            "Connection with identifier '%s' already exists.",
-                            newIdentifier.asSummaryString()));
-        }
+        checkConnectionNotExists(newIdentifier);
 
         execute(
                 (catalog, path) ->
@@ -2163,6 +2154,15 @@ public final class CatalogManager implements CatalogRegistry, AutoCloseable {
                 objectIdentifier,
                 ignoreIfNotExists,
                 "RenameConnection");
+    }
+
+    private void checkConnectionNotExists(ObjectIdentifier objectIdentifier) {
+        if (getConnection(objectIdentifier).isPresent()) {
+            throw new ValidationException(
+                    String.format(
+                            "Connection with identifier '%s' already exists.",
+                            objectIdentifier.asSummaryString()));
+        }
     }
 
     /**

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogManager.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogManager.java
@@ -2142,8 +2142,7 @@ public final class CatalogManager implements CatalogRegistry, AutoCloseable {
             return;
         }
 
-        Optional<CatalogConnection> existingOpt = getConnection(objectIdentifier);
-        if (!existingOpt.isPresent()) {
+        if (getConnection(objectIdentifier).isEmpty()) {
             if (ignoreIfNotExists) {
                 return;
             }

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/GenericInMemoryCatalog.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/GenericInMemoryCatalog.java
@@ -512,6 +512,27 @@ public class GenericInMemoryCatalog extends AbstractCatalog {
     }
 
     @Override
+    public void renameConnection(
+            ObjectPath connectionPath, String newConnectionName, boolean ignoreIfNotExists)
+            throws ConnectionNotExistException, ConnectionAlreadyExistException {
+        checkNotNull(connectionPath);
+        checkArgument(!StringUtils.isNullOrWhitespaceOnly(newConnectionName));
+
+        if (connectionExists(connectionPath)) {
+            ObjectPath newPath =
+                    new ObjectPath(connectionPath.getDatabaseName(), newConnectionName);
+
+            if (connectionExists(newPath)) {
+                throw new ConnectionAlreadyExistException(getName(), newPath);
+            } else {
+                connections.put(newPath, connections.remove(connectionPath));
+            }
+        } else if (!ignoreIfNotExists) {
+            throw new ConnectionNotExistException(getName(), connectionPath);
+        }
+    }
+
+    @Override
     public void dropConnection(ObjectPath connectionPath, boolean ignoreIfNotExists)
             throws ConnectionNotExistException {
         checkNotNull(connectionPath);

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/AlterConnectionRenameOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/AlterConnectionRenameOperation.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.operations.ddl;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.api.internal.TableResultImpl;
+import org.apache.flink.table.api.internal.TableResultInternal;
+import org.apache.flink.table.catalog.ObjectIdentifier;
+
+/** Operation for ALTER CONNECTION .. RENAME TO .. statements. */
+@Internal
+public class AlterConnectionRenameOperation implements AlterOperation {
+
+    private final ObjectIdentifier connectionIdentifier;
+    private final String newConnectionName;
+    private final boolean ignoreIfNotExists;
+
+    public AlterConnectionRenameOperation(
+            ObjectIdentifier connectionIdentifier,
+            String newConnectionName,
+            boolean ignoreIfNotExists) {
+        this.connectionIdentifier = connectionIdentifier;
+        this.newConnectionName = newConnectionName;
+        this.ignoreIfNotExists = ignoreIfNotExists;
+    }
+
+    public ObjectIdentifier getConnectionIdentifier() {
+        return connectionIdentifier;
+    }
+
+    public String getNewConnectionName() {
+        return newConnectionName;
+    }
+
+    public boolean ignoreIfNotExists() {
+        return ignoreIfNotExists;
+    }
+
+    @Override
+    public String asSummaryString() {
+        return String.format(
+                "ALTER CONNECTION %s%s RENAME TO %s",
+                ignoreIfNotExists ? "IF EXISTS " : "",
+                connectionIdentifier.asSummaryString(),
+                newConnectionName);
+    }
+
+    @Override
+    public TableResultInternal execute(Context ctx) {
+        ctx.getCatalogManager()
+                .renameConnection(connectionIdentifier, newConnectionName, ignoreIfNotExists);
+        return TableResultImpl.TABLE_RESULT_OK;
+    }
+}

--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/catalog/CatalogManagerTest.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/catalog/CatalogManagerTest.java
@@ -544,6 +544,51 @@ class CatalogManagerTest {
                 .containsEntry("bootstrap.servers", "localhost:9092");
     }
 
+    @Test
+    public void testRenameTemporaryConnection() {
+        CatalogManager catalogManager = createCatalogManager(null);
+        ObjectIdentifier source =
+                ObjectIdentifier.of(
+                        catalogManager.getCurrentCatalog(),
+                        catalogManager.getCurrentDatabase(),
+                        "conn1");
+        ObjectIdentifier target =
+                ObjectIdentifier.of(
+                        catalogManager.getCurrentCatalog(),
+                        catalogManager.getCurrentDatabase(),
+                        "conn2");
+        Map<String, String> options =
+                new HashMap<String, String>() {
+                    {
+                        put("type", "default");
+                        put("bootstrap.servers", "localhost:9092");
+                    }
+                };
+        catalogManager.createTemporaryConnection(
+                SensitiveConnection.of(options, null), source, false);
+
+        catalogManager.renameConnection(source, "conn2", false);
+
+        assertThat(catalogManager.getConnection(source)).isEmpty();
+        assertThat(catalogManager.getConnection(target))
+                .hasValueSatisfying(
+                        connection ->
+                                assertThat(connection.getOptions())
+                                        .containsEntry("bootstrap.servers", "localhost:9092"));
+    }
+
+    @Test
+    public void testRenameMissingTemporaryConnectionIfExists() {
+        CatalogManager catalogManager = createCatalogManager(null);
+        ObjectIdentifier source =
+                ObjectIdentifier.of(
+                        catalogManager.getCurrentCatalog(),
+                        catalogManager.getCurrentDatabase(),
+                        "conn1");
+
+        catalogManager.renameConnection(source, "conn2", true);
+    }
+
     private CatalogManager createCatalogManager(@Nullable CatalogModificationListener listener) {
         CatalogManager.Builder builder =
                 CatalogManager.newBuilder()

--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/catalog/CatalogManagerTest.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/catalog/CatalogManagerTest.java
@@ -558,12 +558,7 @@ class CatalogManagerTest {
                         catalogManager.getCurrentDatabase(),
                         "conn2");
         Map<String, String> options =
-                new HashMap<String, String>() {
-                    {
-                        put("type", "default");
-                        put("bootstrap.servers", "localhost:9092");
-                    }
-                };
+                Map.of("type", "default", "bootstrap.servers", "localhost:9092");
         catalogManager.createTemporaryConnection(
                 SensitiveConnection.of(options, null), source, false);
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/Catalog.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/Catalog.java
@@ -1042,6 +1042,26 @@ public interface Catalog {
     }
 
     /**
+     * Rename an existing connection.
+     *
+     * @param connectionPath Path of the connection to be renamed
+     * @param newConnectionName the new name of the connection
+     * @param ignoreIfNotExists Flag to specify behavior when the connection does not exist: if set
+     *     to false, throw an exception, if set to true, do nothing.
+     * @throws ConnectionNotExistException if the connection does not exist
+     * @throws ConnectionAlreadyExistException if a connection with the new name already exists
+     * @throws CatalogException in case of any runtime exception
+     */
+    default void renameConnection(
+            ObjectPath connectionPath, String newConnectionName, boolean ignoreIfNotExists)
+            throws ConnectionNotExistException, ConnectionAlreadyExistException, CatalogException {
+        throw new UnsupportedOperationException(
+                String.format(
+                        "renameConnection(ObjectPath, String, boolean) is not implemented for %s.",
+                        this.getClass()));
+    }
+
+    /**
      * Drop a connection.
      *
      * @param connectionPath Path of the connection to be dropped

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/catalog/CatalogTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/catalog/CatalogTest.java
@@ -653,6 +653,61 @@ public abstract class CatalogTest {
     }
 
     @Test
+    public void testRenameConnection() throws Exception {
+        if (!supportsConnections()) {
+            return;
+        }
+        catalog.createDatabase(db1, createDb(), false);
+        CatalogConnection connection = createConnection();
+        catalog.createConnection(connectionPath1, connection, false);
+
+        catalog.renameConnection(connectionPath1, c2, false);
+
+        assertThat(catalog.connectionExists(connectionPath1)).isFalse();
+        assertThat(catalog.getConnection(connectionPath2).getOptions())
+                .isEqualTo(connection.getOptions());
+    }
+
+    @Test
+    public void testRenameConnection_ConnectionAlreadyExistException() throws Exception {
+        if (!supportsConnections()) {
+            return;
+        }
+        catalog.createDatabase(db1, createDb(), false);
+        catalog.createConnection(connectionPath1, createConnection(), false);
+        catalog.createConnection(connectionPath2, createConnection(), false);
+
+        assertThatThrownBy(() -> catalog.renameConnection(connectionPath1, c2, false))
+                .isInstanceOf(ConnectionAlreadyExistException.class)
+                .hasMessage(
+                        "Connection 'db1.c2' already exists in catalog '"
+                                + TEST_CATALOG_NAME
+                                + "'.");
+    }
+
+    @Test
+    public void testRenameMissingConnectionNotExistException() throws Exception {
+        if (!supportsConnections()) {
+            return;
+        }
+        catalog.createDatabase(db1, createDb(), false);
+
+        assertThatThrownBy(() -> catalog.renameConnection(connectionPath1, c2, false))
+                .isInstanceOf(ConnectionNotExistException.class)
+                .hasMessage("Connection 'db1.c1' does not exist in catalog 'test-catalog'.");
+    }
+
+    @Test
+    public void testRenameMissingConnectionIgnoreIfNotExist() throws Exception {
+        if (!supportsConnections()) {
+            return;
+        }
+        catalog.createDatabase(db1, createDb(), false);
+
+        catalog.renameConnection(connectionPath1, c2, true);
+    }
+
+    @Test
     public void testDropMissingConnectionNotExistException() throws Exception {
         if (!supportsConnections()) {
             return;

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/SqlAlterConnectionRenameConverter.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/SqlAlterConnectionRenameConverter.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.operations.converters;
+
+import org.apache.flink.sql.parser.ddl.connection.SqlAlterConnectionRename;
+import org.apache.flink.table.catalog.ObjectIdentifier;
+import org.apache.flink.table.catalog.UnresolvedIdentifier;
+import org.apache.flink.table.operations.Operation;
+import org.apache.flink.table.operations.ddl.AlterConnectionRenameOperation;
+
+/** A converter for {@link SqlAlterConnectionRename}. */
+public class SqlAlterConnectionRenameConverter
+        implements SqlNodeConverter<SqlAlterConnectionRename> {
+
+    @Override
+    public Operation convertSqlNode(
+            SqlAlterConnectionRename sqlAlterConnectionRename, ConvertContext context) {
+        ObjectIdentifier connectionIdentifier =
+                context.getCatalogManager()
+                        .qualifyIdentifier(
+                                UnresolvedIdentifier.of(sqlAlterConnectionRename.getFullName()));
+
+        return new AlterConnectionRenameOperation(
+                connectionIdentifier,
+                sqlAlterConnectionRename.getNewConnectionName().getSimple(),
+                sqlAlterConnectionRename.ifConnectionExists());
+    }
+}

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/SqlNodeConverters.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/SqlNodeConverters.java
@@ -141,6 +141,7 @@ public class SqlNodeConverters {
 
     private static void registerConnectionConverters() {
         register(new SqlCreateConnectionConverter());
+        register(new SqlAlterConnectionRenameConverter());
     }
 
     private static void registerMaterializedTableConverters() {

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlConnectionOperationConverterTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlConnectionOperationConverterTest.java
@@ -23,6 +23,7 @@ import org.apache.flink.table.api.SqlParserException;
 import org.apache.flink.table.catalog.ObjectIdentifier;
 import org.apache.flink.table.catalog.SensitiveConnection;
 import org.apache.flink.table.operations.Operation;
+import org.apache.flink.table.operations.ddl.AlterConnectionRenameOperation;
 import org.apache.flink.table.operations.ddl.CreateConnectionOperation;
 
 import org.junit.jupiter.api.Test;
@@ -120,5 +121,33 @@ class SqlConnectionOperationConverterTest extends SqlNodeToOperationConversionTe
         assertThatThrownBy(() -> parse("CREATE CONNECTION my_conn WITH ()"))
                 .isInstanceOf(SqlValidateException.class)
                 .hasMessageContaining("Connection property list can not be empty.");
+    }
+
+    @Test
+    void testAlterConnectionRename() {
+        Operation operation = parse("ALTER CONNECTION my_conn RENAME TO new_conn");
+        assertThat(operation).isInstanceOf(AlterConnectionRenameOperation.class);
+        AlterConnectionRenameOperation op = (AlterConnectionRenameOperation) operation;
+
+        assertThat(op.getConnectionIdentifier())
+                .isEqualTo(ObjectIdentifier.of("builtin", "default", "my_conn"));
+        assertThat(op.getNewConnectionName()).isEqualTo("new_conn");
+        assertThat(op.ignoreIfNotExists()).isFalse();
+    }
+
+    @Test
+    void testAlterConnectionRenameIfExists() {
+        Operation operation = parse("ALTER CONNECTION IF EXISTS my_conn RENAME TO new_conn");
+        AlterConnectionRenameOperation op = (AlterConnectionRenameOperation) operation;
+        assertThat(op.ignoreIfNotExists()).isTrue();
+    }
+
+    @Test
+    void testAlterConnectionRenameWithFullyQualifiedName() {
+        Operation operation = parse("ALTER CONNECTION cat1.db1.my_conn RENAME TO new_conn");
+        AlterConnectionRenameOperation op = (AlterConnectionRenameOperation) operation;
+        assertThat(op.getConnectionIdentifier())
+                .isEqualTo(ObjectIdentifier.of("cat1", "db1", "my_conn"));
+        assertThat(op.getNewConnectionName()).isEqualTo("new_conn");
     }
 }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/batch/sql/CreateConnectionITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/batch/sql/CreateConnectionITCase.java
@@ -73,6 +73,36 @@ class CreateConnectionITCase extends BatchTestBase {
                 .hasMessageContaining("WritableSecretStore must be configured");
     }
 
+    @Test
+    void testAlterConnectionRenameTemporaryConnection() {
+        tEnv().executeSql("CREATE TEMPORARY CONNECTION my_conn WITH ('k' = 'v')");
+
+        tEnv().executeSql("ALTER CONNECTION my_conn RENAME TO new_conn");
+
+        assertThat(catalogManager().getConnection(connectionIdentifier("my_conn"))).isEmpty();
+        assertThat(catalogManager().getConnection(connectionIdentifier("new_conn")))
+                .hasValueSatisfying(
+                        connection ->
+                                assertThat(connection.getOptions()).containsOnly(entry("k", "v")));
+    }
+
+    @Test
+    void testAlterConnectionRenameIfExists() {
+        tEnv().executeSql("ALTER CONNECTION IF EXISTS missing_conn RENAME TO new_conn");
+
+        assertThat(catalogManager().getConnection(connectionIdentifier("new_conn"))).isEmpty();
+    }
+
+    @Test
+    void testAlterConnectionRenameToExistingConnectionRejected() {
+        tEnv().executeSql("CREATE TEMPORARY CONNECTION my_conn WITH ('k' = 'v')");
+        tEnv().executeSql("CREATE TEMPORARY CONNECTION new_conn WITH ('k' = 'v')");
+
+        assertThatThrownBy(() -> tEnv().executeSql("ALTER CONNECTION my_conn RENAME TO new_conn"))
+                .isInstanceOf(ValidationException.class)
+                .hasMessageContaining("already exists");
+    }
+
     private CatalogManager catalogManager() {
         return ((TableEnvironmentInternal) tEnv()).getCatalogManager();
     }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/batch/sql/CreateConnectionITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/batch/sql/CreateConnectionITCase.java
@@ -18,11 +18,14 @@
 
 package org.apache.flink.table.planner.runtime.batch.sql;
 
+import org.apache.flink.table.api.EnvironmentSettings;
+import org.apache.flink.table.api.TableEnvironment;
 import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.api.internal.TableEnvironmentInternal;
 import org.apache.flink.table.catalog.CatalogManager;
 import org.apache.flink.table.catalog.ObjectIdentifier;
 import org.apache.flink.table.planner.runtime.utils.BatchTestBase;
+import org.apache.flink.table.secret.GenericInMemorySecretStore;
 
 import org.junit.jupiter.api.Test;
 
@@ -101,6 +104,37 @@ class CreateConnectionITCase extends BatchTestBase {
         assertThatThrownBy(() -> tEnv().executeSql("ALTER CONNECTION my_conn RENAME TO new_conn"))
                 .isInstanceOf(ValidationException.class)
                 .hasMessageContaining("already exists");
+    }
+
+    @Test
+    void testAlterTemporaryConnectionRenameToExistingPermanentConnectionRejected() {
+        TableEnvironment tableEnv = tableEnvWithSecretStore();
+        tableEnv.executeSql("CREATE TEMPORARY CONNECTION my_conn WITH ('k' = 'v')");
+        tableEnv.executeSql("CREATE CONNECTION new_conn WITH ('k' = 'v')");
+
+        assertThatThrownBy(() -> tableEnv.executeSql("ALTER CONNECTION my_conn RENAME TO new_conn"))
+                .isInstanceOf(ValidationException.class)
+                .hasMessageContaining("already exists");
+    }
+
+    @Test
+    void testAlterPermanentConnectionRenameToExistingTemporaryConnectionRejected() {
+        TableEnvironment tableEnv = tableEnvWithSecretStore();
+        tableEnv.executeSql("CREATE CONNECTION my_conn WITH ('k' = 'v')");
+        tableEnv.executeSql("CREATE TEMPORARY CONNECTION new_conn WITH ('k' = 'v')");
+
+        assertThatThrownBy(() -> tableEnv.executeSql("ALTER CONNECTION my_conn RENAME TO new_conn"))
+                .isInstanceOf(ValidationException.class)
+                .hasMessageContaining("already exists");
+    }
+
+    private TableEnvironment tableEnvWithSecretStore() {
+        EnvironmentSettings settings =
+                EnvironmentSettings.newInstance()
+                        .inBatchMode()
+                        .withSecretStore(new GenericInMemorySecretStore())
+                        .build();
+        return TableEnvironment.create(settings);
     }
 
     private CatalogManager catalogManager() {

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/batch/sql/CreateConnectionITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/batch/sql/CreateConnectionITCase.java
@@ -103,7 +103,8 @@ class CreateConnectionITCase extends BatchTestBase {
 
         assertThatThrownBy(() -> tEnv().executeSql("ALTER CONNECTION my_conn RENAME TO new_conn"))
                 .isInstanceOf(ValidationException.class)
-                .hasMessageContaining("already exists");
+                .hasMessage(
+                        "Connection with identifier 'default_catalog.default_database.new_conn' already exists.");
     }
 
     @Test
@@ -114,7 +115,8 @@ class CreateConnectionITCase extends BatchTestBase {
 
         assertThatThrownBy(() -> tableEnv.executeSql("ALTER CONNECTION my_conn RENAME TO new_conn"))
                 .isInstanceOf(ValidationException.class)
-                .hasMessageContaining("already exists");
+                .hasMessage(
+                        "Connection with identifier 'default_catalog.default_database.new_conn' already exists.");
     }
 
     @Test
@@ -125,7 +127,8 @@ class CreateConnectionITCase extends BatchTestBase {
 
         assertThatThrownBy(() -> tableEnv.executeSql("ALTER CONNECTION my_conn RENAME TO new_conn"))
                 .isInstanceOf(ValidationException.class)
-                .hasMessageContaining("already exists");
+                .hasMessage(
+                        "Connection with identifier 'default_catalog.default_database.new_conn' already exists.");
     }
 
     private TableEnvironment tableEnvWithSecretStore() {


### PR DESCRIPTION


## What is the purpose of the change

Adds ALTER CONNECTION ... RENAME TO conversion/execution, catalog rename support, temporary connection rename handling, and catalog/runtime tests.


## Brief change log

Add ALTER CONNECTION RENAME operation

## Verifying this change

Unit tests and IT

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no) no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no) yes
  - The serializers: (yes / no / don't know) no
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know) no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know) no
  - The S3 file system connector: (yes / no / don't know) no

## Documentation

  - Does this pull request introduce a new feature? (yes / no) yes
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)

---

##### Was generative AI tooling used to co-author this PR?


- [x] Yes 

