### PR TITLE
[hotfix] Fix compilation with jdk11

### DIFF
--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/sql/join/LateralSnapshotJoinITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/sql/join/LateralSnapshotJoinITCase.java
@@ -153,7 +153,7 @@ public class LateralSnapshotJoinITCase extends StreamingWithStateTestBase {
         final List<Row> probes =
                 IntStream.range(0, probeCount)
                         .mapToObj(i -> Row.of("k", i, ts(String.format("00:00:%02d", i))))
-                        .toList();
+                        .collect(Collectors.toList());
         createProbe(probes, 200L); // last probe at ~1400 ms, well past the last post-flip update
         createUpsertBuild(
                 Arrays.asList(


### PR DESCRIPTION
## What is the purpose of the change

The PR to fix compilation with jdk11

- Nightly broken on Flink master: https://github.com/apache/flink/actions/runs/29887195746

- It runs green on my fork's nightly: https://github.com/raminqaf/flink/actions/runs/29897476389

## Brief change log
`.toList` -> `.collect(Collectors.toList())`

## Verifying this change

run with jdk11

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no )
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: ( no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change the checkbox below to `[X]` followed by the name of the tool, and uncomment the
"Generated-by" line. See the ASF Generative Tooling Guidance for details:
https://www.apache.org/legal/generative-tooling.html

You are responsible for the quality and correctness of every change in this PR
regardless of the tooling used. Low-effort AI-generated PRs will be closed. See
AGENTS.md for the full guidance.
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name and Version]
-->
