### PR TITLE
FLINK-37686 - Do not fail on NOT_OWNED deleted files

### DIFF
--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/fs/ForStFlinkFileSystem.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/fs/ForStFlinkFileSystem.java
@@ -52,6 +52,7 @@ import javax.annotation.Nullable;
 
 import java.io.Closeable;
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.URI;
 import java.util.ArrayList;
@@ -373,7 +374,33 @@ public class ForStFlinkFileSystem extends FileSystem implements Closeable {
             String relativePath = mappingFile.substring(pathStr.length());
             int slashIndex = relativePath.indexOf('/');
             if (slashIndex == -1) { // direct child
-                fileStatuses.add(getFileStatus(new Path(mappingFile)));
+                try {
+                    fileStatuses.add(getFileStatus(new Path(mappingFile)));
+                } catch (FileNotFoundException e) {
+                    // The physical object backing this mapping entry is gone,
+                    // we handle this case by removing the mapping. If the entry is
+                    // NOT_OWNED, ownership of that object was handed to the JobManager.
+                    // The JM's SharedStateRegistry may have deleted it once the last
+                    // checkpoint referencing it was removed.
+                    // Since nothing else prunes the now-deleted mapping entry,
+                    // every subsequent full listing would hit this missing object and fail
+                    // This bug is documented in (FLINK-37686), the block attempts to
+                    // drop the stale entry and skip it rather than failing.
+                    MappingEntry staleEntry = fileMappingManager.mappingEntry(mappingFile);
+                    if (staleEntry != null
+                            && staleEntry.getFileOwnership() == FileOwnership.NOT_OWNED) {
+                        LOG.warn(
+                                "Source object for mapping file {} (resolved source: {}, ownership: NOT_OWNED) "
+                                        + "is missing. Its physical object was owned and deleted by the "
+                                        + "JobManager, the now-deleted mapping is being removed",
+                                mappingFile,
+                                staleEntry.getSourcePath());
+                        fileMappingManager.deleteFileOrDirectory(new Path(mappingFile), false);
+                    } else {
+                        // for all other cases, continue to bubble up the failure
+                        throw e;
+                    }
+                }
             }
         }
         return fileStatuses.toArray(new FileStatus[0]);

--- a/flink-state-backends/flink-statebackend-forst/src/test/java/org/apache/flink/state/forst/fs/ForStFlinkFileSystemTest.java
+++ b/flink-state-backends/flink-statebackend-forst/src/test/java/org/apache/flink/state/forst/fs/ForStFlinkFileSystemTest.java
@@ -36,6 +36,7 @@ import org.apache.flink.state.forst.fs.cache.FileBasedCache;
 import org.apache.flink.state.forst.fs.cache.FileCacheEntry;
 import org.apache.flink.state.forst.fs.cache.SizeBasedCacheLimitPolicy;
 import org.apache.flink.state.forst.fs.cache.SpaceBasedCacheLimitPolicy;
+import org.apache.flink.state.forst.fs.filemapping.FileOwnership;
 import org.apache.flink.state.forst.fs.filemapping.MappingEntry;
 import org.apache.flink.testutils.junit.extensions.parameterized.Parameter;
 import org.apache.flink.testutils.junit.extensions.parameterized.ParameterizedTestExtension;
@@ -49,6 +50,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.URI;
 import java.nio.ByteBuffer;
@@ -68,6 +70,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import static org.apache.flink.state.forst.ForStOptions.CACHE_LRU_ACCESS_BEFORE_PROMOTION;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Tests for {@link ForStFlinkFileSystem}. */
 @ExtendWith(ParameterizedTestExtension.class)
@@ -469,6 +472,79 @@ public class ForStFlinkFileSystemTest {
                         FileSystem.getLocalFileSystem()
                                 .getFileStatus(mappingEntry.getSourcePath())
                                 .getLen());
+    }
+
+    @Test
+    public void testListStatusDropsDeletedNotOwnedEntryAfterGiveUpOwnership() throws IOException {
+        org.apache.flink.core.fs.Path remotePath =
+                new org.apache.flink.core.fs.Path(tempDir.toString() + "/remote");
+        org.apache.flink.core.fs.Path localPath =
+                new org.apache.flink.core.fs.Path(tempDir.toString() + "/local");
+        ForStFlinkFileSystem fileSystem =
+                new ForStFlinkFileSystem(
+                        new ByteBufferReadableLocalFileSystem(),
+                        remotePath.toString(),
+                        localPath.toString(),
+                        null);
+        fileSystem.mkdirs(remotePath);
+        fileSystem.mkdirs(localPath);
+
+        org.apache.flink.core.fs.Path survivorPath =
+                new org.apache.flink.core.fs.Path(remotePath, "survivor.sst");
+        try (ByteBufferWritableFSDataOutputStream os = fileSystem.create(survivorPath)) {
+            os.write(1);
+        }
+
+        org.apache.flink.core.fs.Path notOwnedPath =
+                new org.apache.flink.core.fs.Path(remotePath, "not-owned.sst");
+        try (ByteBufferWritableFSDataOutputStream os = fileSystem.create(notOwnedPath)) {
+            os.write(2);
+        }
+        org.apache.flink.core.fs.Path notOwnedSource =
+                fileSystem.getMappingEntry(notOwnedPath).getSourcePath();
+        fileSystem.giveUpOwnership(notOwnedPath, new FileStateHandle(notOwnedSource, 1L));
+        assertThat(fileSystem.getMappingEntry(notOwnedPath).getFileOwnership())
+                .isEqualTo(FileOwnership.NOT_OWNED);
+
+        // Now the JM is deleting the physical object.
+        fileSystem.getDelegateFS().delete(notOwnedSource, false);
+
+        FileStatus[] statuses = fileSystem.listStatus(remotePath);
+        assertThat(statuses).hasSize(1);
+        assertThat(statuses[0].getPath()).isEqualTo(survivorPath);
+        assertThat(fileSystem.getMappingEntry(notOwnedPath)).isNull();
+        assertThat(fileSystem.getMappingEntry(survivorPath)).isNotNull();
+    }
+
+    @Test
+    public void testListStatusStillFailsForDeletedDbOwnedFile() throws IOException {
+        org.apache.flink.core.fs.Path remotePath =
+                new org.apache.flink.core.fs.Path(tempDir.toString() + "/remote");
+        org.apache.flink.core.fs.Path localPath =
+                new org.apache.flink.core.fs.Path(tempDir.toString() + "/local");
+        ForStFlinkFileSystem fileSystem =
+                new ForStFlinkFileSystem(
+                        new ByteBufferReadableLocalFileSystem(),
+                        remotePath.toString(),
+                        localPath.toString(),
+                        null);
+        fileSystem.mkdirs(remotePath);
+        fileSystem.mkdirs(localPath);
+
+        org.apache.flink.core.fs.Path dbOwnedPath =
+                new org.apache.flink.core.fs.Path(remotePath, "db-owned.sst");
+        try (ByteBufferWritableFSDataOutputStream os = fileSystem.create(dbOwnedPath)) {
+            os.write(1);
+        }
+        MappingEntry entry = fileSystem.getMappingEntry(dbOwnedPath);
+        assertThat(entry.getFileOwnership()).isEqualTo(FileOwnership.SHAREABLE_OWNED_BY_DB);
+
+        // Delete the physical object out from under the DB-owned entry.
+        fileSystem.getDelegateFS().delete(entry.getSourcePath(), false);
+
+        assertThatThrownBy(() -> fileSystem.listStatus(remotePath))
+                .isInstanceOf(FileNotFoundException.class);
+        assertThat(fileSystem.getMappingEntry(dbOwnedPath)).isNotNull();
     }
 
     @Test

--- a/flink-state-backends/flink-statebackend-forst/src/test/java/org/apache/flink/state/forst/fs/ForStFlinkFileSystemTest.java
+++ b/flink-state-backends/flink-statebackend-forst/src/test/java/org/apache/flink/state/forst/fs/ForStFlinkFileSystemTest.java
@@ -506,7 +506,7 @@ public class ForStFlinkFileSystemTest {
         assertThat(fileSystem.getMappingEntry(notOwnedPath).getFileOwnership())
                 .isEqualTo(FileOwnership.NOT_OWNED);
 
-        // Now the JM is deleting the physical object.
+        // Now the JM is deleting the physical object
         fileSystem.getDelegateFS().delete(notOwnedSource, false);
 
         FileStatus[] statuses = fileSystem.listStatus(remotePath);
@@ -539,7 +539,7 @@ public class ForStFlinkFileSystemTest {
         MappingEntry entry = fileSystem.getMappingEntry(dbOwnedPath);
         assertThat(entry.getFileOwnership()).isEqualTo(FileOwnership.SHAREABLE_OWNED_BY_DB);
 
-        // Delete the physical object out from under the DB-owned entry.
+        // Delete the physical object out from under the DB-owned entry
         fileSystem.getDelegateFS().delete(entry.getSourcePath(), false);
 
         assertThatThrownBy(() -> fileSystem.listStatus(remotePath))


### PR DESCRIPTION
## What is the purpose of the change

This PR aims to fix the issue documented in https://issues.apache.org/jira/browse/FLINK-37686 where remote objects cleaned up by the JM cause checkpoint failures even when the object is marked as `NOT_OWNED`.


## Brief change log

  - Added a `FileNotFoundException` catch block to `ForStFlinkFileSystem::listStatus`
  - In this catch block we verify the object is `NOT_OWNED`
  - If true, we assume the JM removed this object and delete it using the `FileMappingManager`
  - Tests have been added to cover this case as well as ensuring the exception still bubbles up if the object is **not** `NOT_OWNED`


## Verifying this change

This change added tests and can be verified as follows:
- Added two new tests to `ForStFlinkFileSystemTest`,  `testListStatusDropsDeletedNotOwnedEntryAfterGiveUpOwnership` and `testListStatusStillFailsForDeletedDbOwnedFile`
- These tests cover the `NOT_OWNED` and verify the removed object is also removed from the `FileMappingManager`, the other test verifies the baseline hasn't changed for other object types

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)

---

##### Was generative AI tooling used to co-author this PR?


- [X] Yes

Generated-by: [Claude Opus]

