### PR TITLE
[FLINK-40217][core] Reject non-finite numbers in Variant JSON conversion

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/types/variant/BinaryVariant.java
+++ b/flink-core/src/main/java/org/apache/flink/types/variant/BinaryVariant.java
@@ -356,8 +356,16 @@ public final class BinaryVariant implements Variant {
                 sb.append(escapeJson(BinaryVariantUtil.getString(value, pos)));
                 break;
             case DOUBLE:
-                sb.append(BinaryVariantUtil.getDouble(value, pos));
-                break;
+                {
+                    final double d = BinaryVariantUtil.getDouble(value, pos);
+                    if (Double.isInfinite(d) || Double.isNaN(d)) {
+                        throw new VariantTypeException(
+                                String.format(
+                                        "Non-finite value %s cannot be serialized to JSON.", d));
+                    }
+                    sb.append(d);
+                    break;
+                }
             case DECIMAL:
                 sb.append(BinaryVariantUtil.getDecimal(value, pos).toPlainString());
                 break;
@@ -382,8 +390,17 @@ public final class BinaryVariant implements Variant {
                                         .atZone(ZoneOffset.UTC)));
                 break;
             case FLOAT:
-                sb.append(BinaryVariantUtil.getFloat(value, pos));
-                break;
+                {
+                    final float f = BinaryVariantUtil.getFloat(value, pos);
+                    if (Float.isInfinite(f) || Float.isNaN(f)) {
+                        throw new VariantTypeException(
+                                String.format(
+                                        "Non-finite value %s cannot be serialized to JSON.",
+                                        (double) f));
+                    }
+                    sb.append(f);
+                    break;
+                }
             case BYTES:
                 appendQuoted(
                         sb,

--- a/flink-core/src/main/java/org/apache/flink/types/variant/BinaryVariantInternalBuilder.java
+++ b/flink-core/src/main/java/org/apache/flink/types/variant/BinaryVariantInternalBuilder.java
@@ -91,6 +91,7 @@ public class BinaryVariantInternalBuilder {
             new VariantTypeException("VARIANT_SIZE_LIMIT");
     public static final VariantTypeException VARIANT_DUPLICATE_KEY_EXCEPTION =
             new VariantTypeException("VARIANT_DUPLICATE_KEY");
+    private static final JsonFactory JSON_FACTORY = new JsonFactory();
 
     public BinaryVariantInternalBuilder(boolean allowDuplicateKeys) {
         this.allowDuplicateKeys = allowDuplicateKeys;
@@ -103,7 +104,7 @@ public class BinaryVariantInternalBuilder {
      */
     public static BinaryVariant parseJson(String json, boolean allowDuplicateKeys)
             throws IOException {
-        try (JsonParser parser = new JsonFactory().createParser(json)) {
+        try (JsonParser parser = JSON_FACTORY.createParser(json)) {
             parser.nextToken();
             return parseJson(parser, allowDuplicateKeys);
         }
@@ -622,7 +623,17 @@ public class BinaryVariantInternalBuilder {
 
     private void parseFloatingPoint(JsonParser parser) throws IOException {
         if (!tryParseDecimal(parser.getText())) {
-            appendDouble(parser.getDoubleValue());
+            final double d = parser.getDoubleValue();
+            // Jackson coerces out-of-range numbers like 1e400 to +/-Infinity. Reject them instead
+            // of storing a non-finite double that toJson() could not render as valid JSON.
+            if (Double.isInfinite(d) || Double.isNaN(d)) {
+                throw new JsonParseException(
+                        parser,
+                        String.format(
+                                "Numeric value '%s' is out of the range of double precision and cannot be stored as a Variant.",
+                                parser.getText()));
+            }
+            appendDouble(d);
         }
     }
 

--- a/flink-core/src/test/java/org/apache/flink/types/variant/BinaryVariantInternalBuilderTest.java
+++ b/flink-core/src/test/java/org/apache/flink/types/variant/BinaryVariantInternalBuilderTest.java
@@ -19,6 +19,8 @@
 package org.apache.flink.types.variant;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.io.IOException;
 import java.math.BigDecimal;
@@ -118,6 +120,15 @@ class BinaryVariantInternalBuilderTest {
         variant = BinaryVariantInternalBuilder.parseJson("{\"k1\":1,\"k1\":2,\"k2\":1.5}", true);
         assertThat(variant.getField("k1").getByte()).isEqualTo((byte) 2);
         assertThat(variant.getField("k2").getDecimal()).isEqualTo(BigDecimal.valueOf(1.5));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"NaN", "Infinity", "-Infinity", "1e400", "-1e400"})
+    void testParseJsonRejectsNonFiniteNumbers(final String nonFiniteNumber) {
+        // NaN and the infinities are not valid JSON; 1e400 is valid JSON but overflows the double
+        // range. Both must be rejected so PARSE_JSON errors and TRY_PARSE_JSON returns NULL.
+        assertThatThrownBy(() -> BinaryVariantInternalBuilder.parseJson(nonFiniteNumber, false))
+                .isInstanceOf(IOException.class);
     }
 
     @Test

--- a/flink-core/src/test/java/org/apache/flink/types/variant/BinaryVariantTest.java
+++ b/flink-core/src/test/java/org/apache/flink/types/variant/BinaryVariantTest.java
@@ -20,6 +20,8 @@ package org.apache.flink.types.variant;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.math.BigDecimal;
 import java.time.Instant;
@@ -234,6 +236,22 @@ class BinaryVariantTest {
         String json = variant.toJson();
         assertThat(json)
                 .isEqualTo("{" + "\"list\":[\"hello\",1]," + "\"object\":{\"ff\":10.0,\"ss\":1}}");
+    }
+
+    @ParameterizedTest
+    @ValueSource(doubles = {Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY, Double.NaN})
+    void testToJsonRejectsNonFiniteDouble(final double nonFinite) {
+        assertThatThrownBy(() -> builder.of(nonFinite).toJson())
+                .isInstanceOf(VariantTypeException.class)
+                .hasMessageContaining("cannot be serialized to JSON");
+    }
+
+    @ParameterizedTest
+    @ValueSource(floats = {Float.POSITIVE_INFINITY, Float.NEGATIVE_INFINITY, Float.NaN})
+    void testToJsonRejectsNonFiniteFloat(final float nonFinite) {
+        assertThatThrownBy(() -> builder.of(nonFinite).toJson())
+                .isInstanceOf(VariantTypeException.class)
+                .hasMessageContaining("cannot be serialized to JSON");
     }
 
     @Test

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/JsonFunctionsITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/JsonFunctionsITCase.java
@@ -87,6 +87,7 @@ class JsonFunctionsITCase extends BuiltInFunctionTestBase {
         testCases.addAll(isJsonSpec());
         testCases.addAll(jsonQuerySpec());
         testCases.addAll(jsonStringSpec());
+        testCases.addAll(parseJsonSpec());
         testCases.addAll(jsonObjectSpec());
         testCases.addAll(jsonSpec());
         testCases.addAll(jsonArraySpec());
@@ -758,6 +759,45 @@ class JsonFunctionsITCase extends BuiltInFunctionTestBase {
                                 "JSON_STRING(f0)",
                                 "{\"field\\ttab\":\"val4\",\"field\\nline\":\"val3\",\"field\\rreturn\":\"val5\",\"field\\\"quote\":\"val1\",\"field\\\\slash\":\"val2\"}",
                                 STRING().notNull()));
+    }
+
+    private static List<TestSetSpec> parseJsonSpec() {
+        // The bulk of parsing behavior is covered by BinaryVariantInternalBuilderTest.
+        return List.of(
+                TestSetSpec.forFunction(BuiltInFunctionDefinitions.PARSE_JSON)
+                        .onFieldsWithData("{\"a\":1,\"b\":[2,3]}", "1e400")
+                        .andDataTypes(STRING().notNull(), STRING().notNull())
+                        .testResult(
+                                jsonString(call("PARSE_JSON", $("f0"))),
+                                "JSON_STRING(PARSE_JSON(f0))",
+                                "{\"a\":1,\"b\":[2,3]}",
+                                STRING().notNull())
+                        .testResult(
+                                jsonString(call("PARSE_JSON", nullOf(STRING()))),
+                                "JSON_STRING(PARSE_JSON(CAST(NULL AS STRING)))",
+                                null,
+                                STRING().nullable())
+                        .testSqlRuntimeError(
+                                "PARSE_JSON(f1)",
+                                TableRuntimeException.class,
+                                "Failed to parse json string")
+                        .testTableApiRuntimeError(
+                                call("PARSE_JSON", $("f1")),
+                                TableRuntimeException.class,
+                                "Failed to parse json string"),
+                TestSetSpec.forFunction(BuiltInFunctionDefinitions.TRY_PARSE_JSON)
+                        .onFieldsWithData("{\"a\":1}", "1e400")
+                        .andDataTypes(STRING().notNull(), STRING().notNull())
+                        .testResult(
+                                jsonString(call("TRY_PARSE_JSON", $("f0"))),
+                                "JSON_STRING(TRY_PARSE_JSON(f0))",
+                                "{\"a\":1}",
+                                STRING())
+                        .testResult(
+                                jsonString(call("TRY_PARSE_JSON", $("f1"))),
+                                "JSON_STRING(TRY_PARSE_JSON(f1))",
+                                null,
+                                STRING()));
     }
 
     private static List<TestSetSpec> jsonSpec() {


### PR DESCRIPTION
## What is the purpose of the change

`PARSE_JSON` accepted JSON numbers outside the double range, such as `1e400`, and silently stored them as `±Infinity`. `Variant.toJson()` then emitted bare `Infinity` / `-Infinity` tokens, which are invalid JSON and cannot be parsed back by `PARSE_JSON`. This closes that gap by rejecting non-finite values on both the parse and the serialize side.

## Brief change log

  - `BinaryVariantInternalBuilder.parseFloatingPoint()` now rejects a non-finite result from `getDoubleValue()` with a clear parse error. `PARSE_JSON('1e400')` fails loudly and `TRY_PARSE_JSON('1e400')` returns `NULL`, so a parsed Variant can never hold a non-finite value.
  - `BinaryVariant.toJson()` now throws a `VariantTypeException` for non-finite `DOUBLE` and `FLOAT` values instead of appending invalid `Infinity` / `NaN` tokens. This guards the builder API, which is the only remaining way to inject a non-finite value.
  - `parseJson` reuses a single static `JsonFactory` instead of allocating one per call.

## Verifying this change

This change added tests and can be verified as follows:

  - Added `BinaryVariantInternalBuilderTest#testParseJsonRejectsNonFiniteNumbers`, parameterized over `NaN`, `Infinity`, `-Infinity`, `1e400`, and `-1e400`, asserting `parseJson` throws (invalid JSON tokens and finite-but-overflowing numbers alike).
  - Added `BinaryVariantTest#testToJsonRejectsNonFiniteDouble` and `#testToJsonRejectsNonFiniteFloat`, parameterized over the infinities and `NaN`, asserting `toJson()` throws instead of emitting invalid JSON.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no** (both changed classes are `@Internal`; the user-visible effect is a semantics change to the `PARSE_JSON` / `TRY_PARSE_JSON` SQL functions on out-of-range numbers)
  - The serializers: **no** (the Variant binary encoding is unchanged)
  - The runtime per-record code paths (performance sensitive): **yes** (on the `PARSE_JSON` / `toJson()` paths; the only added cost is a constant-time finite check, and reusing `JsonFactory` removes a per-call allocation)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

<!--
Generated-by: Claude Code (Claude Opus 4.8)
-->