### PR TITLE
[FLINK-40230][table] `StringToBinary` and `RawToBinary` cast rules might generate runtime code with useless array copy

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/RawToBinaryCastRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/RawToBinaryCastRule.java
@@ -63,7 +63,7 @@ class RawToBinaryCastRule extends AbstractNullAwareCodeGeneratorCastRule<Object,
     isNull$290 = isNull$289;
     if (!isNull$290) {
         byte[] deserializedByteArray$76 = result$289.toBytes(typeSerializer$292);
-        if (deserializedByteArray$76.length <= 3) {
+        if (deserializedByteArray$76.length == 3) {
             result$291 = deserializedByteArray$76;
         } else {
             result$291 = java.util.Arrays.copyOf(deserializedByteArray$76, 3);
@@ -83,14 +83,14 @@ class RawToBinaryCastRule extends AbstractNullAwareCodeGeneratorCastRule<Object,
             LogicalType inputLogicalType,
             LogicalType targetLogicalType) {
         final int targetLength = LogicalTypeChecks.getLength(targetLogicalType);
+        final boolean couldPad = couldPad(targetLogicalType, targetLength);
 
         // Get serializer for RAW type
         final String typeSerializer = context.declareTypeSerializer(inputLogicalType);
         final String deserializedByteArrayTerm =
                 CodeGenUtils.newName(context.getCodeGeneratorContext(), "deserializedByteArray");
 
-        if (context.legacyBehaviour()
-                || !(couldTrim(targetLength) || (couldPad(targetLogicalType, targetLength)))) {
+        if (context.legacyBehaviour() || !(couldTrim(targetLength) || couldPad)) {
             return new CastRuleUtils.CodeWriter()
                     .assignStmt(returnVariable, methodCall(inputTerm, "toBytes", typeSerializer))
                     .toString();
@@ -101,19 +101,12 @@ class RawToBinaryCastRule extends AbstractNullAwareCodeGeneratorCastRule<Object,
                             deserializedByteArrayTerm,
                             methodCall(inputTerm, "toBytes", typeSerializer))
                     .ifStmt(
-                            arrayLength(deserializedByteArrayTerm) + " <= " + targetLength,
-                            thenWriter -> {
-                                if (couldPad(targetLogicalType, targetLength)) {
-                                    trimOrPadByteArray(
-                                            returnVariable,
-                                            targetLength,
-                                            deserializedByteArrayTerm,
-                                            thenWriter);
-                                } else {
+                            arrayLength(deserializedByteArrayTerm)
+                                    + (couldPad ? " == " : " <= ")
+                                    + targetLength,
+                            thenWriter ->
                                     thenWriter.assignStmt(
-                                            returnVariable, deserializedByteArrayTerm);
-                                }
-                            },
+                                            returnVariable, deserializedByteArrayTerm),
                             elseWriter ->
                                     trimOrPadByteArray(
                                             returnVariable,

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/StringToBinaryCastRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/StringToBinaryCastRule.java
@@ -59,10 +59,9 @@ class StringToBinaryCastRule extends AbstractNullAwareCodeGeneratorCastRule<Stri
     isNull$0 = _myInputIsNull;
     if (!isNull$0) {
         byte[] byteArrayTerm$0 = _myInput.toBytes();
-        if (byteArrayTerm$0.length <= 2) {
-            // If could pad
-            result$1 = java.util.Arrays.copyOf(byteArrayTerm$0, 2);
-            // result$1 = byteArrayTerm$0 // If could not pad
+        if (byteArrayTerm$0.length == 2) {
+            // If could pad, condition is "== 2" instead of "<= 2"
+            result$1 = byteArrayTerm$0;
         } else {
             result$1 = java.util.Arrays.copyOf(byteArrayTerm$0, 2);
         }
@@ -86,24 +85,17 @@ class StringToBinaryCastRule extends AbstractNullAwareCodeGeneratorCastRule<Stri
                     .toString();
         } else {
             final int targetLength = LogicalTypeChecks.getLength(targetLogicalType);
+            final boolean couldPad = couldPad(targetLogicalType, targetLength);
             final String byteArrayTerm =
                     CodeGenUtils.newName(context.getCodeGeneratorContext(), "byteArrayTerm");
 
             return new CastRuleUtils.CodeWriter()
                     .declStmt(byte[].class, byteArrayTerm, methodCall(inputTerm, "toBytes"))
                     .ifStmt(
-                            arrayLength(byteArrayTerm) + " <= " + targetLength,
-                            thenWriter -> {
-                                if (couldPad(targetLogicalType, targetLength)) {
-                                    trimOrPadByteArray(
-                                            returnVariable,
-                                            targetLength,
-                                            byteArrayTerm,
-                                            thenWriter);
-                                } else {
-                                    thenWriter.assignStmt(returnVariable, byteArrayTerm);
-                                }
-                            },
+                            arrayLength(byteArrayTerm)
+                                    + (couldPad ? " == " : " <= ")
+                                    + targetLength,
+                            thenWriter -> thenWriter.assignStmt(returnVariable, byteArrayTerm),
                             elseWriter ->
                                     trimOrPadByteArray(
                                             returnVariable,


### PR DESCRIPTION
## What is the purpose of the change

In case of same size it generates code to copy array while in fact there is no need for that
The PR makes the generation more optimal

## Brief change log

rules
## Verifying this change

existing cast tests
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (yes)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change the checkbox below to `[X]` followed by the name of the tool, and uncomment the
"Generated-by" line. See the ASF Generative Tooling Guidance for details:
https://www.apache.org/legal/generative-tooling.html

You are responsible for the quality and correctness of every change in this PR
regardless of the tooling used. Low-effort AI-generated PRs will be closed. See
AGENTS.md for the full guidance.
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name and Version]
-->
