### PR TITLE
[FLINK-40234] Add unit test to demonstrate that busy subtask thread may cause splits to be marked as idle erroneously and cause dropped records

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/streaming/api/operators/SourceOperatorSplitWatermarkAlignmentTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/streaming/api/operators/SourceOperatorSplitWatermarkAlignmentTest.java
@@ -629,6 +629,89 @@ class SourceOperatorSplitWatermarkAlignmentTest {
         assertOutput(actualOutput, Arrays.asList(5, 6));
     }
 
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    void testMultiSplitWithBusySubtask(boolean simulateBusySubtask) throws Exception {
+        long idleTimeout = 100;
+        MockSourceReader sourceReader =
+                new MockSourceReader(WaitingForSplits.DO_NOT_WAIT_FOR_SPLITS, false, true);
+        TestProcessingTimeService processingTimeService = new TestProcessingTimeService();
+        SourceOperator<Integer, MockSourceSplit> operator =
+                createAndOpenSourceOperatorWithIdleness(
+                        sourceReader, processingTimeService, idleTimeout);
+
+        MockSourceSplit split0 = new MockSourceSplit(0, 0, 10);
+        MockSourceSplit split1 = new MockSourceSplit(1, 10, 20);
+        split0.addRecord(5);
+        split1.addRecord(2);
+
+        operator.handleOperatorEvent(
+                new AddSplitEvent<>(
+                        Arrays.asList(split0, split1), new MockSourceSplitSerializer()));
+        CollectingDataOutput<Integer> dataOutput = new CollectingDataOutput<>();
+
+        // Set watermark alignment event to be below that for idle timeout to rule out late records
+        // from large watermark gap across splits.
+        operator.handleOperatorEvent(new WatermarkAlignmentEvent(10));
+
+        // Emit first record (5)
+        operator.emitNext(dataOutput);
+        assertThat(sourceReader.getPausedSplits()).isEmpty();
+
+        if (simulateBusySubtask) {
+            // Simulate a slow synchronous chained operator monopolizing the subtask thread
+            for (int i = 0; i < 10; i++) {
+                processingTimeService.advance(idleTimeout);
+            }
+        }
+
+        assertThat(sourceReader.getPausedSplits()).isEmpty();
+
+        // split1 has a genuinely pending, never-yet-requested record - it should NOT be marked
+        // idle merely because nothing has asked for it yet.
+        assertThat(operator.getSplitMetricGroup(split1.splitId()).isIdle()).isFalse();
+
+        // Once the "busy" operator finally frees up and split1's pending record is requested,
+        // its genuinely on-time timestamp (2) should not arrive behind a watermark that has
+        // already advanced past it (5, driven by split0 alone while split1 was wrongly
+        // excluded as idle).
+
+        // Emit first record (2)
+        operator.emitNext(dataOutput);
+
+        List<Object> events = dataOutput.getEvents();
+        int watermarkIndex = indexOfWatermarkAtLeast(events, 5);
+        int recordIndex = indexOfRecordWithValue(events, 2);
+        assertThat(recordIndex)
+                .as(
+                        "record with timestamp 2 should not arrive behind an already-emitted "
+                                + "watermark of 5")
+                .isLessThan(watermarkIndex == -1 ? Integer.MAX_VALUE : watermarkIndex);
+    }
+
+    private static int indexOfWatermarkAtLeast(List<Object> events, long minTimestamp) {
+        for (int i = 0; i < events.size(); i++) {
+            Object event = events.get(i);
+            if (event instanceof org.apache.flink.streaming.api.watermark.Watermark
+                    && ((org.apache.flink.streaming.api.watermark.Watermark) event).getTimestamp()
+                            >= minTimestamp) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    private static int indexOfRecordWithValue(List<Object> events, int value) {
+        for (int i = 0; i < events.size(); i++) {
+            Object event = events.get(i);
+            if (event instanceof StreamRecord
+                    && ((StreamRecord<?>) event).getValue().equals(value)) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
     private void sampleAllWatermarks(TestProcessingTimeService timeService) throws Exception {
         sampleWatermarks(timeService, WATERMARK_ALIGNMENT_BUFFER_SIZE.defaultValue());
     }


### PR DESCRIPTION
## What is the purpose of the change

Add unit test to demonstrate that busy subtask thread may cause splits to be marked as idle erroneously and cause dropped records. See https://issues.apache.org/jira/browse/FLINK-40234

## Brief change log

Add the `testMultiSplitWithBusySubtask` parameterised test case
- The test case passes when subtask busy-ness is NOT simulated
- The test case fails (split marked as idle and records were emitted behind watermark) when the subtask busyness is simulated. This demonstrates that subtask busy-ness can impact the semantic of a Flink job

## Verifying this change

This PR adds test cases to demonstrate a bug.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: Claude Sonnet 5
