### PR TITLE
[FLINK-40147][s3] Improve Native S3 FileSystem docs when using S3-compatible servers that do not support AWS checksum-validation

### DIFF
--- a/docs/content/docs/deployment/filesystems/s3.md
+++ b/docs/content/docs/deployment/filesystems/s3.md
@@ -172,6 +172,14 @@ In addition to the [common configuration](#common-configuration) options (`s3.ac
 
 View the detailed configuration at [native-s3-fs](https://github.com/apache/flink/tree/master/flink-filesystems/flink-s3-fs-native#configuration-options)
 
+For S3-compatible endpoints, the AWS SDK requires a region. Use the server's region, or `us-east-1` if the server ignores it. Disable checksum validation only if the server does not support it:
+
+```yaml
+s3.endpoint: https://your-s3-compatible-server
+s3.region: us-east-1
+s3.checksum-validation.enabled: false
+```
+
 ---
 
 ### Presto S3 FileSystem

--- a/flink-filesystems/flink-s3-fs-native/README.md
+++ b/flink-filesystems/flink-s3-fs-native/README.md
@@ -277,6 +277,7 @@ For S3-compatible servers (SeaweedFS, LocalStack, Ceph RGW, etc.), set the endpo
 
 ```yaml
 s3.endpoint: http://localhost:8333
+s3.region: us-east-1
 fs.s3.aws.credentials.provider: AnonymousCredentialsProvider
 
 # Required: SeaweedFS serves the S3 API in path-style and does not support
@@ -289,7 +290,9 @@ s3.chunked-encoding.enabled: false
 s3.checksum-validation.enabled: false
 ```
 
-The exact subset of compatibility flags needed depends on the server and version — consult its documentation. The defaults in this filesystem (`path-style-access=false`, `chunked-encoding.enabled=true`, `checksum-validation.enabled=true`) are tuned for AWS S3.
+The AWS SDK requires a region for custom endpoints. Use the server's region, or `us-east-1` if the server ignores it.
+
+Required compatibility flags vary by server and version. Disable checksum validation only if the server does not support it. The defaults (`path-style-access=false`, `chunked-encoding.enabled=true`, `checksum-validation.enabled=true`) target AWS S3.
 
 ## Memory Optimization for Large Files
 


### PR DESCRIPTION
## What is the purpose of the change

Improve Native S3 FileSystem docs when using S3-compatible servers that do not support AWS checksum-validation

## Brief change log

update the doc file


## Verifying this change

doc/ md file content

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no) no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no) no
  - The serializers: (yes / no / don't know) no
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know) no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know) no
  - The S3 file system connector: (yes / no / don't know) yes 

## Documentation

  - Does this pull request introduce a new feature? (yes / no) no
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented) documentation change

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change the checkbox below to `[X]` followed by the name of the tool, and uncomment the
"Generated-by" line. See the ASF Generative Tooling Guidance for details:
https://www.apache.org/legal/generative-tooling.html

You are responsible for the quality and correctness of every change in this PR
regardless of the tooling used. Low-effort AI-generated PRs will be closed. See
AGENTS.md for the full guidance.
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name and Version]
-->
