### PR TITLE
[FLINK-40236][python] Fix _infer_type inferring ARRAY<NULL> for a list with a leading None

### DIFF
--- a/flink-python/pyflink/table/tests/test_types.py
+++ b/flink-python/pyflink/table/tests/test_types.py
@@ -209,6 +209,11 @@ class TypesTests(PyFlinkTestCase):
         # third column is varchar
         self.assertTrue(isinstance(schema.fields[2].data_type, VarCharType))
 
+    def test_infer_array_type_with_leading_none(self):
+        data_type = _infer_type([None, 1])
+        self.assertTrue(isinstance(data_type, ArrayType))
+        self.assertTrue(isinstance(data_type.element_type, BigIntType))
+
     def test_infer_schema_not_enough_names(self):
         schema = _infer_schema_from_data([["a", "b"]], ["col1"])
         self.assertTrue(schema.names, ['col1', '_2'])

--- a/flink-python/pyflink/table/types.py
+++ b/flink-python/pyflink/table/types.py
@@ -1491,7 +1491,7 @@ def _infer_type(obj):
     elif isinstance(obj, list):
         for v in obj:
             if v is not None:
-                return ArrayType(_infer_type(obj[0]))
+                return ArrayType(_infer_type(v))
         else:
             return ArrayType(NullType())
     elif isinstance(obj, array):


### PR DESCRIPTION
## What is the purpose of the change

`_infer_type` in `flink-python/pyflink/table/types.py` inferred a list's element type from `obj[0]` instead of the first non-`None` element it scans for. When the first element is `None`, the array element type collapsed to `NULL`, making schema inference order-dependent:

```
_infer_type([1, None]) -> ArrayType(BigIntType)   # correct
_infer_type([None, 1]) -> ArrayType(NullType)     # wrong; should be BigIntType
```

The `dict` branch just above already handles this correctly (it infers from the found non-`None` value). `from_elements([Row(c=[None, 1])])` without an explicit schema infers `ARRAY<NULL>`, which then typically errors downstream.

## Brief change log

  - Infer the array element type from the scanned non-`None` element `v` rather than `obj[0]`.

## Verifying this change

This change added a test and can be verified as follows:

  - Added `TypesTests.test_infer_array_type_with_leading_none` asserting `_infer_type([None, 1])` yields `ArrayType(BigIntType)`.
  - Verified against the released `apache-flink` wheel: the array element type is `NullType` before the fix and `BigIntType` after (the all-`None` case still yields `ARRAY<NULL>`).

The two commits demonstrate this: the first adds the test only (CI red — `test_infer_array_type_with_leading_none` fails with `AssertionError: False is not true`), the second applies the fix (CI green). Runs on my fork:

  - test only (fails): https://github.com/nikolauspschuetz/flink/actions/runs/30144289029/job/89646257914
  - with fix (passes): https://github.com/nikolauspschuetz/flink/actions/runs/30146231008/job/89649334451 (types module 457 passed / 2 skipped)

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (Claude Code)

Generated-by: Claude Code (Opus 4.8)


