### PR TITLE
[FLINK-40237][cep] Clean up expired NFA state in processing-time timers

### DIFF
--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/operator/CepOperator.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/operator/CepOperator.java
@@ -369,6 +369,11 @@ public class CepOperator<IN, KEY, OUT>
 
         // STEP 4
         updateNFA(nfa);
+
+        // In order to remove dangling partial matches.
+        if (nfa.getPartialMatches().size() == 1 && nfa.getCompletedMatches().isEmpty()) {
+            computationStates.clear();
+        }
     }
 
     private Stream<IN> sort(Collection<IN> elements) {
@@ -549,6 +554,12 @@ public class CepOperator<IN, KEY, OUT>
     boolean hasNonEmptyPQ(KEY key) throws Exception {
         setCurrentKey(key);
         return !elementQueueState.isEmpty();
+    }
+
+    @VisibleForTesting
+    boolean hasNonEmptyNFAState(KEY key) throws Exception {
+        setCurrentKey(key);
+        return computationStates.value() != null;
     }
 
     @VisibleForTesting

--- a/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/operator/CEPOperatorTest.java
+++ b/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/operator/CEPOperatorTest.java
@@ -929,6 +929,24 @@ public class CEPOperatorTest extends TestLogger {
     }
 
     @Test
+    public void testCEPOperatorClearsExpiredNFAStateInProcessingTime() throws Exception {
+        CepOperator<Event, Integer, Map<String, List<Event>>> operator = getKeyedCepOperator(true);
+
+        try (OneInputStreamOperatorTestHarness<Event, Map<String, List<Event>>> harness =
+                CepOperatorTestUtilities.getCepTestHarness(operator)) {
+            harness.open();
+            harness.setProcessingTime(1L);
+            harness.processElement(new StreamRecord<>(new Event(26, "start", 1.0)));
+
+            assertTrue(operator.hasNonEmptyNFAState(26));
+
+            harness.setProcessingTime(20L);
+
+            assertFalse(operator.hasNonEmptyNFAState(26));
+        }
+    }
+
+    @Test
     public void testCEPOperatorSerializationWRocksDB() throws Exception {
         String rocksDbPath = tempFolder.newFolder().getAbsolutePath();
         EmbeddedRocksDBStateBackend rocksDBStateBackend = new EmbeddedRocksDBStateBackend();


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*(For example: This pull request makes task deployment go through the blob server, rather than through RPC. That way we avoid re-transferring them on each deployment (during recovery).)*

This is a follow-up to FLINK-32701. `CepOperator` already cleans up dangling NFA state in `onEventTime()`, but the equivalent cleanup was missing from `onProcessingTime()`. As a result, after patterns expire under processing time, `computationStates` could retain only the initial partial match and never be cleared. This PR applies the same cleanup logic in the processing-time timer path.

## Brief change log

 - Clear `computationStates` in `onProcessingTime()` when only the initial partial match remains and there are no completed matches
  - Add `@VisibleForTesting` helper `hasNonEmptyNFAState(KEY)` to inspect per-key NFA state
  - Add `testCEPOperatorClearsExpiredNFAStateInProcessingTime` to verify expired NFA state is removed after the processing-time timer fires

## Verifying this change

- Added `CEPOperatorTest#testCEPOperatorClearsExpiredNFAStateInProcessingTime`, which processes a start event under processing time, asserts NFA state is present, advances processing time past the pattern timeout, and asserts NFA state is cleared


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable)

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change the checkbox below to `[X]` followed by the name of the tool, and uncomment the
"Generated-by" line. See the ASF Generative Tooling Guidance for details:
https://www.apache.org/legal/generative-tooling.html

You are responsible for the quality and correctness of every change in this PR
regardless of the tooling used. Low-effort AI-generated PRs will be closed. See
AGENTS.md for the full guidance.
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name and Version]
-->
