### PR TITLE
[hotfix][docs] Fix temporal table function expression examples

### DIFF
--- a/docs/content.zh/docs/concepts/sql-table-concepts/temporal_table_function.md
+++ b/docs/content.zh/docs/concepts/sql-table-concepts/temporal_table_function.md
@@ -121,14 +121,14 @@ WHERE
 ```java
 Table result = orders
     .joinLateral(call("rates", $("o_proctime")), $("o_currency").isEqual($("r_currency")))
-    .select($("(o_amount").times($("r_rate")).sum().as("amount"));
+    .select($("o_amount").times($("r_rate")).sum().as("amount"));
 ```
 {{< /tab >}}
 {{< tab "Scala" >}}
 ```scala
 val result = orders
     .joinLateral($"rates(order_time)", $"orders.currency = rates.currency")
-    .select($"(o_amount * r_rate).sum as amount"))
+    .select($"(o_amount * r_rate).sum as amount")
 ```
 {{< /tab >}}
 {{< tab "Python" >}}

--- a/docs/content/docs/concepts/sql-table-concepts/temporal_table_function.md
+++ b/docs/content/docs/concepts/sql-table-concepts/temporal_table_function.md
@@ -121,14 +121,14 @@ WHERE
 ```java
 Table result = orders
     .joinLateral(call("rates", $("o_proctime")), $("o_currency").isEqual($("r_currency")))
-    .select($("(o_amount").times($("r_rate")).sum().as("amount"));
+    .select($("o_amount").times($("r_rate")).sum().as("amount"));
 ```
 {{< /tab >}}
 {{< tab "Scala" >}}
 ```scala
 val result = orders
     .joinLateral($"rates(order_time)", $"orders.currency = rates.currency")
-    .select($"(o_amount * r_rate).sum as amount"))
+    .select($"(o_amount * r_rate).sum as amount")
 ```
 {{< /tab >}}
 {{< tab "Python" >}}


### PR DESCRIPTION
## What is the purpose of the change

The Java temporal table function example includes an opening parenthesis in the `o_amount` column name. The Scala example has an unmatched closing parenthesis. Both errors appear in the English and Chinese documentation.

## Brief change log

- Correct the `o_amount` reference in both Java examples.
- Remove the unmatched closing parenthesis from both Scala examples.

## Verifying this change

The English and Chinese documentation build successfully with Hugo.

## Does this pull request potentially affect one of the following parts:

- Dependencies: no
- Public API: no
- Serializers: no
- Runtime per-record code paths: no
- Deployment or recovery: no
- S3 file system connector: no

## Documentation

- Does this pull request introduce a new feature? no

---

##### Was generative AI tooling used to co-author this PR?

- [X] No