### PR TITLE
[FLINK-40169][table] Add target option to the EARLY_FIRE hint

### DIFF
--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/config/EarlyFireJoinHintOptions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/config/EarlyFireJoinHintOptions.java
@@ -36,13 +36,13 @@ import static org.apache.flink.configuration.ConfigOptions.key;
 @PublicEvolving
 public class EarlyFireJoinHintOptions {
 
-    /** The only operator kind the EARLY_FIRE hint applies to. */
+    /** The only operator kind the EARLY_FIRE hint currently supports. */
     public static final String INTERVAL_JOIN = "interval_join";
 
     public static final ConfigOption<String> TARGET =
             key("target")
                     .stringType()
-                    .defaultValue(INTERVAL_JOIN)
+                    .noDefaultValue()
                     .withDescription(
                             "The operator kind that the EARLY_FIRE hint applies to. Currently only"
                                     + " 'interval_join' is supported. When omitted, the hint applies"

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/config/EarlyFireJoinHintOptions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/config/EarlyFireJoinHintOptions.java
@@ -42,7 +42,7 @@ public class EarlyFireJoinHintOptions {
     public static final ConfigOption<String> TARGET =
             key("target")
                     .stringType()
-                    .noDefaultValue()
+                    .defaultValue(INTERVAL_JOIN)
                     .withDescription(
                             "The operator kind that the EARLY_FIRE hint applies to. Currently only"
                                     + " 'interval_join' is supported. When omitted, the hint applies"

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/config/EarlyFireJoinHintOptions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/config/EarlyFireJoinHintOptions.java
@@ -36,6 +36,18 @@ import static org.apache.flink.configuration.ConfigOptions.key;
 @PublicEvolving
 public class EarlyFireJoinHintOptions {
 
+    /** The only operator kind the EARLY_FIRE hint applies to. */
+    public static final String INTERVAL_JOIN = "interval_join";
+
+    public static final ConfigOption<String> TARGET =
+            key("target")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "The operator kind that the EARLY_FIRE hint applies to. Currently only"
+                                    + " 'interval_join' is supported. When omitted, the hint applies"
+                                    + " to the interval join.");
+
     public static final ConfigOption<Duration> DELAY =
             key("delay")
                     .durationType()
@@ -60,6 +72,7 @@ public class EarlyFireJoinHintOptions {
     static {
         requiredKeys.add(DELAY);
 
+        supportedKeys.add(TARGET);
         supportedKeys.add(DELAY);
         supportedKeys.add(TIME_MODE);
     }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/hint/FlinkHintStrategies.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/hint/FlinkHintStrategies.java
@@ -311,7 +311,7 @@ public abstract class FlinkHintStrategies {
 
                 String target = conf.get(EarlyFireJoinHintOptions.TARGET);
                 litmus.check(
-                        EarlyFireJoinHintOptions.INTERVAL_JOIN.equals(target),
+                        null == target || EarlyFireJoinHintOptions.INTERVAL_JOIN.equals(target),
                         "Invalid EARLY_FIRE hint option: {} value '{}' is not supported, only '{}' is supported currently",
                         EarlyFireJoinHintOptions.TARGET.key(),
                         target,

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/hint/FlinkHintStrategies.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/hint/FlinkHintStrategies.java
@@ -311,7 +311,7 @@ public abstract class FlinkHintStrategies {
 
                 String target = conf.get(EarlyFireJoinHintOptions.TARGET);
                 litmus.check(
-                        null == target || EarlyFireJoinHintOptions.INTERVAL_JOIN.equals(target),
+                        EarlyFireJoinHintOptions.INTERVAL_JOIN.equals(target),
                         "Invalid EARLY_FIRE hint option: {} value '{}' is not supported, only '{}' is supported currently",
                         EarlyFireJoinHintOptions.TARGET.key(),
                         target,

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/hint/FlinkHintStrategies.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/hint/FlinkHintStrategies.java
@@ -308,6 +308,14 @@ public abstract class FlinkHintStrategies {
                         "Invalid EARLY_FIRE hint option: {} value should be at least 1 millisecond but was {}",
                         EarlyFireJoinHintOptions.DELAY.key(),
                         delay);
+
+                String target = conf.get(EarlyFireJoinHintOptions.TARGET);
+                litmus.check(
+                        null == target || EarlyFireJoinHintOptions.INTERVAL_JOIN.equals(target),
+                        "Invalid EARLY_FIRE hint option: {} value '{}' is not supported, only '{}' is supported currently",
+                        EarlyFireJoinHintOptions.TARGET.key(),
+                        target,
+                        EarlyFireJoinHintOptions.INTERVAL_JOIN);
                 return true;
             };
 

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/physical/stream/StreamPhysicalIntervalJoinRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/physical/stream/StreamPhysicalIntervalJoinRule.java
@@ -173,7 +173,7 @@ public class StreamPhysicalIntervalJoinRule
         // target scopes the hint to one operator kind: this rule applies it only when it targets
         // the interval join, and leaves a hint aimed at any other operator kind untouched.
         String target = conf.get(EarlyFireJoinHintOptions.TARGET);
-        if (target != null && !EarlyFireJoinHintOptions.INTERVAL_JOIN.equals(target)) {
+        if (!EarlyFireJoinHintOptions.INTERVAL_JOIN.equals(target)) {
             return new EarlyFire(null, null);
         }
         Duration delay = conf.get(EarlyFireJoinHintOptions.DELAY);

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/physical/stream/StreamPhysicalIntervalJoinRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/physical/stream/StreamPhysicalIntervalJoinRule.java
@@ -170,6 +170,12 @@ public class StreamPhysicalIntervalJoinRule
         }
 
         Configuration conf = Configuration.fromMap(earlyFireHint.kvOptions);
+        // target scopes the hint to one operator kind: this rule applies it only when it targets
+        // the interval join, and leaves a hint aimed at any other operator kind untouched.
+        String target = conf.get(EarlyFireJoinHintOptions.TARGET);
+        if (target != null && !EarlyFireJoinHintOptions.INTERVAL_JOIN.equals(target)) {
+            return new EarlyFire(null, null);
+        }
         Duration delay = conf.get(EarlyFireJoinHintOptions.DELAY);
         TimeMode timeMode = conf.get(EarlyFireJoinHintOptions.TIME_MODE);
         if (timeMode == null) {

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/physical/stream/StreamPhysicalIntervalJoinRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/physical/stream/StreamPhysicalIntervalJoinRule.java
@@ -173,7 +173,7 @@ public class StreamPhysicalIntervalJoinRule
         // target scopes the hint to one operator kind: this rule applies it only when it targets
         // the interval join, and leaves a hint aimed at any other operator kind untouched.
         String target = conf.get(EarlyFireJoinHintOptions.TARGET);
-        if (!EarlyFireJoinHintOptions.INTERVAL_JOIN.equals(target)) {
+        if (target != null && !EarlyFireJoinHintOptions.INTERVAL_JOIN.equals(target)) {
             return new EarlyFire(null, null);
         }
         Duration delay = conf.get(EarlyFireJoinHintOptions.DELAY);

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/hints/stream/EarlyFireJoinHintTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/hints/stream/EarlyFireJoinHintTest.java
@@ -141,6 +141,17 @@ class EarlyFireJoinHintTest extends TableTestBase {
     }
 
     @Test
+    void testEarlyFireUnsupportedTarget() {
+        String sql =
+                "SELECT /*+ EARLY_FIRE('target'='window_join', 'delay'='5s') */ t1.a, t2.b\n"
+                        + "FROM MyTable t1 LEFT OUTER JOIN MyTable2 t2 ON\n"
+                        + "  t1.a = t2.a AND\n"
+                        + "  t1.rowtime BETWEEN t2.rowtime - INTERVAL '10' SECOND AND t2.rowtime + INTERVAL '1' HOUR";
+        assertThatThrownBy(() -> verify(sql))
+                .hasMessageContaining("target value 'window_join' is not supported");
+    }
+
+    @Test
     void testEarlyFireLowerCaseHintNamePreservesOptions() {
         String sql =
                 "SELECT /*+ early_fire('delay'='5s', 'time-mode'='rowtime') */ t1.a, t2.b\n"
@@ -154,6 +165,16 @@ class EarlyFireJoinHintTest extends TableTestBase {
     void testEarlyFireOnRowTimeLeftOuterJoin() {
         String sql =
                 "SELECT /*+ EARLY_FIRE('delay'='5s') */ t1.a, t2.b\n"
+                        + "FROM MyTable t1 LEFT OUTER JOIN MyTable2 t2 ON\n"
+                        + "  t1.a = t2.a AND\n"
+                        + "  t1.rowtime BETWEEN t2.rowtime - INTERVAL '10' SECOND AND t2.rowtime + INTERVAL '1' HOUR";
+        verify(sql);
+    }
+
+    @Test
+    void testEarlyFireExplicitTargetIntervalJoin() {
+        String sql =
+                "SELECT /*+ EARLY_FIRE('target'='interval_join', 'delay'='5s') */ t1.a, t2.b\n"
                         + "FROM MyTable t1 LEFT OUTER JOIN MyTable2 t2 ON\n"
                         + "  t1.a = t2.a AND\n"
                         + "  t1.rowtime BETWEEN t2.rowtime - INTERVAL '10' SECOND AND t2.rowtime + INTERVAL '1' HOUR";

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/hints/stream/EarlyFireJoinHintTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/hints/stream/EarlyFireJoinHintTest.xml
@@ -16,6 +16,38 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 <Root>
+  <TestCase name="testEarlyFireExplicitTargetIntervalJoin">
+    <Resource name="sql">
+      <![CDATA[SELECT /*+ EARLY_FIRE('target'='interval_join', 'delay'='5s') */ t1.a, t2.b
+FROM MyTable t1 LEFT OUTER JOIN MyTable2 t2 ON
+  t1.a = t2.a AND
+  t1.rowtime BETWEEN t2.rowtime - INTERVAL '10' SECOND AND t2.rowtime + INTERVAL '1' HOUR]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$6])
++- LogicalJoin(condition=[AND(=($0, $5), >=($4, -($9, 10000:INTERVAL SECOND)), <=($4, +($9, 3600000:INTERVAL HOUR)))], joinType=[left], joinHints=[[[EARLY_FIRE inheritPath:[0] options:{delay=5s, target=interval_join}]]])
+   :- LogicalWatermarkAssigner(rowtime=[rowtime], watermark=[$4])
+   :  +- LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[PROCTIME()], rowtime=[$3])
+   :     +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+   +- LogicalWatermarkAssigner(rowtime=[rowtime], watermark=[$4])
+      +- LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[PROCTIME()], rowtime=[$3])
+         +- LogicalTableScan(table=[[default_catalog, default_database, MyTable2]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[a, b])
++- IntervalJoin(joinType=[LeftOuterJoin], windowBounds=[isRowTime=true, leftLowerBound=-10000, leftUpperBound=3600000, leftTimeIndex=1, rightTimeIndex=2], where=[((a = a0) AND (rowtime >= (rowtime0 - 10000:INTERVAL SECOND)) AND (rowtime <= (rowtime0 + 3600000:INTERVAL HOUR)))], select=[a, rowtime, a0, b, rowtime0], earlyFireDelay=[5000], earlyFireTimeMode=[ROWTIME])
+   :- Exchange(distribution=[hash[a]])
+   :  +- WatermarkAssigner(rowtime=[rowtime], watermark=[rowtime])
+   :     +- TableSourceScan(table=[[default_catalog, default_database, MyTable, project=[a, rowtime], metadata=[]]], fields=[a, rowtime])
+   +- Exchange(distribution=[hash[a]])
+      +- WatermarkAssigner(rowtime=[rowtime], watermark=[rowtime])
+         +- TableSourceScan(table=[[default_catalog, default_database, MyTable2, project=[a, b, rowtime], metadata=[]]], fields=[a, b, rowtime])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testEarlyFireLowerCaseHintNamePreservesOptions">
     <Resource name="sql">
       <![CDATA[SELECT /*+ early_fire('delay'='5s', 'time-mode'='rowtime') */ t1.a, t2.b


### PR DESCRIPTION
Part of the FLIP-497 implementation stack under umbrella [FLINK-36953](https://issues.apache.org/jira/browse/FLINK-36953). Landing order:

| Step | Sub-task | Scope |
| --- | --- | --- |
| PR-1a | [FLINK-40167](https://issues.apache.org/jira/browse/FLINK-40167) | EARLY_FIRE hint surface + option validation (#28353, merged) |
| PR-1b | [FLINK-40168](https://issues.apache.org/jira/browse/FLINK-40168) | Thread the hint into the interval join (#28796, merged) |
| **PR-2 (this PR)** | [FLINK-40169](https://issues.apache.org/jira/browse/FLINK-40169) | `target` option |
| PR-3 | [FLINK-40170](https://issues.apache.org/jira/browse/FLINK-40170) | Update-producing changelog mode + insert-only guard |
| PR-4 | [FLINK-40171](https://issues.apache.org/jira/browse/FLINK-40171) | Runtime early-fire emit + retraction |
| PR-5 | [FLINK-40172](https://issues.apache.org/jira/browse/FLINK-40172) | Processing-time early fire on an event-time join |
| PR-6 | [FLINK-40173](https://issues.apache.org/jira/browse/FLINK-40173) | State restore coverage |
| PR-7 | [FLINK-40174](https://issues.apache.org/jira/browse/FLINK-40174) | User-facing documentation |

## What is the purpose of the change

Adds an optional `target` option to the `EARLY_FIRE` hint so a hint can be explicitly scoped to a single operator kind. Only `interval_join` is accepted today, and an omitted `target` means `interval_join`, so existing hints keep their meaning. This is a forward-compatibility guard: it keeps a bare `EARLY_FIRE` hint from silently expanding its scope if other operators honor the hint in the future.

## Brief change log

  - Add `EarlyFireJoinHintOptions.TARGET` (optional `stringType`) and the `INTERVAL_JOIN` constant.
  - The `EARLY_FIRE` KV option checker validates `target` against the supported set. Any other value fails planning.
  - `StreamPhysicalIntervalJoinRule` applies the hint only when it targets the interval join, and leaves a hint aimed at another operator kind untouched. That rule-level check is redundant with validation today, since an unsupported value already fails planning. It is there so that a hint aimed at a future operator kind is ignored by this rule rather than misapplied.

## Verifying this change

This change added tests and can be verified as follows:

  - `EarlyFireJoinHintTest`: an explicit `target='interval_join'` still threads `earlyFireDelay`/`earlyFireTimeMode` into the exec plan, and an unsupported `target` value fails planning with a message naming the supported set.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes (a new option on the `@PublicEvolving` `EarlyFireJoinHintOptions`)
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes (an option on the FLIP-497 hint)
  - If yes, how is the feature documented? in the documentation PR at the end of this stack (PR-7)

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: Claude Code (Anthropic)
