### PR TITLE
[FLINK-40222][table] Fix precision loss for INTERVAL literals

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/expressions/ValueLiteralExpression.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/expressions/ValueLiteralExpression.java
@@ -414,7 +414,7 @@ public final class ValueLiteralExpression implements ResolvedExpression {
             YearMonthIntervalType type, Period period) {
         final long totalMonths = period.toTotalMonths();
         final long years = totalMonths / 12;
-        final long months = totalMonths % 12;
+        final int months = (int) (totalMonths % 12);
         final int yearPrecision = type.getYearPrecision();
         return String.format("INTERVAL '%d-%d' YEAR(%d) TO MONTH", years, months, yearPrecision);
     }
@@ -426,9 +426,9 @@ public final class ValueLiteralExpression implements ResolvedExpression {
     private static String formatDayTimeIntervalLiteral(
             DayTimeIntervalType type, Duration duration) {
         final long days = duration.toDays();
-        final long hours = duration.toHours() % 24;
-        final long minutes = duration.toMinutes() % 60;
-        final long seconds = duration.getSeconds() % 60;
+        final int hours = duration.toHoursPart();
+        final int minutes = duration.toMinutesPart();
+        final int seconds = duration.toSecondsPart();
         final int dayPrecision = type.getDayPrecision();
         final int fractionalPrecision = type.getFractionalPrecision();
         final String fraction = formatFractionalSeconds(duration.getNano(), fractionalPrecision);

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/expressions/ValueLiteralExpression.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/expressions/ValueLiteralExpression.java
@@ -23,11 +23,13 @@ import org.apache.flink.table.api.TableException;
 import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.inference.CallContext;
+import org.apache.flink.table.types.logical.DayTimeIntervalType;
 import org.apache.flink.table.types.logical.DecimalType;
 import org.apache.flink.table.types.logical.LocalZonedTimestampType;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.LogicalTypeFamily;
 import org.apache.flink.table.types.logical.LogicalTypeRoot;
+import org.apache.flink.table.types.logical.YearMonthIntervalType;
 import org.apache.flink.table.types.utils.ValueDataTypeConverter;
 import org.apache.flink.table.utils.DateTimeUtils;
 import org.apache.flink.table.utils.EncodingUtils;
@@ -288,18 +290,11 @@ public final class ValueLiteralExpression implements ResolvedExpression {
                         getValueAs(Instant.class).get(),
                         ((LocalZonedTimestampType) dataType.getLogicalType()).getPrecision());
             case INTERVAL_YEAR_MONTH:
-                final Period period = getValueAs(Period.class).get().normalized();
-                return String.format(
-                        "INTERVAL '%d-%d' YEAR TO MONTH", period.getYears(), period.getMonths());
+                return formatYearMonthIntervalLiteral(
+                        (YearMonthIntervalType) logicalType, getValueAs(Period.class).get());
             case INTERVAL_DAY_TIME:
-                final Duration duration = getValueAs(Duration.class).get();
-                return String.format(
-                        "INTERVAL '%d %02d:%02d:%02d.%d' DAY TO SECOND(3)",
-                        duration.toDays(),
-                        duration.toHours() % 24,
-                        duration.toMinutes() % 60,
-                        duration.getSeconds() % 60,
-                        duration.getNano() / 1_000_000);
+                return formatDayTimeIntervalLiteral(
+                        (DayTimeIntervalType) logicalType, getValueAs(Duration.class).get());
             case DESCRIPTOR:
                 final ColumnList columnList = getValueAs(ColumnList.class).get();
                 if (!columnList.getDataTypes().isEmpty()) {
@@ -409,6 +404,51 @@ public final class ValueLiteralExpression implements ResolvedExpression {
                             "Data type '%s' does not support a conversion from class '%s'.",
                             dataType, candidate.getName()));
         }
+    }
+
+    /**
+     * Formats a year-month interval value as a SQL literal, including explicit precision on the
+     * {@code YEAR} field.
+     */
+    private static String formatYearMonthIntervalLiteral(
+            YearMonthIntervalType type, Period period) {
+        final long totalMonths = period.toTotalMonths();
+        final long years = totalMonths / 12;
+        final long months = totalMonths % 12;
+        final int yearPrecision = type.getYearPrecision();
+        return String.format("INTERVAL '%d-%d' YEAR(%d) TO MONTH", years, months, yearPrecision);
+    }
+
+    /**
+     * Formats a day-time interval value as a SQL literal, including explicit precision on the
+     * {@code DAY} and {@code SECOND} field.
+     */
+    private static String formatDayTimeIntervalLiteral(
+            DayTimeIntervalType type, Duration duration) {
+        final long days = duration.toDays();
+        final long hours = duration.toHours() % 24;
+        final long minutes = duration.toMinutes() % 60;
+        final long seconds = duration.getSeconds() % 60;
+        final int dayPrecision = type.getDayPrecision();
+        final int fractionalPrecision = type.getFractionalPrecision();
+        final String fraction = formatFractionalSeconds(duration.getNano(), fractionalPrecision);
+
+        return String.format(
+                "INTERVAL '%d %02d:%02d:%02d%s' DAY(%d) TO SECOND(%d)",
+                days, hours, minutes, seconds, fraction, dayPrecision, fractionalPrecision);
+    }
+
+    /**
+     * Formats the fractional-seconds suffix (including the leading {@code .}) from a raw nanosecond
+     * value to {@code fractionalPrecision} digits. Returns an empty string when {@code
+     * fractionalPrecision} is 0.
+     */
+    private static String formatFractionalSeconds(int nanos, int fractionalPrecision) {
+        if (fractionalPrecision == 0) {
+            return "";
+        }
+        final String nanosString = String.format("%09d", nanos);
+        return "." + nanosString.substring(0, fractionalPrecision);
     }
 
     /** Supports (nested) arrays and makes string values more explicit. */

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/utils/ValueDataTypeConverter.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/utils/ValueDataTypeConverter.java
@@ -218,11 +218,11 @@ public final class ValueDataTypeConverter {
     }
 
     private static int yearPrecision(long years) {
-        return String.valueOf(years).length();
+        return String.valueOf(Math.abs(years)).length();
     }
 
     private static int dayPrecision(long days) {
-        return String.valueOf(days).length();
+        return String.valueOf(Math.abs(days)).length();
     }
 
     private ValueDataTypeConverter() {

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/utils/ValueDataTypeConverter.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/utils/ValueDataTypeConverter.java
@@ -83,8 +83,7 @@ public final class ValueDataTypeConverter {
             convertedDataType =
                     convertToLocalZonedTimestampType(((java.time.Instant) value).getNano());
         } else if (value instanceof java.time.Period) {
-            convertedDataType =
-                    convertToYearMonthIntervalType(((java.time.Period) value).getYears());
+            convertedDataType = convertToYearMonthIntervalType((java.time.Period) value);
         } else if (value instanceof java.time.Duration) {
             final java.time.Duration duration = (java.time.Duration) value;
             convertedDataType = convertToDayTimeIntervalType(duration.toDays(), duration.getNano());
@@ -156,7 +155,8 @@ public final class ValueDataTypeConverter {
         return DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(fractionalSecondPrecision(nanos));
     }
 
-    private static DataType convertToYearMonthIntervalType(int years) {
+    private static DataType convertToYearMonthIntervalType(java.time.Period period) {
+        final long years = period.toTotalMonths() / 12;
         return DataTypes.INTERVAL(DataTypes.YEAR(yearPrecision(years)), DataTypes.MONTH());
     }
 
@@ -217,7 +217,7 @@ public final class ValueDataTypeConverter {
         return String.format("%09d", nanos).replaceAll("0+$", "").length();
     }
 
-    private static int yearPrecision(int years) {
+    private static int yearPrecision(long years) {
         return String.valueOf(years).length();
     }
 

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/expressions/ExpressionTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/expressions/ExpressionTest.java
@@ -22,6 +22,7 @@ import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.functions.ScalarFunction;
 import org.apache.flink.table.functions.ScalarFunctionDefinition;
+import org.apache.flink.table.types.DataType;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -33,6 +34,7 @@ import java.nio.charset.StandardCharsets;
 import java.sql.Date;
 import java.sql.Time;
 import java.sql.Timestamp;
+import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -293,6 +295,16 @@ class ExpressionTest {
                 .isEqualTo(expected);
     }
 
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("intervalLiteralTestCases")
+    void testIntervalAsSerializableString(
+            String caseName, Object value, DataType dataType, String expected) {
+        assertThat(
+                        new ValueLiteralExpression(value, dataType)
+                                .asSerializableString(DefaultSqlFactory.INSTANCE))
+                .isEqualTo(expected);
+    }
+
     // --------------------------------------------------------------------------------------------
 
     private static Expression createExpressionTree(Integer nestedValue) {
@@ -364,5 +376,119 @@ class ExpressionTest {
                         Instant.ofEpochSecond(-9223372036L, 0),
                         9,
                         "TO_TIMESTAMP_LTZ(-9223372036000000000, 9)"));
+    }
+
+    private static Stream<Arguments> intervalLiteralTestCases() {
+        return Stream.of(
+                Arguments.of(
+                        "YEAR_TO_MONTH maximum",
+                        Period.of(9999, 11, 0),
+                        DataTypes.INTERVAL(DataTypes.YEAR(4), DataTypes.MONTH()).notNull(),
+                        "INTERVAL '9999-11' YEAR(4) TO MONTH"),
+                Arguments.of(
+                        "YEAR_TO_MONTH default precision",
+                        Period.ofMonths(470),
+                        DataTypes.INTERVAL(DataTypes.YEAR(), DataTypes.MONTH()).notNull(),
+                        "INTERVAL '39-2' YEAR(2) TO MONTH"),
+                Arguments.of(
+                        "YEAR with months not dropped",
+                        Period.of(5, 3, 0),
+                        DataTypes.INTERVAL(DataTypes.YEAR()).notNull(),
+                        "INTERVAL '5-3' YEAR(2) TO MONTH"),
+                Arguments.of(
+                        "YEAR only whole years",
+                        Period.ofYears(120),
+                        DataTypes.INTERVAL(DataTypes.YEAR(3)).notNull(),
+                        "INTERVAL '120-0' YEAR(3) TO MONTH"),
+                Arguments.of(
+                        "MONTH only",
+                        Period.ofMonths(50),
+                        DataTypes.INTERVAL(DataTypes.MONTH()).notNull(),
+                        "INTERVAL '4-2' YEAR(2) TO MONTH"),
+                Arguments.of(
+                        "DAY(3) three-digit value",
+                        Duration.ofDays(100),
+                        DataTypes.INTERVAL(DataTypes.DAY(3)).notNull(),
+                        "INTERVAL '100 00:00:00.000000' DAY(3) TO SECOND(6)"),
+                Arguments.of(
+                        "DAY_TO_HOUR",
+                        Duration.ofDays(5).plusHours(7),
+                        DataTypes.INTERVAL(DataTypes.DAY(2), DataTypes.HOUR()).notNull(),
+                        "INTERVAL '5 07:00:00.000000' DAY(2) TO SECOND(6)"),
+                Arguments.of(
+                        "DAY_TO_MINUTE",
+                        Duration.ofDays(5).plusHours(7).plusMinutes(8),
+                        DataTypes.INTERVAL(DataTypes.DAY(2), DataTypes.MINUTE()).notNull(),
+                        "INTERVAL '5 07:08:00.000000' DAY(2) TO SECOND(6)"),
+                Arguments.of(
+                        "DAY_TO_SECOND fractional padding",
+                        Duration.ofDays(1).plusMillis(5),
+                        DataTypes.INTERVAL(DataTypes.DAY(2), DataTypes.SECOND(3)).notNull(),
+                        "INTERVAL '1 00:00:00.005' DAY(2) TO SECOND(3)"),
+                Arguments.of(
+                        "DAY_TO_SECOND nanosecond precision (string only; sub-ms not round-trippable)",
+                        Duration.ofDays(99).plusSeconds(34).plusNanos(999_000_001),
+                        DataTypes.INTERVAL(DataTypes.DAY(2), DataTypes.SECOND(9)).notNull(),
+                        "INTERVAL '99 00:00:34.999000001' DAY(2) TO SECOND(9)"),
+                Arguments.of(
+                        "DAY_TO_SECOND zero fractional precision",
+                        Duration.ofDays(1).plusSeconds(30),
+                        DataTypes.INTERVAL(DataTypes.DAY(2), DataTypes.SECOND(0)).notNull(),
+                        "INTERVAL '1 00:00:30' DAY(2) TO SECOND(0)"),
+                Arguments.of(
+                        "HOUR only preserves whole value",
+                        Duration.ofHours(30),
+                        DataTypes.INTERVAL(DataTypes.HOUR()).notNull(),
+                        "INTERVAL '1 06:00:00.000000' DAY(2) TO SECOND(6)"),
+                Arguments.of(
+                        "HOUR with minutes not dropped",
+                        Duration.ofHours(5).plusMinutes(30),
+                        DataTypes.INTERVAL(DataTypes.HOUR()).notNull(),
+                        "INTERVAL '0 05:30:00.000000' DAY(2) TO SECOND(6)"),
+                Arguments.of(
+                        "HOUR_TO_MINUTE",
+                        Duration.ofHours(30).plusMinutes(15),
+                        DataTypes.INTERVAL(DataTypes.HOUR(), DataTypes.MINUTE()).notNull(),
+                        "INTERVAL '1 06:15:00.000000' DAY(2) TO SECOND(6)"),
+                Arguments.of(
+                        "HOUR_TO_SECOND",
+                        Duration.ofHours(30).plusMinutes(15).plusSeconds(20).plusNanos(500_000_000),
+                        DataTypes.INTERVAL(DataTypes.HOUR(), DataTypes.SECOND(6)).notNull(),
+                        "INTERVAL '1 06:15:20.500000' DAY(2) TO SECOND(6)"),
+                Arguments.of(
+                        "MINUTE only",
+                        Duration.ofMinutes(45),
+                        DataTypes.INTERVAL(DataTypes.MINUTE()).notNull(),
+                        "INTERVAL '0 00:45:00.000000' DAY(2) TO SECOND(6)"),
+                Arguments.of(
+                        "MINUTE >= 100 (0 days, fits DAY(2))",
+                        Duration.ofMinutes(100),
+                        DataTypes.INTERVAL(DataTypes.MINUTE()).notNull(),
+                        "INTERVAL '0 01:40:00.000000' DAY(2) TO SECOND(6)"),
+                Arguments.of(
+                        "MINUTE_TO_SECOND",
+                        Duration.ofMinutes(45).plusSeconds(45).plusMillis(120),
+                        DataTypes.INTERVAL(DataTypes.MINUTE(), DataTypes.SECOND(2)).notNull(),
+                        "INTERVAL '0 00:45:45.12' DAY(2) TO SECOND(2)"),
+                Arguments.of(
+                        "SECOND standalone",
+                        Duration.ofSeconds(45).plusMillis(750),
+                        DataTypes.INTERVAL(DataTypes.SECOND(4)).notNull(),
+                        "INTERVAL '0 00:00:45.7500' DAY(2) TO SECOND(4)"),
+                Arguments.of(
+                        "SECOND >= 100 (0 days, fits DAY(2))",
+                        Duration.ofSeconds(150),
+                        DataTypes.INTERVAL(DataTypes.SECOND(3)).notNull(),
+                        "INTERVAL '0 00:02:30.000' DAY(2) TO SECOND(3)"),
+                Arguments.of(
+                        "Large day value under its natural DAY(3) type (= 10000 hours)",
+                        Duration.ofDays(416).plusHours(16),
+                        DataTypes.INTERVAL(DataTypes.DAY(3), DataTypes.HOUR()).notNull(),
+                        "INTERVAL '416 16:00:00.000000' DAY(3) TO SECOND(6)"),
+                Arguments.of(
+                        "DAY maximum precision",
+                        Duration.ofDays(999_999),
+                        DataTypes.INTERVAL(DataTypes.DAY(6)).notNull(),
+                        "INTERVAL '999999 00:00:00.000000' DAY(6) TO SECOND(6)"));
     }
 }

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/ValueDataTypeConverterTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/ValueDataTypeConverterTest.java
@@ -87,6 +87,10 @@ class ValueDataTypeConverterTest {
                         DataTypes.INTERVAL(DataTypes.YEAR(4), DataTypes.MONTH())
                                 .bridgedTo(Period.class)),
                 of(
+                        Period.ofMonths(470),
+                        DataTypes.INTERVAL(DataTypes.YEAR(2), DataTypes.MONTH())
+                                .bridgedTo(Period.class)),
+                of(
                         Duration.ofMillis(1100),
                         DataTypes.INTERVAL(DataTypes.DAY(1), DataTypes.SECOND(1))
                                 .bridgedTo(Duration.class)),

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/calcite/FlinkTypeFactory.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/calcite/FlinkTypeFactory.java
@@ -42,6 +42,7 @@ import org.apache.flink.table.types.logical.BitmapType;
 import org.apache.flink.table.types.logical.BooleanType;
 import org.apache.flink.table.types.logical.CharType;
 import org.apache.flink.table.types.logical.DateType;
+import org.apache.flink.table.types.logical.DayTimeIntervalType;
 import org.apache.flink.table.types.logical.DecimalType;
 import org.apache.flink.table.types.logical.DescriptorType;
 import org.apache.flink.table.types.logical.DoubleType;
@@ -798,7 +799,7 @@ public class FlinkTypeFactory extends JavaTypeFactoryImpl implements ExtendedRel
             case INTERVAL_MINUTE:
             case INTERVAL_MINUTE_SECOND:
             case INTERVAL_SECOND:
-                if (relDataType.getPrecision() > 3) {
+                if (relDataType.getPrecision() > DayTimeIntervalType.MAX_DAY_PRECISION) {
                     throw new TableException(
                             "DAY_INTERVAL_TYPES precision is not supported: "
                                     + relDataType.getPrecision());

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/api/QueryOperationTestPrograms.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/api/QueryOperationTestPrograms.java
@@ -281,7 +281,7 @@ public class QueryOperationTestPrograms {
                                     + "        TUMBLE((\n"
                                     + "            SELECT `$$T_SOURCE`.`a`, `$$T_SOURCE`.`b`, "
                                     + "`$$T_SOURCE`.`ts` FROM `default_catalog`.`default_database`.`s` $$T_SOURCE\n"
-                                    + "        ), DESCRIPTOR(`ts`), INTERVAL '0 00:00:05.0' DAY TO SECOND(3))\n"
+                                    + "        ), DESCRIPTOR(`ts`), INTERVAL '0 00:00:05.000' DAY(2) TO SECOND(3))\n"
                                     + "    ) $$T_WIN_AGG GROUP BY window_start, window_end, `$$T_WIN_AGG`.`b`\n"
                                     + ") $$T_PROJECT")
                     .build();
@@ -961,8 +961,8 @@ public class QueryOperationTestPrograms {
                     .runSql(
                             "SELECT `$$T_PROJECT`.`k`, (LAST_VALUE(`$$T_PROJECT`.`v`) "
                                     + "OVER(PARTITION BY `$$T_PROJECT`.`k` "
-                                    + "ORDER BY `$$T_PROJECT`.`ts` RANGE BETWEEN INTERVAL '0 "
-                                    + "00:00:02.0' DAY TO SECOND(3) PRECEDING AND CURRENT ROW)) AS `_c1`, `$$T_PROJECT`.`ts` FROM (\n"
+                                    + "ORDER BY `$$T_PROJECT`.`ts` RANGE BETWEEN INTERVAL "
+                                    + "'0 00:00:02.000' DAY(2) TO SECOND(3) PRECEDING AND CURRENT ROW)) AS `_c1`, `$$T_PROJECT`.`ts` FROM (\n"
                                     + "    SELECT `$$T_SOURCE`.`k`, `$$T_SOURCE`.`v`, "
                                     + "`$$T_SOURCE`.`ts` FROM `default_catalog`.`default_database`.`data` $$T_SOURCE\n"
                                     + ") $$T_PROJECT")

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/calcite/FlinkTypeFactoryTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/calcite/FlinkTypeFactoryTest.java
@@ -22,12 +22,15 @@ import org.apache.flink.api.common.serialization.SerializerConfigImpl;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeinfo.Types;
 import org.apache.flink.api.java.typeutils.runtime.kryo.KryoSerializer;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.api.TableException;
 import org.apache.flink.table.legacy.types.logical.TypeInformationRawType;
 import org.apache.flink.table.types.logical.ArrayType;
 import org.apache.flink.table.types.logical.BigIntType;
 import org.apache.flink.table.types.logical.BooleanType;
 import org.apache.flink.table.types.logical.CharType;
 import org.apache.flink.table.types.logical.DateType;
+import org.apache.flink.table.types.logical.DayTimeIntervalType;
 import org.apache.flink.table.types.logical.DecimalType;
 import org.apache.flink.table.types.logical.DoubleType;
 import org.apache.flink.table.types.logical.FloatType;
@@ -47,7 +50,10 @@ import org.apache.flink.table.types.logical.VarBinaryType;
 import org.apache.flink.table.types.logical.VarCharType;
 import org.apache.flink.table.types.logical.utils.LogicalTypeMerging;
 
+import org.apache.calcite.avatica.util.TimeUnit;
 import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.sql.SqlIntervalQualifier;
+import org.apache.calcite.sql.parser.SqlParserPos;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
@@ -62,6 +68,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Tests for {@link FlinkTypeFactory}. */
 @Execution(ExecutionMode.CONCURRENT)
@@ -135,6 +142,47 @@ class FlinkTypeFactoryTest {
                         FlinkTypeFactory.toLogicalType(
                                 typeFactory.createFieldTypeFromLogicalType(logicalType.copy(true))))
                 .isEqualTo(logicalType.copy(true));
+    }
+
+    @Test
+    void testDayTimeIntervalLeadingPrecisionUpToMaxIsSupported() {
+        FlinkTypeFactory typeFactory =
+                new FlinkTypeFactory(
+                        Thread.currentThread().getContextClassLoader(), FlinkTypeSystem.INSTANCE);
+
+        RelDataType intervalType =
+                typeFactory.createSqlIntervalType(
+                        new SqlIntervalQualifier(
+                                TimeUnit.DAY,
+                                DayTimeIntervalType.MAX_DAY_PRECISION,
+                                TimeUnit.SECOND,
+                                RelDataType.PRECISION_NOT_SPECIFIED,
+                                SqlParserPos.ZERO));
+
+        assertThat(FlinkTypeFactory.toLogicalType(intervalType))
+                .isEqualTo(DataTypes.INTERVAL(DataTypes.SECOND(3)).notNull().getLogicalType());
+    }
+
+    @Test
+    void testDayTimeIntervalLeadingPrecisionAboveMaxIsRejected() {
+        FlinkTypeFactory typeFactory =
+                new FlinkTypeFactory(
+                        Thread.currentThread().getContextClassLoader(), FlinkTypeSystem.INSTANCE);
+
+        RelDataType intervalType =
+                typeFactory.createSqlIntervalType(
+                        new SqlIntervalQualifier(
+                                TimeUnit.DAY,
+                                DayTimeIntervalType.MAX_DAY_PRECISION + 1,
+                                TimeUnit.SECOND,
+                                RelDataType.PRECISION_NOT_SPECIFIED,
+                                SqlParserPos.ZERO));
+
+        assertThatThrownBy(() -> FlinkTypeFactory.toLogicalType(intervalType))
+                .isInstanceOf(TableException.class)
+                .hasMessageContaining(
+                        "DAY_INTERVAL_TYPES precision is not supported: "
+                                + (DayTimeIntervalType.MAX_DAY_PRECISION + 1));
     }
 
     @Test

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/expressions/LiteralExpressionsSerializationITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/expressions/LiteralExpressionsSerializationITCase.java
@@ -63,8 +63,13 @@ public class LiteralExpressionsSerializationITCase {
         final LocalDateTime localDateTimeWithoutSeconds =
                 LocalDateTime.of(localDate, localTimeWithoutSeconds);
         final Instant instant = Instant.ofEpochMilli(1234567);
-        final Duration duration = Duration.ofDays(99).plusSeconds(34).plusMillis(999);
-        final Period period = Period.ofMonths(470);
+        final Duration defaultDuration = Duration.ofDays(99).plusSeconds(34).plusMillis(999);
+        final Period defaultPeriod = Period.ofMonths(470);
+        final Period yearMonthPeriod = Period.ofMonths(9999 * 12 + 11);
+        final Duration dayHourDuration = Duration.ofDays(100).plusHours(5);
+        final Duration secondPrecisionDuration = Duration.ofSeconds(45).plusMillis(750);
+        final Duration maxDayDuration = Duration.ofDays(999_999);
+        final Period derivedLargePeriod = Period.ofMonths(1200);
         final Table t =
                 env.fromValues(1)
                         .select(
@@ -90,13 +95,27 @@ public class LiteralExpressionsSerializationITCase {
                                 lit(instant, DataTypes.TIMESTAMP_LTZ(6).notNull()),
                                 lit(instant, DataTypes.TIMESTAMP_LTZ(9).notNull()),
                                 lit(
-                                        duration,
+                                        defaultDuration,
                                         DataTypes.INTERVAL(DataTypes.DAY(), DataTypes.SECOND(9))
                                                 .notNull()),
                                 lit(
-                                        period,
+                                        defaultPeriod,
                                         DataTypes.INTERVAL(DataTypes.YEAR(), DataTypes.MONTH())
-                                                .notNull()));
+                                                .notNull()),
+                                lit(
+                                        yearMonthPeriod,
+                                        DataTypes.INTERVAL(DataTypes.YEAR(4), DataTypes.MONTH())
+                                                .notNull()),
+                                lit(
+                                        dayHourDuration,
+                                        DataTypes.INTERVAL(DataTypes.DAY(3), DataTypes.HOUR())
+                                                .notNull()),
+                                lit(
+                                        secondPrecisionDuration,
+                                        DataTypes.INTERVAL(DataTypes.SECOND(4)).notNull()),
+                                lit(maxDayDuration, DataTypes.INTERVAL(DataTypes.DAY(6)).notNull()),
+                                lit(defaultPeriod),
+                                lit(derivedLargePeriod));
         final ProjectQueryOperation operation = (ProjectQueryOperation) t.getQueryOperation();
         final String exprStr =
                 operation.getProjectList().stream()
@@ -129,8 +148,14 @@ public class LiteralExpressionsSerializationITCase {
                                 + "TO_TIMESTAMP_LTZ(1234567, 3),\n"
                                 + "TO_TIMESTAMP_LTZ(1234567000, 6),\n"
                                 + "TO_TIMESTAMP_LTZ(1234567000000, 9),\n"
-                                + "INTERVAL '99 00:00:34.999' DAY TO SECOND(3),\n"
-                                + "INTERVAL '39-2' YEAR TO MONTH");
+                                + "INTERVAL '99 00:00:34.999000000' DAY(2) TO SECOND(9),\n"
+                                + "INTERVAL '39-2' YEAR(2) TO MONTH,\n"
+                                + "INTERVAL '9999-11' YEAR(4) TO MONTH,\n"
+                                + "INTERVAL '100 05:00:00.000000' DAY(3) TO SECOND(6),\n"
+                                + "INTERVAL '0 00:00:45.7500' DAY(2) TO SECOND(4),\n"
+                                + "INTERVAL '999999 00:00:00.000000' DAY(6) TO SECOND(6),\n"
+                                + "INTERVAL '39-2' YEAR(2) TO MONTH,\n"
+                                + "INTERVAL '100-0' YEAR(3) TO MONTH");
 
         final TableResult tableResult = env.sqlQuery(String.format("SELECT %s", exprStr)).execute();
         final List<Row> results = CollectionUtil.iteratorToList(tableResult.collect());
@@ -158,7 +183,13 @@ public class LiteralExpressionsSerializationITCase {
                                 instant,
                                 instant,
                                 instant,
-                                duration,
-                                period));
+                                defaultDuration,
+                                defaultPeriod,
+                                yearMonthPeriod,
+                                dayHourDuration,
+                                secondPrecisionDuration,
+                                maxDayDuration,
+                                defaultPeriod,
+                                derivedLargePeriod));
     }
 }


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

`ValueLiteralExpression.asSerializableString()` produced INTERVAL SQL literals that dropped leading-field precision and large day-precision values could not be re-parsed at all. This change serializes each interval with the precision taken from the literal's type and corrects derived-type precision sizing.

## Brief change log

- In `ValueLiteralExpression` reading precision from the type, fixing dropped leading-field precision and value loss on coarse resolutions
- Size derived interval-type precision from the normalized total in `ValueDataTypeConverter`so bare literals get a reparseable precision
- Raise the day-time reparse cap in `FlinkTypeFactory` from `3` to `DayTimeIntervalType.MAX_DAY_PRECISION`
- Rework `ExpressionTest` interval cases and update `QueryOperationTestPrograms`
- Add `DAY(6)` and derived-type year-month tests to `LiteralExpressionsSerializationITCase`, precision guards to `FlinkTypeFactoryTest`, and a derived-type case to `ValueDataTypeConverterTest`


## Verifying this change

- Rework `ExpressionTest` interval cases and update `QueryOperationTestPrograms`
- Add `DAY(6)` and derived-type year-month tests to `LiteralExpressionsSerializationITCase`
- Add precision guard tests to `FlinkTypeFactoryTest`
- Add a derived-type test case to `ValueDataTypeConverterTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? n/a

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change the checkbox below to `[X]` followed by the name of the tool, and uncomment the
"Generated-by" line. See the ASF Generative Tooling Guidance for details:
https://www.apache.org/legal/generative-tooling.html

You are responsible for the quality and correctness of every change in this PR
regardless of the tooling used. Low-effort AI-generated PRs will be closed. See
AGENTS.md for the full guidance.
-->

- [x] Yes (please specify the tool below)

Generated-by: Claude Code (Opus 4.8 with 1M context)