### PR TITLE
[FLINK-40248][ci] Add nightly snapshot publishing to GHA pipeline

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -154,6 +154,9 @@ jobs:
       - name: "Initialize job"
         uses: "./.github/actions/job_init"
         with:
+          # In order for other repository's(e.g. flink-docker, flink-benchmarks) CI to 
+          # cover all supported jdks, keep it to the minimum supported version.
+          # Upgrade this only when we drop support for this jdk version.
           jdk_version: 11
           maven_repo_folder: ${{ env.MAVEN_REPO_FOLDER }}
           source_directory: ${{ env.MOUNTED_WORKING_DIR }}
@@ -225,6 +228,9 @@ jobs:
       - name: "Initialize job"
         uses: "./.github/actions/job_init"
         with:
+          # In order for other repository's(e.g. flink-docker, flink-benchmarks) CI to 
+          # cover all supported jdks, keep it to the minimum supported version.
+          # Upgrade this only when we drop support for this jdk version.
           jdk_version: 11
           maven_repo_folder: ${{ env.MAVEN_REPO_FOLDER }}
           source_directory: ${{ env.MOUNTED_WORKING_DIR }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -27,6 +27,38 @@ concurrency:
 
 permissions: read-all
 
+env:
+  # Branches whose nightly snapshots are published by this pipeline (binaries
+  # to S3, jars to repository.apache.org). Branches not listed here will build
+  # snapshots, and keep them as build artifacts of the workflow run only.
+  # This allows the migration from Azure Pipelines to GitHub Actions to happen
+  # one release branch at a time, without both pipelines publishing over each
+  # other: add a branch here once its snapshots are no longer published by
+  # the Azure pipeline, or while it is in the shadow phase described under
+  # SHADOW_SNAPSHOT_BRANCHES below.
+  #
+  # Adding a branch here needs a matching change to that branch's copy of
+  # tools/azure-pipelines/build-apache-repo.yml, ideally in the same commit.
+  # Remove the "cron_snapshot_deployment" build-nightly-dist.yml template from
+  # the "cron_build" stage in tools/azure-pipelines/build-apache-repo.yml
+  # so that the Azure pipeline stops publishing snapshots for the branch.
+  # Removing that template will stop snapshots being published by AZP
+  PUBLISH_SNAPSHOT_BRANCHES: '["master"]'
+
+  # Branches in the shadow phase, where this pipeline and the Azure pipeline both
+  # publish the same branch so that their output can be compared. Binaries for
+  # these branches are uploaded to a GHA-specific prefix in the S3 bucket instead
+  # of the bucket root, so that the two pipelines don't overwrite each other.
+  # (Snapshot jars in Maven don't need an equivalent, as they are timestamped.)
+  #
+  # A branch belongs here only while it is *also* still being published by the
+  # Azure pipeline. Remove it from this list in the same commit that removes the
+  # branch's "cron_snapshot_deployment" template from build-apache-repo.yml, so
+  # that it starts publishing to the bucket root as the Azure pipeline stops.
+  # Leaving a branch here after AZP has stopped means nothing is publishing its
+  # snapshots to the location that consumers read from.
+  SHADOW_SNAPSHOT_BRANCHES: '["master"]'
+
 jobs:
   pre-compile-checks:
     name: "Pre-compile Checks"
@@ -103,9 +135,10 @@ jobs:
       CONTAINER_LOCAL_WORKING_DIR: /root/flink
       MAVEN_REPO_FOLDER: /root/.m2/repository
       MAVEN_ARGS: -Dmaven.repo.local=/root/.m2/repository
+      RELEASE_DIR: /root/flink/tools/releasing/release
     steps:
       - name: "Flink Checkout"
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
       - name: "Initialize job"
@@ -132,15 +165,26 @@ jobs:
           echo "Created files:"
           find ./releasing/release
           cd ..
+      # Uploaded for every branch so that the binaries can be inspected and
+      # compared against the ones the Azure pipeline produces.
+      - name: "Upload snapshot binary release as build artifact"
+        uses: actions/upload-artifact@v7
+        with:
+          name: snapshot-binary-release-${{ github.run_number }}
+          path: ${{ env.RELEASE_DIR }}
+          if-no-files-found: error
+          retention-days: 5
       - name: "Upload artifacts to S3"
+        if: ${{ contains(fromJSON(env.PUBLISH_SNAPSHOT_BRANCHES), github.ref_name) }}
         working-directory: ${{ env.CONTAINER_LOCAL_WORKING_DIR }}
         shell: bash
         run: |
           source ./tools/ci/deploy_nightly_to_s3.sh
-          # while AZP snapshot release builds are still being uploaded
-          #  upload to a separate GHA-specific prefix to avoid overwrites
-          upload_to_s3 ./tools/releasing/release gha-trial/
+          # branches in the shadow phase upload to a GHA-specific prefix, so that
+          #  they don't overwrite the builds AZP is still uploading
+          upload_to_s3 ./tools/releasing/release "${S3_PREFIX}"
         env:
+          S3_PREFIX: ${{ contains(fromJSON(env.SHADOW_SNAPSHOT_BRANCHES), github.ref_name) && 'gha-trial/' || '' }}
           ARTIFACTS_S3_BUCKET: ${{ secrets.ARTIFACTS_S3_BUCKET }}
           AWS_ACCESS_KEY_ID: ${{ secrets.ARTIFACTS_AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.ARTIFACTS_AWS_SECRET_ACCESS_KEY }}
@@ -157,9 +201,11 @@ jobs:
       CONTAINER_LOCAL_WORKING_DIR: /root/flink
       MAVEN_REPO_FOLDER: /root/.m2/repository
       MAVEN_ARGS: -Dmaven.repo.local=/root/.m2/repository
+      STAGING_JARS_DIR: /root/staging-jars
+      STAGING_JARS_TARBALL: /root/staging-jars.tar.gz
     steps:
       - name: "Flink Checkout"
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
       - name: "Initialize job"
@@ -204,11 +250,36 @@ jobs:
           EOF
 
           export CUSTOM_OPTIONS="${MVN_GLOBAL_OPTIONS_WITHOUT_MIRROR} -Dgpg.skip -Drat.skip -Dcheckstyle.skip --settings $(pwd)/deploy-settings.xml"
+
+          if [ "${PUBLISH_SNAPSHOTS}" != "true" ]; then
+            # this branch's snapshot jars are published by the Azure pipeline, so
+            #  deploy into a local repository that is kept as a build artifact
+            #  instead of pushing to repository.apache.org
+            echo "'${GITHUB_REF_NAME}' does not publish snapshots - deploying to ${STAGING_JARS_DIR} instead of repository.apache.org"
+            export CUSTOM_OPTIONS="${CUSTOM_OPTIONS} -DaltDeploymentRepository=staging::file://${STAGING_JARS_DIR}"
+          fi
+
           export MVN_RUN_VERBOSE=true
           ./releasing/deploy_staging_jars.sh
         env:
           MAVEN_DEPLOY_USER: ${{ secrets.MAVEN_DEPLOY_USER }}
           MAVEN_DEPLOY_PASS: ${{ secrets.MAVEN_DEPLOY_PASS }}
+          PUBLISH_SNAPSHOTS: ${{ contains(fromJSON(env.PUBLISH_SNAPSHOT_BRANCHES), github.ref_name) }}
+      - name: "Archive locally deployed snapshot jars"
+        if: ${{ !contains(fromJSON(env.PUBLISH_SNAPSHOT_BRANCHES), github.ref_name) }}
+        shell: bash
+        run: |
+          du -sh "${STAGING_JARS_DIR}"
+          tar --create --gzip --file "${STAGING_JARS_TARBALL}" -C "${STAGING_JARS_DIR}" .
+          ls -lh "${STAGING_JARS_TARBALL}"
+      - name: "Upload snapshot jars as build artifact"
+        if: ${{ !contains(fromJSON(env.PUBLISH_SNAPSHOT_BRANCHES), github.ref_name) }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: snapshot-maven-jars-${{ github.run_number }}
+          path: ${{ env.STAGING_JARS_TARBALL }}
+          if-no-files-found: error
+          retention-days: 5
 
   build_python_wheels:
     name: "Build Python Wheels on ${{ matrix.os_name }}"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -92,6 +92,122 @@ jobs:
       - name: "Build docs and check for broken links"
         run: ./tools/ci/docs.sh
 
+  snapshot_binary:
+    name: "Snapshot Binary Release"
+    runs-on: ubuntu-24.04
+    container:
+      image: apache/flink-ci-docker:java_8_11_17_21_25_maven_386_jammy
+      options: --init --privileged
+    env:
+      MOUNTED_WORKING_DIR: /__w/flink/flink
+      CONTAINER_LOCAL_WORKING_DIR: /root/flink
+      MAVEN_REPO_FOLDER: /root/.m2/repository
+      MAVEN_ARGS: -Dmaven.repo.local=/root/.m2/repository
+    steps:
+      - name: "Flink Checkout"
+        uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+      - name: "Initialize job"
+        uses: "./.github/actions/job_init"
+        with:
+          jdk_version: 11
+          maven_repo_folder: ${{ env.MAVEN_REPO_FOLDER }}
+          source_directory: ${{ env.MOUNTED_WORKING_DIR }}
+          target_directory: ${{ env.CONTAINER_LOCAL_WORKING_DIR }}
+      - name: "Build snapshot binary release"
+        working-directory: ${{ env.CONTAINER_LOCAL_WORKING_DIR }}
+        shell: bash
+        run: |
+          # errexit needs to be disabled explicitly here because maven-utils.sh handles the error if a mirror is not available
+          set +o errexit
+          source ./tools/ci/maven-utils.sh
+          set -o errexit
+          run_mvn -version
+          export MVN="run_mvn"
+          export RELEASE_VERSION=$(MVN_RUN_VERBOSE=false run_mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+          echo "Determined RELEASE_VERSION as '$RELEASE_VERSION'"
+          cd tools
+          MVN_RUN_VERBOSE=true SKIP_GPG=true ./releasing/create_binary_release.sh
+          echo "Created files:"
+          find ./releasing/release
+          cd ..
+      - name: "Upload artifacts to S3"
+        working-directory: ${{ env.CONTAINER_LOCAL_WORKING_DIR }}
+        shell: bash
+        run: |
+          source ./tools/ci/deploy_nightly_to_s3.sh
+          upload_to_s3 ./tools/releasing/release
+        env:
+          ARTIFACTS_S3_BUCKET: ${{ secrets.ARTIFACTS_S3_BUCKET }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.ARTIFACTS_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.ARTIFACTS_AWS_SECRET_ACCESS_KEY }}
+
+  snapshot_maven:
+    name: "Snapshot Maven Deploy"
+    runs-on: ubuntu-24.04
+    timeout-minutes: 240
+    container:
+      image: apache/flink-ci-docker:java_8_11_17_21_25_maven_386_jammy
+      options: --init --privileged
+    env:
+      MOUNTED_WORKING_DIR: /__w/flink/flink
+      CONTAINER_LOCAL_WORKING_DIR: /root/flink
+      MAVEN_REPO_FOLDER: /root/.m2/repository
+      MAVEN_ARGS: -Dmaven.repo.local=/root/.m2/repository
+    steps:
+      - name: "Flink Checkout"
+        uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+      - name: "Initialize job"
+        uses: "./.github/actions/job_init"
+        with:
+          jdk_version: 11
+          maven_repo_folder: ${{ env.MAVEN_REPO_FOLDER }}
+          source_directory: ${{ env.MOUNTED_WORKING_DIR }}
+          target_directory: ${{ env.CONTAINER_LOCAL_WORKING_DIR }}
+      - name: "Deploy Maven snapshot"
+        working-directory: ${{ env.CONTAINER_LOCAL_WORKING_DIR }}
+        shell: bash
+        run: |
+          # errexit needs to be disabled explicitly here because maven-utils.sh handles the error if a mirror is not available
+          set +o errexit
+          source ./tools/ci/maven-utils.sh
+          set -o errexit
+          run_mvn -version
+
+          cd tools
+          cat << EOF > deploy-settings.xml
+          <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                    xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+                                        https://maven.apache.org/xsd/settings-1.0.0.xsd">
+            <servers>
+              <server>
+                <id>apache.snapshots.https</id>
+                <username>${MAVEN_DEPLOY_USER}</username>
+                <password>${MAVEN_DEPLOY_PASS}</password>
+              </server>
+            </servers>
+            <mirrors>
+              <mirror>
+                <id>google-maven-central</id>
+                <name>GCS Maven Central mirror</name>
+                <url>https://maven-central-eu.storage-download.googleapis.com/maven2/</url>
+                <mirrorOf>central</mirrorOf>
+              </mirror>
+            </mirrors>
+          </settings>
+          EOF
+
+          export CUSTOM_OPTIONS="${MVN_GLOBAL_OPTIONS_WITHOUT_MIRROR} -Dgpg.skip -Drat.skip -Dcheckstyle.skip --settings $(pwd)/deploy-settings.xml"
+          export MVN_RUN_VERBOSE=true
+          ./releasing/deploy_staging_jars.sh
+        env:
+          MAVEN_DEPLOY_USER: ${{ secrets.MAVEN_DEPLOY_USER }}
+          MAVEN_DEPLOY_PASS: ${{ secrets.MAVEN_DEPLOY_PASS }}
+
   build_python_wheels:
     name: "Build Python Wheels on ${{ matrix.os_name }}"
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -37,13 +37,22 @@ env:
   # the Azure pipeline, or while it is in the shadow phase described under
   # SHADOW_SNAPSHOT_BRANCHES below.
   #
+  # Each branch runs its own copy of this workflow, so a branch not listed
+  # here is never at risk of a scheduled run publishing its snapshots. This
+  # guard instead protects against a manual workflow_dispatch of this
+  # workflow on a branch that isn't meant to publish yet.
+  #
   # Adding a branch here needs a matching change to that branch's copy of
   # tools/azure-pipelines/build-apache-repo.yml, ideally in the same commit.
   # Remove the "cron_snapshot_deployment" build-nightly-dist.yml template from
   # the "cron_build" stage in tools/azure-pipelines/build-apache-repo.yml
   # so that the Azure pipeline stops publishing snapshots for the branch.
   # Removing that template will stop snapshots being published by AZP
-  PUBLISH_SNAPSHOT_BRANCHES: '["master"]'
+  #
+  # No branches are published by this pipeline yet, pending agreement on the
+  # dev mailing list to start the migration. 
+  # Example: '["master"]'
+  PUBLISH_SNAPSHOT_BRANCHES: '[]'
 
   # Branches in the shadow phase, where this pipeline and the Azure pipeline both
   # publish the same branch so that their output can be compared. Binaries for
@@ -57,7 +66,9 @@ env:
   # that it starts publishing to the bucket root as the Azure pipeline stops.
   # Leaving a branch here after AZP has stopped means nothing is publishing its
   # snapshots to the location that consumers read from.
-  SHADOW_SNAPSHOT_BRANCHES: '["master"]'
+  #
+  # Example: '["master"]'
+  SHADOW_SNAPSHOT_BRANCHES: '[]'
 
 jobs:
   pre-compile-checks:
@@ -135,7 +146,6 @@ jobs:
       CONTAINER_LOCAL_WORKING_DIR: /root/flink
       MAVEN_REPO_FOLDER: /root/.m2/repository
       MAVEN_ARGS: -Dmaven.repo.local=/root/.m2/repository
-      RELEASE_DIR: /root/flink/tools/releasing/release
     steps:
       - name: "Flink Checkout"
         uses: actions/checkout@v7
@@ -171,7 +181,7 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: snapshot-binary-release-${{ github.run_number }}
-          path: ${{ env.RELEASE_DIR }}
+          path: /root/flink/tools/releasing/release
           if-no-files-found: error
           retention-days: 5
       - name: "Upload artifacts to S3"
@@ -179,9 +189,13 @@ jobs:
         working-directory: ${{ env.CONTAINER_LOCAL_WORKING_DIR }}
         shell: bash
         run: |
+          if [[ -z "${ARTIFACTS_S3_BUCKET}" || -z "${AWS_ACCESS_KEY_ID}" || -z "${AWS_SECRET_ACCESS_KEY}" ]]; then
+            echo "::warning::Skipping S3 upload: ARTIFACTS_S3_BUCKET/ARTIFACTS_AWS_ACCESS_KEY_ID/ARTIFACTS_AWS_SECRET_ACCESS_KEY secrets are not set up yet"
+            exit 0
+          fi
           source ./tools/ci/deploy_nightly_to_s3.sh
           # branches in the shadow phase upload to a GHA-specific prefix, so that
-          #  they don't overwrite the builds AZP is still uploading
+          # they don't overwrite the builds AZP is still uploading
           upload_to_s3 ./tools/releasing/release "${S3_PREFIX}"
         env:
           S3_PREFIX: ${{ contains(fromJSON(env.SHADOW_SNAPSHOT_BRANCHES), github.ref_name) && 'gha-trial/' || '' }}
@@ -226,41 +240,7 @@ jobs:
           run_mvn -version
 
           cd tools
-          cat << EOF > deploy-settings.xml
-          <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
-                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                    xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
-                                        https://maven.apache.org/xsd/settings-1.0.0.xsd">
-            <servers>
-              <server>
-                <id>apache.snapshots.https</id>
-                <username>${MAVEN_DEPLOY_USER}</username>
-                <password>${MAVEN_DEPLOY_PASS}</password>
-              </server>
-            </servers>
-            <mirrors>
-              <mirror>
-                <id>google-maven-central</id>
-                <name>GCS Maven Central mirror</name>
-                <url>https://maven-central-eu.storage-download.googleapis.com/maven2/</url>
-                <mirrorOf>central</mirrorOf>
-              </mirror>
-            </mirrors>
-          </settings>
-          EOF
-
-          export CUSTOM_OPTIONS="${MVN_GLOBAL_OPTIONS_WITHOUT_MIRROR} -Dgpg.skip -Drat.skip -Dcheckstyle.skip --settings $(pwd)/deploy-settings.xml"
-
-          if [ "${PUBLISH_SNAPSHOTS}" != "true" ]; then
-            # this branch's snapshot jars are published by the Azure pipeline, so
-            #  deploy into a local repository that is kept as a build artifact
-            #  instead of pushing to repository.apache.org
-            echo "'${GITHUB_REF_NAME}' does not publish snapshots - deploying to ${STAGING_JARS_DIR} instead of repository.apache.org"
-            export CUSTOM_OPTIONS="${CUSTOM_OPTIONS} -DaltDeploymentRepository=staging::file://${STAGING_JARS_DIR}"
-          fi
-
-          export MVN_RUN_VERBOSE=true
-          ./releasing/deploy_staging_jars.sh
+          ./releasing/deploy_nightly_maven_snapshot.sh
         env:
           MAVEN_DEPLOY_USER: ${{ secrets.MAVEN_DEPLOY_USER }}
           MAVEN_DEPLOY_PASS: ${{ secrets.MAVEN_DEPLOY_PASS }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -137,7 +137,9 @@ jobs:
         shell: bash
         run: |
           source ./tools/ci/deploy_nightly_to_s3.sh
-          upload_to_s3 ./tools/releasing/release
+          # while AZP snapshot release builds are still being uploaded
+          #  upload to a separate GHA-specific prefix to avoid overwrites
+          upload_to_s3 ./tools/releasing/release gha-trial/
         env:
           ARTIFACTS_S3_BUCKET: ${{ secrets.ARTIFACTS_S3_BUCKET }}
           AWS_ACCESS_KEY_ID: ${{ secrets.ARTIFACTS_AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -128,7 +128,7 @@ jobs:
           export RELEASE_VERSION=$(MVN_RUN_VERBOSE=false run_mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
           echo "Determined RELEASE_VERSION as '$RELEASE_VERSION'"
           cd tools
-          MVN_RUN_VERBOSE=true SKIP_GPG=true ./releasing/create_binary_release.sh
+          MVN_RUN_VERBOSE=true SKIP_GPG=true SKIP_PYTHON_WHEELS=true ./releasing/create_binary_release.sh
           echo "Created files:"
           find ./releasing/release
           cd ..

--- a/tools/azure-pipelines/build-nightly-dist.yml
+++ b/tools/azure-pipelines/build-nightly-dist.yml
@@ -51,7 +51,10 @@ jobs:
             export RELEASE_VERSION=$(MVN_RUN_VERBOSE=false run_mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
             echo "Determined RELEASE_VERSION as '$RELEASE_VERSION' "
             cd tools
-            MVN_RUN_VERBOSE=true SKIP_GPG=true ./releasing/create_binary_release.sh
+            if ! MVN_RUN_VERBOSE=true SKIP_GPG=true SKIP_PYTHON_WHEELS=true ./releasing/create_binary_release.sh; then
+              echo "create_binary_release.sh failed" 1>&2
+              exit 1
+            fi
             echo "Created files:"
             find ./releasing/release
             cd ..

--- a/tools/ci/deploy_nightly_to_s3.sh
+++ b/tools/ci/deploy_nightly_to_s3.sh
@@ -23,6 +23,7 @@ set -e -x
 
 function upload_to_s3() {
 	local FILES_DIR=$1
+	local PREFIX=${2:-}
 
 	# The AWS CLI reads credentials from the environment (AWS_ACCESS_KEY_ID /
 	# AWS_SECRET_ACCESS_KEY), so they are never placed on a command line and
@@ -41,5 +42,5 @@ function upload_to_s3() {
 
 	# Mirrors the previous uploader's behaviour: copy the directory contents to
 	# the bucket root using the bucket's default (private) ACL.
-	aws s3 cp "$FILES_DIR" "s3://$ARTIFACTS_S3_BUCKET/" --recursive --no-progress
+	aws s3 cp "$FILES_DIR" "s3://$ARTIFACTS_S3_BUCKET/${PREFIX}" --recursive --no-progress
 }

--- a/tools/releasing/create_binary_release.sh
+++ b/tools/releasing/create_binary_release.sh
@@ -21,6 +21,11 @@
 ## Variables with defaults (if not overwritten by environment)
 ##
 SKIP_GPG=${SKIP_GPG:-false}
+# Set to true for automated builds (e.g. nightly snapshots) which
+#  do not try to include Python wheels in the binary release.
+# Defaults to false for manual use, when the release manager will
+#  first download platform wheels to flink-python/dist
+SKIP_PYTHON_WHEELS=${SKIP_PYTHON_WHEELS:-false}
 MVN=${MVN:-mvn}
 
 if [ -z "${RELEASE_VERSION:-}" ]; then
@@ -135,6 +140,8 @@ make_python_release() {
   # py39,py310,py311,py312 for mac 10.9, 11.0 and linux (12 wheel packages)
   EXPECTED_WHEEL_PACKAGES_NUM=12
   # Need to move the downloaded wheel packages from Azure CI to the directory flink-python/dist manually.
+  # (update glob behaviour to expand to nothing if there are no matching files)
+  shopt -s nullglob
   for wheel_file in *.whl; do
     if [[ ! ${wheel_file} =~ ^apache_flink-$PYFLINK_VERSION- ]]; then
         echo -e "\033[31;1mThe file name of the python package: ${wheel_file} is not consistent with given release version: ${PYFLINK_VERSION}!\033[0m"
@@ -143,9 +150,14 @@ make_python_release() {
     cp ${wheel_file} "${PYTHON_RELEASE_DIR}/${wheel_file}"
     wheel_packages_num=$((wheel_packages_num+1))
   done
+  shopt -u nullglob
   if [[ ${wheel_packages_num} != ${EXPECTED_WHEEL_PACKAGES_NUM} ]]; then
-    echo -e "\033[31;1mThe number of wheel packages ${wheel_packages_num} is not equal to the expected number ${EXPECTED_WHEEL_PACKAGES_NUM}!\033[0m"
-    exit 1
+    if [[ "$SKIP_PYTHON_WHEELS" == "true" ]]; then
+      echo "SKIP_PYTHON_WHEELS is set: found ${wheel_packages_num} wheel(s) instead of the expected ${EXPECTED_WHEEL_PACKAGES_NUM}; continuing without them"
+    else
+      echo -e "\033[31;1mThe number of wheel packages ${wheel_packages_num} is not equal to the expected number ${EXPECTED_WHEEL_PACKAGES_NUM}!\033[0m"
+      exit 1
+    fi
   fi
 
   cd ${PYTHON_RELEASE_DIR}

--- a/tools/releasing/create_binary_release.sh
+++ b/tools/releasing/create_binary_release.sh
@@ -22,9 +22,9 @@
 ##
 SKIP_GPG=${SKIP_GPG:-false}
 # Set to true for automated builds (e.g. nightly snapshots) which
-#  do not try to include Python wheels in the binary release.
+# do not try to include Python wheels in the binary release.
 # Defaults to false for manual use, when the release manager will
-#  first download platform wheels to flink-python/dist
+# first download platform wheels to flink-python/dist
 SKIP_PYTHON_WHEELS=${SKIP_PYTHON_WHEELS:-false}
 MVN=${MVN:-mvn}
 
@@ -38,6 +38,8 @@ set -o errexit
 set -o nounset
 # print command before executing
 set -o xtrace
+
+trap 'echo "create_binary_release.sh failed (line ${LINENO})" 1>&2' ERR
 
 CURR_DIR=`pwd`
 if [[ `basename $CURR_DIR` != "tools" ]] ; then

--- a/tools/releasing/deploy_nightly_maven_snapshot.sh
+++ b/tools/releasing/deploy_nightly_maven_snapshot.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+##
+## Variables with defaults (if not overwritten by environment)
+##
+PUBLISH_SNAPSHOTS=${PUBLISH_SNAPSHOTS:-false}
+
+if [ -z "${MAVEN_DEPLOY_USER:-}" ] || [ -z "${MAVEN_DEPLOY_PASS:-}" ]; then
+    echo "MAVEN_DEPLOY_USER / MAVEN_DEPLOY_PASS were not set."
+    exit 1
+fi
+if [ -z "${MVN_GLOBAL_OPTIONS_WITHOUT_MIRROR:-}" ]; then
+    echo "MVN_GLOBAL_OPTIONS_WITHOUT_MIRROR was not set. Source tools/ci/maven-utils.sh first."
+    exit 1
+fi
+if [ "${PUBLISH_SNAPSHOTS}" != "true" ] && [ -z "${STAGING_JARS_DIR:-}" ]; then
+    echo "STAGING_JARS_DIR was not set."
+    exit 1
+fi
+
+# fail immediately
+set -o errexit
+set -o nounset
+# print command before executing
+set -o xtrace
+
+trap 'echo "deploy_nightly_maven_snapshot.sh failed (line ${LINENO})" 1>&2' ERR
+
+CURR_DIR=`pwd`
+if [[ `basename $CURR_DIR` != "tools" ]] ; then
+  echo "You have to call the script from the tools/ dir"
+  exit 1
+fi
+
+cat << EOF > deploy-settings.xml
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+                              https://maven.apache.org/xsd/settings-1.0.0.xsd">
+  <servers>
+    <server>
+      <id>apache.snapshots.https</id>
+      <username>${MAVEN_DEPLOY_USER}</username>
+      <password>${MAVEN_DEPLOY_PASS}</password>
+    </server>
+  </servers>
+  <mirrors>
+    <mirror>
+      <id>google-maven-central</id>
+      <name>GCS Maven Central mirror</name>
+      <url>https://maven-central-eu.storage-download.googleapis.com/maven2/</url>
+      <mirrorOf>central</mirrorOf>
+    </mirror>
+  </mirrors>
+</settings>
+EOF
+
+export CUSTOM_OPTIONS="${MVN_GLOBAL_OPTIONS_WITHOUT_MIRROR} -Dgpg.skip -Drat.skip -Dcheckstyle.skip --settings $(pwd)/deploy-settings.xml"
+
+if [ "${PUBLISH_SNAPSHOTS}" != "true" ]; then
+  # this branch's snapshot jars are published by the Azure pipeline, so
+  #  deploy into a local repository that is kept as a build artifact
+  #  instead of pushing to repository.apache.org
+  echo "Not publishing snapshots - deploying to ${STAGING_JARS_DIR} instead of repository.apache.org"
+  export CUSTOM_OPTIONS="${CUSTOM_OPTIONS} -DaltDeploymentRepository=staging::file://${STAGING_JARS_DIR}"
+fi
+
+export MVN_RUN_VERBOSE=true
+./releasing/deploy_staging_jars.sh


### PR DESCRIPTION
## What is the purpose of the change

The nightly Azure pipeline publishes two things that the GitHub Actions nightly
workflow currently doesn't: release binaries uploaded to S3, and snapshot jars
deployed to repository.apache.org. That gap needs closing before Flink can move off
Azure Pipelines (FLINK-27075).

Which pipeline publishes a given branch will be configuration held in the GHA nightly 
workflow itself.

Because that workflow is versioned per branch, each branch can be switched over 
independently, and a branch that hasn't been switched over yet still builds its 
snapshots on GHA (keeping them as build artifacts of the workflow run rather than 
publishing them).

The aim of this is to make sure that the new GHA jobs get exercised on every branch
before they become the canonical source of anything we publish.

`master` is deliberately listed in *both* of the lists described below, which is the
first phase of the rollout proposed on FLINK-40248: GHA publishes master's binaries
under a `gha-trial/` prefix while Azure continues to publish to the bucket root, so the
two can be compared over a series of nightly runs before anything depends on GHA's
output. 

Removing master from the shadow list and removing Azure's `cron_snapshot_deployment` 
job will be a follow-up, once the outputs have been confirmed to match.


## Brief change log

  - Adds `snapshot_binary` and `snapshot_maven` jobs to `.github/workflows/nightly.yml`,
    mirroring the `cron_snapshot_deployment_binary` and `cron_snapshot_deployment_maven`
    jobs in `tools/azure-pipelines/build-nightly-dist.yml`. Both run on JDK 11, the
    minimum supported version, matching the Azure jobs.
  - `PUBLISH_SNAPSHOT_BRANCHES` lists branches whose snapshots this pipeline publishes.
    Because `nightly.yml` is versioned per branch, this is per-branch configuration, 
    and a branch that has the change backported without being added to the list defaults 
    closed: it builds, but publishes nothing.
  - `SHADOW_SNAPSHOT_BRANCHES` lists branches that GHA and Azure are both publishing
    during comparison. Binaries for those branches are uploaded to a `gha-trial/` prefix
    in the S3 bucket rather than the bucket root, so the two pipelines can't overwrite
    each other. Snapshot jars uploaded to Maven need no equivalent renaming, as they 
    already have timestamped names.
  - The binary release is uploaded as a GHA build artifact on every branch, whether or
    not it publishes, so its contents can be compared against what Azure produces.
  - When a branch isn't publishing, the Maven job deploys into a local repository via
    `-DaltDeploymentRepository` and uploads that as a tarball artifact, instead of
    deploying to repository.apache.org.
  - `tools/ci/deploy_nightly_to_s3.sh`: `upload_to_s3` takes an optional destination
    prefix, defaulting to the existing behaviour of writing to the bucket root.
  - `tools/releasing/create_binary_release.sh`: adds `SKIP_PYTHON_WHEELS`, defaulting to
    `false` so the manual release process is unaffected. Nightly builds set it to
    `true`, so a binary release can be produced without the 12 platform wheels that a
    release manager downloads by hand beforehand. Also enables `nullglob` around the
    wheel loop, so it doesn't iterate over a literal `*.whl` when no wheels are present.
  - `tools/azure-pipelines/build-nightly-dist.yml`: sets `SKIP_PYTHON_WHEELS=true`, and
    now checks the exit code of `create_binary_release.sh`. Previously the nightly Azure
    build depended on the missing-wheels check failing, with that failure masked by the
    `echo`/`find` commands following it in the same inline script — which meant any
    other error in the script was silently ignored too.


## Verifying this change

This change is a CI configuration change without test coverage. I'll verify by
running affected pipelines on my fork. 


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components),
    Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no 


## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: Claude Sonnet 5
