### PR TITLE
[FLINK-40250][table] Throw ValidationException for non-orderable types used as keys

### DIFF
--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/test/program/FailingSqlTestStep.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/test/program/FailingSqlTestStep.java
@@ -42,10 +42,8 @@ public final class FailingSqlTestStep implements TestStep {
     FailingSqlTestStep(
             String sql, Class<? extends Exception> expectedException, String expectedErrorMessage) {
         Preconditions.checkArgument(
-                // UnsupportedOperationException is a special case in GenerateUtils#generateCompare
                 expectedException == ValidationException.class
-                        || expectedException == TableRuntimeException.class
-                        || expectedException == UnsupportedOperationException.class,
+                        || expectedException == TableRuntimeException.class,
                 "Usually a SQL query should fail with either validation or runtime exception. "
                         + "Otherwise this might require an update to the exception design.");
         this.sql = sql;

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/GenerateUtils.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/GenerateUtils.scala
@@ -20,6 +20,7 @@ package org.apache.flink.table.planner.codegen
 import org.apache.flink.api.common.ExecutionConfig
 import org.apache.flink.api.common.serialization.SerializerConfigImpl
 import org.apache.flink.api.common.typeinfo.{AtomicType => AtomicTypeInfo}
+import org.apache.flink.table.api.ValidationException
 import org.apache.flink.table.data._
 import org.apache.flink.table.data.binary.{BinaryRowData, BinaryStringData}
 import org.apache.flink.table.data.utils.JoinedRowData
@@ -636,9 +637,10 @@ object GenerateUtils {
         INTERVAL_YEAR_MONTH | INTERVAL_DAY_TIME =>
       s"($leftTerm > $rightTerm ? 1 : $leftTerm < $rightTerm ? -1 : 0)"
     case TIMESTAMP_WITH_TIME_ZONE | MULTISET | MAP | VARIANT | BITMAP =>
-      throw new UnsupportedOperationException(
-        s"Type($t) is not an orderable data type, " +
-          s"it is not supported as a ORDER_BY/GROUP_BY/JOIN_EQUAL field.")
+      throw new ValidationException(
+        s"Type '$t' cannot be ordered, so it cannot be used as a key for sorting, grouping, " +
+          s"or joining (for example in ORDER BY, GROUP BY, DISTINCT, or a join condition). " +
+          s"Remove it from the key, or replace it with a value that can be ordered.")
     // TODO support MULTISET and MAP?
     case ARRAY =>
       val at = t.asInstanceOf[ArrayType]

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/BitmapSemanticTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/BitmapSemanticTest.java
@@ -19,6 +19,7 @@
 package org.apache.flink.table.planner.plan.nodes.exec.stream;
 
 import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.functions.AggregateFunction;
 import org.apache.flink.table.functions.ScalarFunction;
 import org.apache.flink.table.functions.TableFunction;
@@ -217,9 +218,11 @@ public class BitmapSemanticTest extends SemanticTestBase {
                             "INSERT INTO sink_t "
                                     + "SELECT FIRST_VALUE(ts) OVER (ORDER BY bm) "
                                     + "FROM TABLE(TUMBLE(TABLE t, DESCRIPTOR(ts), INTERVAL '1' SECOND))",
-                            UnsupportedOperationException.class,
-                            "Type(BITMAP) is not an orderable data type, "
-                                    + "it is not supported as a ORDER_BY/GROUP_BY/JOIN_EQUAL field.")
+                            ValidationException.class,
+                            "Type 'BITMAP' cannot be ordered, so it cannot be used as a key for "
+                                    + "sorting, grouping, or joining (for example in ORDER BY, "
+                                    + "GROUP BY, DISTINCT, or a join condition). Remove it from the "
+                                    + "key, or replace it with a value that can be ordered.")
                     .build();
 
     static final TableTestProgram BITMAP_AS_DISTINCT_KEY =

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/CalcITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/CalcITCase.scala
@@ -1063,8 +1063,12 @@ class CalcITCase extends BatchTestBase {
     assertThatThrownBy(
       () =>
         checkResult("SELECT COUNT(*) FROM SmallTable3 GROUP BY MAP[1, 'Hello', 2, 'Hi']", Seq()))
+      .isInstanceOf(classOf[ValidationException])
       .hasMessage(
-        "Type(MAP<INT NOT NULL, VARCHAR(5) NOT NULL> NOT NULL) is not an orderable data type, it is not supported as a ORDER_BY/GROUP_BY/JOIN_EQUAL field.")
+        "Type 'MAP<INT NOT NULL, VARCHAR(5) NOT NULL> NOT NULL' cannot be ordered, so it cannot " +
+          "be used as a key for sorting, grouping, or joining (for example in ORDER BY, GROUP " +
+          "BY, DISTINCT, or a join condition). Remove it from the key, or replace it with a " +
+          "value that can be ordered.")
   }
 
   @Test


### PR DESCRIPTION
## What is the purpose of the change

Using a non-orderable type (MAP, MULTISET, VARIANT, BITMAP, TIMESTAMP_WITH_TIME_ZONE) as a sort, grouping, or join key threw a raw UnsupportedOperationException from comparator code generation. This changes it to a ValidationException with a clearer, actionable message, since it is invalid user SQL rather than an internal error.

## Brief change log

- Throw ValidationException instead of UnsupportedOperationException for non-orderable types in GenerateUtils.generateCompare, with a message that names the type and the remedy.
- Update CalcITCase and BitmapSemanticTest to expect ValidationException and the new message.
- Remove the now-unused UnsupportedOperationException allowance from FailingSqlTestStep.

## Verifying this change

- CalcITCase
- BitmapSemanticTest

## Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): (no)
- The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
- The serializers: (no)
- The runtime per-record code paths (performance sensitive): (no)
- Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
- The S3 file system connector: (no)

## Documentation

- Does this pull request introduce a new feature? (no)
- If yes, how is the feature documented? (not applicable)

---

##### Was generative AI tooling used to co-author this PR?

- [x] Yes (please specify the tool below)

2.1.220 (Claude Code) with Opus 4.8