### PR TITLE
[FLINK-40269][runtime] Fix channel state assignment for duplicate connections

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/TaskStateAssignment.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/TaskStateAssignment.java
@@ -53,7 +53,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -230,11 +229,6 @@ class TaskStateAssignment {
         return downstreamAssignments;
     }
 
-    private static int getAssignmentIndex(
-            TaskStateAssignment[] assignments, TaskStateAssignment assignment) {
-        return Arrays.asList(assignments).indexOf(assignment);
-    }
-
     public TaskStateAssignment[] getUpstreamAssignments() {
         if (upstreamAssignments == null) {
             upstreamAssignments =
@@ -272,12 +266,6 @@ class TaskStateAssignment {
                                 instanceID,
                                 inputOperatorID,
                                 getUpstreamAssignments(),
-                                (assignment, recompute) -> {
-                                    int assignmentIndex =
-                                            getAssignmentIndex(
-                                                    assignment.getDownstreamAssignments(), this);
-                                    return assignment.getOutputMapping(assignmentIndex, recompute);
-                                },
                                 inputSubtaskMappings,
                                 this::getInputMapping,
                                 true))
@@ -320,11 +308,6 @@ class TaskStateAssignment {
                 instanceID,
                 outputOperatorID,
                 getDownstreamAssignments(),
-                (downstreamAssignment, recompute) -> {
-                    int assignmentIndex =
-                            getAssignmentIndex(downstreamAssignment.getUpstreamAssignments(), this);
-                    return downstreamAssignment.getInputMapping(assignmentIndex, recompute);
-                },
                 outputSubtaskMappings,
                 this::getOutputMapping,
                 false);
@@ -355,7 +338,6 @@ class TaskStateAssignment {
             OperatorInstanceID instanceID,
             OperatorID expectedOperatorID,
             TaskStateAssignment[] connectedAssignments,
-            BiFunction<TaskStateAssignment, Boolean, SubtasksRescaleMapping> mappingRetriever,
             Map<Integer, SubtasksRescaleMapping> subtaskGateOrPartitionMappings,
             Function<Integer, SubtasksRescaleMapping> subtaskMappingCalculator,
             boolean isInput) {
@@ -364,8 +346,11 @@ class TaskStateAssignment {
         }
 
         SubtasksRescaleMapping[] rescaledChannelsMappings =
-                Arrays.stream(connectedAssignments)
-                        .map(assignment -> mappingRetriever.apply(assignment, false))
+                IntStream.range(0, connectedAssignments.length)
+                        .mapToObj(
+                                index ->
+                                        getConnectedMapping(
+                                                isInput, index, connectedAssignments[index], false))
                         .toArray(SubtasksRescaleMapping[]::new);
 
         // no state on input and output, especially for any aligned checkpoint
@@ -378,7 +363,6 @@ class TaskStateAssignment {
                 createGateOrPartitionRescalingDescriptors(
                         instanceID,
                         connectedAssignments,
-                        assignment -> mappingRetriever.apply(assignment, true),
                         subtaskGateOrPartitionMappings,
                         subtaskMappingCalculator,
                         rescaledChannelsMappings,
@@ -398,7 +382,6 @@ class TaskStateAssignment {
             createGateOrPartitionRescalingDescriptors(
                     OperatorInstanceID instanceID,
                     TaskStateAssignment[] connectedAssignments,
-                    Function<TaskStateAssignment, SubtasksRescaleMapping> mappingCalculator,
                     Map<Integer, SubtasksRescaleMapping> subtaskGateOrPartitionMappings,
                     Function<Integer, SubtasksRescaleMapping> subtaskMappingCalculator,
                     SubtasksRescaleMapping[] rescaledChannelsMappings,
@@ -415,8 +398,11 @@ class TaskStateAssignment {
                                     Optional.ofNullable(rescaledChannelsMappings[partition])
                                             .orElseGet(
                                                     () ->
-                                                            mappingCalculator.apply(
-                                                                    connectedAssignment));
+                                                            getConnectedMapping(
+                                                                    isInput,
+                                                                    partition,
+                                                                    connectedAssignment,
+                                                                    true));
                             SubtasksRescaleMapping subtaskMapping =
                                     Optional.ofNullable(
                                                     subtaskGateOrPartitionMappings.get(partition))
@@ -485,12 +471,42 @@ class TaskStateAssignment {
         }
     }
 
+    private SubtasksRescaleMapping getOutputMapping(
+            IntermediateDataSetID resultId, boolean recompute) {
+        return getOutputMapping(findResultPartitionIndex(resultId), recompute);
+    }
+
     private SubtasksRescaleMapping getInputMapping(int assignmentIndex, boolean recompute) {
         SubtasksRescaleMapping mapping = inputSubtaskMappings.get(assignmentIndex);
         if (recompute && mapping == null) {
             return getInputMapping(assignmentIndex);
         } else {
             return mapping;
+        }
+    }
+
+    private SubtasksRescaleMapping getInputMapping(
+            IntermediateDataSetID resultId, boolean recompute) {
+        return getInputMapping(findInputGateIndex(resultId), recompute);
+    }
+
+    /**
+     * Resolves the mapping on {@code connectedAssignment} that corresponds to {@code index} on
+     * {@code this} assignment, disambiguating by {@link IntermediateDataSetID} rather than by array
+     * position (multiple edges can connect the same pair of job vertices).
+     */
+    private SubtasksRescaleMapping getConnectedMapping(
+            boolean isInput,
+            int index,
+            TaskStateAssignment connectedAssignment,
+            boolean recompute) {
+        if (isInput) {
+            IntermediateDataSetID resultId = executionJobVertex.getInputs().get(index).getId();
+            return connectedAssignment.getOutputMapping(resultId, recompute);
+        } else {
+            IntermediateDataSetID resultId =
+                    executionJobVertex.getProducedDataSets()[index].getId();
+            return connectedAssignment.getInputMapping(resultId, recompute);
         }
     }
 
@@ -547,12 +563,8 @@ class TaskStateAssignment {
         if (upstreamAssignment != null && upstreamAssignment.hasOutputState()) {
             IntermediateResult inputResult = executionJobVertex.getInputs().get(gateIndex);
             IntermediateDataSetID resultId = inputResult.getId();
-            IntermediateResult[] producedDataSets = inputResult.getProducer().getProducedDataSets();
-            for (int i = 0; i < producedDataSets.length; i++) {
-                if (producedDataSets[i].getId().equals(resultId)) {
-                    return upstreamAssignment.outputStatePartitions.contains(i);
-                }
-            }
+            return upstreamAssignment.outputStatePartitions.contains(
+                    upstreamAssignment.findResultPartitionIndex(resultId));
         }
 
         return false;
@@ -571,12 +583,8 @@ class TaskStateAssignment {
             IntermediateResult producedResult =
                     executionJobVertex.getProducedDataSets()[partitionIndex];
             IntermediateDataSetID resultId = producedResult.getId();
-            List<IntermediateResult> inputs = downstreamAssignment.executionJobVertex.getInputs();
-            for (int i = 0; i < inputs.size(); i++) {
-                if (inputs.get(i).getId().equals(resultId)) {
-                    return downstreamAssignment.inputStateGates.contains(i);
-                }
-            }
+            return downstreamAssignment.inputStateGates.contains(
+                    downstreamAssignment.findInputGateIndex(resultId));
         }
         return false;
     }
@@ -642,15 +650,35 @@ class TaskStateAssignment {
 
         IntermediateResult producedResult =
                 executionJobVertex.getProducedDataSets()[partitionIndex];
-        IntermediateDataSetID resultId = producedResult.getId();
-        List<IntermediateResult> inputs = downstreamAssignment.executionJobVertex.getInputs();
+        return downstreamAssignment.findInputGateIndex(producedResult.getId());
+    }
+
+    private int findInputGateIndex(IntermediateDataSetID resultId) {
+        List<IntermediateResult> inputs = executionJobVertex.getInputs();
         for (int i = 0; i < inputs.size(); i++) {
             if (inputs.get(i).getId().equals(resultId)) {
                 return i;
             }
         }
         throw new IllegalArgumentException(
-                "No channel rescaler found during rescaling of channel state");
+                "No input gate found for intermediate data set "
+                        + resultId
+                        + " in "
+                        + executionJobVertex.getName());
+    }
+
+    private int findResultPartitionIndex(IntermediateDataSetID resultId) {
+        IntermediateResult[] producedDataSets = executionJobVertex.getProducedDataSets();
+        for (int i = 0; i < producedDataSets.length; i++) {
+            if (producedDataSets[i].getId().equals(resultId)) {
+                return i;
+            }
+        }
+        throw new IllegalArgumentException(
+                "No result partition found for intermediate data set "
+                        + resultId
+                        + " in "
+                        + executionJobVertex.getName());
     }
 
     @Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/StateAssignmentOperationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/StateAssignmentOperationTest.java
@@ -581,6 +581,72 @@ class StateAssignmentOperationTest {
                                                 RESCALING))));
     }
 
+    @Test
+    void testChannelStateAssignmentUsesResultIdForDuplicateJobVertexConnections()
+            throws JobException, JobExecutionException {
+        int oldParallelism = 3;
+        int newParallelism = 2;
+        JobVertex upstream = createJobVertex(new OperatorID(), newParallelism);
+        JobVertex downstream = createJobVertex(new OperatorID(), newParallelism);
+        OperatorID upstreamOperator = upstream.getOperatorIDs().get(0).getGeneratedOperatorID();
+        OperatorID downstreamOperator = downstream.getOperatorIDs().get(0).getGeneratedOperatorID();
+        Random random = new Random();
+
+        OperatorState upstreamState =
+                new OperatorState("", "", upstreamOperator, oldParallelism, MAX_P);
+        OperatorState downstreamState =
+                new OperatorState("", "", downstreamOperator, oldParallelism, MAX_P);
+        for (int i = 0; i < oldParallelism; i++) {
+            upstreamState.putState(
+                    i,
+                    OperatorSubtaskState.builder()
+                            .setResultSubpartitionState(
+                                    new StateObjectCollection<>(
+                                            asList(
+                                                    createNewResultSubpartitionStateHandle(
+                                                            10, 0, random),
+                                                    createNewResultSubpartitionStateHandle(
+                                                            10, 1, random))))
+                            .build());
+            downstreamState.putState(
+                    i,
+                    OperatorSubtaskState.builder()
+                            .setInputChannelState(
+                                    new StateObjectCollection<>(
+                                            asList(
+                                                    createNewInputChannelStateHandle(10, 0, random),
+                                                    createNewInputChannelStateHandle(
+                                                            10, 1, random))))
+                            .build());
+        }
+        Map<OperatorID, OperatorState> states = new HashMap<>();
+        states.put(upstreamOperator, upstreamState);
+        states.put(downstreamOperator, downstreamState);
+
+        connectVertices(upstream, downstream, RANGE, RANGE);
+        connectVertices(upstream, downstream, ROUND_ROBIN, ROUND_ROBIN);
+
+        Map<OperatorID, ExecutionJobVertex> vertices = toExecutionVertices(upstream, downstream);
+
+        new StateAssignmentOperation(0, new HashSet<>(vertices.values()), states, false, false)
+                .assignStates();
+
+        InflightDataRescalingDescriptor outputDescriptor =
+                getAssignedState(vertices.get(upstreamOperator), upstreamOperator, 0)
+                        .getOutputRescalingDescriptor();
+        InflightDataRescalingDescriptor inputDescriptor =
+                getAssignedState(vertices.get(downstreamOperator), downstreamOperator, 0)
+                        .getInputRescalingDescriptor();
+        assertThat(outputDescriptor.getChannelMapping(0))
+                .isEqualTo(RANGE.getNewToOldSubtasksMapping(oldParallelism, newParallelism));
+        assertThat(outputDescriptor.getChannelMapping(1))
+                .isEqualTo(ROUND_ROBIN.getNewToOldSubtasksMapping(oldParallelism, newParallelism));
+        assertThat(inputDescriptor.getChannelMapping(0))
+                .isEqualTo(RANGE.getNewToOldSubtasksMapping(oldParallelism, newParallelism));
+        assertThat(inputDescriptor.getChannelMapping(1))
+                .isEqualTo(ROUND_ROBIN.getNewToOldSubtasksMapping(oldParallelism, newParallelism));
+    }
+
     private InflightDataGateOrPartitionRescalingDescriptor gate(
             int[] oldIndices,
             RescaleMappings rescaleMapping,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/CommonTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/CommonTestUtils.java
@@ -345,12 +345,25 @@ public class CommonTestUtils {
     /** Wait for one checkpoint with in-flight buffers. */
     public static String waitForCheckpointWithInflightBuffers(JobID jobID, MiniCluster miniCluster)
             throws Exception {
+        return waitForCheckpointWithInflightBuffers(jobID, miniCluster, 1);
+    }
+
+    /**
+     * Wait for at least {@code minCompletedCheckpoints} completed checkpoints and return the latest
+     * checkpoint with in-flight buffers.
+     */
+    public static String waitForCheckpointWithInflightBuffers(
+            JobID jobID, MiniCluster miniCluster, long minCompletedCheckpoints) throws Exception {
         CompletableFuture<String> checkpointPath = new CompletableFuture<>();
         waitForCheckpoints(
                 jobID,
                 miniCluster,
                 checkpointStatsSnapshot -> {
                     if (checkpointStatsSnapshot == null) {
+                        return false;
+                    }
+                    if (checkpointStatsSnapshot.getCounts().getNumberOfCompletedCheckpoints()
+                            < minCompletedCheckpoints) {
                         return false;
                     }
                     CompletedCheckpointStats latestCompletedCheckpoint =

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/UnalignedCheckpointRescaleSameUpstreamITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/UnalignedCheckpointRescaleSameUpstreamITCase.java
@@ -1,0 +1,258 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.test.checkpointing;
+
+import org.apache.flink.api.common.JobStatus;
+import org.apache.flink.api.common.functions.MapFunction;
+import org.apache.flink.api.java.functions.KeySelector;
+import org.apache.flink.configuration.CheckpointingOptions;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.ExternalizedCheckpointRetention;
+import org.apache.flink.configuration.MemorySize;
+import org.apache.flink.configuration.RestartStrategyOptions;
+import org.apache.flink.configuration.StateRecoveryOptions;
+import org.apache.flink.configuration.TaskManagerOptions;
+import org.apache.flink.core.execution.JobClient;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.minicluster.MiniCluster;
+import org.apache.flink.runtime.minicluster.MiniClusterJobClient;
+import org.apache.flink.runtime.testutils.CommonTestUtils;
+import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.co.CoMapFunction;
+import org.apache.flink.streaming.api.functions.sink.v2.DiscardingSink;
+import org.apache.flink.test.junit5.InjectMiniCluster;
+import org.apache.flink.test.junit5.MiniClusterExtension;
+import org.apache.flink.testutils.junit.extensions.parameterized.Parameter;
+import org.apache.flink.testutils.junit.extensions.parameterized.ParameterizedTestExtension;
+import org.apache.flink.testutils.junit.extensions.parameterized.Parameters;
+
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.io.TempDir;
+
+import javax.annotation.Nullable;
+
+import java.io.File;
+import java.time.Duration;
+import java.util.Collections;
+
+import static org.apache.flink.configuration.RestartStrategyOptions.RestartStrategyType.NO_RESTART_STRATEGY;
+
+/**
+ * Integration test for unaligned checkpoint rescaling when one downstream task receives multiple
+ * inputs derived from the same upstream stream.
+ */
+@ExtendWith(ParameterizedTestExtension.class)
+class UnalignedCheckpointRescaleSameUpstreamITCase {
+
+    private static final int INITIAL_PARALLELISM = 2;
+    private static final int RESTORED_PARALLELISM = 4;
+    private static final int SLOTS_PER_TASK_MANAGER = 8;
+    private static final int CHECKPOINTS_TO_WAIT = 10;
+
+    @RegisterExtension
+    private static final MiniClusterExtension MINI_CLUSTER_EXTENSION =
+            new MiniClusterExtension(
+                    new MiniClusterResourceConfiguration.Builder()
+                            .setConfiguration(
+                                    new Configuration()
+                                            .set(CheckpointingOptions.MAX_RETAINED_CHECKPOINTS, 50))
+                            .setNumberTaskManagers(1)
+                            .setNumberSlotsPerTaskManager(SLOTS_PER_TASK_MANAGER)
+                            .build());
+
+    @TempDir private File temporaryFolder;
+
+    @Parameter private boolean recoverOutputOnDownstream;
+
+    @Parameter(1)
+    private SameUpstreamDag dag;
+
+    @Parameters(name = "recoverOutputOnDownstream={0}, dag={1}")
+    private static Object[][] parameters() {
+        return new Object[][] {
+            new Object[] {false, SameUpstreamDag.CONNECT},
+            new Object[] {true, SameUpstreamDag.CONNECT},
+            new Object[] {false, SameUpstreamDag.UNION},
+            new Object[] {true, SameUpstreamDag.UNION}
+        };
+    }
+
+    @TestTemplate
+    void testRescaleFromUnalignedCheckpointWithSameUpstream(
+            @InjectMiniCluster MiniCluster miniCluster) throws Exception {
+        final JobGraph initialJobGraph =
+                createJobGraph(null, INITIAL_PARALLELISM, recoverOutputOnDownstream);
+
+        final JobClient initialJobClient = submitJob(initialJobGraph, miniCluster);
+        final String checkpointPath;
+        try {
+            waitForRunning(initialJobClient, miniCluster);
+            checkpointPath =
+                    CommonTestUtils.waitForCheckpointWithInflightBuffers(
+                            initialJobGraph.getJobID(), miniCluster, CHECKPOINTS_TO_WAIT);
+        } finally {
+            initialJobClient.cancel().get();
+        }
+
+        final JobGraph restoredJobGraph =
+                createJobGraph(checkpointPath, RESTORED_PARALLELISM, recoverOutputOnDownstream);
+
+        final JobClient restoredJobClient = submitJob(restoredJobGraph, miniCluster);
+        try {
+            waitForRunning(restoredJobClient, miniCluster);
+            CommonTestUtils.waitForCheckpointWithInflightBuffers(
+                    restoredJobGraph.getJobID(), miniCluster);
+        } finally {
+            cancelIfRunning(restoredJobClient);
+        }
+    }
+
+    private JobGraph createJobGraph(
+            @Nullable String recoveryPath, int parallelism, boolean recoverOutputOnDownstream)
+            throws Exception {
+        final StreamExecutionEnvironment env =
+                StreamExecutionEnvironment.getExecutionEnvironment(
+                        createConfiguration(recoveryPath, recoverOutputOnDownstream));
+        env.disableOperatorChaining();
+        dag.build(env, parallelism);
+        return env.getStreamGraph().getJobGraph();
+    }
+
+    private Configuration createConfiguration(
+            @Nullable String recoveryPath, boolean recoverOutputOnDownstream) {
+        final Configuration conf = new Configuration();
+        conf.set(CheckpointingOptions.CHECKPOINTING_INTERVAL, Duration.ofSeconds(1));
+        conf.set(CheckpointingOptions.ALIGNED_CHECKPOINT_TIMEOUT, Duration.ofSeconds(0));
+        conf.set(RestartStrategyOptions.RESTART_STRATEGY, NO_RESTART_STRATEGY.getMainValue());
+        conf.set(
+                CheckpointingOptions.EXTERNALIZED_CHECKPOINT_RETENTION,
+                ExternalizedCheckpointRetention.RETAIN_ON_CANCELLATION);
+        conf.set(CheckpointingOptions.CHECKPOINTS_DIRECTORY, temporaryFolder.toURI().toString());
+        conf.set(CheckpointingOptions.ENABLE_UNALIGNED, true);
+        conf.set(
+                CheckpointingOptions.UNALIGNED_RECOVER_OUTPUT_ON_DOWNSTREAM,
+                recoverOutputOnDownstream);
+        conf.set(TaskManagerOptions.MEMORY_SEGMENT_SIZE, MemorySize.parse("4 kb"));
+        if (recoveryPath != null) {
+            conf.set(StateRecoveryOptions.SAVEPOINT_PATH, recoveryPath);
+        }
+        return conf;
+    }
+
+    private static JobClient submitJob(JobGraph jobGraph, MiniCluster miniCluster)
+            throws Exception {
+        miniCluster.submitJob(jobGraph).get();
+        return new MiniClusterJobClient(
+                jobGraph.getJobID(),
+                miniCluster,
+                Thread.currentThread().getContextClassLoader(),
+                MiniClusterJobClient.JobFinalizationBehavior.NOTHING);
+    }
+
+    private static void waitForRunning(JobClient jobClient, MiniCluster miniCluster)
+            throws Exception {
+        CommonTestUtils.waitForJobStatus(jobClient, Collections.singletonList(JobStatus.RUNNING));
+        CommonTestUtils.waitForAllTaskRunning(miniCluster, jobClient.getJobID(), false);
+    }
+
+    private static void cancelIfRunning(JobClient jobClient) throws Exception {
+        if (jobClient.getJobStatus().get() != JobStatus.FAILED) {
+            jobClient.cancel().get();
+        }
+    }
+
+    private static class SleepingCoMap<T> implements CoMapFunction<T, T, T> {
+        @Override
+        public T map1(T value) throws Exception {
+            Thread.sleep(1);
+            return value;
+        }
+
+        @Override
+        public T map2(T value) throws Exception {
+            Thread.sleep(5);
+            return value;
+        }
+    }
+
+    private static class SleepingMap<T> implements MapFunction<T, T> {
+        @Override
+        public T map(T value) throws Exception {
+            Thread.sleep(5);
+            return value;
+        }
+    }
+
+    private enum SameUpstreamDag {
+        CONNECT {
+            @Override
+            void build(StreamExecutionEnvironment env, int parallelism) {
+                final DataStream<Long> upstream =
+                        env.fromSequence(0, Long.MAX_VALUE)
+                                .name("Upstream")
+                                .uid("upstream")
+                                .setParallelism(parallelism);
+                final DataStream<Long> leftInput = upstream.rebalance();
+                final DataStream<Long> rightInput =
+                        upstream.keyBy((KeySelector<Long, Long>) value -> value);
+
+                leftInput
+                        .connect(rightInput)
+                        .map(new SleepingCoMap<>())
+                        .name("Co-Map")
+                        .uid("co-map")
+                        .setParallelism(parallelism)
+                        .sinkTo(new DiscardingSink<>())
+                        .name("Discarding Sink")
+                        .uid("sink")
+                        .setParallelism(parallelism);
+            }
+        },
+        UNION {
+            @Override
+            void build(StreamExecutionEnvironment env, int parallelism) {
+                final DataStream<Long> upstream =
+                        env.fromSequence(0, Long.MAX_VALUE)
+                                .name("Upstream")
+                                .uid("upstream")
+                                .setParallelism(parallelism);
+                final DataStream<Long> leftInput = upstream.rebalance();
+                final DataStream<Long> rightInput =
+                        upstream.keyBy((KeySelector<Long, Long>) value -> value);
+
+                leftInput
+                        .union(rightInput)
+                        .map(new SleepingMap<>())
+                        .name("Slow Map")
+                        .uid("slow-map")
+                        .setParallelism(parallelism)
+                        .sinkTo(new DiscardingSink<>())
+                        .name("Discarding Sink")
+                        .uid("sink")
+                        .setParallelism(parallelism);
+            }
+        };
+
+        abstract void build(StreamExecutionEnvironment env, int parallelism);
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

This pull request fixes channel state assignment for unaligned checkpoint recovery when a downstream job vertex has multiple input gates connected to the same upstream job vertex.

Previously, `TaskStateAssignment` looked up connected assignments by the upstream/downstream `TaskStateAssignment` instance. If multiple edges connect the same pair of job vertices, this can select the first matching edge and use the wrong input gate or result partition mapping.

## Brief change log

- Use `IntermediateDataSetID` to resolve the corresponding input gate and result partition during channel state assignment.
- Add an ITCase covering unaligned checkpoint rescaling with duplicate same-upstream inputs.
- Add a unit test covering duplicate job vertex connections with different channel state mappers.

## Verifying this change

This change added tests and can be verified as follows:

- `./mvnw -pl flink-runtime -Dtest=StateAssignmentOperationTest -Djdk11 -Pjava11-target test`
- `./mvnw -pl flink-tests -Dtest=UnalignedCheckpointRescaleSameUpstreamITCase -Dsurefire.failIfNoSpecifiedTests=false -Djdk11 -Pjava11-target -DtrimStackTrace=false surefire:test@integration-tests`

## Does this pull request potentially affect one of the following parts:

- Dependencies: no
- Public API: no
- Serializers: no
- Runtime per-record code paths: no
- Deployment or recovery: yes, checkpoint recovery
- S3 file system connector: no

## Documentation

- Does this pull request introduce a new feature? no
