### PR TITLE
[FLINK-40283][tests] Rename `CorrelateITCase2` to `Correlate2ITCase` to make executing while CI/local tests

### DIFF
--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/Correlate2ITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/Correlate2ITCase.scala
@@ -25,7 +25,7 @@ import org.apache.flink.table.planner.runtime.utils.TestData._
 
 import org.junit.jupiter.api.{BeforeEach, Test}
 
-class CorrelateITCase2 extends BatchTestBase {
+class Correlate2ITCase extends BatchTestBase {
 
   @BeforeEach
   override def before(): Unit = {


### PR DESCRIPTION
## What is the purpose of the change

The problem is with pom where pattern for unit tests does not run integration tests ending with something different than `ITCase`

## Brief change log

test rename

## Verifying this change

CI logs should contain `Correlate2ITCase`
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change the checkbox below to `[X]` and replace the placeholder in the "Generated-by"
line with the tool name and version. Otherwise remove the "Generated-by" line.
See the ASF Generative Tooling Guidance for details:
https://www.apache.org/legal/generative-tooling.html

You are responsible for the quality and correctness of every change in this PR
regardless of the tooling used. Low-effort AI-generated PRs will be closed. See
AGENTS.md for the full guidance.
-->

- [ ] Yes (please specify the tool below)

Generated-by: [Tool Name and Version]
