### PR TITLE
[FLINK-40285][table] `MLPredictSemanticTests` fails because of `ON CONFLICT`

### DIFF
--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/MLPredictTestPrograms.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/MLPredictTestPrograms.java
@@ -20,6 +20,7 @@ package org.apache.flink.table.planner.plan.nodes.exec.stream;
 
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.Expressions;
+import org.apache.flink.table.api.InsertConflictStrategy;
 import org.apache.flink.table.api.ModelDescriptor;
 import org.apache.flink.table.api.Schema;
 import org.apache.flink.table.api.config.ExecutionConfigOptions;
@@ -182,7 +183,8 @@ public class MLPredictTestPrograms {
                                             env.from("features").asArgument("INPUT"),
                                             env.fromModel("chatgpt").asArgument("MODEL"),
                                             descriptor("feature").asArgument("ARGS")),
-                            "sink")
+                            "sink",
+                            InsertConflictStrategy.deduplicate())
                     .build();
 
     public static final TableTestProgram ASYNC_ML_PREDICT_TABLE_API =
@@ -209,7 +211,8 @@ public class MLPredictTestPrograms {
                                                                             DataTypes.STRING())
                                                                     .notNull())
                                                     .asArgument("CONFIG")),
-                            "sink")
+                            "sink",
+                            InsertConflictStrategy.deduplicate())
                     .build();
 
     public static final TableTestProgram ASYNC_ML_PREDICT_TABLE_API_MAP_EXPRESSION_CONFIG =
@@ -235,7 +238,8 @@ public class MLPredictTestPrograms {
                                                             "max-concurrent-operations",
                                                             "10")
                                                     .asArgument("CONFIG")),
-                            "sink")
+                            "sink",
+                            InsertConflictStrategy.deduplicate())
                     .build();
 
     public static final TableTestProgram ML_PREDICT_MODEL_API =
@@ -248,7 +252,8 @@ public class MLPredictTestPrograms {
                                     env.fromModel("chatgpt")
                                             .predict(
                                                     env.from("features"), ColumnList.of("feature")),
-                            "sink")
+                            "sink",
+                            InsertConflictStrategy.deduplicate())
                     .build();
 
     public static final TableTestProgram ASYNC_ML_PREDICT_MODEL_API =
@@ -270,7 +275,8 @@ public class MLPredictTestPrograms {
                                                             "true",
                                                             "max-concurrent-operations",
                                                             "10")),
-                            "sink")
+                            "sink",
+                            InsertConflictStrategy.deduplicate())
                     .build();
 
     public static final TableTestProgram ML_PREDICT_ANON_MODEL_API =
@@ -304,6 +310,7 @@ public class MLPredictTestPrograms {
                                                             .build())
                                             .predict(
                                                     env.from("features"), ColumnList.of("feature")),
-                            "sink")
+                            "sink",
+                            InsertConflictStrategy.deduplicate())
                     .build();
 }


### PR DESCRIPTION

## What is the purpose of the change

The PR is to fix `MLPredictSemanticTests`  by introducing `InsertConflictStrategy.deduplicate()` as for others like in https://github.com/apache/flink/pull/27426
## Brief change log
`MLPredictSemanticTests`

## Verifying this change

`MLPredictSemanticTests`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change the checkbox below to `[X]` and replace the placeholder in the "Generated-by"
line with the tool name and version. Otherwise remove the "Generated-by" line.
See the ASF Generative Tooling Guidance for details:
https://www.apache.org/legal/generative-tooling.html

You are responsible for the quality and correctness of every change in this PR
regardless of the tooling used. Low-effort AI-generated PRs will be closed. See
AGENTS.md for the full guidance.
-->

- [ ] Yes (please specify the tool below)

Generated-by: [Tool Name and Version]
