### PR TITLE
[FLINK-40286][table] Adapt keyless upsert sink should fall back to retract to `MiscSemanticTests`

### DIFF
--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/common/CalcTestPrograms.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/common/CalcTestPrograms.java
@@ -328,7 +328,7 @@ public class CalcTestPrograms {
                     .setupTableSink(
                             SinkTestStep.newBuilder("coalesce_sink")
                                     .addSchema("order_id_str STRING")
-                                    .consumedValues("+I[1]", "+I[2]")
+                                    .consumedValues("+I[1]", "-D[1]", "+I[1]", "+I[2]")
                                     .build())
                     .runSql(
                             "INSERT INTO coalesce_sink "


### PR DESCRIPTION


## What is the purpose of the change

The PR fixes tests after FLINK-40111 changes

## Brief change log

test itself

## Verifying this change

running test

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: ( no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change the checkbox below to `[X]` and replace the placeholder in the "Generated-by"
line with the tool name and version. Otherwise remove the "Generated-by" line.
See the ASF Generative Tooling Guidance for details:
https://www.apache.org/legal/generative-tooling.html

You are responsible for the quality and correctness of every change in this PR
regardless of the tooling used. Low-effort AI-generated PRs will be closed. See
AGENTS.md for the full guidance.
-->

- [ ] Yes (please specify the tool below)

Generated-by: [Tool Name and Version]
