### PR TITLE
[FLINK-40288][table] Use correct type in `ExprCodeGenerator#visitFieldAccess`

### DIFF
--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/ExprCodeGenerator.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/ExprCodeGenerator.scala
@@ -389,7 +389,8 @@ class ExprCodeGenerator(
     val index = rexFieldAccess.getField.getIndex
     val fieldAccessExpr = generateFieldAccess(ctx, refExpr.resultType, refExpr.resultTerm, index)
 
-    val resultType = fieldAccessExpr.resultType
+    // Use the field access' own (planner-derived) type: a field of a nullable parent row is nullable even if declared NOT NULL.
+    val resultType = FlinkTypeFactory.toLogicalType(rexFieldAccess.getType)
 
     val resultTypeTerm = primitiveTypeTermForType(resultType)
     val defaultValue = primitiveDefaultValue(resultType)
@@ -410,7 +411,7 @@ class ExprCodeGenerator(
          |}
          |""".stripMargin
 
-    GeneratedExpression(resultTerm, nullTerm, resultCode, fieldAccessExpr.resultType)
+    GeneratedExpression(resultTerm, nullTerm, resultCode, resultType)
   }
 
   override def visitLiteral(literal: RexLiteral): GeneratedExpression = {


### PR DESCRIPTION
## What is the purpose of the change

The PR fixes JoinSemanticTests behavior for nested types

## Brief change log


ExprCodeGenerator
## Verifying this change
JoinSemanticTests
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change the checkbox below to `[X]` and replace the placeholder in the "Generated-by"
line with the tool name and version. Otherwise remove the "Generated-by" line.
See the ASF Generative Tooling Guidance for details:
https://www.apache.org/legal/generative-tooling.html

You are responsible for the quality and correctness of every change in this PR
regardless of the tooling used. Low-effort AI-generated PRs will be closed. See
AGENTS.md for the full guidance.
-->

- [ ] Yes (please specify the tool below)

Generated-by: [Tool Name and Version]
