### PR TITLE
[FLINK-40290][metrics] Fix duplicate quantile 1.0 in OpenTelemetry histogram summary

### DIFF
--- a/flink-metrics/flink-metrics-otel/src/main/java/org/apache/flink/metrics/otel/OpenTelemetryMetricAdapter.java
+++ b/flink-metrics/flink-metrics-otel/src/main/java/org/apache/flink/metrics/otel/OpenTelemetryMetricAdapter.java
@@ -185,7 +185,6 @@ class OpenTelemetryMetricAdapter {
                             histogram.getStatistics().getQuantile(histogramQuantile)));
         }
         quantileList.add(ImmutableValueAtQuantile.create(1, histogram.getStatistics().getMax()));
-        quantileList.add(ImmutableValueAtQuantile.create(1, histogram.getStatistics().getMax()));
         return Optional.of(
                 ImmutableMetricData.createDoubleSummary(
                         collectionMetadata.getOtelResource(),

--- a/flink-metrics/flink-metrics-otel/src/test/java/org/apache/flink/metrics/otel/OpenTelemetryMetricAdapterTest.java
+++ b/flink-metrics/flink-metrics-otel/src/test/java/org/apache/flink/metrics/otel/OpenTelemetryMetricAdapterTest.java
@@ -33,6 +33,7 @@ import io.opentelemetry.sdk.metrics.data.LongPointData;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.metrics.data.MetricDataType;
 import io.opentelemetry.sdk.metrics.data.SummaryPointData;
+import io.opentelemetry.sdk.metrics.data.ValueAtQuantile;
 import io.opentelemetry.sdk.metrics.internal.data.ImmutableGaugeData;
 import io.opentelemetry.sdk.metrics.internal.data.ImmutableHistogramData;
 import io.opentelemetry.sdk.metrics.internal.data.ImmutableSumData;
@@ -192,6 +193,15 @@ public class OpenTelemetryMetricAdapterTest {
 
         assertThat(summaryPointData.getValues().get(5).getQuantile()).isEqualTo(1);
         assertThat(summaryPointData.getValues().get(5).getValue()).isEqualTo(6);
+
+        // The summary must expose exactly one entry per quantile (min, the configured
+        // HISTOGRAM_QUANTILES and max) with no duplicated quantile 1.0.
+        assertThat(summaryPointData.getValues())
+                .hasSize(OpenTelemetryMetricAdapter.HISTOGRAM_QUANTILES.length + 2);
+        assertThat(summaryPointData.getValues())
+                .extracting(ValueAtQuantile::getQuantile)
+                .doesNotHaveDuplicates()
+                .containsExactly(0d, 0.5d, 0.75d, 0.95d, 0.99d, 1d);
 
         assertThat(asStringMap(summaryPointData.getAttributes())).isEqualTo(VARIABLES);
     }


### PR DESCRIPTION
## What is the purpose of the change

`OpenTelemetryMetricAdapter#convertHistogram` appended the histogram max
(quantile `1.0`) to the emitted summary twice, so every OpenTelemetry summary
data point contained a duplicated `quantile=1.0` entry. This fixes the
duplicate so each quantile is emitted exactly once.

## Brief change log

- Remove the duplicated `quantileList.add(... quantile 1.0 / max ...)` call in
  `OpenTelemetryMetricAdapter#convertHistogram`.
- Extend `OpenTelemetryMetricAdapterTest#testHistogram` to assert the summary
  contains exactly `min + HISTOGRAM_QUANTILES + max` entries, has no duplicate
  quantiles, and emits the exact quantile sequence `[0, 0.5, 0.75, 0.95, 0.99, 1]`.

## Verifying this change

This change is covered by the existing (now strengthened)
`OpenTelemetryMetricAdapterTest#testHistogram`, which fails on the previous code
(duplicate quantile 1.0) and passes with the fix.

## Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): no
- The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
- The serializers: no
- The runtime per-record code paths (performance sensitive): no
- Anything that affects deployment or recovery: no
- The S3 file system connector: no

## Documentation

- Does this pull request introduce a new feature? no
- If yes, how is the feature documented? not applicable
