### PR TITLE
[FLINK-40291][metrics] Fix instrumentation scope hardcoded

### DIFF
--- a/flink-metrics/flink-metrics-otel/src/main/java/org/apache/flink/metrics/otel/OpenTelemetryMetricAdapter.java
+++ b/flink-metrics/flink-metrics-otel/src/main/java/org/apache/flink/metrics/otel/OpenTelemetryMetricAdapter.java
@@ -55,7 +55,8 @@ class OpenTelemetryMetricAdapter {
     static final double[] HISTOGRAM_QUANTILES = {0.5, 0.75, 0.95, 0.99};
 
     static final InstrumentationScopeInfo INSTRUMENTATION_SCOPE_INFO =
-            InstrumentationScopeInfo.create(OpenTelemetryMetricAdapter.class.getPackage().getName());
+            InstrumentationScopeInfo.create(
+                    OpenTelemetryMetricAdapter.class.getPackage().getName());
 
     public static Optional<MetricData> convertCounter(
             CollectionMetadata collectionMetadata,

--- a/flink-metrics/flink-metrics-otel/src/main/java/org/apache/flink/metrics/otel/OpenTelemetryMetricAdapter.java
+++ b/flink-metrics/flink-metrics-otel/src/main/java/org/apache/flink/metrics/otel/OpenTelemetryMetricAdapter.java
@@ -55,7 +55,7 @@ class OpenTelemetryMetricAdapter {
     static final double[] HISTOGRAM_QUANTILES = {0.5, 0.75, 0.95, 0.99};
 
     static final InstrumentationScopeInfo INSTRUMENTATION_SCOPE_INFO =
-            InstrumentationScopeInfo.create("io.confluent.flink.common.metrics");
+            InstrumentationScopeInfo.create(OpenTelemetryMetricAdapter.class.getPackage().getName());
 
     public static Optional<MetricData> convertCounter(
             CollectionMetadata collectionMetadata,

--- a/flink-metrics/flink-metrics-otel/src/test/java/org/apache/flink/metrics/otel/OpenTelemetryMetricReporterITCase.java
+++ b/flink-metrics/flink-metrics-otel/src/test/java/org/apache/flink/metrics/otel/OpenTelemetryMetricReporterITCase.java
@@ -103,7 +103,7 @@ public class OpenTelemetryMetricReporterITCase extends OpenTelemetryTestBase {
                     JsonNode scopeMetrics =
                             json.findPath("resourceMetrics").findPath("scopeMetrics");
                     assertThat(scopeMetrics.findPath("scope").findPath("name").asText())
-                            .isEqualTo("io.confluent.flink.common.metrics");
+                            .isEqualTo("org.apache.flink.metrics.otel");
                     JsonNode metrics = scopeMetrics.findPath("metrics");
 
                     List<String> metricNames = extractMetricNames(json);


### PR DESCRIPTION
## What is the purpose of the change

This scope name is emitted as the `scope.name` field on every OTel ScopeMetrics envelope produced by the reporter. It does not reference Flink at all, which is confusing for operators inspecting exported data and for anyone configuring OTel Collector processors/filters that match on instrumentation scope name.


## Brief change log
- Derive the OTel instrumentation scope name from the module's own package
- Update relevant test


## Verifying this change
This change added tests and can be verified as follows:
- Update relevant test

