### PR TITLE
[FLINK-40292][table-runtime] Add UdfMetrics helper for UDF metrics

### DIFF
--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/metrics/UdfMetrics.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/metrics/UdfMetrics.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.operators.metrics;
+
+import org.apache.flink.metrics.Counter;
+import org.apache.flink.metrics.Histogram;
+import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.metrics.ThreadSafeSimpleCounter;
+import org.apache.flink.runtime.metrics.DescriptiveStatisticsHistogram;
+import org.apache.flink.util.Preconditions;
+
+/**
+ * Per-operator metrics for a single user-defined function, registered under {@code
+ * <operator>.udf.<udfName>}: {@code udfProcessingTime} (a latency histogram) and {@code
+ * udfExceptionCount} (a counter of exceptions escaping the function).
+ *
+ * <p>Timing is sampled: only one invocation out of every {@code sampleInterval} is measured, so a
+ * hot function does not pay {@code System.nanoTime()} on every record. The sample decision advances
+ * a plain {@code int} and is only ever taken on the task thread, so it needs no synchronization.
+ * The two registered metrics are safe for the async completion thread to touch: the histogram
+ * synchronizes internally and the exception counter is {@link ThreadSafeSimpleCounter}.
+ */
+public final class UdfMetrics {
+
+    private static final int HISTORY_SIZE = 128;
+
+    private final int sampleInterval;
+    private final Histogram processingTime;
+    private final Counter exceptionCount;
+
+    // Sample counter; only touched on the task thread, hence a plain int with no synchronization.
+    private int invocationCount = 0;
+
+    private UdfMetrics(int sampleInterval, Histogram processingTime, Counter exceptionCount) {
+        this.sampleInterval = sampleInterval;
+        this.processingTime = processingTime;
+        this.exceptionCount = exceptionCount;
+    }
+
+    /**
+     * Registers the {@code udfProcessingTime} histogram and {@code udfExceptionCount} counter under
+     * {@code <operatorMetricGroup>.udf.<udfName>}.
+     *
+     * @param sampleInterval measure one invocation out of every {@code sampleInterval}; must be
+     *     {@code >= 1} ({@code 1} measures every invocation)
+     */
+    public static UdfMetrics register(
+            MetricGroup operatorMetricGroup, String udfName, int sampleInterval) {
+        Preconditions.checkArgument(
+                sampleInterval >= 1,
+                "UDF metric sample interval must be >= 1, but was %s.",
+                sampleInterval);
+        MetricGroup group = operatorMetricGroup.addGroup("udf", udfName);
+        return new UdfMetrics(
+                sampleInterval,
+                group.histogram(
+                        "udfProcessingTime", new DescriptiveStatisticsHistogram(HISTORY_SIZE)),
+                group.counter("udfExceptionCount", new ThreadSafeSimpleCounter()));
+    }
+
+    /**
+     * Returns {@code true} for the one invocation in every {@code sampleInterval} whose processing
+     * time should be measured. Must be called once per invocation, on the task thread only.
+     */
+    public boolean shouldSample() {
+        if (sampleInterval == 1) {
+            return true;
+        }
+        invocationCount = (invocationCount + 1 < sampleInterval) ? invocationCount + 1 : 0;
+        return invocationCount == 1;
+    }
+
+    /** Records an elapsed processing time (nanoseconds) for a sampled invocation. */
+    public void update(long elapsedNanos) {
+        processingTime.update(elapsedNanos);
+    }
+
+    /** Counts one exception escaping the user-defined function. */
+    public void markException() {
+        exceptionCount.inc();
+    }
+}

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/metrics/UdfMetrics.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/metrics/UdfMetrics.java
@@ -40,6 +40,7 @@ public final class UdfMetrics {
 
     private static final int HISTORY_SIZE = 128;
 
+    // Counted in invocations, not in time: one call out of every sampleInterval is timed.
     private final int sampleInterval;
     private final Histogram processingTime;
     private final Counter exceptionCount;
@@ -57,8 +58,8 @@ public final class UdfMetrics {
      * Registers the {@code udfProcessingTime} histogram and {@code udfExceptionCount} counter under
      * {@code <operatorMetricGroup>.udf.<udfName>}.
      *
-     * @param sampleInterval measure one invocation out of every {@code sampleInterval}; must be
-     *     {@code >= 1} ({@code 1} measures every invocation)
+     * @param sampleInterval a number of invocations, not a duration: one call out of every {@code
+     *     sampleInterval} is timed. Must be {@code >= 1} ({@code 1} measures every invocation).
      */
     public static UdfMetrics register(
             MetricGroup operatorMetricGroup, String udfName, int sampleInterval) {

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/metrics/UdfMetricsTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/metrics/UdfMetricsTest.java
@@ -1,0 +1,140 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.operators.metrics;
+
+import org.apache.flink.metrics.Counter;
+import org.apache.flink.metrics.Histogram;
+import org.apache.flink.metrics.ThreadSafeSimpleCounter;
+import org.apache.flink.metrics.testutils.MetricListener;
+import org.apache.flink.runtime.metrics.DescriptiveStatisticsHistogram;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Tests for {@link UdfMetrics}. */
+class UdfMetricsTest {
+
+    private MetricListener metricListener;
+
+    @BeforeEach
+    void setUp() {
+        metricListener = new MetricListener();
+    }
+
+    @Test
+    void sampleEveryNth() {
+        UdfMetrics metrics = register("myUdf", 100);
+
+        List<Integer> sampledCalls = new ArrayList<>();
+        for (int call = 1; call <= 300; call++) {
+            if (metrics.shouldSample()) {
+                sampledCalls.add(call);
+            }
+        }
+
+        // With interval 100 exactly one call in every 100 is sampled, on the 1st, 101st, 201st.
+        assertThat(sampledCalls).containsExactly(1, 101, 201);
+    }
+
+    @Test
+    void sampleEveryCallWhenIntervalOne() {
+        UdfMetrics metrics = register("myUdf", 1);
+
+        for (int call = 0; call < 10; call++) {
+            assertThat(metrics.shouldSample()).isTrue();
+        }
+    }
+
+    @Test
+    void rejectsNonPositiveInterval() {
+        assertThatThrownBy(() -> register("myUdf", 0)).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> register("myUdf", -1))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void registrationNamesAndTypes() {
+        register("myUdf", 100);
+
+        assertThat(metricListener.getHistogram("udf", "myUdf", "udfProcessingTime"))
+                .get()
+                .isInstanceOf(DescriptiveStatisticsHistogram.class);
+        assertThat(metricListener.getCounter("udf", "myUdf", "udfExceptionCount"))
+                .get()
+                .isInstanceOf(ThreadSafeSimpleCounter.class);
+    }
+
+    @Test
+    void updateFeedsHistogram() {
+        UdfMetrics metrics = register("myUdf", 1);
+        Histogram histogram =
+                metricListener.getHistogram("udf", "myUdf", "udfProcessingTime").get();
+
+        metrics.update(10L);
+        metrics.update(20L);
+        metrics.update(30L);
+
+        assertThat(histogram.getCount()).isEqualTo(3L);
+        assertThat(histogram.getStatistics().getMin()).isEqualTo(10L);
+        assertThat(histogram.getStatistics().getMax()).isEqualTo(30L);
+    }
+
+    @Test
+    void markExceptionCounts() {
+        UdfMetrics metrics = register("myUdf", 1);
+        Counter counter = metricListener.getCounter("udf", "myUdf", "udfExceptionCount").get();
+
+        metrics.markException();
+        metrics.markException();
+
+        assertThat(counter.getCount()).isEqualTo(2L);
+    }
+
+    @Test
+    void metricsAreIndependentPerUdf() {
+        UdfMetrics first = register("firstUdf", 1);
+        register("secondUdf", 1);
+        Histogram firstHistogram =
+                metricListener.getHistogram("udf", "firstUdf", "udfProcessingTime").get();
+        Counter firstCounter =
+                metricListener.getCounter("udf", "firstUdf", "udfExceptionCount").get();
+        Histogram secondHistogram =
+                metricListener.getHistogram("udf", "secondUdf", "udfProcessingTime").get();
+        Counter secondCounter =
+                metricListener.getCounter("udf", "secondUdf", "udfExceptionCount").get();
+
+        first.update(10L);
+        first.markException();
+
+        assertThat(firstHistogram.getCount()).isEqualTo(1L);
+        assertThat(firstCounter.getCount()).isEqualTo(1L);
+        assertThat(secondHistogram.getCount()).isZero();
+        assertThat(secondCounter.getCount()).isZero();
+    }
+
+    private UdfMetrics register(String udfName, int sampleInterval) {
+        return UdfMetrics.register(metricListener.getMetricGroup(), udfName, sampleInterval);
+    }
+}


### PR DESCRIPTION
This is the first PR of the FLIP-485 implementation, split into a stack of small, independently reviewable PRs under the umbrella issue [FLINK-38071](https://issues.apache.org/jira/browse/FLINK-38071). Landing order:

| Step | Sub-task | Scope |
|---|---|---|
| **PR-1 (this PR)** | [FLINK-40292](https://issues.apache.org/jira/browse/FLINK-40292) | `UdfMetrics` helper: registration, sampling, timing, exception counting |
| PR-2 | [FLINK-40293](https://issues.apache.org/jira/browse/FLINK-40293) | Config options + sync scalar/table instrumentation |
| PR-3 | [FLINK-40294](https://issues.apache.org/jira/browse/FLINK-40294) | Async scalar/table instrumentation |
| PR-4 | [FLINK-40295](https://issues.apache.org/jira/browse/FLINK-40295) | User-facing documentation |

[FLIP-485](https://cwiki.apache.org/confluence/spaces/FLINK/pages/373885706/FLIP-485+Add+UDF+Metrics) passed the [vote](https://lists.apache.org/thread/symqpswsohl2s5wmtkcw0jjp1w5dot0n) on 2026-08-01. This series supersedes the single reference-implementation draft in #28692, which is closed.

## What is the purpose of the change

FLIP-485 adds opt-in, per-operator observability for SQL/Table user-defined functions, so operators can see inside UDF "black boxes" when debugging latency or errors, and so autoscaling gets a reliable "the problem is in user code" signal.

This PR adds only the shared runtime helper, `UdfMetrics`. It owns metric registration, the sampling decision, timing, and exception counting, and it is the piece both the synchronous and the asynchronous paths use. It has no caller yet; the first caller arrives in PR-2. Keeping it separate makes the sampling and registration logic reviewable on its own.

## Brief change log

- Add `UdfMetrics` in `flink-table-runtime` (`org.apache.flink.table.runtime.operators.metrics`, beside `SimpleGauge`). It registers `udfProcessingTime` and `udfExceptionCount` under `addGroup("udf", udfName)` on the operator metric group, so the full identifier is `<operator_name>.udf.<udf_name>.<metric>`.
- `udfProcessingTime` is a `DescriptiveStatisticsHistogram` of per-invocation nanoseconds, sampled with the same counter-based scheme as state latency tracking (FLINK-21736), including the `interval == 1` "measure every call" case.
- `udfExceptionCount` is a `ThreadSafeSimpleCounter`, incremented on every exception and not sampled.
- The histogram is safe to update from an async callback thread; the sampling counter is only advanced on the task thread at dispatch.

## Verifying this change

This change added tests and can be verified as follows:

- `UdfMetricsTest` covers metric registration and naming, the sampling decision across the interval boundary, the `sample-interval = 1` case, rejection of a non-positive interval, timing recorded into the histogram, exception counting, and that two UDFs registered on the same operator get independent metrics.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no. Nothing calls this class yet; the call sites and their gating arrive in PR-2 and PR-3.
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes, as the first step of FLIP-485
  - If yes, how is the feature documented? JavaDocs here; the user-facing documentation lands in PR-4.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: Claude Code (Anthropic Claude Opus 4.8 and Claude Opus 5)
