### PR TITLE
[FLINK-40301][table] Merge Calc nodes before ChangelogNormalize projection pushdown

### DIFF
--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkStreamRuleSets.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkStreamRuleSets.scala
@@ -540,6 +540,7 @@ object FlinkStreamRuleSets {
   val CHANGELOG_NORMALIZE_TRANSPOSE_RULES: RuleSet = RuleSets.ofList(
     WatermarkAssignerChangelogNormalizeTransposeRule.WITH_CALC,
     WatermarkAssignerChangelogNormalizeTransposeRule.WITHOUT_CALC,
+    FlinkCalcMergeRule.STREAM_PHYSICAL_INSTANCE,
     // reduce state size in ChangelogNormalize
     PushCalcPastChangelogNormalizeRule.INSTANCE
   )

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/rules/physical/stream/WatermarkAssignerChangelogNormalizeTransposeRuleTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/rules/physical/stream/WatermarkAssignerChangelogNormalizeTransposeRuleTest.xml
@@ -125,6 +125,38 @@ Calc(select=[a, b, f], where=[f], changelogMode=[I])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testPushdownCalcNotAffectChangelogNormalizeKey2">
+    <Resource name="sql">
+      <![CDATA[
+SELECT f, count(*)
+FROM (select ingestion_time, f, a from t2) t2
+group by f
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalAggregate(group=[{0}], EXPR$1=[COUNT()])
++- LogicalProject(f=[$1])
+   +- LogicalProject(ingestion_time=[$1], f=[$3], a=[$2])
+      +- LogicalWatermarkAssigner(rowtime=[ingestion_time], watermark=[$1])
+         +- LogicalProject(k=[$0], ingestion_time=[CAST($3):TIMESTAMP(3) *ROWTIME*], a=[$1], f=[$2])
+            +- LogicalTableScan(table=[[default_catalog, default_database, t2, metadata=[ts]]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+GroupAggregate(groupBy=[f], select=[f, COUNT_RETRACT(*) AS EXPR$1], changelogMode=[I,UA,D])
++- Exchange(distribution=[hash[f]], changelogMode=[I,UB,UA,D])
+   +- Calc(select=[f], changelogMode=[I,UB,UA,D])
+      +- ChangelogNormalize(key=[a], changelogMode=[I,UB,UA,D])
+         +- Exchange(distribution=[hash[a]], changelogMode=[I,UA,D])
+            +- Calc(select=[f, a], changelogMode=[I,UA,D])
+               +- WatermarkAssigner(rowtime=[ingestion_time], watermark=[ingestion_time], changelogMode=[I,UA,D])
+                  +- Calc(select=[f, CAST(ingestion_time AS TIMESTAMP(3) *ROWTIME*) AS ingestion_time, a], changelogMode=[I,UA,D])
+                     +- TableSourceScan(table=[[default_catalog, default_database, t2, project=[f, a], metadata=[ts]]], fields=[f, a, ingestion_time], changelogMode=[I,UA,D])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testPushdownNewCalcAndWatermarkAssignerWithCalc">
     <Resource name="sql">
       <![CDATA[

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/rules/physical/stream/WatermarkAssignerChangelogNormalizeTransposeRuleTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/rules/physical/stream/WatermarkAssignerChangelogNormalizeTransposeRuleTest.scala
@@ -75,6 +75,31 @@ class WatermarkAssignerChangelogNormalizeTransposeRuleTest extends TableTestBase
                      | 'enable-watermark-push-down' = 'true'
                      |)
                      |""".stripMargin)
+    util.addTable("""
+                    |CREATE TABLE t1 (
+                    |  ingestion_time TIMESTAMP(3) METADATA FROM 'ts',
+                    |  a VARCHAR NOT NULL,
+                    |  b VARCHAR NOT NULL,
+                    |  WATERMARK FOR ingestion_time AS ingestion_time
+                    |) WITH (
+                    | 'connector' = 'values',
+                    | 'readable-metadata' = 'ts:TIMESTAMP(3)'
+                    |)
+      """.stripMargin)
+    util.addTable("""
+                    |CREATE TABLE t2 (
+                    |  k VARBINARY,
+                    |  ingestion_time TIMESTAMP(3) METADATA FROM 'ts',
+                    |  a VARCHAR NOT NULL,
+                    |  f BOOLEAN NOT NULL,
+                    |  WATERMARK FOR `ingestion_time` AS `ingestion_time`,
+                    |  PRIMARY KEY (`a`) NOT ENFORCED
+                    |) WITH (
+                    | 'connector' = 'values',
+                    | 'readable-metadata' = 'ts:TIMESTAMP(3)',
+                    | 'changelog-mode' = 'I,UA,D'
+                    |)
+      """.stripMargin)
   }
 
   // ----------------------------------------------------------------------------------------
@@ -169,31 +194,6 @@ class WatermarkAssignerChangelogNormalizeTransposeRuleTest extends TableTestBase
 
   @Test
   def testPushdownCalcNotAffectChangelogNormalizeKey(): Unit = {
-    util.addTable("""
-                    |CREATE TABLE t1 (
-                    |  ingestion_time TIMESTAMP(3) METADATA FROM 'ts',
-                    |  a VARCHAR NOT NULL,
-                    |  b VARCHAR NOT NULL,
-                    |  WATERMARK FOR ingestion_time AS ingestion_time
-                    |) WITH (
-                    | 'connector' = 'values',
-                    | 'readable-metadata' = 'ts:TIMESTAMP(3)'
-                    |)
-      """.stripMargin)
-    util.addTable("""
-                    |CREATE TABLE t2 (
-                    |  k VARBINARY,
-                    |  ingestion_time TIMESTAMP(3) METADATA FROM 'ts',
-                    |  a VARCHAR NOT NULL,
-                    |  f BOOLEAN NOT NULL,
-                    |  WATERMARK FOR `ingestion_time` AS `ingestion_time`,
-                    |  PRIMARY KEY (`a`) NOT ENFORCED
-                    |) WITH (
-                    | 'connector' = 'values',
-                    | 'readable-metadata' = 'ts:TIMESTAMP(3)',
-                    | 'changelog-mode' = 'I,UA,D'
-                    |)
-      """.stripMargin)
     // After FLINK-28988 applied, the filter will not be pushed down into left input of join and get
     // a more optimal plan (upsert mode without ChangelogNormalize).
     val sql =
@@ -201,6 +201,17 @@ class WatermarkAssignerChangelogNormalizeTransposeRuleTest extends TableTestBase
         |SELECT t1.a, t1.b, t2.f
         |FROM t1 INNER JOIN t2 FOR SYSTEM_TIME AS OF t1.ingestion_time
         | ON t1.a = t2.a WHERE t2.f = true
+        |""".stripMargin
+    util.verifyRelPlan(sql, ExplainDetail.CHANGELOG_MODE)
+  }
+
+  @Test
+  def testPushdownCalcNotAffectChangelogNormalizeKey2(): Unit = {
+    val sql =
+      """
+        |SELECT f, count(*)
+        |FROM (select ingestion_time, f, a from t2) t2
+        |group by f
         |""".stripMargin
     util.verifyRelPlan(sql, ExplainDetail.CHANGELOG_MODE)
   }


### PR DESCRIPTION
## What is the purpose of the change

This change fixes an optimizer issue where adjacent Calc nodes created by watermark transposition prevent unused fields from being projected out on the input side of `ChangelogNormalize`. This unnecessarily increases the shuffle row width and `ChangelogNormalize` state size.

## Brief change log

- Add `FlinkCalcMergeRule.STREAM_PHYSICAL_INSTANCE` to `CHANGELOG_NORMALIZE_TRANSPOSE_RULES` so that Calc nodes created by `WatermarkAssignerChangelogNormalizeTransposeRule` are merged before `PushCalcPastChangelogNormalizeRule` runs.
- Add `testPushdownCalcNotAffectChangelogNormalizeKey2` to `WatermarkAssignerChangelogNormalizeTransposeRuleTest`.

## Verifying this change

`WatermarkAssignerChangelogNormalizeTransposeRuleTest#testPushdownCalcNotAffectChangelogNormalizeKey2` verifies that only the required field `f` and the `ChangelogNormalize` key `a` are projected to its input side. The rowtime field `ingestion_time` remains available to `WatermarkAssigner` without entering the shuffle or `ChangelogNormalize` state.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable