### PR TITLE
[FLINK-40303][table] Skip non-key NOT NULL checks for key-only deletes

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecSink.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecSink.java
@@ -188,7 +188,7 @@ public abstract class CommonExecSink extends ExecNodeBase<Object>
                 TableLineageUtils.extractLineageDataset(outputObject);
 
         Transformation<RowData> sinkTransform =
-                applyConstraintValidations(inputTransform, config, persistedRowType);
+                applyConstraintValidations(inputTransform, config, persistedRowType, primaryKeys);
 
         if (hasPk) {
             sinkTransform =
@@ -252,14 +252,17 @@ public abstract class CommonExecSink extends ExecNodeBase<Object>
     private Transformation<RowData> applyConstraintValidations(
             Transformation<RowData> inputTransform,
             ExecNodeConfig config,
-            RowType physicalRowType) {
+            RowType physicalRowType,
+            int[] primaryKeys) {
         final Optional<ConstraintEnforcerExecutor> enforcerExecutor =
                 ConstraintEnforcerExecutor.create(
                         physicalRowType,
                         config.get(ExecutionConfigOptions.TABLE_EXEC_SINK_NOT_NULL_ENFORCER),
                         config.get(ExecutionConfigOptions.TABLE_EXEC_SINK_TYPE_LENGTH_ENFORCER),
                         config.get(
-                                ExecutionConfigOptions.TABLE_EXEC_SINK_NESTED_CONSTRAINT_ENFORCER));
+                                ExecutionConfigOptions.TABLE_EXEC_SINK_NESTED_CONSTRAINT_ENFORCER),
+                        inputChangelogMode.keyOnlyDeletes(),
+                        primaryKeys);
 
         return enforcerExecutor
                 .map(

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/DeletesByKeyPrograms.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/DeletesByKeyPrograms.java
@@ -79,7 +79,7 @@ public final class DeletesByKeyPrograms {
             INSERT_SELECT_DELETE_BY_KEY_DELETE_BY_KEY_WITH_NOT_NULL_SINK =
                     TableTestProgram.of(
                                     "select-delete-on-key-to-not-null-sink",
-                                    "No ChangelogNormalize: validates that key-only deletes can contain null"
+                                    "No ChangelogNormalize: validates that key-only delete can contain null"
                                             + " non-key fields when writing to a sink with NOT NULL constraints")
                             .setupTableSource(
                                     SourceTestStep.newBuilder("source_t")

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/DeletesByKeyPrograms.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/DeletesByKeyPrograms.java
@@ -75,6 +75,35 @@ public final class DeletesByKeyPrograms {
                     .runSql("INSERT INTO sink_t SELECT id, name, `value` FROM source_t")
                     .build();
 
+    public static final TableTestProgram
+            INSERT_SELECT_DELETE_BY_KEY_DELETE_BY_KEY_WITH_NOT_NULL_SINK =
+                    TableTestProgram.of(
+                                    "select-delete-on-key-to-not-null-sink",
+                                    "No ChangelogNormalize: validates that key-only deletes can contain null"
+                                            + " non-key fields when writing to a sink with NOT NULL constraints")
+                            .setupTableSource(
+                                    SourceTestStep.newBuilder("source_t")
+                                            .addSchema(
+                                                    "id INT PRIMARY KEY NOT ENFORCED",
+                                                    "name STRING")
+                                            .addOption("changelog-mode", "I,UA,D")
+                                            .addOption("source.produces-delete-by-key", "true")
+                                            .producedValues(
+                                                    Row.ofKind(RowKind.INSERT, 1, "Alice"),
+                                                    Row.ofKind(RowKind.DELETE, 1, null))
+                                            .build())
+                            .setupTableSink(
+                                    SinkTestStep.newBuilder("sink_t")
+                                            .addSchema(
+                                                    "id INT PRIMARY KEY NOT ENFORCED",
+                                                    "name STRING NOT NULL")
+                                            .addOption("changelog-mode", "I,UA,D")
+                                            .addOption("sink.supports-delete-by-key", "true")
+                                            .consumedValues("+I[1, Alice]", "-D[1, null]")
+                                            .build())
+                            .runSql("INSERT INTO sink_t SELECT id, name FROM source_t")
+                            .build();
+
     public static final TableTestProgram INSERT_SELECT_DELETE_BY_KEY_DELETE_BY_KEY_WITH_PROJECTION =
             TableTestProgram.of(
                             "select-delete-on-key-to-delete-on-key-with-projection",

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/DeletesByKeySemanticTests.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/DeletesByKeySemanticTests.java
@@ -30,6 +30,7 @@ public class DeletesByKeySemanticTests extends SemanticTestBase {
     public List<TableTestProgram> programs() {
         return List.of(
                 DeletesByKeyPrograms.INSERT_SELECT_DELETE_BY_KEY_DELETE_BY_KEY,
+                DeletesByKeyPrograms.INSERT_SELECT_DELETE_BY_KEY_DELETE_BY_KEY_WITH_NOT_NULL_SINK,
                 DeletesByKeyPrograms.INSERT_SELECT_DELETE_BY_KEY_FULL_DELETE,
                 DeletesByKeyPrograms.INSERT_SELECT_FULL_DELETE_FULL_DELETE,
                 DeletesByKeyPrograms.INSERT_SELECT_DELETE_BY_KEY_DELETE_BY_KEY_WITH_PROJECTION,

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/sink/constraint/ConstraintEnforcerExecutor.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/sink/constraint/ConstraintEnforcerExecutor.java
@@ -70,10 +70,16 @@ public class ConstraintEnforcerExecutor implements Serializable {
             final RowType physicalType,
             final NotNullEnforcer notNullEnforcer,
             final TypeLengthEnforcer typeLengthEnforcer,
-            final NestedEnforcer nestedConstraints) {
+            final NestedEnforcer nestedConstraints,
+            final boolean keyOnlyDeletes,
+            final int[] primaryKeyIndices) {
         final Constraint[] topLevelConstraints =
                 createConstraints(
-                        physicalType, notNullEnforcer, typeLengthEnforcer, nestedConstraints);
+                        physicalType,
+                        notNullEnforcer,
+                        typeLengthEnforcer,
+                        nestedConstraints,
+                        keyOnlyDeletes ? primaryKeyIndices : null);
 
         return create(topLevelConstraints);
     }
@@ -83,6 +89,16 @@ public class ConstraintEnforcerExecutor implements Serializable {
             final NotNullEnforcer notNullEnforcer,
             final TypeLengthEnforcer typeLengthEnforcer,
             final NestedEnforcer nestedEnforcer) {
+        return createConstraints(
+                physicalType, notNullEnforcer, typeLengthEnforcer, nestedEnforcer, null);
+    }
+
+    private static Constraint[] createConstraints(
+            final RowType physicalType,
+            final NotNullEnforcer notNullEnforcer,
+            final TypeLengthEnforcer typeLengthEnforcer,
+            final NestedEnforcer nestedEnforcer,
+            final @Nullable int[] keyOnlyDeleteFieldIndices) {
         final String[] fieldNames = physicalType.getFieldNames().toArray(new String[0]);
         final List<Constraint> constraints = new ArrayList<>();
 
@@ -98,7 +114,8 @@ public class ConstraintEnforcerExecutor implements Serializable {
                     new NotNullConstraint(
                             NotNullEnforcementStrategy.of(notNullEnforcer),
                             notNullFieldIndices,
-                            notNullFieldNames));
+                            notNullFieldNames,
+                            keyOnlyDeleteFieldIndices));
         }
 
         if (typeLengthEnforcer != TypeLengthEnforcer.IGNORE) {

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/sink/constraint/NotNullConstraint.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/sink/constraint/NotNullConstraint.java
@@ -21,6 +21,9 @@ package org.apache.flink.table.runtime.operators.sink.constraint;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.table.api.config.ExecutionConfigOptions;
 import org.apache.flink.table.data.RowData;
+import org.apache.flink.types.RowKind;
+
+import org.apache.commons.lang3.ArrayUtils;
 
 import javax.annotation.Nullable;
 
@@ -32,14 +35,17 @@ final class NotNullConstraint implements Constraint {
     private final NotNullEnforcementStrategy enforcementStrategy;
     private final int[] notNullFieldIndices;
     private final String[] notNullFieldNames;
+    private final @Nullable int[] keyOnlyDeleteFieldIndices;
 
     NotNullConstraint(
             NotNullEnforcementStrategy enforcementStrategy,
             int[] notNullFieldIndices,
-            String[] notNullFieldNames) {
+            String[] notNullFieldNames,
+            @Nullable int[] keyOnlyDeleteFieldIndices) {
         this.enforcementStrategy = enforcementStrategy;
         this.notNullFieldIndices = notNullFieldIndices;
         this.notNullFieldNames = notNullFieldNames;
+        this.keyOnlyDeleteFieldIndices = keyOnlyDeleteFieldIndices;
     }
 
     @Nullable
@@ -47,6 +53,12 @@ final class NotNullConstraint implements Constraint {
     public RowData enforce(RowData input) {
         for (int i = 0; i < notNullFieldIndices.length; i++) {
             final int index = notNullFieldIndices[i];
+            // Non-key fields have no value semantics in a key-only DELETE.
+            if (input.getRowKind() == RowKind.DELETE
+                    && keyOnlyDeleteFieldIndices != null
+                    && !ArrayUtils.contains(keyOnlyDeleteFieldIndices, index)) {
+                continue;
+            }
             if (input.isNullAt(index)) {
                 switch (enforcementStrategy) {
                     case ERROR:


### PR DESCRIPTION
## What is the purpose of the change

Key-only DELETE records set non-key fields to null. When a sink declares NOT NULL constraints on non-key columns, the constraint enforcer incorrectly rejects these valid DELETE records.

## Brief change log

- Pass the input changelog's key-only DELETE semantic and sink primary key indices from `CommonExecSink` to `ConstraintEnforcerExecutor`.
- Update `NotNullConstraint` to skip non-key fields for key-only DELETE records while continuing to validate primary key fields.
- Add semantic coverage for writing a key-only DELETE to a sink with a NOT NULL non-key column.

## Verifying this change

Added `INSERT_SELECT_DELETE_BY_KEY_DELETE_BY_KEY_WITH_NOT_NULL_SINK` to `DeletesByKeySemanticTests`. The test covers a key-only source and sink, verifies that ChangelogNormalize can remain eliminated, and expects `-D[1, null]` to be accepted by a sink whose non-key column is NOT NULL.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable