### PR TITLE
[FLINK-40304][table] Fix PTF partition columns for multiple table arguments

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamPhysicalProcessTableFunction.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamPhysicalProcessTableFunction.java
@@ -515,7 +515,7 @@ public class StreamPhysicalProcessTableFunction extends AbstractRelNode
                 // f(t1 PARTITION BY (k1, k2), t2 PARTITION BY (k3, k4))
                 // -> [k1, k2, k3, k4, function out...]
                 final List<Integer> partitionColumns =
-                        IntStream.range(pos, partitionKeyCount)
+                        IntStream.range(pos, pos + partitionKeyCount)
                                 .boxed()
                                 .collect(Collectors.toList());
                 pos += partitionKeyCount;

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/stream/sql/ProcessTableFunctionTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/stream/sql/ProcessTableFunctionTest.java
@@ -94,7 +94,7 @@ class ProcessTableFunctionTest extends TableTestBase {
                         "CREATE VIEW t AS SELECT * FROM (VALUES ('Bob', 12), ('Alice', 42)) AS T(name, score)");
         util.tableEnv()
                 .executeSql(
-                        "CREATE VIEW t_city AS SELECT * FROM (VALUES ('Bob', 'London'), ('Alice', 'Berlin')) AS T(name, city)");
+                        "CREATE VIEW t_city AS SELECT * FROM (VALUES ('Bob', 'Tokyo'), ('Alice', 'Berlin')) AS T(name, city)");
         util.tableEnv()
                 .executeSql("CREATE VIEW t_name_diff AS SELECT 'Bob' AS name, 12 AS different");
         util.tableEnv()

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/stream/sql/ProcessTableFunctionTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/stream/sql/ProcessTableFunctionTest.java
@@ -46,6 +46,7 @@ import org.apache.flink.table.planner.plan.nodes.exec.stream.ProcessTableFunctio
 import org.apache.flink.table.planner.plan.nodes.exec.stream.ProcessTableFunctionTestUtils.SetSemanticTableRetractArgFunction;
 import org.apache.flink.table.planner.plan.nodes.exec.stream.ProcessTableFunctionTestUtils.TypedRowSemanticTableFunction;
 import org.apache.flink.table.planner.plan.nodes.exec.stream.ProcessTableFunctionTestUtils.TypedSetSemanticTableFunction;
+import org.apache.flink.table.planner.plan.nodes.exec.stream.ProcessTableFunctionTestUtils.UpdatingJoinFunction;
 import org.apache.flink.table.planner.plan.nodes.exec.stream.ProcessTableFunctionTestUtils.UpdatingRetractRowSemanticFunction;
 import org.apache.flink.table.planner.plan.nodes.exec.stream.ProcessTableFunctionTestUtils.UpdatingUpsertFunction;
 import org.apache.flink.table.planner.plan.nodes.exec.stream.ProcessTableFunctionTestUtils.User;
@@ -92,6 +93,9 @@ class ProcessTableFunctionTest extends TableTestBase {
                 .executeSql(
                         "CREATE VIEW t AS SELECT * FROM (VALUES ('Bob', 12), ('Alice', 42)) AS T(name, score)");
         util.tableEnv()
+                .executeSql(
+                        "CREATE VIEW t_city AS SELECT * FROM (VALUES ('Bob', 'London'), ('Alice', 'Berlin')) AS T(name, city)");
+        util.tableEnv()
                 .executeSql("CREATE VIEW t_name_diff AS SELECT 'Bob' AS name, 12 AS different");
         util.tableEnv()
                 .executeSql("CREATE VIEW t_type_diff AS SELECT 'Bob' AS name, TRUE AS isValid");
@@ -111,6 +115,10 @@ class ProcessTableFunctionTest extends TableTestBase {
         util.tableEnv()
                 .executeSql(
                         "CREATE TABLE t_keyed_sink (`name` STRING, `out` STRING) WITH ('connector' = 'blackhole')");
+        util.tableEnv()
+                .executeSql(
+                        "CREATE TABLE t_key_only_delete_sink (`name` STRING, `name0` STRING PRIMARY KEY NOT ENFORCED, `out` STRING) "
+                                + "WITH ('connector' = 'values', 'sink-insert-only' = 'false', 'sink.supports-delete-by-key' = 'true')");
         util.tableEnv()
                 .executeSql(
                         "CREATE TABLE t_full_delete_sink (`name` STRING PRIMARY KEY NOT ENFORCED, `name0` STRING, `count` BIGINT, `mode` STRING) "
@@ -136,6 +144,17 @@ class ProcessTableFunctionTest extends TableTestBase {
                                 + "in1 => TABLE t PARTITION BY name,"
                                 + "in2 => TABLE t PARTITION BY name)");
         util.verifyRelPlan("SELECT * FROM v");
+    }
+
+    @Test
+    void testUpsertKeyWithMultipleTableArgs() {
+        util.addTemporarySystemFunction("f", UpdatingJoinFunction.class);
+        util.tableEnv()
+                .executeSql(
+                        "CREATE VIEW v AS SELECT * FROM f("
+                                + "scoreTable => TABLE t PARTITION BY name,"
+                                + "cityTable => TABLE t_city PARTITION BY name)");
+        util.verifyRelPlanInsert("INSERT INTO t_key_only_delete_sink SELECT * FROM v");
     }
 
     @Test

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/ProcessTableFunctionTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/ProcessTableFunctionTest.xml
@@ -469,6 +469,35 @@ ProcessTableFunction(invocation=[f(1, true, DEFAULT(), DEFAULT())], uid=[null], 
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testUpsertKeyWithMultipleTableArgs">
+    <Resource name="sql">
+      <![CDATA[INSERT INTO t_key_only_delete_sink SELECT * FROM v]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.t_key_only_delete_sink], fields=[name, name0, out])
++- LogicalProject(name=[$0], name0=[$1], out=[$2])
+   +- LogicalProject(name=[$0], name0=[$1], out=[$2])
+      +- LogicalTableFunctionScan(invocation=[f(TABLE(#0) PARTITION BY($0), TABLE(#1) PARTITION BY($0), DEFAULT(), DEFAULT())], rowType=[RecordType(VARCHAR(5) name, VARCHAR(5) name0, VARCHAR(2147483647) out)])
+         :- LogicalProject(name=[$0], score=[$1])
+         :  +- LogicalProject(name=[$0], score=[$1])
+         :     +- LogicalValues(tuples=[[{ _UTF-16LE'Bob', 12 }, { _UTF-16LE'Alice', 42 }]])
+         +- LogicalProject(name=[$0], city=[$1])
+            +- LogicalProject(name=[$0], city=[$1])
+               +- LogicalValues(tuples=[[{ _UTF-16LE'Bob', _UTF-16LE'London' }, { _UTF-16LE'Alice', _UTF-16LE'Berlin' }]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.t_key_only_delete_sink], fields=[name, name0, out])
++- ProcessTableFunction(invocation=[f(TABLE(#0) PARTITION BY($0), TABLE(#1) PARTITION BY($0), DEFAULT(), DEFAULT())], uid=[f], select=[name,name0,out], rowType=[RecordType(VARCHAR(5) name, VARCHAR(5) name0, VARCHAR(2147483647) out)])
+   :- Exchange(distribution=[hash[name]])
+   :  +- Values(tuples=[[{ _UTF-16LE'Bob', 12 }, { _UTF-16LE'Alice', 42 }]])
+   +- Exchange(distribution=[hash[name]])
+      +- Values(tuples=[[{ _UTF-16LE'Bob', _UTF-16LE'London' }, { _UTF-16LE'Alice', _UTF-16LE'Berlin' }]])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testViewOfDifferentPartitionKey">
     <Resource name="sql">
       <![CDATA[SELECT * FROM v]]>

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/ProcessTableFunctionTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/ProcessTableFunctionTest.xml
@@ -484,7 +484,7 @@ LogicalSink(table=[default_catalog.default_database.t_key_only_delete_sink], fie
          :     +- LogicalValues(tuples=[[{ _UTF-16LE'Bob', 12 }, { _UTF-16LE'Alice', 42 }]])
          +- LogicalProject(name=[$0], city=[$1])
             +- LogicalProject(name=[$0], city=[$1])
-               +- LogicalValues(tuples=[[{ _UTF-16LE'Bob', _UTF-16LE'London' }, { _UTF-16LE'Alice', _UTF-16LE'Berlin' }]])
+               +- LogicalValues(tuples=[[{ _UTF-16LE'Bob', _UTF-16LE'Tokyo' }, { _UTF-16LE'Alice', _UTF-16LE'Berlin' }]])
 ]]>
     </Resource>
     <Resource name="optimized rel plan">
@@ -494,7 +494,7 @@ Sink(table=[default_catalog.default_database.t_key_only_delete_sink], fields=[na
    :- Exchange(distribution=[hash[name]])
    :  +- Values(tuples=[[{ _UTF-16LE'Bob', 12 }, { _UTF-16LE'Alice', 42 }]])
    +- Exchange(distribution=[hash[name]])
-      +- Values(tuples=[[{ _UTF-16LE'Bob', _UTF-16LE'London' }, { _UTF-16LE'Alice', _UTF-16LE'Berlin' }]])
+      +- Values(tuples=[[{ _UTF-16LE'Bob', _UTF-16LE'Tokyo' }, { _UTF-16LE'Alice', _UTF-16LE'Berlin' }]])
 ]]>
     </Resource>
   </TestCase>


### PR DESCRIPTION
## What is the purpose of the change

This change fixes incorrect partition-column positions inferred for a PTF with multiple table arguments. The bug can omit an upsert key from a later table argument and prevent a valid query from being planned for an upsert sink.

## Brief change log

- Correct `StreamPhysicalProcessTableFunction#toPartitionColumns` to account for the cumulative output offset when deriving partition columns.
- Add a regression plan test whose sink primary key corresponds to the partition column of the second table argument.

## Verifying this change

Added `ProcessTableFunctionTest#testUpsertKeyWithMultipleTableArgs` to verify that the partition column of the second table argument remains a valid upsert key. The targeted regression test and the complete `ProcessTableFunctionTest` suite with 69 tests passed.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable