### PR TITLE
[FLINK-40308][tests] Rename planner *Tests classes to *Test so they execute

### DIFF
--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/batch/LateralSnapshotJoinBatchSemanticTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/batch/LateralSnapshotJoinBatchSemanticTest.java
@@ -29,7 +29,7 @@ import java.util.List;
  * BatchPhysicalLateralSnapshotJoinRule} degrades the join to a regular join of the probe side
  * against the (final) build side.
  */
-public class LateralSnapshotJoinBatchSemanticTests extends BatchSemanticTestBase {
+public class LateralSnapshotJoinBatchSemanticTest extends BatchSemanticTestBase {
 
     @Override
     public List<TableTestProgram> programs() {

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/batch/MLPredictBatchSemanticTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/batch/MLPredictBatchSemanticTest.java
@@ -28,7 +28,7 @@ import static org.apache.flink.table.planner.plan.nodes.exec.stream.MLPredictTes
 import static org.apache.flink.table.planner.plan.nodes.exec.stream.MLPredictTestPrograms.SYNC_ML_PREDICT_TABLE_API;
 
 /** Semantic tests for {@link BatchExecMLPredictTableFunction} using Table API. */
-public class MLPredictBatchSemanticTests extends BatchSemanticTestBase {
+public class MLPredictBatchSemanticTest extends BatchSemanticTestBase {
 
     @Override
     public List<TableTestProgram> programs() {

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/ChangelogNormalizeSemanticTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/ChangelogNormalizeSemanticTest.java
@@ -18,21 +18,25 @@
 
 package org.apache.flink.table.planner.plan.nodes.exec.stream;
 
-import org.apache.flink.table.planner.plan.nodes.exec.common.CalcTestPrograms;
 import org.apache.flink.table.planner.plan.nodes.exec.testutils.SemanticTestBase;
 import org.apache.flink.table.test.program.TableTestProgram;
 
 import java.util.List;
 
-/** Semantic tests for various {@link StreamExecNode}s. */
-public class MiscSemanticTests extends SemanticTestBase {
+/** Semantic tests for {@link StreamExecChangelogNormalize}. */
+public class ChangelogNormalizeSemanticTest extends SemanticTestBase {
 
     @Override
     public List<TableTestProgram> programs() {
         return List.of(
-                WindowRankTestPrograms.WINDOW_RANK_HOP_TVF_NAMED_MIN_TOP_1,
-                CalcTestPrograms.CURRENT_WATERMARK,
-                CalcTestPrograms.COALESCE_NESTED_ROW_LEFT_JOIN,
-                WatermarkAssignerTestPrograms.WATERMARK_ASSIGNER_PUSHDOWN_DECODE);
+                ChangelogNormalizeSemanticTestPrograms.UPSERT_SOURCE_WITH_NON_KEY_FILTER,
+                ChangelogNormalizeSemanticTestPrograms.UPSERT_SOURCE_WITH_KEY_FILTER,
+                ChangelogNormalizeSemanticTestPrograms.UPSERT_SOURCE_WITH_NO_FILTER,
+                ChangelogNormalizeSemanticTestPrograms.KAFKA_SOURCE_WITH_NON_KEY_FILTER,
+                ChangelogNormalizeSemanticTestPrograms.KAFKA_SOURCE_WITH_KEY_FILTER,
+                ChangelogNormalizeSemanticTestPrograms.KAFKA_SOURCE_WITH_NO_FILTER,
+                ChangelogNormalizeSemanticTestPrograms.RETRACT_SOURCE_NO_FILTER,
+                ChangelogNormalizeSemanticTestPrograms.RETRACT_SOURCE_WITH_NON_KEY_FILTER,
+                ChangelogNormalizeSemanticTestPrograms.RETRACT_SOURCE_WITH_KEY_FILTER);
     }
 }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/ConstraintEnforcerSemanticTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/ConstraintEnforcerSemanticTest.java
@@ -25,7 +25,7 @@ import org.apache.flink.table.test.program.TableTestProgram;
 import java.util.List;
 
 /** Semantic tests for {@link ConstraintEnforcer}. */
-public class ConstraintEnforcerSemanticTests extends SemanticTestBase {
+public class ConstraintEnforcerSemanticTest extends SemanticTestBase {
 
     @Override
     public List<TableTestProgram> programs() {

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/DeletesByKeySemanticTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/DeletesByKeySemanticTest.java
@@ -18,24 +18,22 @@
 
 package org.apache.flink.table.planner.plan.nodes.exec.stream;
 
-import org.apache.flink.table.planner.plan.nodes.exec.common.JoinSemanticTestPrograms;
 import org.apache.flink.table.planner.plan.nodes.exec.testutils.SemanticTestBase;
 import org.apache.flink.table.test.program.TableTestProgram;
 
 import java.util.List;
 
-/** Semantic tests for {@link StreamExecJoin}. */
-public class JoinSemanticTests extends SemanticTestBase {
+/** Semantic tests for various {@link StreamExecNode}s and sources producing deletes by key only. */
+public class DeletesByKeySemanticTest extends SemanticTestBase {
+
     @Override
     public List<TableTestProgram> programs() {
         return List.of(
-                JoinSemanticTestPrograms.OUTER_JOIN_CHANGELOG_TEST,
-                JoinSemanticTestPrograms.ANTI_JOIN_ON_NESTED,
-                JoinSemanticTestPrograms.LEFT_JOIN_NOT_NULL_NESTED_ROW,
-                JoinSemanticTestPrograms.RIGHT_JOIN_NOT_NULL_NESTED_ROW,
-                JoinSemanticTestPrograms.FULL_JOIN_NOT_NULL_NESTED_ROW,
-                JoinSemanticTestPrograms.LEFT_JOIN_NULLABLE_NESTED_ROW,
-                JoinSemanticTestPrograms.RIGHT_JOIN_NULLABLE_NESTED_ROW,
-                JoinSemanticTestPrograms.FULL_JOIN_NULLABLE_NESTED_ROW);
+                DeletesByKeyPrograms.INSERT_SELECT_DELETE_BY_KEY_DELETE_BY_KEY,
+                DeletesByKeyPrograms.INSERT_SELECT_DELETE_BY_KEY_FULL_DELETE,
+                DeletesByKeyPrograms.INSERT_SELECT_FULL_DELETE_FULL_DELETE,
+                DeletesByKeyPrograms.INSERT_SELECT_DELETE_BY_KEY_DELETE_BY_KEY_WITH_PROJECTION,
+                DeletesByKeyPrograms.JOIN_INTO_FULL_DELETES,
+                DeletesByKeyPrograms.JOIN_INTO_DELETES_BY_KEY);
     }
 }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/FromChangelogSemanticTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/FromChangelogSemanticTest.java
@@ -26,7 +26,7 @@ import org.apache.flink.table.test.program.TableTestProgram;
 import java.util.List;
 
 /** Semantic tests for the built-in FROM_CHANGELOG process table function. */
-public class FromChangelogSemanticTests extends SemanticTestBase {
+public class FromChangelogSemanticTest extends SemanticTestBase {
 
     @Override
     protected void applyDefaultEnvironmentOptions(TableConfig config) {

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/JoinSemanticTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/JoinSemanticTest.java
@@ -18,22 +18,24 @@
 
 package org.apache.flink.table.planner.plan.nodes.exec.stream;
 
+import org.apache.flink.table.planner.plan.nodes.exec.common.JoinSemanticTestPrograms;
 import org.apache.flink.table.planner.plan.nodes.exec.testutils.SemanticTestBase;
 import org.apache.flink.table.test.program.TableTestProgram;
 
 import java.util.List;
 
-/** Semantic tests for various {@link StreamExecNode}s and sources producing deletes by key only. */
-public class DeletesByKeySemanticTests extends SemanticTestBase {
-
+/** Semantic tests for {@link StreamExecJoin}. */
+public class JoinSemanticTest extends SemanticTestBase {
     @Override
     public List<TableTestProgram> programs() {
         return List.of(
-                DeletesByKeyPrograms.INSERT_SELECT_DELETE_BY_KEY_DELETE_BY_KEY,
-                DeletesByKeyPrograms.INSERT_SELECT_DELETE_BY_KEY_FULL_DELETE,
-                DeletesByKeyPrograms.INSERT_SELECT_FULL_DELETE_FULL_DELETE,
-                DeletesByKeyPrograms.INSERT_SELECT_DELETE_BY_KEY_DELETE_BY_KEY_WITH_PROJECTION,
-                DeletesByKeyPrograms.JOIN_INTO_FULL_DELETES,
-                DeletesByKeyPrograms.JOIN_INTO_DELETES_BY_KEY);
+                JoinSemanticTestPrograms.OUTER_JOIN_CHANGELOG_TEST,
+                JoinSemanticTestPrograms.ANTI_JOIN_ON_NESTED,
+                JoinSemanticTestPrograms.LEFT_JOIN_NOT_NULL_NESTED_ROW,
+                JoinSemanticTestPrograms.RIGHT_JOIN_NOT_NULL_NESTED_ROW,
+                JoinSemanticTestPrograms.FULL_JOIN_NOT_NULL_NESTED_ROW,
+                JoinSemanticTestPrograms.LEFT_JOIN_NULLABLE_NESTED_ROW,
+                JoinSemanticTestPrograms.RIGHT_JOIN_NULLABLE_NESTED_ROW,
+                JoinSemanticTestPrograms.FULL_JOIN_NULLABLE_NESTED_ROW);
     }
 }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/LateralSnapshotJoinSemanticTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/LateralSnapshotJoinSemanticTest.java
@@ -23,20 +23,21 @@ import org.apache.flink.table.test.program.TableTestProgram;
 
 import java.util.List;
 
-/** Semantic tests for {@link StreamExecChangelogNormalize}. */
-public class ChangelogNormalizeSemanticTests extends SemanticTestBase {
-
+/** Semantic tests for {@link StreamExecLateralSnapshotJoin}. */
+public class LateralSnapshotJoinSemanticTest extends SemanticTestBase {
     @Override
     public List<TableTestProgram> programs() {
         return List.of(
-                ChangelogNormalizeSemanticTestPrograms.UPSERT_SOURCE_WITH_NON_KEY_FILTER,
-                ChangelogNormalizeSemanticTestPrograms.UPSERT_SOURCE_WITH_KEY_FILTER,
-                ChangelogNormalizeSemanticTestPrograms.UPSERT_SOURCE_WITH_NO_FILTER,
-                ChangelogNormalizeSemanticTestPrograms.KAFKA_SOURCE_WITH_NON_KEY_FILTER,
-                ChangelogNormalizeSemanticTestPrograms.KAFKA_SOURCE_WITH_KEY_FILTER,
-                ChangelogNormalizeSemanticTestPrograms.KAFKA_SOURCE_WITH_NO_FILTER,
-                ChangelogNormalizeSemanticTestPrograms.RETRACT_SOURCE_NO_FILTER,
-                ChangelogNormalizeSemanticTestPrograms.RETRACT_SOURCE_WITH_NON_KEY_FILTER,
-                ChangelogNormalizeSemanticTestPrograms.RETRACT_SOURCE_WITH_KEY_FILTER);
+                LateralSnapshotJoinSemanticTestPrograms.INNER_JOIN,
+                LateralSnapshotJoinSemanticTestPrograms.LEFT_JOIN,
+                LateralSnapshotJoinSemanticTestPrograms.SELECT_STAR,
+                LateralSnapshotJoinSemanticTestPrograms.COMPOSITE_KEYS,
+                LateralSnapshotJoinSemanticTestPrograms.NON_EQUI,
+                LateralSnapshotJoinSemanticTestPrograms.EMPTY_BUILD_INNER,
+                LateralSnapshotJoinSemanticTestPrograms.EMPTY_BUILD_LEFT,
+                LateralSnapshotJoinSemanticTestPrograms.FLIP_AT_END,
+                LateralSnapshotJoinSemanticTestPrograms.DEFAULT_COMPILE_TIME,
+                LateralSnapshotJoinSemanticTestPrograms.LIVE_JOIN,
+                LateralSnapshotJoinSemanticTestPrograms.BUFFERED_THEN_DRAINED);
     }
 }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/MiscSemanticTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/MiscSemanticTest.java
@@ -18,26 +18,21 @@
 
 package org.apache.flink.table.planner.plan.nodes.exec.stream;
 
+import org.apache.flink.table.planner.plan.nodes.exec.common.CalcTestPrograms;
 import org.apache.flink.table.planner.plan.nodes.exec.testutils.SemanticTestBase;
 import org.apache.flink.table.test.program.TableTestProgram;
 
 import java.util.List;
 
-/** Semantic tests for {@link StreamExecLateralSnapshotJoin}. */
-public class LateralSnapshotJoinSemanticTests extends SemanticTestBase {
+/** Semantic tests for various {@link StreamExecNode}s. */
+public class MiscSemanticTest extends SemanticTestBase {
+
     @Override
     public List<TableTestProgram> programs() {
         return List.of(
-                LateralSnapshotJoinSemanticTestPrograms.INNER_JOIN,
-                LateralSnapshotJoinSemanticTestPrograms.LEFT_JOIN,
-                LateralSnapshotJoinSemanticTestPrograms.SELECT_STAR,
-                LateralSnapshotJoinSemanticTestPrograms.COMPOSITE_KEYS,
-                LateralSnapshotJoinSemanticTestPrograms.NON_EQUI,
-                LateralSnapshotJoinSemanticTestPrograms.EMPTY_BUILD_INNER,
-                LateralSnapshotJoinSemanticTestPrograms.EMPTY_BUILD_LEFT,
-                LateralSnapshotJoinSemanticTestPrograms.FLIP_AT_END,
-                LateralSnapshotJoinSemanticTestPrograms.DEFAULT_COMPILE_TIME,
-                LateralSnapshotJoinSemanticTestPrograms.LIVE_JOIN,
-                LateralSnapshotJoinSemanticTestPrograms.BUFFERED_THEN_DRAINED);
+                WindowRankTestPrograms.WINDOW_RANK_HOP_TVF_NAMED_MIN_TOP_1,
+                CalcTestPrograms.CURRENT_WATERMARK,
+                CalcTestPrograms.COALESCE_NESTED_ROW_LEFT_JOIN,
+                WatermarkAssignerTestPrograms.WATERMARK_ASSIGNER_PUSHDOWN_DECODE);
     }
 }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/MultiJoinSemanticTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/MultiJoinSemanticTest.java
@@ -26,7 +26,7 @@ import org.apache.flink.table.test.program.TableTestProgram;
 import java.util.List;
 
 /** Semantic tests for {@link StreamExecMultiJoin}. */
-public class MultiJoinSemanticTests extends SemanticTestBase {
+public class MultiJoinSemanticTest extends SemanticTestBase {
 
     @Override
     protected void applyDefaultEnvironmentOptions(TableConfig config) {

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/ProcessTableFunctionRestoreTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/ProcessTableFunctionRestoreTest.java
@@ -24,9 +24,9 @@ import org.apache.flink.table.test.program.TableTestProgram;
 import java.util.List;
 
 /** Restore tests for {@link StreamExecProcessTableFunction}. */
-public class ProcessTableFunctionRestoreTests extends RestoreTestBase {
+public class ProcessTableFunctionRestoreTest extends RestoreTestBase {
 
-    protected ProcessTableFunctionRestoreTests() {
+    protected ProcessTableFunctionRestoreTest() {
         super(StreamExecProcessTableFunction.class);
     }
 

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/ProcessTableFunctionSemanticTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/ProcessTableFunctionSemanticTest.java
@@ -24,7 +24,7 @@ import org.apache.flink.table.test.program.TableTestProgram;
 import java.util.List;
 
 /** Semantic tests for {@link StreamExecProcessTableFunction}. */
-public class ProcessTableFunctionSemanticTests extends SemanticTestBase {
+public class ProcessTableFunctionSemanticTest extends SemanticTestBase {
 
     @Override
     public List<TableTestProgram> programs() {

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/SinkSemanticTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/SinkSemanticTest.java
@@ -30,7 +30,7 @@ import java.util.List;
 import java.util.Map;
 
 /** Semantic tests for {@link StreamExecSink}. */
-public class SinkSemanticTests extends SemanticTestBase {
+public class SinkSemanticTest extends SemanticTestBase {
 
     @Override
     public EnumSet<TestKind> supportedSetupSteps() {

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/ToChangelogSemanticTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/ToChangelogSemanticTest.java
@@ -26,7 +26,7 @@ import org.apache.flink.table.test.program.TableTestProgram;
 import java.util.List;
 
 /** Semantic tests for the built-in TO_CHANGELOG process table function. */
-public class ToChangelogSemanticTests extends SemanticTestBase {
+public class ToChangelogSemanticTest extends SemanticTestBase {
 
     @Override
     protected void applyDefaultEnvironmentOptions(TableConfig config) {

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/sql/join/LateralSnapshotJoinITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/sql/join/LateralSnapshotJoinITCase.java
@@ -49,7 +49,7 @@ import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThatList;
 /**
  * Result tests for the {@code LATERAL SNAPSHOT} processing-time temporal join that are
  * non-deterministic or benefit from dual-backend (HEAP/ROCKSDB) coverage. Deterministic,
- * backend-agnostic cases live in {@code LateralSnapshotJoinSemanticTests}; time-driven behavior
+ * backend-agnostic cases live in {@code LateralSnapshotJoinSemanticTest}; time-driven behavior
  * (idle-timeout flip, state-TTL eviction) in {@code LateralSnapshotJoinOperatorTest}.
  *
  * <p>To stabilize results, each build source appends a non-matching "flip-trigger" row at {@link


### PR DESCRIPTION
## What is the purpose of the change

`flink-table-planner/pom.xml` narrows the `integration-tests` surefire include to
`**/*ITCase.*`, while the root pom's unit include is `**/*Test.*` (`test.unit.pattern`).
Test classes suffixed `*Tests` match neither pattern, so they are silently never
executed and the build still reports success.

This affects 14 classes in the planner. It is the same class of problem as FLINK-40283.

## Brief change log

  - Renamed 11 stream `*SemanticTests` classes to `*SemanticTest` (ChangelogNormalize,
    ConstraintEnforcer, DeletesByKey, FromChangelog, Join, LateralSnapshotJoin, Misc,
    MultiJoin, ProcessTableFunction, Sink, ToChangelog)
  - Renamed 2 batch classes: `LateralSnapshotJoinBatchSemanticTests`,
    `MLPredictBatchSemanticTests`
  - Renamed `ProcessTableFunctionRestoreTests` to `ProcessTableFunctionRestoreTest`
  - Updated one `{@code ...}` Javadoc reference in `LateralSnapshotJoinITCase`

The singular `*Test` suffix is the convention already used by the siblings of these
classes, which do run: `BitmapSemanticTest`, `VariantSemanticTest`, and 43
`*RestoreTest` classes. No logic was changed; the diff is 16 lines, all class names.

## Verifying this change

This change is a test rename, so the verification is that the tests now execute.

  - CI logs should contain all 14 renamed classes
  - Ran locally: 204 tests execute and pass, with 1 skip that is a pre-existing
    `@Disabled` in `RestoreTestBase`

Two classes matching the same broken pattern are deliberately **not** included:

  - `MLPredictSemanticTests` fails 6/6 on an unrelated upsert-key validation once it
    runs, tracked separately
  - `RestoreTestCompleteness` is covered by FLINK-40307

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: Claude Code (claude-opus-5)
