### PR TITLE
[hotfix][docs] Document config options missing from the configuration reference

### DIFF
--- a/docs/layouts/shortcodes/generated/common_host_port_section.html
+++ b/docs/layouts/shortcodes/generated/common_host_port_section.html
@@ -69,6 +69,12 @@
             <td>The port that the client connects to. If rest.bind-port has not been specified, then the REST server will bind to this port. Attention: This option is respected only if the high-availability configuration is NONE.</td>
         </tr>
         <tr>
+            <td><h5>rest.url-prefix</h5></td>
+            <td style="word-wrap: break-word;">"/"</td>
+            <td>String</td>
+            <td>The url prefix that should be used by clients to construct the full target url, must start and end with '/'. This will be added between the address and version prefix. For example, if the option is set to '/foo/', the overview query URL will be transformed to 'localhost:8081/foo/v1/overview'. Attention: This option is respected only if the high-availability configuration is NONE.</td>
+        </tr>
+        <tr>
             <td><h5>taskmanager.bind-host</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>String</td>

--- a/docs/layouts/shortcodes/generated/expert_cluster_section.html
+++ b/docs/layouts/shortcodes/generated/expert_cluster_section.html
@@ -56,5 +56,11 @@
             <td>String</td>
             <td>Local working directory for Flink processes. The working directory can be used to store information that can be used upon process recovery. If not configured, then it will default to a randomly picked temporary directory defined via <code class="highlighter-rouge">io.tmp.dirs</code>.</td>
         </tr>
+        <tr>
+            <td><h5>shuffle-service-factory.class</h5></td>
+            <td style="word-wrap: break-word;">"org.apache.flink.runtime.io.network.NettyShuffleServiceFactory"</td>
+            <td>String</td>
+            <td>The full class name of the shuffle service factory implementation to be used by the cluster. The default implementation uses Netty for network communication and local memory as well disk space to store results on a TaskExecutor.</td>
+        </tr>
     </tbody>
 </table>

--- a/flink-core/src/main/java/org/apache/flink/configuration/RestOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/RestOptions.java
@@ -58,6 +58,7 @@ public class RestOptions {
                                     + " collisions when multiple Rest servers are running on the same machine.");
 
     /** The url prefix that should be used by clients to construct the full target url. */
+    @Documentation.Section(Documentation.Sections.COMMON_HOST_PORT)
     public static final ConfigOption<String> URL_PREFIX =
             key("rest.url-prefix")
                     .stringType()

--- a/flink-python/docs/locales/zh/LC_MESSAGES/user_guide/configuration.po
+++ b/flink-python/docs/locales/zh/LC_MESSAGES/user_guide/configuration.po
@@ -22,7 +22,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PyFlink 2.3.dev0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-02-12 21:08+0100\n"
+"POT-Creation-Date: 2026-08-02 21:52+0530\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: zh\n"
@@ -123,8 +123,9 @@ msgid "python.archives"
 msgstr ""
 
 #: ../../user_guide/configuration.rst:90 ../../user_guide/configuration.rst:110
-#: ../../user_guide/configuration.rst:154
-#: ../../user_guide/configuration.rst:158
+#: ../../user_guide/configuration.rst:134
+#: ../../user_guide/configuration.rst:162
+#: ../../user_guide/configuration.rst:166
 msgid "(none)"
 msgstr ""
 
@@ -132,8 +133,9 @@ msgstr ""
 #: ../../user_guide/configuration.rst:103
 #: ../../user_guide/configuration.rst:107
 #: ../../user_guide/configuration.rst:111
-#: ../../user_guide/configuration.rst:155
-#: ../../user_guide/configuration.rst:159
+#: ../../user_guide/configuration.rst:131
+#: ../../user_guide/configuration.rst:163
+#: ../../user_guide/configuration.rst:167
 msgid "String"
 msgstr ""
 
@@ -231,19 +233,19 @@ msgstr ""
 #: ../../user_guide/configuration.rst:114
 #: ../../user_guide/configuration.rst:118
 #: ../../user_guide/configuration.rst:122
-#: ../../user_guide/configuration.rst:130
-#: ../../user_guide/configuration.rst:134
 #: ../../user_guide/configuration.rst:138
-#: ../../user_guide/configuration.rst:162
+#: ../../user_guide/configuration.rst:142
+#: ../../user_guide/configuration.rst:146
+#: ../../user_guide/configuration.rst:170
 msgid "1000"
 msgstr ""
 
 #: ../../user_guide/configuration.rst:115
 #: ../../user_guide/configuration.rst:119
-#: ../../user_guide/configuration.rst:131
-#: ../../user_guide/configuration.rst:135
 #: ../../user_guide/configuration.rst:139
-#: ../../user_guide/configuration.rst:163
+#: ../../user_guide/configuration.rst:143
+#: ../../user_guide/configuration.rst:147
+#: ../../user_guide/configuration.rst:171
 msgid "Integer"
 msgstr ""
 
@@ -289,17 +291,17 @@ msgid "python.fn-execution.memory.managed"
 msgstr ""
 
 #: ../../user_guide/configuration.rst:126
-#: ../../user_guide/configuration.rst:142
-#: ../../user_guide/configuration.rst:146
-#: ../../user_guide/configuration.rst:166
+#: ../../user_guide/configuration.rst:150
+#: ../../user_guide/configuration.rst:154
+#: ../../user_guide/configuration.rst:174
 msgid "true"
 msgstr ""
 
 #: ../../user_guide/configuration.rst:127
-#: ../../user_guide/configuration.rst:143
-#: ../../user_guide/configuration.rst:147
 #: ../../user_guide/configuration.rst:151
-#: ../../user_guide/configuration.rst:167
+#: ../../user_guide/configuration.rst:155
+#: ../../user_guide/configuration.rst:159
+#: ../../user_guide/configuration.rst:175
 msgid "Boolean"
 msgstr ""
 
@@ -312,32 +314,68 @@ msgid ""
 msgstr ""
 
 #: ../../user_guide/configuration.rst:129
-msgid "python.map-state.iterate-response-batch-size"
+msgid "python.logging.default.level"
+msgstr ""
+
+#: ../../user_guide/configuration.rst:130
+msgid "\"INFO\""
 msgstr ""
 
 #: ../../user_guide/configuration.rst:132
+msgid ""
+"Controls the default log level of python loggers, available values: OFF, "
+"ERROR, WARN, INFO, DEBUG, TRACE."
+msgstr ""
+
+#: ../../user_guide/configuration.rst:133
+msgid "python.logging.level.overrides"
+msgstr ""
+
+#: ../../user_guide/configuration.rst:135
+msgid "Map"
+msgstr ""
+
+#: ../../user_guide/configuration.rst:136
+msgid ""
+"This option controls the log levels for specifically named loggers. The "
+"expected format is \"Name: LogLevel...\". Supports a logging hierarchy "
+"based off of names that are '.' separated. For example, by specifying the"
+" value \"a.b.c.Foo: DEBUG\", the logger for the class 'a.b.c.Foo' will be"
+" configured to output logs at the DEBUG level. Similarly, by specifying "
+"the value \"a.b.c:WARN\", all loggers underneath the 'a.b.c' package will"
+" be configured to output logs at the WARN level. System.out and "
+"System.err levels are configured via loggers of the corresponding name. "
+"Also, note that when multiple overrides are specified, the exact name "
+"followed by the closest parent takes precedence."
+msgstr ""
+
+#: ../../user_guide/configuration.rst:137
+msgid "python.map-state.iterate-response-batch-size"
+msgstr ""
+
+#: ../../user_guide/configuration.rst:140
 msgid ""
 "The maximum number of the MapState keys/entries sent to Python UDF worker"
 " in each batch when iterating a Python MapState. Note that this is an "
 "experimental flag and might not be available in future releases."
 msgstr ""
 
-#: ../../user_guide/configuration.rst:133
+#: ../../user_guide/configuration.rst:141
 msgid "python.map-state.read-cache-size"
 msgstr ""
 
-#: ../../user_guide/configuration.rst:136
+#: ../../user_guide/configuration.rst:144
 msgid ""
 "The maximum number of cached entries for a single Python MapState. Note "
 "that this is an experimental flag and might not be available in future "
 "releases."
 msgstr ""
 
-#: ../../user_guide/configuration.rst:137
+#: ../../user_guide/configuration.rst:145
 msgid "python.map-state.write-cache-size"
 msgstr ""
 
-#: ../../user_guide/configuration.rst:140
+#: ../../user_guide/configuration.rst:148
 msgid ""
 "The maximum number of cached write requests for a single Python MapState."
 " The write requests will be flushed to the state backend (managed in the "
@@ -346,35 +384,35 @@ msgid ""
 "in future releases."
 msgstr ""
 
-#: ../../user_guide/configuration.rst:141
+#: ../../user_guide/configuration.rst:149
 msgid "python.metric.enabled"
 msgstr ""
 
-#: ../../user_guide/configuration.rst:144
+#: ../../user_guide/configuration.rst:152
 msgid ""
 "When it is false, metric for Python will be disabled. You can disable the"
 " metric to achieve better performance at some circumstance."
 msgstr ""
 
-#: ../../user_guide/configuration.rst:145
+#: ../../user_guide/configuration.rst:153
 msgid "python.operator-chaining.enabled"
 msgstr ""
 
-#: ../../user_guide/configuration.rst:148
+#: ../../user_guide/configuration.rst:156
 msgid ""
 "Python operator chaining allows non-shuffle operations to be co-located "
 "in the same thread fully avoiding serialization and de-serialization."
 msgstr ""
 
-#: ../../user_guide/configuration.rst:149
+#: ../../user_guide/configuration.rst:157
 msgid "python.profile.enabled"
 msgstr ""
 
-#: ../../user_guide/configuration.rst:150
+#: ../../user_guide/configuration.rst:158
 msgid "false"
 msgstr ""
 
-#: ../../user_guide/configuration.rst:152
+#: ../../user_guide/configuration.rst:160
 msgid ""
 "Specifies whether to enable Python worker profiling. The profile result "
 "will be displayed in the log file of the TaskManager periodically. The "
@@ -382,22 +420,22 @@ msgid ""
 "python.fn-execution.bundle.size and python.fn-execution.bundle.time."
 msgstr ""
 
-#: ../../user_guide/configuration.rst:153
+#: ../../user_guide/configuration.rst:161
 msgid "python.pythonpath"
 msgstr ""
 
-#: ../../user_guide/configuration.rst:156
+#: ../../user_guide/configuration.rst:164
 msgid ""
 "Specify the path on the Worker Node where the Flink Python Dependencies "
 "are installed, which gets added into the PYTHONPATH of the Python Worker."
 " The option is equivalent to the command line option \"-pypath\"."
 msgstr ""
 
-#: ../../user_guide/configuration.rst:157
+#: ../../user_guide/configuration.rst:165
 msgid "python.requirements"
 msgstr ""
 
-#: ../../user_guide/configuration.rst:160
+#: ../../user_guide/configuration.rst:168
 msgid ""
 "Specify a requirements.txt file which defines the third-party "
 "dependencies. These dependencies will be installed and added to the "
@@ -407,22 +445,22 @@ msgid ""
 "The option is equivalent to the command line option \"-pyreq\"."
 msgstr ""
 
-#: ../../user_guide/configuration.rst:161
+#: ../../user_guide/configuration.rst:169
 msgid "python.state.cache-size"
 msgstr ""
 
-#: ../../user_guide/configuration.rst:164
+#: ../../user_guide/configuration.rst:172
 msgid ""
 "The maximum number of states cached in a Python UDF worker. Note that "
 "this is an experimental flag and might not be available in future "
 "releases."
 msgstr ""
 
-#: ../../user_guide/configuration.rst:165
+#: ../../user_guide/configuration.rst:173
 msgid "python.systemenv.enabled"
 msgstr ""
 
-#: ../../user_guide/configuration.rst:168
+#: ../../user_guide/configuration.rst:176
 msgid "Specify whether to load System Environment when starting Python worker."
 msgstr ""
 

--- a/flink-python/docs/user_guide/configuration.rst
+++ b/flink-python/docs/user_guide/configuration.rst
@@ -126,6 +126,14 @@ Python Options
      - true
      - Boolean
      - If set, the Python worker will configure itself to use the managed memory budget of the task slot. Otherwise, it will use the Off-Heap Memory of the task slot. In this case, users should set the Task Off-Heap Memory using the configuration key taskmanager.memory.task.off-heap.size.
+   * - python.logging.default.level
+     - "INFO"
+     - String
+     - Controls the default log level of python loggers, available values: OFF, ERROR, WARN, INFO, DEBUG, TRACE.
+   * - python.logging.level.overrides
+     - (none)
+     - Map
+     - This option controls the log levels for specifically named loggers. The expected format is "Name: LogLevel...". Supports a logging hierarchy based off of names that are '.' separated. For example, by specifying the value "a.b.c.Foo: DEBUG", the logger for the class 'a.b.c.Foo' will be configured to output logs at the DEBUG level. Similarly, by specifying the value "a.b.c:WARN", all loggers underneath the 'a.b.c' package will be configured to output logs at the WARN level. System.out and System.err levels are configured via loggers of the corresponding name. Also, note that when multiple overrides are specified, the exact name followed by the closest parent takes precedence.
    * - python.map-state.iterate-response-batch-size
      - 1000
      - Integer

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/shuffle/ShuffleServiceOptions.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/shuffle/ShuffleServiceOptions.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.shuffle;
 
 import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.annotation.docs.Documentation;
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.ConfigOptions;
 
@@ -35,6 +36,7 @@ public class ShuffleServiceOptions {
     /**
      * The full class name of the shuffle service factory implementation to be used by the cluster.
      */
+    @Documentation.Section(Documentation.Sections.EXPERT_CLUSTER)
     public static final ConfigOption<String> SHUFFLE_SERVICE_FACTORY_CLASS =
             ConfigOptions.key("shuffle-service-factory.class")
                     .stringType()


### PR DESCRIPTION
## What is the purpose of the change

Four config options never appeared in the documentation. `rest.url-prefix` and `shuffle-service-factory.class` carry no `@Documentation.Section`, so the generator emits them only into per-class tables that no page includes. Two PyFlink logging options were missing from the PyFlink configuration page.

## Brief change log

- Annotate `rest.url-prefix` with `COMMON_HOST_PORT` (matching its sibling `rest.path`) and `shuffle-service-factory.class` with `EXPERT_CLUSTER`; regenerate the two affected section tables.
- Add `python.logging.default.level` and `python.logging.level.overrides` (added in FLINK-38690) to `flink-python/docs/user_guide/configuration.rst`.
- Regenerate the Chinese message catalog via `make gettext` + `sphinx-intl update`. New entries are intentionally left untranslated.

## Verifying this change

This change is already covered by existing tests: `ConfigOptionsDocsCompletenessITCase`, run with `mvn package -pl flink-docs -am`. Re-running the generator afterwards produces no further diff, and all four options now render on the configuration reference or the PyFlink configuration page.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes — `RestOptions` and `ShuffleServiceOptions` are `@PublicEvolving`, but only a documentation annotation was added; no API change
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: Claude Code (claude-opus-5)
