### PR TITLE
[FLINK-40317][tests] Make DeletesByKeySemanticTests more stable

### DIFF
--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/DeletesByKeyPrograms.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/DeletesByKeyPrograms.java
@@ -237,13 +237,8 @@ public final class DeletesByKeyPrograms {
                                             "`value` INT")
                                     .addOption("changelog-mode", "I,UA,D")
                                     .addOption("sink.supports-delete-by-key", "false")
-                                    .consumedValues(
-                                            "+I[1, Alice, 10]",
-                                            "+I[2, Bob, 20]",
-                                            "+I[3, Emily, 30]",
-                                            "-D[1, Alice, 10]",
-                                            "+U[3, Emily, 40]",
-                                            "+U[2, BOB, 20]")
+                                    .testMaterializedData()
+                                    .consumedValues("+I[3, Emily, 40]", "+I[2, BOB, 20]")
                                     .build())
                     .runSql(
                             "INSERT INTO sink_t SELECT l.id, r.name, l.`value` FROM left_t l JOIN right_t r ON l.id = r.id")
@@ -291,13 +286,8 @@ public final class DeletesByKeyPrograms {
                                             "`value` INT")
                                     .addOption("changelog-mode", "I,UA,D")
                                     .addOption("sink.supports-delete-by-key", "true")
-                                    .consumedValues(
-                                            "+I[1, Alice, 10]",
-                                            "+I[2, Bob, 20]",
-                                            "+I[3, Emily, 30]",
-                                            "-D[1, Alice, null]",
-                                            "+U[3, Emily, 40]",
-                                            "+U[2, BOB, 20]")
+                                    .testMaterializedData()
+                                    .consumedValues("+I[2, BOB, 20]", "+I[3, Emily, 40]")
                                     .build())
                     .runSql(
                             "INSERT INTO sink_t SELECT l.id, r.name, l.`value` FROM left_t l JOIN right_t r ON l.id = r.id")


### PR DESCRIPTION

## What is the purpose of the change
The PR is to make DeletesByKeySemanticTests more stable by using testMaterializeData

## Brief change log

DeletesByKeySemanticTests

## Verifying this change
run same tests 10000 times locally
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable)

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change the checkbox below to `[X]` and replace the placeholder in the "Generated-by"
line with the tool name and version. Otherwise remove the "Generated-by" line.
See the ASF Generative Tooling Guidance for details:
https://www.apache.org/legal/generative-tooling.html

You are responsible for the quality and correctness of every change in this PR
regardless of the tooling used. Low-effort AI-generated PRs will be closed. See
AGENTS.md for the full guidance.
-->

- [ ] Yes (please specify the tool below)

Generated-by: [Tool Name and Version]
