### PR TITLE
[hotfix][ci] Add ignore pattern in case of Azure

### DIFF
--- a/tools/azure-pipelines/build_properties.sh
+++ b/tools/azure-pipelines/build_properties.sh
@@ -45,18 +45,24 @@ function github_num_commits() {
 	return $GITHUB_NUM_COMMITS
 }
 
-#
-# Returns 0 if the change is a documentation-only pull request
-#
-function is_docs_only_pullrequest() {
+# Returns 0 if the change only touches ignored paths (IGNORE_PATHS pipeline variable, newline-separated pathspec globs), e.g. a documentation-only pull request.
+function is_ignored_pattern_pullrequest() {
 	github_num_commits
 	GITHUB_NUM_COMMITS=$?
 	if [[ $GITHUB_NUM_COMMITS == 0 ]]; then
 		return 1
 	fi
 
-	if [[ $(git diff --name-only HEAD..HEAD~$GITHUB_NUM_COMMITS | grep -v "docs/") == "" ]] ; then
-		echo "INFO: This is a docs only change. Changed files:"
+	# A diff that lists nothing after the git excludes means only ignored paths changed.
+	local exclude_pathspecs=()
+	local pattern
+	while IFS= read -r pattern; do
+		[[ -z "$pattern" ]] && continue
+		exclude_pathspecs+=(":(exclude,glob)$pattern")
+	done <<< "$IGNORE_PATHS"
+
+	if [[ $(git diff --name-only HEAD..HEAD~$GITHUB_NUM_COMMITS -- . "${exclude_pathspecs[@]}") == "" ]] ; then
+		echo "INFO: Only ignored paths changed ($IGNORE_PATHS). Changed files:"
 		git diff --name-only HEAD..HEAD~$GITHUB_NUM_COMMITS
 		return 0
 	fi

--- a/tools/azure-pipelines/e2e-template.yml
+++ b/tools/azure-pipelines/e2e-template.yml
@@ -31,11 +31,23 @@ jobs:
   cancelTimeoutInMinutes: 1
   workspace:
     clean: all
+  variables:
+    # Newline-separated git pathspec globs (GitHub Actions "paths-ignore" style); PRs touching only these skip e2e.
+    IGNORE_PATHS: |
+      docs/**
+      **/*.md
+      .idea/**
+      .asf.yaml
+      .editorconfig
+      .git-blame-ignore-revs
+      .gitignore
+      .gitattributes
+      .github/**
   steps:
     # Skip e2e test execution if this is a documentation only pull request (master / release builds will still be checked regularly)
     - bash: |
         source ./tools/azure-pipelines/build_properties.sh
-        is_docs_only_pullrequest
+        is_ignored_pattern_pullrequest
         if [[ "$?" == 0 ]] ; then
           echo "##[debug]This is a documentation-only change. Skipping e2e execution."
           echo "##vso[task.setvariable variable=skip;]1"


### PR DESCRIPTION


## What is the purpose of the change

The PR is to run less Azure jobs in case of non code or non azure related. changes

## Brief change log

azure ci


## Verifying this change

azure ci

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (yes no )
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: ( no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change the checkbox below to `[X]` and replace the placeholder in the "Generated-by"
line with the tool name and version. Otherwise remove the "Generated-by" line.
See the ASF Generative Tooling Guidance for details:
https://www.apache.org/legal/generative-tooling.html

You are responsible for the quality and correctness of every change in this PR
regardless of the tooling used. Low-effort AI-generated PRs will be closed. See
AGENTS.md for the full guidance.
-->

- [ ] Yes (please specify the tool below)

Generated-by: [Tool Name and Version]
