### PR TITLE
[BP-2.2][FLINK-40311][tests] Rename `EndiannessAccessChecks` to `EndiannessAccessChecksTest`

### DIFF
--- a/flink-core/src/test/java/org/apache/flink/core/memory/EndiannessAccessChecksTest.java
+++ b/flink-core/src/test/java/org/apache/flink/core/memory/EndiannessAccessChecksTest.java
@@ -29,7 +29,7 @@ import static org.assertj.core.api.Assertions.within;
  * Verifies correct accesses with regards to endianness in {@link MemorySegment} (in both heap and
  * off-heap modes).
  */
-class EndiannessAccessChecks {
+class EndiannessAccessChecksTest {
 
     @Test
     void testOnHeapSegment() {


### PR DESCRIPTION

Cherry-pick from https://github.com/apache/flink/commit/bd1becc5177482c17ce5ddbdb9fa2335f7cad853