### PR TITLE
[FLINK-40322][python] Fix Array/Multiset from_sql_type to decode elements

### DIFF
--- a/flink-python/pyflink/table/tests/test_types.py
+++ b/flink-python/pyflink/table/tests/test_types.py
@@ -549,6 +549,18 @@ class TypesTests(PyFlinkTestCase):
         dt = DataTypes.DATE()
         self.assertEqual(dt.from_sql_type(0), datetime.date(1970, 1, 1))
 
+    def test_array_from_sql_type_converts_elements(self):
+        at = DataTypes.ARRAY(DataTypes.DATE())
+        self.assertEqual(
+            at.from_sql_type([0, 1]),
+            [datetime.date(1970, 1, 1), datetime.date(1970, 1, 2)])
+
+    def test_multiset_from_sql_type_converts_elements(self):
+        mst = DataTypes.MULTISET(DataTypes.DATE())
+        self.assertEqual(
+            mst.from_sql_type([0, 1]),
+            [datetime.date(1970, 1, 1), datetime.date(1970, 1, 2)])
+
     @unittest.skipIf(on_windows(), "Windows x64 system only support the datetime not larger "
                                    "than time.ctime(32536799999), so this test can't run "
                                    "under Windows platform")

--- a/flink-python/pyflink/table/types.py
+++ b/flink-python/pyflink/table/types.py
@@ -931,7 +931,7 @@ class ArrayType(DataType):
     def from_sql_type(self, obj):
         if not self.need_conversion():
             return obj
-        return obj and [self.element_type.to_sql_type(v) for v in obj]
+        return obj and [self.element_type.from_sql_type(v) for v in obj]
 
 
 class ListViewType(DataType):
@@ -1059,7 +1059,7 @@ class MultisetType(DataType):
     def from_sql_type(self, obj):
         if not self.need_conversion():
             return obj
-        return obj and [self.element_type.to_sql_type(v) for v in obj]
+        return obj and [self.element_type.from_sql_type(v) for v in obj]
 
 
 class RowField(object):


### PR DESCRIPTION
## Summary

ArrayType and MultisetType were calling `to_sql_type` on elements in `from_sql_type`, which is the wrong direction. This caused decoding of ARRAY<DATE> and MULTISET<DATE> to fail with `AttributeError: 'int' object has no attribute 'toordinal'`.

Fixed by calling `from_sql_type` instead (matching MapType.from_sql_type behavior).

## Brief change log

- Add: test_array_from_sql_type_converts_elements
- Add: test_multiset_from_sql_type_converts_elements
- Fix: ArrayType.from_sql_type to decode elements via from_sql_type
- Fix: MultisetType.from_sql_type to decode elements via from_sql_type

## Verifying this change

- [x] Added tests that verify the fix (test suite will pass on CI)
- [x] Related to existing test for MapType.from_sql_type consistency
- [x] Regression tests for ARRAY<DATE> and MULTISET<DATE>

##### Was generative AI tooling used to co-author this PR?
[x] Yes (Claude Code (Opus 4.8))

Generated-by: Claude Code (Opus 4.8)
