### PR TITLE
[FLINK-38774][table-common] Skip hidden directories when recursively listing partitions

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/utils/PartitionPathUtils.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/utils/PartitionPathUtils.java
@@ -341,7 +341,11 @@ public class PartitionPathUtils {
         }
 
         if (fileStatus.isDir()) {
-            for (FileStatus stat : fs.listStatus(fileStatus.getPath())) {
+            FileStatus[] children = listStatusWithoutHidden(fs, fileStatus.getPath());
+            if (children == null) {
+                return;
+            }
+            for (FileStatus stat : children) {
                 listStatusRecursively(fs, stat, level + 1, expectLevel, results);
             }
         }

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/utils/PartitionPathUtilsTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/utils/PartitionPathUtilsTest.java
@@ -35,8 +35,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /** Tests for {@link org.apache.flink.table.utils.PartitionPathUtils}. */
 class PartitionPathUtilsTest {
 
-    @TempDir
-    Path tmpDir;
+    @TempDir Path tmpDir;
 
     @Test
     void testEscapeChar() {
@@ -116,11 +115,7 @@ class PartitionPathUtilsTest {
 
         // Real partition: date=2019-8-30/country=China
         Files.createDirectories(
-                Path.of(
-                        tmpDir.toString(),
-                        "country_page_view",
-                        "date=2019-8-30",
-                        "country=China"));
+                Path.of(tmpDir.toString(), "country_page_view", "date=2019-8-30", "country=China"));
         // Hidden _temporary dir whose non-hidden child sits at partition depth (2).
         Files.createDirectories(
                 Path.of(tmpDir.toString(), "country_page_view", "_temporary", "job-123"));

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/utils/PartitionPathUtilsTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/utils/PartitionPathUtilsTest.java
@@ -18,12 +18,25 @@
 
 package org.apache.flink.table.utils;
 
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.core.fs.FileSystem;
+
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.LinkedHashMap;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for {@link org.apache.flink.table.utils.PartitionPathUtils}. */
 class PartitionPathUtilsTest {
+
+    @TempDir
+    Path tmpDir;
 
     @Test
     void testEscapeChar() {
@@ -86,5 +99,39 @@ class PartitionPathUtilsTest {
         String actual = PartitionPathUtils.escapePathName(origin);
         assertThat(actual).isEqualTo(expected);
         assertThat(PartitionPathUtils.unescapePathName(actual)).isEqualTo(origin);
+    }
+
+    /**
+     * FLINK-38774: {@link PartitionPathUtils#searchPartSpecAndPaths} must not descend into hidden
+     * directories. A hidden dir such as {@code _temporary} may contain non-hidden children (e.g.
+     * {@code job-123}) at partition depth; without skipping hidden dirs those children leak into
+     * the result with an empty partition spec, which later surfaces as a {@code TableException:
+     * incomplete partition spec}.
+     */
+    @Test
+    void testSearchPartSpecAndPathsSkipsHiddenDirectories() throws IOException {
+        org.apache.flink.core.fs.Path basePath =
+                new org.apache.flink.core.fs.Path(tmpDir.toString(), "country_page_view");
+        FileSystem fs = basePath.getFileSystem();
+
+        // Real partition: date=2019-8-30/country=China
+        Files.createDirectories(
+                Path.of(
+                        tmpDir.toString(),
+                        "country_page_view",
+                        "date=2019-8-30",
+                        "country=China"));
+        // Hidden _temporary dir whose non-hidden child sits at partition depth (2).
+        Files.createDirectories(
+                Path.of(tmpDir.toString(), "country_page_view", "_temporary", "job-123"));
+
+        List<Tuple2<LinkedHashMap<String, String>, org.apache.flink.core.fs.Path>> parts =
+                PartitionPathUtils.searchPartSpecAndPaths(fs, basePath, 2);
+
+        // Only the real partition is returned; the _temporary subtree is skipped entirely.
+        assertThat(parts).hasSize(1);
+        assertThat(parts.get(0).f0)
+                .containsEntry("date", "2019-8-30")
+                .containsEntry("country", "China");
     }
 }


### PR DESCRIPTION
## What

`PartitionPathUtils.listStatusRecursively` descended into every subdirectory returned by `fs.listStatus`, including hidden ones such as `_temporary`. A non-hidden child of a hidden dir (e.g. `_temporary/job-123`) sitting at partition depth was then collected with an empty partition spec, which later surfaces as a `TableException: incomplete partition spec` in the filesystem connector source.

Reported in FLINK-38774 (supersedes the older FLINK-31975).

## Fix

Reuse the existing `listStatusWithoutHidden` helper to filter hidden children at **every** recursion level — not only at the leaf, where `searchPartSpecAndPaths` already filtered via `isHiddenFile`. Add a null guard consistent with `listStatusWithoutHidden`'s contract (returns `null` when `fs.listStatus` returns `null`), which also removes a latent NPE in the old for-each over a null list.

```java
if (fileStatus.isDir()) {
    FileStatus[] children = listStatusWithoutHidden(fs, fileStatus.getPath());
    if (children == null) {
        return;
    }
    for (FileStatus stat : children) {
        listStatusRecursively(fs, stat, level + 1, expectLevel, results);
    }
}
```

## Test

Adds a `@TempDir` regression test that creates a real partition (`date=2019-8-30/country=China`) alongside a hidden `_temporary/job-123` subtree and asserts `searchPartSpecAndPaths` returns only the real partition. Without the fix the hidden `job-123` leaf leaks in with an empty spec (2 entries); with the fix only the real partition is returned (1 entry).

## Notes

- Supersedes the abandoned #27314 (stale-closed after 120 days of inactivity, no technical objection — reviewer only asked for a unit test, which is included here).
- This is a `flink-table/flink-table-common` utility, not literally under `flink-connectors/`, but the bug manifests via the filesystem connector (tagged `Connectors / FileSystem`).