### PR TITLE
[FLINK-40305][core] Decode VARIANT strings and object keys as UTF-8

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/types/variant/BinaryVariantUtil.java
+++ b/flink-core/src/main/java/org/apache/flink/types/variant/BinaryVariantUtil.java
@@ -23,6 +23,7 @@ import org.apache.flink.types.variant.Variant.Type;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
 import java.util.Arrays;
@@ -528,7 +529,7 @@ public class BinaryVariantUtil {
                 length = readUnsigned(value, pos + 1, U32_SIZE);
             }
             checkIndex(start + length - 1, value.length);
-            return new String(value, start, length);
+            return new String(value, start, length, StandardCharsets.UTF_8);
         }
         throw unexpectedType(Type.STRING);
     }
@@ -625,6 +626,7 @@ public class BinaryVariantUtil {
             throw malformedVariant();
         }
         checkIndex(stringStart + nextOffset - 1, metadata.length);
-        return new String(metadata, stringStart + offset, nextOffset - offset);
+        return new String(
+                metadata, stringStart + offset, nextOffset - offset, StandardCharsets.UTF_8);
     }
 }

--- a/flink-core/src/test/java/org/apache/flink/types/variant/BinaryVariantInternalBuilderTest.java
+++ b/flink-core/src/test/java/org/apache/flink/types/variant/BinaryVariantInternalBuilderTest.java
@@ -122,6 +122,18 @@ class BinaryVariantInternalBuilderTest {
         assertThat(variant.getField("k2").getDecimal()).isEqualTo(BigDecimal.valueOf(1.5));
     }
 
+    @Test
+    void testParseJsonWithNonAsciiStringsAndKeys() throws IOException {
+        String json = "{\"schlüssel\":\"Grüße, 世界 🚀\",\"キー\":[\"äöü\"]}";
+
+        BinaryVariant variant = BinaryVariantInternalBuilder.parseJson(json, false);
+
+        assertThat(variant.getFieldNames()).containsExactlyInAnyOrder("schlüssel", "キー");
+        assertThat(variant.getField("schlüssel").getString()).isEqualTo("Grüße, 世界 🚀");
+        assertThat(variant.getField("キー").getElement(0).getString()).isEqualTo("äöü");
+        assertThat(variant.toJson()).isEqualTo(json);
+    }
+
     @ParameterizedTest
     @ValueSource(strings = {"NaN", "Infinity", "-Infinity", "1e400", "-1e400"})
     void testParseJsonRejectsNonFiniteNumbers(final String nonFiniteNumber) {

--- a/flink-core/src/test/java/org/apache/flink/types/variant/BinaryVariantTest.java
+++ b/flink-core/src/test/java/org/apache/flink/types/variant/BinaryVariantTest.java
@@ -24,10 +24,12 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
+import java.util.Collections;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -252,6 +254,53 @@ class BinaryVariantTest {
         assertThatThrownBy(() -> builder.of(nonFinite).toJson())
                 .isInstanceOf(VariantTypeException.class)
                 .hasMessageContaining("cannot be serialized to JSON");
+    }
+
+    @Test
+    void testNonAsciiStringsAndFieldNames() {
+        // Multi-byte code points make the UTF-8 byte length differ from the character count, so a
+        // charset mismatch between writing and reading mangles the text instead of preserving it.
+        final String nestedKey = "キー";
+        final String shortValue = "Grüße, 世界 🚀";
+        final String longValue = String.join("", Collections.nCopies(20, "äö🚀"));
+
+        assertThat(longValue.getBytes(StandardCharsets.UTF_8).length)
+                .as("long string must not fit into the short string encoding")
+                .isGreaterThan(BinaryVariantUtil.MAX_SHORT_STR_SIZE);
+
+        final BinaryVariant variant =
+                (BinaryVariant)
+                        builder.object()
+                                .add("schlüssel", builder.of(shortValue))
+                                .add(
+                                        nestedKey,
+                                        builder.object()
+                                                .add("schlüssel", builder.of(longValue))
+                                                .build())
+                                .build();
+
+        // Reading through the raw binaries is what happens once a variant has been serialized, and
+        // it is the only path that decodes the field names from the metadata.
+        final BinaryVariant decoded = new BinaryVariant(variant.getValue(), variant.getMetadata());
+
+        assertThat(decoded.getFieldNames()).containsExactlyInAnyOrder("schlüssel", nestedKey);
+        assertThat(decoded.getField("schlüssel").getString()).isEqualTo(shortValue);
+        assertThat(decoded.getField(nestedKey).getFieldNames()).containsExactly("schlüssel");
+        assertThat(decoded.getField(nestedKey).getField("schlüssel").getString())
+                .isEqualTo(longValue);
+        assertThat(decoded.toJson())
+                .isEqualTo(
+                        "{\""
+                                + "schlüssel"
+                                + "\":\""
+                                + shortValue
+                                + "\",\""
+                                + nestedKey
+                                + "\":{\""
+                                + "schlüssel"
+                                + "\":\""
+                                + longValue
+                                + "\"}}");
     }
 
     @Test


### PR DESCRIPTION
## Brief change log                                                                                                                          
                                                                                                                                               
  - `BinaryVariantUtil.getString` decodes string values as UTF-8 instead of using the JVM default charset                                    
  - `BinaryVariantUtil.getMetadataKey` decodes object field names the same way                                                               
  - Added round-trip coverage for non-ASCII string values and object field names                                                             
                                                                                                                                             
## Verifying this change                                                                                                                     
                                                                                                                                             
This change added tests and can be verified as follows:                                                                                      
                                                                                                                                             
  - `BinaryVariantTest.testNonAsciiStringsAndFieldNames` builds an object with non-ASCII field names and values, then re-reads it through    
`new BinaryVariant(value, metadata)`. That is the path taken once a variant has been serialized, and the only one that decodes field names   
from the metadata dictionary. It asserts `getFieldNames()`, `getField(...)`, `getString()` and `toJson()`. The values cover both string encodings, one short and one past `MAX_SHORT_STR_SIZE` so `LONG_STR` is exercised too.                                                       
  - `BinaryVariantInternalBuilderTest.testParseJsonWithNonAsciiStringsAndKeys` covers the `PARSE_JSON` path with non-ASCII keys and values,  and asserts the document round-trips byte for byte.                                                                                          
  - Red-green verified. With the fix reverted, both tests fail on Temurin 17 under `-Dfile.encoding=ISO-8859-1`, and pass with the fix applied. On a UTF-8 JVM they pass either way. That is inherent to the bug rather than a gap in the tests, since JEP 400 makes UTF-8 the  default from Java 18 on.                                                                                                                     
                                                                                                                                             
## Does this pull request potentially affect one of the following parts:                                                                     
                                                                                                                                             
  - Dependencies (does it add or upgrade a dependency): **no**                                                                               
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**. `BinaryVariantUtil` is `@Internal`. The observable behaviour of `@PublicEvolving Variant` does change, but only so that non-ASCII text decodes correctly. No signatures change.                 
  - The serializers: **no**. `VariantSerializer` writes and reads the raw `value` and `metadata` byte arrays, and the binary layout is  untouched, so existing state stays readable. Nothing was corrupted at rest either. The writer always encoded UTF-8, so only the read path was affected.                                                                                                                                    
  - The runtime per-record code paths (performance sensitive): **yes**, in the sense that `getString` and `getMetadataKey` run per record for VARIANT access. Naming the charset adds no work. On Java 18+ it selects the same decoder the JDK already picked implicitly.                  
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: **no**         
  - The S3 file system connector: **no**                                                                                                     
                                                                                                                                             
## Documentation                                                                                                                             
                                                                                                                                             
  - Does this pull request introduce a new feature? **no**                                                                                   
  - If yes, how is the feature documented? **not applicable**                                                                                
                                                                                                                                             
---                                                                                                                                          
                                                                                                                                             
##### Was generative AI tooling used to co-author this PR?                                                                                   
                                                                                                                                             
- [X] Yes (please specify the tool below)                                                                                                    
                                                                                                                                             
Generated-by: Claude Code (Claude Opus 5)            