### PR TITLE
[FLINK-40326][core] Do not over-grant permits in GatedRateLimiter

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/connector/source/util/ratelimit/GatedRateLimiter.java
+++ b/flink-core/src/main/java/org/apache/flink/api/connector/source/util/ratelimit/GatedRateLimiter.java
@@ -28,14 +28,18 @@ import static org.apache.flink.util.Preconditions.checkArgument;
 
 /**
  * An implementation of {@link RateLimiter} that completes defined number of futures in-between the
- * external notification events. The first cycle completes immediately, without waiting for the
- * external notifications.
+ * external notification events. The first cycle does not wait for an external notification: its
+ * capacity is available from the start, so requests complete immediately for as long as the
+ * capacity left covers them.
  */
 @Internal
 public class GatedRateLimiter<Split extends SourceSplit> implements RateLimiter<Split> {
 
     private final int capacityPerCycle;
     private int capacityLeft;
+
+    /** Completed while the current cycle has capacity left, incomplete once it has run out. */
+    private CompletableFuture<Void> gatingFuture = CompletableFuture.completedFuture(null);
 
     /**
      * Instantiates a new GatedRateLimiter.
@@ -48,14 +52,10 @@ public class GatedRateLimiter<Split extends SourceSplit> implements RateLimiter<
         this.capacityLeft = capacityPerCycle;
     }
 
-    transient CompletableFuture<Void> gatingFuture = null;
-
     @Override
     public CompletionStage<Void> acquire(int numberOfEvents) {
-        if (gatingFuture == null) {
-            gatingFuture = CompletableFuture.completedFuture(null);
-        }
-        if (capacityLeft <= 0) {
+        checkArgument(numberOfEvents > 0, "Number of events has to be a positive number.");
+        if (capacityLeft < numberOfEvents) {
             gatingFuture = new CompletableFuture<>();
         }
         return gatingFuture.thenRun(() -> capacityLeft -= numberOfEvents);

--- a/flink-core/src/main/java/org/apache/flink/api/connector/source/util/ratelimit/RateLimiter.java
+++ b/flink-core/src/main/java/org/apache/flink/api/connector/source/util/ratelimit/RateLimiter.java
@@ -48,7 +48,7 @@ public interface RateLimiter<SplitT extends SourceSplit> {
      * correct functioning, the next invocation of this method should only happen after the
      * previously returned future has been completed.
      *
-     * @param numberOfEvents The number of events.
+     * @param numberOfEvents The number of events, which has to be a positive number.
      */
     CompletionStage<Void> acquire(int numberOfEvents);
 

--- a/flink-tests/src/test/java/org/apache/flink/api/connector/source/lib/util/GatedRateLimiterTest.java
+++ b/flink-tests/src/test/java/org/apache/flink/api/connector/source/lib/util/GatedRateLimiterTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.api.connector.source.lib.util;
 
+import org.apache.flink.api.connector.source.lib.NumberSequenceSource.NumberSequenceSplit;
 import org.apache.flink.api.connector.source.util.ratelimit.GatedRateLimiter;
 
 import org.junit.jupiter.api.Test;
@@ -25,6 +26,7 @@ import org.junit.jupiter.api.Test;
 import java.util.concurrent.CompletionStage;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class GatedRateLimiterTest {
 
@@ -32,7 +34,8 @@ class GatedRateLimiterTest {
     void testCapacityNotExceededOnCheckpoint() {
         int capacityPerCycle = 5;
 
-        final GatedRateLimiter gatedRateLimiter = new GatedRateLimiter(capacityPerCycle);
+        final GatedRateLimiter<NumberSequenceSplit> gatedRateLimiter =
+                new GatedRateLimiter<>(capacityPerCycle);
         for (int x = 0; x < capacityPerCycle; x++) {
             assertThat(gatedRateLimiter.acquire()).isCompleted();
         }
@@ -49,5 +52,76 @@ class GatedRateLimiterTest {
 
         CompletionStage<Void> postCheckpoint = gatedRateLimiter.acquire();
         assertThat(postCheckpoint).isNotCompleted();
+    }
+
+    @Test
+    void testCapacityNotExceededWhenAcquiringMultipleEvents() {
+        int capacityPerCycle = 5;
+
+        final GatedRateLimiter<NumberSequenceSplit> gatedRateLimiter =
+                new GatedRateLimiter<>(capacityPerCycle);
+        assertThat(gatedRateLimiter.acquire(3)).isCompleted();
+
+        // Only two permits are left in this cycle, so a request for three events has to wait even
+        // though the remaining capacity is still greater than zero.
+        CompletionStage<Void> exceedsRemainingCapacity = gatedRateLimiter.acquire(3);
+        assertThat(exceedsRemainingCapacity).isNotCompleted();
+
+        gatedRateLimiter.notifyCheckpointComplete(0);
+
+        assertThat(exceedsRemainingCapacity).isCompleted();
+    }
+
+    @Test
+    void testRequestLargerThanCapacityIsReleasedByNextCycle() {
+        final GatedRateLimiter<NumberSequenceSplit> gatedRateLimiter = new GatedRateLimiter<>(2);
+
+        // A single request may legitimately exceed the capacity of an entire cycle. It must not
+        // deadlock: resetting the capacity on the next completed checkpoint releases it.
+        CompletionStage<Void> exceedsWholeCycle = gatedRateLimiter.acquire(3);
+        assertThat(exceedsWholeCycle).isNotCompleted();
+
+        gatedRateLimiter.notifyCheckpointComplete(0);
+
+        assertThat(exceedsWholeCycle).isCompleted();
+
+        // Because completing it took 3 events from a cycle that only had 2, a further checkpoint is
+        // needed before requests are allowed again.
+        CompletionStage<Void> followingRequest = gatedRateLimiter.acquire(1);
+        assertThat(followingRequest).isNotCompleted();
+
+        gatedRateLimiter.notifyCheckpointComplete(1);
+
+        assertThat(followingRequest).isCompleted();
+        assertThat(gatedRateLimiter.acquire(1)).isCompleted();
+    }
+
+    @Test
+    void testCheckpointCompleteBeforeFirstAcquire() {
+        int capacityPerCycle = 5;
+
+        final GatedRateLimiter<NumberSequenceSplit> gatedRateLimiter =
+                new GatedRateLimiter<>(capacityPerCycle);
+
+        // A checkpoint can complete before the reader has emitted anything, for instance while it
+        // is still waiting for its first split assignment.
+        gatedRateLimiter.notifyCheckpointComplete(0);
+
+        for (int x = 0; x < capacityPerCycle; x++) {
+            assertThat(gatedRateLimiter.acquire()).isCompleted();
+        }
+        assertThat(gatedRateLimiter.acquire()).isNotCompleted();
+    }
+
+    @Test
+    void testNonPositiveNumberOfEventsIsRejected() {
+        final GatedRateLimiter<NumberSequenceSplit> gatedRateLimiter = new GatedRateLimiter<>(5);
+
+        assertThatThrownBy(() -> gatedRateLimiter.acquire(0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("positive");
+        assertThatThrownBy(() -> gatedRateLimiter.acquire(-1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("positive");
     }
 }


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

The decrement in acquire() was generalized from a constant 1 to numberOfEvents as part of FLIP-535, but the gate was left closing only at capacityLeft <= 0, so a cycle can admit more events than capacityPerCycle. The gate is now closed unless the capacity left covers the whole request.


## Brief change log

- Close the gate in GatedRateLimiter#acquire(int) unless the capacity left covers the whole request, rather than only once it has reached zero 
- Reject a non-positive numberOfEvents
- Initialize gatingFuture eagerly, so notifyCheckpointComplete before the first acquire() no longer throws a NullPointerException 
- Correct the class Javadoc


## Verifying this change

This change added the following tests:
- *Added four tests to `GatedRateLimiterTest`, one per defect, each fails against the unfixed code* 

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes, but Javadoc only )
  - The serializers: (no, a transient modifier is dropped, but GatedRateLimiter does not implement Serializable (only RateLimiterStrategy does), so it had no effect.)
  - The runtime per-record code paths (performance sensitive): (yes, acquire(int) is called once per input record when rate limiting is enabled.)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change the checkbox below to `[X]` and replace the placeholder in the "Generated-by"
line with the tool name and version. Otherwise remove the "Generated-by" line.
See the ASF Generative Tooling Guidance for details:
https://www.apache.org/legal/generative-tooling.html

You are responsible for the quality and correctness of every change in this PR
regardless of the tooling used. Low-effort AI-generated PRs will be closed. See
AGENTS.md for the full guidance.
-->

- [ ] Yes (please specify the tool below)

Generated-by: [Tool Name and Version]
