### PR TITLE
[FLINK-40332][table] Prevent path traversal in FileCatalogStore catalog names

### DIFF
--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/FileCatalogStore.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/FileCatalogStore.java
@@ -260,6 +260,27 @@ public class FileCatalogStore extends AbstractCatalogStore {
     }
 
     private Path getCatalogPath(String catalogName) {
-        return new Path(catalogStorePath, catalogName + FILE_EXTENSION);
+        Path catalogPath;
+        try {
+            catalogPath = new Path(catalogStorePath, catalogName + FILE_EXTENSION);
+        } catch (Exception e) {
+            // e.g. catalogName embeds its own scheme-qualified URI (like "file:///etc/passwd"),
+            // which Path may reject outright while merging it against catalogStorePath.
+            throw new CatalogException(String.format("Invalid catalog name '%s'.", catalogName), e);
+        }
+
+        // catalogName is caller-supplied and may try to escape catalogStorePath, e.g. via ".."
+        // segments. Path's own resolution above already fully normalizes the result (RFC 3986
+        // dot-segment removal), so checking that the *resolved* path's parent is still
+        // catalogStorePath is sufficient to reject every variant of escape, without needing to
+        // inspect catalogName itself.
+        if (!catalogStorePath.equals(catalogPath.getParent())) {
+            throw new CatalogException(
+                    String.format(
+                            "Invalid catalog name '%s'. It resolves to '%s', which is outside of "
+                                    + "the catalog store directory '%s'.",
+                            catalogName, catalogPath, catalogStorePath));
+        }
+        return catalogPath;
     }
 }

--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/catalog/FileCatalogStoreTest.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/catalog/FileCatalogStoreTest.java
@@ -107,6 +107,38 @@ class FileCatalogStoreTest {
     }
 
     @Test
+    void testStoreCatalogRejectsPathTraversal() throws Exception {
+        CatalogStore catalogStore = initCatalogStore();
+        catalogStore.open();
+
+        // A malicious catalog name that, if not validated, resolves outside of the
+        // catalog store directory: tempDir/dummy-catalog-store/../escaped.yaml ->
+        // tempDir/escaped.yaml.
+        String maliciousName = "../escaped";
+        File escapedFile = tempDir.resolve("escaped" + FileCatalogStore.FILE_EXTENSION).toFile();
+
+        assertThatThrownBy(() -> catalogStore.storeCatalog(maliciousName, DUMMY_CATALOG))
+                .isInstanceOf(CatalogException.class);
+        assertThat(escapedFile).doesNotExist();
+    }
+
+    @Test
+    void testStoreCatalogRejectsAbsoluteSchemeOverride() throws Exception {
+        CatalogStore catalogStore = initCatalogStore();
+        catalogStore.open();
+
+        // A catalog name that embeds its own absolute file:// URI. Per RFC 3986 §5.3, resolving
+        // an absolute reference against a base URI discards the base entirely, so if this isn't
+        // rejected, the catalog store directory is bypassed altogether.
+        File escapedFile = tempDir.resolve("escaped" + FileCatalogStore.FILE_EXTENSION).toFile();
+        String maliciousName = "file://" + escapedFile.getAbsolutePath().replace(".yaml", "");
+
+        assertThatThrownBy(() -> catalogStore.storeCatalog(maliciousName, DUMMY_CATALOG))
+                .isInstanceOf(CatalogException.class);
+        assertThat(escapedFile).doesNotExist();
+    }
+
+    @Test
     void testRemoveExisting() {
         CatalogStore catalogStore = initCatalogStore();
         catalogStore.open();


### PR DESCRIPTION
## What is the purpose of the change

`FileCatalogStore.getCatalogPath()` built the on-disk path for a catalog's configuration file by directly concatenating the caller-supplied `catalogName` onto `catalogStorePath`, with no validation. Since `Path`'s URI resolution collapses `..` segments (and discards the base entirely if the child is itself a scheme-qualified absolute URI), a `catalogName` such as `../../etc/cron.d/evil` or `file:///etc/passwd` resolves outside of `catalogStorePath`.

Any caller able to invoke `CREATE CATALOG`, `DROP CATALOG`, or read a catalog (e.g. via the SQL Gateway) could use this to write, delete, or read arbitrary files reachable by the Flink process.

This PR rejects any `catalogName` that resolves outside of `catalogStorePath`, closing the path traversal.

## Brief change log

  - `FileCatalogStore#getCatalogPath` now resolves the catalog file path and
    verifies its immediate parent is still exactly `catalogStorePath` before
    returning it, throwing `CatalogException` otherwise
  - Wrapped the `Path` construction itself in a try/catch, since a
    scheme-qualified `catalogName` (e.g. `file:///...`) can make `Path`'s own
    merge logic throw an unwrapped `IllegalArgumentException`, which is not
    part of this class's documented `CatalogException` contract

## Verifying this change

This change added tests and can be verified as follows:

  - Added `FileCatalogStoreTest#testStoreCatalogRejectsPathTraversal`, which
    uses `catalogName = "../escaped"` and asserts `storeCatalog` throws
    `CatalogException` and that no file is created outside of the catalog
    store directory. This test fails against the pre-fix code (no exception
    is thrown, and the file is written outside the intended directory).
  - Added
    `FileCatalogStoreTest#testStoreCatalogRejectsAbsoluteSchemeOverride`,
    which uses a `catalogName` embedding its own `file://` URI, covering the
    scheme-override bypass variant of the same issue.
  - All existing tests in `FileCatalogStoreTest` continue to pass.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no (`FileCatalogStore` is `@Internal`)
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: Claude Code (claude-sonnet-5)
