### PR TITLE
[FLINK-40361][ci] Extract license check into a separate job in Azure

### DIFF
--- a/tools/azure-pipelines/e2e-template.yml
+++ b/tools/azure-pipelines/e2e-template.yml
@@ -140,7 +140,8 @@ jobs:
         sudo apt install ./libssl1.0.0_*.deb
       displayName: Prepare E2E run
       condition: not(eq(variables['SKIP'], '1'))
-    - script: ${{parameters.environment}} PROFILE="$PROFILE -Dfast -Pskip-webui-build" ./tools/ci/compile_ci.sh
+    # e2e only needs the built binary; MVN_LICENSE_CHECK_ARGS="" skips all QA (convergence, license, structural) and the DEBUG shade logging, which run in the license_check job.
+    - script: MVN_LICENSE_CHECK_ARGS="" ${{parameters.environment}} PROFILE="$PROFILE -Dfast -Pskip-webui-build" ./tools/ci/compile_ci.sh
       displayName: Build Flink
       condition: not(eq(variables['SKIP'], '1'))
     - script: ${{parameters.environment}} FLINK_DIR=`pwd`/build-target ./tools/ci/uploading_watchdog.sh flink-end-to-end-tests/run-nightly-tests.sh ${{parameters.group}}

--- a/tools/azure-pipelines/e2e-template.yml
+++ b/tools/azure-pipelines/e2e-template.yml
@@ -140,7 +140,8 @@ jobs:
         sudo apt install ./libssl1.0.0_*.deb
       displayName: Prepare E2E run
       condition: not(eq(variables['SKIP'], '1'))
-    - script: ${{parameters.environment}} PROFILE="$PROFILE -Dfast -Pskip-webui-build" ./tools/ci/compile_ci.sh
+    # e2e only needs the build; skip all QA checks (they run in the qa_check job) so it can build with -T1C
+    - script: SKIP_QA_CHECKS=true MVN_COMPILE_THREADS=1C ${{parameters.environment}} PROFILE="$PROFILE -Pskip-webui-build" ./tools/ci/compile_ci.sh
       displayName: Build Flink
       condition: not(eq(variables['SKIP'], '1'))
     - script: ${{parameters.environment}} FLINK_DIR=`pwd`/build-target ./tools/ci/uploading_watchdog.sh flink-end-to-end-tests/run-nightly-tests.sh ${{parameters.group}}

--- a/tools/azure-pipelines/jobs-template.yml
+++ b/tools/azure-pipelines/jobs-template.yml
@@ -67,8 +67,11 @@ jobs:
       echo "##vso[task.setvariable variable=PATH]$JAVA_HOME_${{parameters.jdk}}_X64/bin:$PATH"
     displayName: "Set JDK"
   # Compile
+  # SKIP_QA_CHECKS skips all QA checks (javadoc/scala/shaded/bundled/license); they run in the
+  # dedicated qa_check job. This lets the compile build run fast and multi-threaded (-T1C), off the
+  # test critical path.
   - script: |
-      ${{parameters.environment}} ./tools/ci/compile_ci.sh || exit $?
+      SKIP_QA_CHECKS=true MVN_COMPILE_THREADS=1C ${{parameters.environment}} ./tools/ci/compile_ci.sh || exit $?
       ./tools/ci/create_build_artifact.sh
     displayName: Compile
 
@@ -77,6 +80,40 @@ jobs:
     inputs:
       targetPath: $(FLINK_ARTIFACT_DIR)
       artifact: FlinkCompileArtifact-${{parameters.stage_name}}
+
+# All QA checks (javadoc/scala/shaded/bundled/license) run here: this job builds Flink from scratch
+# single-threaded and validates it. Runs as an independent job (in parallel with compile/test) so it
+# is off the test critical path.
+- job: qa_check_${{parameters.stage_name}}
+  # succeeded() is needed to allow job cancellation
+  condition: and(succeeded(), not(eq(variables['MODE'], 'e2e')))
+  pool: ${{parameters.test_pool_definition}}
+  container: ${{parameters.container}}
+  timeoutInMinutes: 240
+  cancelTimeoutInMinutes: 1
+  workspace:
+    clean: all
+  steps:
+  # if on Azure, free up disk space
+  - script: ./tools/ci/free_disk_space.sh
+    target: host
+    condition: not(eq('${{parameters.test_pool_definition.name}}', 'Default'))
+    displayName: Free up disk space
+  - task: Cache@2
+    inputs:
+      key: $(PIPELINE_START_YEAR) | $(CACHE_KEY)
+      restoreKeys: $(PIPELINE_START_YEAR) | $(CACHE_FALLBACK_KEY)
+      path: $(MAVEN_CACHE_FOLDER)
+    continueOnError: true # continue the build even if the cache fails.
+    condition: not(eq('${{parameters.test_pool_definition.name}}', 'Default'))
+    displayName: Cache Maven local repo
+  - script: |
+      echo "##vso[task.setvariable variable=JAVA_HOME]$JAVA_HOME_${{parameters.jdk}}_X64"
+      echo "##vso[task.setvariable variable=PATH]$JAVA_HOME_${{parameters.jdk}}_X64/bin:$PATH"
+    displayName: "Set JDK"
+  # Build from scratch single-threaded and run all QA checks (no SKIP_QA_CHECKS).
+  - script: ${{parameters.environment}} ./tools/ci/compile_ci.sh
+    displayName: QA checks
 
 - job: test_${{parameters.stage_name}}
   dependsOn: compile_${{parameters.stage_name}}

--- a/tools/azure-pipelines/jobs-template.yml
+++ b/tools/azure-pipelines/jobs-template.yml
@@ -67,8 +67,9 @@ jobs:
       echo "##vso[task.setvariable variable=PATH]$JAVA_HOME_${{parameters.jdk}}_X64/bin:$PATH"
     displayName: "Set JDK"
   # Compile
+  # Fast multi-threaded build that only produces the test artifact; all QA (structural + convergence + license) runs single-threaded in the license_check job (MVN_LICENSE_CHECK_ARGS="" disables it here).
   - script: |
-      ${{parameters.environment}} ./tools/ci/compile_ci.sh || exit $?
+      MVN_LICENSE_CHECK_ARGS="" ${{parameters.environment}} ./tools/ci/compile_ci.sh -Dfast || exit $?
       ./tools/ci/create_build_artifact.sh
     displayName: Compile
 
@@ -77,6 +78,38 @@ jobs:
     inputs:
       targetPath: $(FLINK_ARTIFACT_DIR)
       artifact: FlinkCompileArtifact-${{parameters.stage_name}}
+
+# All QA (structural + convergence + license) runs single-threaded here, off the critical path (no dependsOn), so the compile job can build fast with -Dfast -T1C.
+- job: license_check_${{parameters.stage_name}}
+  # succeeded() is needed to allow job cancellation
+  condition: and(succeeded(), not(eq(variables['MODE'], 'e2e')))
+  pool: ${{parameters.test_pool_definition}}
+  container: ${{parameters.container}}
+  timeoutInMinutes: 240
+  cancelTimeoutInMinutes: 1
+  workspace:
+    clean: all
+  steps:
+  # if on Azure, free up disk space
+  - script: ./tools/ci/free_disk_space.sh
+    target: host
+    condition: not(eq('${{parameters.test_pool_definition.name}}', 'Default'))
+    displayName: Free up disk space
+  - task: Cache@2
+    inputs:
+      key: $(PIPELINE_START_YEAR) | $(CACHE_KEY)
+      restoreKeys: $(PIPELINE_START_YEAR) | $(CACHE_FALLBACK_KEY)
+      path: $(MAVEN_CACHE_FOLDER)
+    continueOnError: true # continue the build even if the cache fails.
+    condition: not(eq('${{parameters.test_pool_definition.name}}', 'Default'))
+    displayName: Cache Maven local repo
+  - script: |
+      echo "##vso[task.setvariable variable=JAVA_HOME]$JAVA_HOME_${{parameters.jdk}}_X64"
+      echo "##vso[task.setvariable variable=PATH]$JAVA_HOME_${{parameters.jdk}}_X64/bin:$PATH"
+    displayName: "Set JDK"
+  # Full single-threaded build (deploy + -Pcheck-convergence) running every structural QA check and the license check.
+  - script: ${{parameters.environment}} ./tools/ci/compile_ci.sh
+    displayName: QA checks
 
 - job: test_${{parameters.stage_name}}
   dependsOn: compile_${{parameters.stage_name}}

--- a/tools/ci/compile.sh
+++ b/tools/ci/compile.sh
@@ -58,9 +58,19 @@ echo "==========================================================================
 
 EXIT_CODE=0
 
-# run with -T1 because our maven output parsers don't support multi-threaded builds
-$MVN clean deploy -DaltDeploymentRepository=validation_repository::default::file:$MVN_VALIDATION_DIR -Dflink.convergence.phase=install -Pcheck-convergence \
-    -Dmaven.javadoc.skip=true -U -DskipTests -Dorg.slf4j.simpleLogger.log.org.apache.maven.plugins.shade=DEBUG "${@}" -T1 | tee $MVN_CLEAN_COMPILE_OUT
+# Maven QA-check args: dependency convergence, the deploy that stages jars for the license check, and the shade DEBUG log the bundled-optional check parses. Default runs full QA; the fast compile job and e2e pass MVN_LICENSE_CHECK_ARGS="" to build only (QA runs in the license_check job). Non-empty also enables the structural QA + license blocks below.
+MVN_LICENSE_CHECK_ARGS="${MVN_LICENSE_CHECK_ARGS-deploy -DaltDeploymentRepository=validation_repository::default::file:$MVN_VALIDATION_DIR -Dflink.convergence.phase=install -Pcheck-convergence -Dorg.slf4j.simpleLogger.log.org.apache.maven.plugins.shade=DEBUG}"
+if [[ -n "$MVN_LICENSE_CHECK_ARGS" ]]; then
+    BUILD_GOAL_ARGS="$MVN_LICENSE_CHECK_ARGS"
+    MVN_COMPILE_THREADS="${MVN_COMPILE_THREADS:-1}"
+else
+    BUILD_GOAL_ARGS="install"
+    MVN_COMPILE_THREADS="${MVN_COMPILE_THREADS:-1C}"
+fi
+
+# Default -T1 because our output parsers (bundled-optional/shade) don't support multi-threaded builds; the fast compile job sets MVN_COMPILE_THREADS=1C together with MVN_LICENSE_CHECK_ARGS="" so those parsing checks are skipped.
+$MVN clean ${BUILD_GOAL_ARGS} \
+    -Dmaven.javadoc.skip=true -U -DskipTests "${@}" -T${MVN_COMPILE_THREADS} | tee $MVN_CLEAN_COMPILE_OUT
 
 EXIT_CODE=${PIPESTATUS[0]}
 
@@ -78,6 +88,9 @@ if [ $EXIT_CODE != 0 ]; then
 
     exit $EXIT_CODE
 fi
+
+# Structural QA (javadoc/scala/shaded/bundled) runs only in QA mode (MVN_LICENSE_CHECK_ARGS non-empty); the fast compile job and e2e skip it.
+if [[ -n "$MVN_LICENSE_CHECK_ARGS" ]]; then
 
 echo "============ Checking Javadocs ============"
 
@@ -111,10 +124,17 @@ EXIT_CODE=$(($EXIT_CODE+$?))
 check_shaded_artifacts_s3_fs presto
 EXIT_CODE=$(($EXIT_CODE+$?))
 
+fi
+
+# License check needs the staged deploy dir; runs only in QA mode (MVN_LICENSE_CHECK_ARGS non-empty).
+if [[ -n "$MVN_LICENSE_CHECK_ARGS" ]]; then
+
 echo "============ Run license check ============"
 
 find $MVN_VALIDATION_DIR
 MVN=$MVN ${CI_DIR}/license_check.sh $MVN_CLEAN_COMPILE_OUT $MVN_VALIDATION_DIR || exit $?
+
+fi
 
 exit $EXIT_CODE
 

--- a/tools/ci/compile.sh
+++ b/tools/ci/compile.sh
@@ -58,9 +58,22 @@ echo "==========================================================================
 
 EXIT_CODE=0
 
-# run with -T1 because our maven output parsers don't support multi-threaded builds
-$MVN clean deploy -DaltDeploymentRepository=validation_repository::default::file:$MVN_VALIDATION_DIR -Dflink.convergence.phase=install -Pcheck-convergence \
-    -Dmaven.javadoc.skip=true -U -DskipTests -Dorg.slf4j.simpleLogger.log.org.apache.maven.plugins.shade=DEBUG "${@}" -T1 | tee $MVN_CLEAN_COMPILE_OUT
+# QA builds add shade DEBUG output and deploy to a local repo for the license check; other builds build fast and only install
+if [[ "${SKIP_QA_CHECKS:-false}" != "true" ]]; then
+    BUILD_MODE_ARGS="-Dorg.slf4j.simpleLogger.log.org.apache.maven.plugins.shade=DEBUG"
+    DEPLOY_ARGS="deploy -DaltDeploymentRepository=validation_repository::default::file:$MVN_VALIDATION_DIR -Dflink.convergence.phase=install -Pcheck-convergence"
+else
+    BUILD_MODE_ARGS="-Pfast"
+    DEPLOY_ARGS="install"
+fi
+# Only force snapshot updates (-U) unless the global Maven options already disable them (--no-snapshot-updates)
+UPDATE_SNAPSHOTS_ARG="-U"
+if [[ "${MVN_GLOBAL_OPTIONS_WITHOUT_MIRROR}" == *"--no-snapshot-updates"* ]]; then
+    UPDATE_SNAPSHOTS_ARG=""
+fi
+# The bundled/license QA checks parse single-threaded output (-T1); QA-skipping builds may set MVN_COMPILE_THREADS (e.g. 1C)
+$MVN clean ${DEPLOY_ARGS} \
+    -Dmaven.javadoc.skip=true ${UPDATE_SNAPSHOTS_ARG} -DskipTests ${BUILD_MODE_ARGS} "${@}" -T${MVN_COMPILE_THREADS:-1} | tee $MVN_CLEAN_COMPILE_OUT
 
 EXIT_CODE=${PIPESTATUS[0]}
 
@@ -79,6 +92,9 @@ if [ $EXIT_CODE != 0 ]; then
     exit $EXIT_CODE
 fi
 
+# All QA checks run only in the dedicated QA job (and local runs); compile/e2e skip them via SKIP_QA_CHECKS
+if [[ "${SKIP_QA_CHECKS:-false}" != "true" ]]; then
+
 echo "============ Checking Javadocs ============"
 
 javadoc_output=/tmp/javadoc.out
@@ -94,10 +110,6 @@ if [ $EXIT_CODE != 0 ] ; then
   exit $EXIT_CODE
 fi
 
-echo "============ Checking bundled dependencies marked as optional ============"
-
-MVN=$MVN ${CI_DIR}/verify_bundled_optional.sh $MVN_CLEAN_COMPILE_OUT || exit $?
-
 echo "============ Checking scala suffixes ============"
 
 MVN=$MVN ${CI_DIR}/verify_scala_suffixes.sh || exit $?
@@ -111,10 +123,16 @@ EXIT_CODE=$(($EXIT_CODE+$?))
 check_shaded_artifacts_s3_fs presto
 EXIT_CODE=$(($EXIT_CODE+$?))
 
+echo "============ Checking bundled dependencies marked as optional ============"
+
+MVN=$MVN ${CI_DIR}/verify_bundled_optional.sh $MVN_CLEAN_COMPILE_OUT || exit $?
+
 echo "============ Run license check ============"
 
 find $MVN_VALIDATION_DIR
 MVN=$MVN ${CI_DIR}/license_check.sh $MVN_CLEAN_COMPILE_OUT $MVN_VALIDATION_DIR || exit $?
+
+fi
 
 exit $EXIT_CODE
 


### PR DESCRIPTION


## What is the purpose of the change

This extractions allows to run single threaded job (required for license check) in a parallel thread while the important things in fast path

e.g. 2h 10 min https://dev.azure.com/apache-flink/apache-flink/_build/results?buildId=77956&view=results
vs 2h 40 min in current master https://dev.azure.com/apache-flink/apache-flink/_build/results?buildId=77950&view=results
## Brief change log

Azure


## Verifying this change

Azure
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: ( no )
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: ( no)
  - The S3 file system connector: ( no )

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable )

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change the checkbox below to `[X]` and replace the placeholder in the "Generated-by"
line with the tool name and version. Otherwise remove the "Generated-by" line.
See the ASF Generative Tooling Guidance for details:
https://www.apache.org/legal/generative-tooling.html

You are responsible for the quality and correctness of every change in this PR
regardless of the tooling used. Low-effort AI-generated PRs will be closed. See
AGENTS.md for the full guidance.
-->

- [ ] Yes (please specify the tool below)

Generated-by: [Tool Name and Version]
