### PR TITLE
[FLINK-40338][table-runtime] ELT() throws ClassCastException when index is not INT

### DIFF
--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/StringFunctionsITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/StringFunctionsITCase.java
@@ -207,6 +207,11 @@ class StringFunctionsITCase extends BuiltInFunctionTestBase {
                                 "java",
                                 DataTypes.VARCHAR(5))
                         .testResult(
+                                $("f4").elt($("f3"), $("f2")),
+                                "ELT(f4, f3, f2)",
+                                null,
+                                DataTypes.BYTES())
+                        .testResult(
                                 lit(2).elt($("f2"), $("f3"), $("f3")),
                                 "ELT(2, f2, f3, f3)",
                                 new byte[] {1, 2, 3},

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/StringFunctionsITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/StringFunctionsITCase.java
@@ -149,12 +149,15 @@ class StringFunctionsITCase extends BuiltInFunctionTestBase {
     private Stream<TestSetSpec> eltTestCases() {
         return Stream.of(
                 TestSetSpec.forFunction(BuiltInFunctionDefinitions.ELT)
-                        .onFieldsWithData(null, null, null, new byte[] {1, 2, 3})
+                        .onFieldsWithData(null, null, null, new byte[] {1, 2, 3}, (byte) 2, (short) 2, 2L)
                         .andDataTypes(
                                 DataTypes.INT(),
                                 DataTypes.STRING(),
                                 DataTypes.BYTES(),
-                                DataTypes.BYTES())
+                                DataTypes.BYTES(),
+                                DataTypes.TINYINT(),
+                                DataTypes.SMALLINT(),
+                                DataTypes.BIGINT())
                         // null input
                         .testResult(
                                 $("f0").elt("a", "b"), "ELT(f0, 'a', 'b')", null, DataTypes.CHAR(1))
@@ -182,20 +185,27 @@ class StringFunctionsITCase extends BuiltInFunctionTestBase {
                                 DataTypes.VARCHAR(5))
                         .testResult(
                                 lit(2).elt("a", "b"), "ELT(2, 'a', 'b')", "b", DataTypes.CHAR(1))
-                        // FLINK-40338: non-INT INTEGER_NUMERIC index must not throw ClassCastException
+                        // FLINK-40338: non-INT INTEGER_NUMERIC index must not throw ClassCastException.
+                        // Constant case covers the ExpressionReducer (constant-folding) path;
+                        // field-reference cases below cover the codegen'd operator path.
                         .testResult(
                                 lit(2).cast(DataTypes.TINYINT()).elt("scala", "java"),
                                 "ELT(CAST(2 AS TINYINT), 'scala', 'java')",
                                 "java",
                                 DataTypes.VARCHAR(5))
                         .testResult(
-                                lit(2).cast(DataTypes.SMALLINT()).elt("scala", "java"),
-                                "ELT(CAST(2 AS SMALLINT), 'scala', 'java')",
+                                $("f4").elt("scala", "java"),
+                                "ELT(f4, 'scala', 'java')",
                                 "java",
                                 DataTypes.VARCHAR(5))
                         .testResult(
-                                lit(2).cast(DataTypes.BIGINT()).elt("scala", "java"),
-                                "ELT(CAST(2 AS BIGINT), 'scala', 'java')",
+                                $("f5").elt("scala", "java"),
+                                "ELT(f5, 'scala', 'java')",
+                                "java",
+                                DataTypes.VARCHAR(5))
+                        .testResult(
+                                $("f6").elt("scala", "java"),
+                                "ELT(f6, 'scala', 'java')",
                                 "java",
                                 DataTypes.VARCHAR(5))
                         .testResult(

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/StringFunctionsITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/StringFunctionsITCase.java
@@ -149,7 +149,8 @@ class StringFunctionsITCase extends BuiltInFunctionTestBase {
     private Stream<TestSetSpec> eltTestCases() {
         return Stream.of(
                 TestSetSpec.forFunction(BuiltInFunctionDefinitions.ELT)
-                        .onFieldsWithData(null, null, null, new byte[] {1, 2, 3}, (byte) 2, (short) 2, 2L)
+                        .onFieldsWithData(
+                                null, null, null, new byte[] {1, 2, 3}, (byte) 2, (short) 2, 2L)
                         .andDataTypes(
                                 DataTypes.INT(),
                                 DataTypes.STRING(),

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/StringFunctionsITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/StringFunctionsITCase.java
@@ -185,9 +185,6 @@ class StringFunctionsITCase extends BuiltInFunctionTestBase {
                                 DataTypes.VARCHAR(5))
                         .testResult(
                                 lit(2).elt("a", "b"), "ELT(2, 'a', 'b')", "b", DataTypes.CHAR(1))
-                        // FLINK-40338: non-INT INTEGER_NUMERIC index must not throw ClassCastException.
-                        // Constant case covers the ExpressionReducer (constant-folding) path;
-                        // field-reference cases below cover the codegen'd operator path.
                         .testResult(
                                 lit(2).cast(DataTypes.TINYINT()).elt("scala", "java"),
                                 "ELT(CAST(2 AS TINYINT), 'scala', 'java')",

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/StringFunctionsITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/StringFunctionsITCase.java
@@ -182,6 +182,22 @@ class StringFunctionsITCase extends BuiltInFunctionTestBase {
                                 DataTypes.VARCHAR(5))
                         .testResult(
                                 lit(2).elt("a", "b"), "ELT(2, 'a', 'b')", "b", DataTypes.CHAR(1))
+                        // FLINK-40338: non-INT INTEGER_NUMERIC index must not throw ClassCastException
+                        .testResult(
+                                lit(2).cast(DataTypes.TINYINT()).elt("scala", "java"),
+                                "ELT(CAST(2 AS TINYINT), 'scala', 'java')",
+                                "java",
+                                DataTypes.VARCHAR(5))
+                        .testResult(
+                                lit(2).cast(DataTypes.SMALLINT()).elt("scala", "java"),
+                                "ELT(CAST(2 AS SMALLINT), 'scala', 'java')",
+                                "java",
+                                DataTypes.VARCHAR(5))
+                        .testResult(
+                                lit(2).cast(DataTypes.BIGINT()).elt("scala", "java"),
+                                "ELT(CAST(2 AS BIGINT), 'scala', 'java')",
+                                "java",
+                                DataTypes.VARCHAR(5))
                         .testResult(
                                 lit(2).elt($("f2"), $("f3"), $("f3")),
                                 "ELT(2, f2, f3, f3)",

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/EltFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/EltFunction.java
@@ -40,9 +40,6 @@ public class EltFunction extends BuiltInScalarFunction {
         if (idx < 1 || idx > exprs.length) {
             return null;
         }
-        // Narrow the already-unboxed long instead of casting the Number reference.
-        // Casting `index` (java.lang.Number) to int compiles to a checkcast to Integer
-        // followed by unboxing, which throws ClassCastException for Byte/Short/Long.
         return exprs[(int) idx - 1];
     }
 }

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/EltFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/EltFunction.java
@@ -40,6 +40,9 @@ public class EltFunction extends BuiltInScalarFunction {
         if (idx < 1 || idx > exprs.length) {
             return null;
         }
-        return exprs[(int) index - 1];
+        // Narrow the already-unboxed long instead of casting the Number reference.
+        // Casting `index` (java.lang.Number) to int compiles to a checkcast to Integer
+        // followed by unboxing, which throws ClassCastException for Byte/Short/Long.
+        return exprs[(int) idx - 1];
     }
 }


### PR DESCRIPTION
## Problem fixed & how

`ELT(index, expr, exprs...)` accepts any `INTEGER_NUMERIC` index (`TINYINT`/`SMALLINT`/`INT`/`BIGINT`). However, `EltFunction#eval` declares `index` as `java.lang.Number` and indexes the varargs array with `exprs[(int) index - 1]`. Per JLS 5.5, casting a `Number` reference to `int` compiles to a `checkcast` to `Integer` followed by unboxing, so a `Byte`, `Short`, or `Long` value throws `ClassCastException` on the success path (`1 <= index <= exprs.length`).

```sql
SELECT ELT(CAST(2 AS BIGINT), 'scala', 'java');
-- java.lang.ClassCastException: class java.lang.Long cannot be cast to class java.lang.Integer
```

Same for `CAST(2 AS TINYINT)` and `CAST(2 AS SMALLINT)`.

The out-of-range guard above the cast uses `index.longValue()`, so out-of-range indices of any type still return `NULL` correctly; the exception only fires in the valid range. That is why the existing test `ELT(9223372036854775807, 'ab', 'b')` passes (returns `NULL` before reaching the cast) and every other existing test uses an `INT` literal.

Present since [FLINK-35987](https://issues.apache.org/jira/browse/FLINK-35987) introduced ELT; confirmed absent from release-1.20 and present from release-2.0.

**Fix:** narrow the already-unboxed `long idx` (computed above for the range check) via primitive narrowing `(int) idx` (JLS 5.1.3, no `checkcast`) instead of casting the `Number` reference.

## Behavior modified

- **previous:** `ELT` with a non-INT `INTEGER_NUMERIC` index (`TINYINT`/`SMALLINT`/`BIGINT`) in the valid range `1 <= index <= exprs.length` threw `ClassCastException`.
- **now:** non-INT integer indices correctly return the corresponding expression.
- **impact:** only the success path for non-INT integer indices; `INT` indices, `NULL`, and out-of-range behavior are unchanged.

## Code refactored

`EltFunction.eval`: `exprs[(int) index - 1]` → `exprs[(int) idx - 1]`, with a 3-line comment explaining the JLS rationale.

## Features added

N/A

## Functions optimized

N/A

## Test plan

- [x] Added 3 regression cases to `StringFunctionsITCase.eltTestCases()` covering `TINYINT`, `SMALLINT`, and `BIGINT` indices (the three types that previously threw `ClassCastException`). Each expects the correct expression (`"java"` for index 2).
- [ ] The local environment runs Java 8 and cannot build Flink master (requires Java 11+), so verification relies on CI:
  ```
  mvn -pl flink-table/flink-table-planner -am test -Dtest=StringFunctionsITCase
  ```
