### PR TITLE
[FLINK-34474][formats] Reset Avro decoder after a failed deserialization

### DIFF
--- a/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/AvroDeserializationSchema.java
+++ b/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/AvroDeserializationSchema.java
@@ -198,7 +198,10 @@ public class AvroDeserializationSchema<T> implements DeserializationSchema<T> {
             if (encoding == AvroEncoding.JSON) {
                 this.decoder = DecoderFactory.get().jsonDecoder(getReaderSchema(), inputStream);
             } else {
-                this.decoder = DecoderFactory.get().binaryDecoder(inputStream, this.decoder);
+                // Rebuild the BinaryDecoder bound to the input stream. The pooled
+                // decoder is discarded (passing null as reuse) so a poisoned internal
+                // buffer cannot leak into the next message.
+                this.decoder = DecoderFactory.get().binaryDecoder(inputStream, null);
             }
         } catch (IOException e) {
             // jsonDecoder only throws on schema/input issues that cannot occur here

--- a/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/AvroDeserializationSchema.java
+++ b/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/AvroDeserializationSchema.java
@@ -181,7 +181,30 @@ public class AvroDeserializationSchema<T> implements DeserializationSchema<T> {
             ((JsonDecoder) this.decoder).configure(inputStream);
         }
 
-        return datumReader.read(null, decoder);
+        try {
+            return datumReader.read(null, decoder);
+        } catch (IOException | RuntimeException e) {
+            // FLINK-34474: a failed read can leave the pooled decoder in an
+            // inconsistent internal state, so that subsequent reads return
+            // corrupted data even after the input buffer is reset. Discard
+            // the poisoned decoder so the next message starts from a clean state.
+            resetDecoder();
+            throw e;
+        }
+    }
+
+    private void resetDecoder() {
+        try {
+            if (encoding == AvroEncoding.JSON) {
+                this.decoder = DecoderFactory.get().jsonDecoder(getReaderSchema(), inputStream);
+            } else {
+                this.decoder = DecoderFactory.get().binaryDecoder(inputStream, this.decoder);
+            }
+        } catch (IOException e) {
+            // jsonDecoder only throws on schema/input issues that cannot occur here
+            // (the schema is cached and the input is an in-memory stream).
+            throw new RuntimeException(e);
+        }
     }
 
     void checkAvroInitialized() throws IOException {

--- a/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/AvroDeserializationSchemaTest.java
+++ b/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/AvroDeserializationSchemaTest.java
@@ -118,8 +118,7 @@ class AvroDeserializationSchemaTest {
         byte[] corrupt = new byte[] {100, 0, 0, 0, 0, 0, 0, 0};
 
         assertThat(deserializer.deserialize(validBytes)).isEqualTo(valid);
-        assertThatThrownBy(() -> deserializer.deserialize(corrupt))
-                .isInstanceOf(Exception.class);
+        assertThatThrownBy(() -> deserializer.deserialize(corrupt)).isInstanceOf(Exception.class);
         // FLINK-34474: a subsequent valid message must still deserialize,
         // instead of being poisoned by the prior failed read.
         assertThat(deserializer.deserialize(validBytes)).isEqualTo(valid);

--- a/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/AvroDeserializationSchemaTest.java
+++ b/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/AvroDeserializationSchemaTest.java
@@ -24,15 +24,19 @@ import org.apache.flink.formats.avro.generated.Address;
 import org.apache.flink.formats.avro.generated.UnionLogicalType;
 import org.apache.flink.formats.avro.utils.TestDataGenerator;
 
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 
 import java.time.Instant;
+import java.util.Collections;
 import java.util.Random;
 
 import static org.apache.flink.formats.avro.utils.AvroTestUtils.writeRecord;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Tests for {@link AvroDeserializationSchema}. */
 class AvroDeserializationSchemaTest {
@@ -84,5 +88,40 @@ class AvroDeserializationSchemaTest {
         byte[] encodedData = writeRecord(data, encoding);
         UnionLogicalType deserializedData = deserializer.deserialize(encodedData);
         assertThat(deserializedData).isEqualTo(data);
+    }
+
+    @ParameterizedTest
+    @EnumSource(AvroEncoding.class)
+    void testDeserializeRecoversFromCorruptMessage(AvroEncoding encoding) throws Exception {
+        // Schema with a 2-branch union so a corrupt tag triggers an
+        // ArrayIndexOutOfBoundsException mid-read (FLINK-34474 reproducer).
+        Schema schema = Schema.createRecord("corruptTest", null, null, false);
+        schema.setFields(
+                Collections.singletonList(
+                        new Schema.Field(
+                                "f",
+                                Schema.createUnion(
+                                        Schema.create(Schema.Type.STRING),
+                                        Schema.create(Schema.Type.INT)))));
+
+        DeserializationSchema<GenericRecord> deserializer =
+                AvroDeserializationSchema.forGeneric(schema, encoding);
+
+        GenericRecord valid = new GenericData.Record(schema);
+        valid.put("f", "hello");
+        byte[] validBytes = writeRecord(valid, schema, encoding);
+
+        // The leading byte (100) decodes to an out-of-range union tag (zig-zag 50)
+        // and throws mid-read; the trailing bytes are left unconsumed in the
+        // pooled BinaryDecoder's internal buffer, poisoning subsequent reads
+        // unless the decoder is reset (FLINK-34474).
+        byte[] corrupt = new byte[] {100, 0, 0, 0, 0, 0, 0, 0};
+
+        assertThat(deserializer.deserialize(validBytes)).isEqualTo(valid);
+        assertThatThrownBy(() -> deserializer.deserialize(corrupt))
+                .isInstanceOf(Exception.class);
+        // FLINK-34474: a subsequent valid message must still deserialize,
+        // instead of being poisoned by the prior failed read.
+        assertThat(deserializer.deserialize(validBytes)).isEqualTo(valid);
     }
 }


### PR DESCRIPTION
## Problem fixed & how

`AvroDeserializationSchema` reuses a pooled `MutableByteArrayInputStream` and `Decoder` across messages. On each `deserialize` it swaps the input buffer via `inputStream.setBuffer(message)`, then calls `datumReader.read(null, decoder)`.

The JSON path reconfigures the `JsonDecoder` every call (`((JsonDecoder) decoder).configure(inputStream)`), but the binary path's `BinaryDecoder` is created once in `checkAvroInitialized` and never reconfigured afterwards — `setBuffer` only swaps the underlying stream, it does not touch the decoder's internal buffer.

When `datumReader.read` fails mid-record (e.g. a corrupt byte decodes to an out-of-range union tag → `ArrayIndexOutOfBoundsException`), the pooled `BinaryDecoder` keeps unconsumed bytes in its internal buffer. The next message swaps the input buffer, but the decoder's buffer is not cleared, so subsequent reads return corrupted data and every following message fails.

Reproducer (reported, binary encoding): `valid → invalid → valid → valid` becomes `VALID → FAILED → FAILED → FAILED`.

## Behavior modified

- **previous**: after a failed `deserialize` (binary encoding), the pooled decoder stayed poisoned; every subsequent message failed regardless of content.
- **now**: on a failed read, the decoder is discarded and rebuilt bound to the current input stream, so the next message starts from a clean state. The original exception is rethrown unchanged.
- **impact**: failure path only; successful deserialization is unchanged.

## Code refactored

`deserialize` wraps `datumReader.read` in a try-catch; on failure it calls a new `resetDecoder()` (rebuilds the JSON or binary decoder bound to the current input stream — `binaryDecoder(inputStream, this.decoder)` follows Avro's recommended reuse pattern) and then rethrows the original exception.

## Features added / Functions optimized

N/A

## Test plan

- [x] Added `testDeserializeRecoversFromCorruptMessage` (parameterized over `BINARY` and `JSON`): a 2-branch union schema (`string | int`) where a multi-byte corrupt payload (leading byte `100` → zig-zag tag 50, out of range for 2 branches) throws mid-read and leaves trailing bytes in the decoder buffer; asserts `valid → corrupt throws → valid still succeeds`.
- [ ] The local environment runs Java 8 and cannot build Flink master (requires Java 11+), so verification relies on CI:
  ```
  mvn -pl flink-formats/flink-avro -am test -Dtest=AvroDeserializationSchemaTest
  ```
