### PR TITLE
[FLINK-40345][checkpoint] Do not recycle the failed buffer twice in FilteringHandler

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/RecoveredChannelStateHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/RecoveredChannelStateHandler.java
@@ -328,7 +328,9 @@ class FilteringHandler extends AbstractInputChannelRecoveredStateHandler {
                 channel.onRecoveredStateBuffer(filteredBuffers.get(i));
             }
         } catch (Throwable t) {
-            for (int j = i; j < filteredBuffers.size(); j++) {
+            // Start at i + 1: onRecoveredStateBuffer() takes over the buffer before anything can
+            // fail, so recycling the buffer at index i again would corrupt its reference count.
+            for (int j = i + 1; j < filteredBuffers.size(); j++) {
                 filteredBuffers.get(j).recycleBuffer();
             }
             throw t;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/InputChannelRecoveredStateHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/InputChannelRecoveredStateHandlerTest.java
@@ -24,6 +24,7 @@ import org.apache.flink.runtime.checkpoint.RescaleMappings;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
 import org.apache.flink.runtime.io.network.buffer.NetworkBuffer;
 import org.apache.flink.runtime.io.network.buffer.NetworkBufferPool;
+import org.apache.flink.runtime.io.network.partition.consumer.FailingRecoveredInputChannel;
 import org.apache.flink.runtime.io.network.partition.consumer.InputChannelBuilder;
 import org.apache.flink.runtime.io.network.partition.consumer.InputGate;
 import org.apache.flink.runtime.io.network.partition.consumer.SingleInputGate;
@@ -33,10 +34,13 @@ import org.apache.flink.runtime.memory.MemoryManager;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.Arrays;
 import java.util.HashSet;
+import java.util.List;
 
 import static org.apache.flink.runtime.checkpoint.InflightDataRescalingDescriptorUtil.mappings;
 import static org.apache.flink.runtime.checkpoint.InflightDataRescalingDescriptorUtil.to;
+import static org.apache.flink.runtime.io.network.buffer.BufferBuilderTestUtils.buildSomeBuffer;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -121,9 +125,14 @@ class InputChannelRecoveredStateHandlerTest extends RecoveredChannelStateHandler
     private FilteringHandler buildFilteringInputChannelStateHandler() {
         // Empty GateFilterHandler array: filtering is "enabled" structurally, but no gate-level
         // filter logic runs. Suitable for exercising getBuffer() routing only.
-        ChannelStateFilteringHandler stubFilteringHandler =
+        return buildFilteringInputChannelStateHandler(
+                inputGate,
                 new ChannelStateFilteringHandler(
-                        new ChannelStateFilteringHandler.GateFilterHandler[0]);
+                        new ChannelStateFilteringHandler.GateFilterHandler[0]));
+    }
+
+    private FilteringHandler buildFilteringInputChannelStateHandler(
+            SingleInputGate inputGate, ChannelStateFilteringHandler stubFilteringHandler) {
         return (FilteringHandler)
                 AbstractInputChannelRecoveredStateHandler.create(
                         new InputGate[] {inputGate},
@@ -281,6 +290,49 @@ class InputChannelRecoveredStateHandlerTest extends RecoveredChannelStateHandler
                     filteringHandler.getBuffer(channelInfo);
             second.context.recycleBuffer();
         }
+    }
+
+    @Test
+    void testFilteredBuffersRecycledOnceWhenDeliveryFails() throws Exception {
+        List<Buffer> filteredBuffers =
+                Arrays.asList(buildSomeBuffer(), buildSomeBuffer(), buildSomeBuffer());
+        ChannelStateFilteringHandler filteringHandler =
+                new ChannelStateFilteringHandler(
+                        new ChannelStateFilteringHandler.GateFilterHandler[0]) {
+                    @Override
+                    public List<Buffer> filterAndRewrite(
+                            int gateIndex,
+                            int oldSubtaskIndex,
+                            int oldChannelIndex,
+                            Buffer sourceBuffer,
+                            BufferSupplier bufferSupplier) {
+                        sourceBuffer.recycleBuffer();
+                        return filteredBuffers;
+                    }
+                };
+        // The gate fails while taking over the first filtered buffer.
+        SingleInputGate failingGate =
+                new SingleInputGateBuilder()
+                        .setChannelFactory(
+                                (builder, gate) -> new FailingRecoveredInputChannel(gate, 0))
+                        .setSegmentProvider(networkBufferPool)
+                        .build();
+
+        try (FilteringHandler handler =
+                buildFilteringInputChannelStateHandler(failingGate, filteringHandler)) {
+            RecoveredChannelStateHandler.BufferWithContext<Buffer> bufferWithContext =
+                    handler.getBuffer(channelInfo);
+            bufferWithContext.context.setSize(1);
+
+            assertThatThrownBy(() -> handler.recover(channelInfo, 0, bufferWithContext))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessage("Delivery failed on purpose.");
+        }
+
+        // The first buffer is owned by the channel, the undelivered ones are recycled exactly once.
+        assertThat(filteredBuffers.get(0).isRecycled()).isFalse();
+        assertThat(filteredBuffers.get(1).isRecycled()).isTrue();
+        assertThat(filteredBuffers.get(2).isRecycled()).isTrue();
     }
 
     @Test

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/FailingRecoveredInputChannel.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/FailingRecoveredInputChannel.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition.consumer;
+
+import org.apache.flink.metrics.SimpleCounter;
+import org.apache.flink.runtime.io.network.buffer.Buffer;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
+import org.apache.flink.runtime.io.network.partition.ResultSubpartitionIndexSet;
+
+/**
+ * A {@link RecoveredInputChannel} that starts failing {@link #onRecoveredStateBuffer} once the
+ * given number of buffers has been taken over. The failing call takes over its buffer as well, like
+ * the production implementations do.
+ */
+public class FailingRecoveredInputChannel extends RecoveredInputChannel {
+
+    private final int failAfterBuffers;
+
+    private int deliveredBuffers;
+
+    public FailingRecoveredInputChannel(SingleInputGate inputGate, int failAfterBuffers) {
+        super(
+                inputGate,
+                0,
+                new ResultPartitionID(),
+                new ResultSubpartitionIndexSet(0),
+                0,
+                0,
+                new SimpleCounter(),
+                new SimpleCounter(),
+                1);
+        this.failAfterBuffers = failAfterBuffers;
+    }
+
+    @Override
+    public void onRecoveredStateBuffer(Buffer buffer) {
+        super.onRecoveredStateBuffer(buffer);
+        if (++deliveredBuffers > failAfterBuffers) {
+            throw new IllegalStateException("Delivery failed on purpose.");
+        }
+    }
+
+    @Override
+    protected InputChannel toInputChannelInternal(boolean needsRecovery) {
+        return new TestInputChannel(inputGate, 0);
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

Reported from https://github.com/apache/flink/pull/28661#pullrequestreview-4832855136

When the delivery of a filtered buffer fails, `FilteringHandler#recoverWithFiltering` recycles a buffer that the input channel already owns, corrupting its reference count.

## Brief change log

  - The compensating loop in the catch block starts at `i + 1`: `onRecoveredStateBuffer()` takes  over the buffer at index `i` before anything can fail.

## Verifying this change

This change added tests and can be verified as follows:

  - Added `InputChannelRecoveredStateHandlerTest#testFilteredBuffersRecycledOnceWhenDeliveryFails`,  which fails the delivery of the first filtered buffer and asserts that only the undelivered buffers are recycled.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: yes, the error handling of channel state recovery
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
