### PR TITLE
[hotfix][ci] Bump GitHub script action to version 9

### DIFF
--- a/.github/workflows/nightly-trigger.yml
+++ b/.github/workflows/nightly-trigger.yml
@@ -53,7 +53,7 @@ jobs:
           branch: ${{ matrix.branch }}
 
       - name: Trigger Workflow
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const branch = '${{ matrix.branch }}';


### PR DESCRIPTION


## What is the purpose of the change

Now there is a warning in nightly logs 
>Pre-compile Checks / Basic QANode.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/github-script@v7. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
--


The PR bumps github script actions as suggested
## Brief change log
gha
## Verifying this change

gha

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes )
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: ( no)
  - The runtime per-record code paths (performance sensitive): (no )
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: ( no )
  - The S3 file system connector: ( no)

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable)

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change the checkbox below to `[X]` and replace the placeholder in the "Generated-by"
line with the tool name and version. Otherwise remove the "Generated-by" line.
See the ASF Generative Tooling Guidance for details:
https://www.apache.org/legal/generative-tooling.html

You are responsible for the quality and correctness of every change in this PR
regardless of the tooling used. Low-effort AI-generated PRs will be closed. See
AGENTS.md for the full guidance.
-->

- [ ] Yes (please specify the tool below)

Generated-by: [Tool Name and Version]
