### PR TITLE
[FLINK-40358][s3][tests] Use native S3 filesystem for all S3 end-to-end tests

### DIFF
--- a/flink-end-to-end-tests/README.md
+++ b/flink-end-to-end-tests/README.md
@@ -46,9 +46,8 @@ export IT_CASE_S3_SECRET_KEY=<secret-key>
 The tests requiring these credentials are:
 
 ```
-$ FLINK_DIR=<flink dir> flink-end-to-end-tests/run-single-test.sh flink-end-to-end-tests/test-scripts/test_batch_wordcount.sh hadoop
-$ FLINK_DIR=<flink dir> flink-end-to-end-tests/run-single-test.sh flink-end-to-end-tests/test-scripts/test_batch_wordcount.sh hadoop_with_provider
-$ FLINK_DIR=<flink dir> flink-end-to-end-tests/run-single-test.sh flink-end-to-end-tests/test-scripts/test_batch_wordcount.sh presto
+$ FLINK_DIR=<flink dir> flink-end-to-end-tests/run-single-test.sh flink-end-to-end-tests/test-scripts/test_batch_wordcount.sh native
+$ FLINK_DIR=<flink dir> flink-end-to-end-tests/run-single-test.sh flink-end-to-end-tests/test-scripts/test_batch_wordcount.sh native_with_provider
 ```
 
 `test_kubernetes_materialized_table.sh` also reads these variables but additionally requires a
@@ -60,8 +59,8 @@ Docker daemon but no AWS credentials:
 
 ```
 $ FLINK_DIR=<flink dir> flink-end-to-end-tests/run-single-test.sh skip flink-end-to-end-tests/test-scripts/test_file_sink.sh s3
-$ FLINK_DIR=<flink dir> flink-end-to-end-tests/run-single-test.sh flink-end-to-end-tests/test-scripts/test_batch_wordcount.sh hadoop_seaweedfs
-$ FLINK_DIR=<flink dir> flink-end-to-end-tests/run-single-test.sh flink-end-to-end-tests/test-scripts/test_batch_wordcount.sh presto_seaweedfs_read
+$ FLINK_DIR=<flink dir> flink-end-to-end-tests/run-single-test.sh flink-end-to-end-tests/test-scripts/test_batch_wordcount.sh native_seaweedfs
+$ FLINK_DIR=<flink dir> flink-end-to-end-tests/run-single-test.sh flink-end-to-end-tests/test-scripts/test_batch_wordcount.sh native_seaweedfs_read
 ```
 
 

--- a/flink-end-to-end-tests/run-nightly-tests.sh
+++ b/flink-end-to-end-tests/run-nightly-tests.sh
@@ -185,8 +185,8 @@ function run_group_2 {
     run_test "File Sink end-to-end test" "$END_TO_END_DIR/test-scripts/test_file_sink.sh local" "skip_check_exceptions"
     run_test "File Sink s3 end-to-end test" "$END_TO_END_DIR/test-scripts/test_file_sink.sh s3" "skip_check_exceptions"
 
-    run_test "Wordcount Hadoop S3 SeaweedFS read-write end-to-end test" "$END_TO_END_DIR/test-scripts/test_batch_wordcount.sh hadoop_seaweedfs"
-    run_test "Wordcount Presto S3 SeaweedFS read end-to-end test" "$END_TO_END_DIR/test-scripts/test_batch_wordcount.sh presto_seaweedfs_read"
+    run_test "Wordcount native S3 SeaweedFS read-write end-to-end test" "$END_TO_END_DIR/test-scripts/test_batch_wordcount.sh native_seaweedfs"
+    run_test "Wordcount native S3 SeaweedFS read end-to-end test" "$END_TO_END_DIR/test-scripts/test_batch_wordcount.sh native_seaweedfs_read"
 }
 
 function run_group_3 {
@@ -220,7 +220,7 @@ function run_group_4 {
 
     run_test "Dependency shading of table modules test" "$END_TO_END_DIR/test-scripts/test_table_shaded_dependencies.sh"
 
-    run_test "Shaded Hadoop S3A with credentials provider end-to-end test" "$END_TO_END_DIR/test-scripts/test_batch_wordcount.sh hadoop_with_provider"
+    run_test "Native S3 with credentials provider end-to-end test" "$END_TO_END_DIR/test-scripts/test_batch_wordcount.sh native_with_provider"
 
     run_test "Failure Enricher end-to-end test" "$END_TO_END_DIR/test-scripts/test_failure_enricher.sh" "skip_check_exceptions"
 

--- a/flink-end-to-end-tests/test-scripts/common_s3.sh
+++ b/flink-end-to-end-tests/test-scripts/common_s3.sh
@@ -61,20 +61,23 @@ S3_TEST_DATA_WORDS_URI="s3://$IT_CASE_S3_BUCKET/static/words"
 #   IT_CASE_S3_ACCESS_KEY
 #   IT_CASE_S3_SECRET_KEY
 # Arguments:
-#   $1 - s3 filesystem type (hadoop/presto)
+#   $1 - s3 filesystem type (defaults to native)
 # Returns:
 #   None
 ###################################
 function s3_setup {
-  add_optional_plugin "s3-fs-$1"
+  local filesystem_type="${1:-native}"
+  add_optional_plugin "s3-fs-$filesystem_type"
   set_config_key "s3.access-key" "$IT_CASE_S3_ACCESS_KEY"
   set_config_key "s3.secret-key" "$IT_CASE_S3_SECRET_KEY"
+  set_config_key "s3.region" "$AWS_REGION"
 }
 
 function s3_setup_with_provider {
-  add_optional_plugin "s3-fs-$1"
+  local filesystem_type="${1:-native}"
+  add_optional_plugin "s3-fs-$filesystem_type"
   # reads (AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY)
-  set_config_key "$2" "com.amazonaws.auth.EnvironmentVariableCredentialsProvider"
+  set_config_key "$2" "software.amazon.awssdk.auth.credentials.EnvironmentVariableCredentialsProvider"
 }
 
 source "$(dirname "$0")"/common_s3_operations.sh

--- a/flink-end-to-end-tests/test-scripts/common_s3_seaweedfs.sh
+++ b/flink-end-to-end-tests/test-scripts/common_s3_seaweedfs.sh
@@ -92,15 +92,17 @@ s3_start
 #   IT_CASE_S3_ACCESS_KEY
 #   IT_CASE_S3_SECRET_KEY
 # Arguments:
-#   $1 - s3 filesystem type (hadoop/presto)
+#   $1 - s3 filesystem type (defaults to native)
 # Returns:
 #   None
 ###################################
 function s3_setup {
-  add_optional_plugin "s3-fs-$1"
+  local filesystem_type="${1:-native}"
+  add_optional_plugin "s3-fs-$filesystem_type"
 
   set_config_key "s3.access-key" "$AWS_ACCESS_KEY_ID"
   set_config_key "s3.secret-key" "$AWS_SECRET_ACCESS_KEY"
+  set_config_key "s3.region" "$AWS_REGION"
   # change endpoint to seaweedfs's location
   set_config_key "s3.endpoint" "$S3_ENDPOINT"
   # If the test is using virtual host style (default), then it tries to reach seaweedfs on <bucket>.localhost:<port>,
@@ -110,9 +112,10 @@ function s3_setup {
 }
 
 function s3_setup_with_provider {
-  add_optional_plugin "s3-fs-$1"
+  local filesystem_type="${1:-native}"
+  add_optional_plugin "s3-fs-$filesystem_type"
   # reads (AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY)
-  set_config_key "$2" "com.amazonaws.auth.EnvironmentVariableCredentialsProvider"
+  set_config_key "$2" "software.amazon.awssdk.auth.credentials.EnvironmentVariableCredentialsProvider"
   # change endpoint to seaweedfs's location
   set_config_key "s3.endpoint" "$S3_ENDPOINT"
   # If the test is using virtual host style (default), then it tries to reach seaweedfs on <bucket>.localhost:<port>,

--- a/flink-end-to-end-tests/test-scripts/test_batch_wordcount.sh
+++ b/flink-end-to-end-tests/test-scripts/test_batch_wordcount.sh
@@ -30,41 +30,33 @@ case $INPUT_TYPE in
     (file)
         ARGS="--execution-mode BATCH --input ${TEST_INFRA_DIR}/test-data/words --output ${OUTPUT_PATH}"
     ;;
-    (hadoop)
+    (native)
         source "$(dirname "$0")"/common_s3.sh
-        s3_setup hadoop
+        s3_setup
         ARGS="--execution-mode BATCH --input ${S3_TEST_DATA_WORDS_URI} --output s3://$IT_CASE_S3_BUCKET/$S3_PREFIX"
         OUTPUT_PATH="$TEST_DATA_DIR/$S3_PREFIX"
         on_exit "s3_delete_by_full_path_prefix '$S3_PREFIX'"
         fetch_complete_result=(s3_get_by_full_path_and_filename_prefix "$OUTPUT_PATH" "${S3_PREFIX}" true)
     ;;
-    (hadoop_seaweedfs)
+    (native_seaweedfs)
         source "$(dirname "$0")"/common_s3_seaweedfs.sh
-        s3_setup hadoop
+        s3_setup
         ARGS="--execution-mode BATCH --input ${S3_TEST_DATA_WORDS_URI} --output s3://$IT_CASE_S3_BUCKET/$S3_PREFIX"
         OUTPUT_PATH="$TEST_DATA_DIR/$S3_PREFIX"
         on_exit "s3_delete_by_full_path_prefix '$S3_PREFIX'"
         fetch_complete_result=(s3_get_by_full_path_and_filename_prefix "$OUTPUT_PATH" "${S3_PREFIX}" true)
     ;;
-    (hadoop_with_provider)
+    (native_with_provider)
         source "$(dirname "$0")"/common_s3.sh
-        s3_setup_with_provider hadoop "fs.s3a.aws.credentials.provider"
+        s3_setup_with_provider native "fs.s3.aws.credentials.provider"
         ARGS="--execution-mode BATCH --input ${S3_TEST_DATA_WORDS_URI} --output s3://$IT_CASE_S3_BUCKET/$S3_PREFIX"
         OUTPUT_PATH="$TEST_DATA_DIR/$S3_PREFIX"
         on_exit "s3_delete_by_full_path_prefix '$S3_PREFIX'"
         fetch_complete_result=(s3_get_by_full_path_and_filename_prefix "$OUTPUT_PATH" "${S3_PREFIX}" true)
     ;;
-    (presto)
-        source "$(dirname "$0")"/common_s3.sh
-        s3_setup presto
-        ARGS="--execution-mode BATCH --input ${S3_TEST_DATA_WORDS_URI} --output s3://$IT_CASE_S3_BUCKET/$S3_PREFIX"
-        OUTPUT_PATH="$TEST_DATA_DIR/$S3_PREFIX"
-        on_exit "s3_delete_by_full_path_prefix '$S3_PREFIX'"
-        fetch_complete_result=(s3_get_by_full_path_and_filename_prefix "$OUTPUT_PATH" "${S3_PREFIX}" true)
-    ;;
-    (presto_seaweedfs_read)
+    (native_seaweedfs_read)
         source "$(dirname "$0")"/common_s3_seaweedfs.sh
-        s3_setup presto
+        s3_setup
         ARGS="--execution-mode BATCH --input ${S3_TEST_DATA_WORDS_URI} --output ${OUTPUT_PATH}"
     ;;
     (dummy-fs)
@@ -85,7 +77,7 @@ start_cluster
 # The test may run against different source types.
 # But the sources should provide the same test data, so the checksum stays the same for all tests.
 ${FLINK_DIR}/bin/flink run -p 1 ${FLINK_DIR}/examples/streaming/WordCount.jar ${ARGS}
-# Fetches result from AWS s3 to the OUTPUT_PATH, no-op for other filesystems and the presto_seaweedfs_read test
+# Fetches result from AWS S3 to OUTPUT_PATH; this is a no-op for local output tests.
 
 # it seems we need a function for retry_times
 function fetch_it() {

--- a/flink-end-to-end-tests/test-scripts/test_file_sink.sh
+++ b/flink-end-to-end-tests/test-scripts/test_file_sink.sh
@@ -62,7 +62,7 @@ if [ "${OUT_TYPE}" == "local" ]; then
   echo "[INFO] Test run in local environment: No S3 environment is loaded."
 elif [ "${OUT_TYPE}" == "s3" ]; then
   source "$(dirname "$0")"/common_s3_seaweedfs.sh
-  s3_setup hadoop
+  s3_setup
 
   # overwrites JOB_OUTPUT_PATH to point to S3
   S3_DATA_PREFIX="${RANDOM_PREFIX}"

--- a/flink-end-to-end-tests/test-scripts/test_kubernetes_materialized_table.sh
+++ b/flink-end-to-end-tests/test-scripts/test_kubernetes_materialized_table.sh
@@ -29,10 +29,35 @@ LOCAL_LOGS_PATH="${TEST_DATA_DIR}/log"
 IMAGE_BUILD_RETRIES=3
 IMAGE_BUILD_BACKOFF=2
 
-# copy test-filesystem jar & hadoop plugin
+JM_LOG_CAPTURE="${LOCAL_LOGS_PATH}/jobmanager-captured.log"
+JM_LOG_CAPTURE_PID=""
+
+function start_jm_log_capture {
+  local jm_pod_name=$1
+  mkdir -p "${LOCAL_LOGS_PATH}"
+  if [ -n "${JM_LOG_CAPTURE_PID}" ]; then
+    kill "${JM_LOG_CAPTURE_PID}" 2> /dev/null || true
+  fi
+  echo "[INFO] Streaming JobManager logs of ${jm_pod_name} to ${JM_LOG_CAPTURE}"
+  ( kubectl logs -f "${jm_pod_name}" >> "${JM_LOG_CAPTURE}" 2>&1 ) &
+  JM_LOG_CAPTURE_PID=$!
+}
+
+function dump_captured_jm_logs_on_failure {
+  if [ -n "${JM_LOG_CAPTURE_PID}" ]; then
+    kill "${JM_LOG_CAPTURE_PID}" 2> /dev/null || true
+  fi
+  if [ "${TRAPPED_EXIT_CODE}" != "0" ] && [ -s "${JM_LOG_CAPTURE}" ]; then
+    echo "[INFO] Captured JobManager logs before teardown:"
+    cat "${JM_LOG_CAPTURE}"
+  fi
+}
+on_exit dump_captured_jm_logs_on_failure
+
+# copy test-filesystem jar and enable the native S3 plugin
 TEST_FILE_SYSTEM_JAR=`ls ${END_TO_END_DIR}/../flink-test-utils-parent/flink-table-filesystem-test-utils/target/flink-table-filesystem-test-utils-*.jar`
 cp $TEST_FILE_SYSTEM_JAR ${FLINK_DIR}/lib/
-add_optional_plugin "s3-fs-hadoop"
+add_optional_plugin "s3-fs-native"
 
 # start kubernetes
 start_kubernetes
@@ -47,7 +72,7 @@ fi
 # setup materialized table data dir
 echo "[INFO] Start S3 env"
 source "$(dirname "$0")"/common_s3_seaweedfs.sh
-s3_setup hadoop
+s3_setup
 S3_TEST_DATA_WORDS_URI="s3://$IT_CASE_S3_BUCKET/"
 MATERIALIZED_TABLE_DATA_DIR="${S3_TEST_DATA_WORDS_URI}/test_materialized_table-$(uuidgen)"
 
@@ -218,6 +243,7 @@ create_materialized_table_in_continous_mode $session_handle "my_materialized_tab
 echo "[INFO] Wait deployment ${APPLICATION_CLUSTER_ID} Available"
 kubectl wait --for=condition=Available --timeout=30s deploy/${APPLICATION_CLUSTER_ID} || exit 1
 jm_pod_name=$(kubectl get pods --selector="app=${APPLICATION_CLUSTER_ID},component=jobmanager" -o jsonpath='{..metadata.name}')
+start_jm_log_capture $jm_pod_name
 echo "[INFO] Wait first checkpoint finished"
 wait_num_checkpoints $jm_pod_name 1
 
@@ -232,6 +258,7 @@ echo "[INFO] Resume materialized table"
 execute_statement $session_handle "alter materialized table my_materialized_table_in_continuous_mode resume"
 kubectl wait --for=condition=Available --timeout=30s deploy/${APPLICATION_CLUSTER_ID} || exit 1
 jm_pod_name=$(kubectl get pods --selector="app=${APPLICATION_CLUSTER_ID},component=jobmanager" -o jsonpath='{..metadata.name}')
+start_jm_log_capture $jm_pod_name
 echo "[INFO] Wait resumed job finished the first checkpoint"
 wait_num_checkpoints $jm_pod_name 1
 

--- a/flink-filesystems/flink-s3-fs-native/src/main/java/org/apache/flink/fs/s3native/NativeS3FileSystem.java
+++ b/flink-filesystems/flink-s3-fs-native/src/main/java/org/apache/flink/fs/s3native/NativeS3FileSystem.java
@@ -37,6 +37,7 @@ import org.apache.flink.util.concurrent.FutureUtils;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.CopyObjectRequest;
 import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
@@ -45,6 +46,7 @@ import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
 import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
 import software.amazon.awssdk.services.s3.model.ListObjectsV2Response;
 import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.S3Exception;
 import software.amazon.awssdk.services.s3.model.S3Object;
 
@@ -53,6 +55,7 @@ import javax.annotation.Nullable;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.URI;
+import java.nio.file.FileAlreadyExistsException;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
@@ -207,21 +210,17 @@ class NativeS3FileSystem extends FileSystem
 
             final HeadObjectResponse response = s3Client.headObject(request);
             final Long contentLength = response.contentLength();
-
-            // In S3, a successful HeadObject with null/zero contentLength means
-            // this is a directory marker (prefix), not an actual file
-            if (contentLength == null || contentLength == 0) {
-                LOG.debug(
-                        "HeadObject returned null/zero content length, verifying if directory: {}",
-                        key);
-                return getDirectoryStatus(s3Client, key, path);
-            }
-
-            final long size = contentLength;
             final long modificationTime =
                     (response.lastModified() != null)
                             ? response.lastModified().toEpochMilli()
                             : System.currentTimeMillis();
+
+            if (isDirectoryMarkerKey(key)) {
+                LOG.debug("HeadObject resolved directory marker: {}", key);
+                return getDirectoryStatus(s3Client, key, path);
+            }
+
+            final long size = (contentLength != null) ? contentLength : 0L;
 
             LOG.trace(
                     "HeadObject successful for {} - size: {}, lastModified: {}",
@@ -262,6 +261,67 @@ class NativeS3FileSystem extends FileSystem
 
             throw S3ExceptionUtils.toIOException(
                     String.format("Failed to get file status for s3://%s/%s", bucketName, key), e);
+        }
+    }
+
+    /**
+     * Decides whether a key that resolves to an existing S3 object should be treated as a directory
+     * marker rather than a regular file. Only the bucket root ({@code ""}) and keys ending in
+     * {@code "/"} are directory markers; a zero-byte object whose key has no trailing slash is a
+     * genuine empty file.
+     */
+    @VisibleForTesting
+    static boolean isDirectoryMarkerKey(String key) {
+        return key.isEmpty() || key.endsWith("/");
+    }
+
+    /**
+     * Returns the directory-marker key for the parent of {@code key}, or {@code null} when {@code
+     * key} has no parent other than the bucket root. Both {@code "a/b/c"} and {@code "a/b/c/"}
+     * yield {@code "a/b/"}.
+     */
+    @VisibleForTesting
+    @Nullable
+    static String parentDirectoryMarkerKey(String key) {
+        if (key == null || key.isEmpty()) {
+            return null;
+        }
+        final String trimmed = key.endsWith("/") ? key.substring(0, key.length() - 1) : key;
+        final int lastSlash = trimmed.lastIndexOf('/');
+        if (lastSlash < 0) {
+            // top-level object; its parent is the bucket root, which has no marker
+            return null;
+        }
+        return trimmed.substring(0, lastSlash + 1);
+    }
+
+    /**
+     * Best-effort removal of the redundant directory marker for the parent of {@code key}. Once a
+     * real object exists under a prefix, the empty marker created by {@link #mkdirs(Path)} is no
+     * longer needed to keep the directory visible, and leaving it behind causes markers to
+     * accumulate and keeps logically-empty directories "alive" after their contents are removed.
+     * Failures are swallowed because the marker is only bookkeeping and must never fail the
+     * operation that triggered the cleanup.
+     */
+    private void deleteParentDirectoryMarkerQuietly(String key) {
+        final String parentMarker = parentDirectoryMarkerKey(key);
+        if (parentMarker == null) {
+            return;
+        }
+        try {
+            clientProvider
+                    .getS3Client()
+                    .deleteObject(
+                            DeleteObjectRequest.builder()
+                                    .bucket(bucketName)
+                                    .key(parentMarker)
+                                    .build());
+        } catch (S3Exception e) {
+            LOG.debug(
+                    "Could not delete redundant directory marker s3://{}/{}: {}",
+                    bucketName,
+                    parentMarker,
+                    S3ExceptionUtils.errorMessage(e));
         }
     }
 
@@ -397,6 +457,15 @@ class NativeS3FileSystem extends FileSystem
                     delete(file.getPath(), true);
                 }
 
+                if (!key.isEmpty()) {
+                    final String directoryMarkerKey = key.endsWith("/") ? key : key + "/";
+                    s3Client.deleteObject(
+                            DeleteObjectRequest.builder()
+                                    .bucket(bucketName)
+                                    .key(directoryMarkerKey)
+                                    .build());
+                }
+
                 return true;
             }
         } catch (FileNotFoundException e) {
@@ -410,23 +479,65 @@ class NativeS3FileSystem extends FileSystem
      * Creates a directory at the specified path.
      *
      * <p><b>S3 Behavior:</b> S3 is a flat object store and doesn't have true directories. Directory
-     * semantics are simulated through key prefixes. This method always returns true because:
-     *
-     * <ul>
-     *   <li>S3 doesn't require directories to exist before creating objects with that prefix
-     *   <li>Creating an empty "directory marker" object (key ending with /) is optional
-     *   <li>Most S3 implementations don't create these markers for consistency with Hadoop FS
-     * </ul>
-     *
-     * <p>If explicit directory markers are needed, consider using a custom implementation.
-     *
-     * @return always returns true (S3 doesn't require explicit directory creation)
+     * semantics are simulated through key prefixes. An empty directory marker is created so that
+     * the directory remains visible until a child object is written.
      */
     @Override
     public boolean mkdirs(Path path) throws IOException {
         checkNotClosed();
-        LOG.debug("mkdirs called for {} - S3 doesn't require explicit directory creation", path);
-        return true;
+        final String key = NativeS3ObjectOperations.extractKey(path);
+        if (key.isEmpty()) {
+            return true;
+        }
+
+        try {
+            final FileStatus status = getFileStatus(path);
+            if (status.isDir()) {
+                return true;
+            }
+            throw new FileAlreadyExistsException("File already exists: " + path);
+        } catch (FileNotFoundException ignored) {
+            // Create the missing directory below.
+        }
+
+        final String directoryMarkerKey = key.endsWith("/") ? key : key + "/";
+        try {
+            putDirectoryMarker(
+                    clientProvider.getS3Client(),
+                    bucketName,
+                    directoryMarkerKey,
+                    clientProvider.getEncryptionConfig());
+            // The new marker makes any marker for the parent directory redundant.
+            deleteParentDirectoryMarkerQuietly(directoryMarkerKey);
+            return true;
+        } catch (S3Exception e) {
+            throw new IOException("Failed to create directory: " + path, e);
+        }
+    }
+
+    @VisibleForTesting
+    static void putDirectoryMarker(
+            S3Client s3Client,
+            String bucketName,
+            String directoryMarkerKey,
+            S3EncryptionConfig encryptionConfig) {
+        final PutObjectRequest.Builder requestBuilder =
+                PutObjectRequest.builder().bucket(bucketName).key(directoryMarkerKey);
+
+        if (encryptionConfig.isEnabled()) {
+            requestBuilder.serverSideEncryption(encryptionConfig.getServerSideEncryption());
+            if (encryptionConfig.getEncryptionType() == S3EncryptionConfig.EncryptionType.SSE_KMS) {
+                if (encryptionConfig.getKmsKeyId() != null) {
+                    requestBuilder.ssekmsKeyId(encryptionConfig.getKmsKeyId());
+                }
+                if (encryptionConfig.hasEncryptionContext()) {
+                    requestBuilder.ssekmsEncryptionContext(
+                            encryptionConfig.serializeEncryptionContext());
+                }
+            }
+        }
+
+        s3Client.putObject(requestBuilder.build(), RequestBody.empty());
     }
 
     @Override
@@ -447,6 +558,8 @@ class NativeS3FileSystem extends FileSystem
         }
 
         final String key = NativeS3ObjectOperations.extractKey(path);
+        // Writing a real object makes any marker for its parent directory redundant.
+        deleteParentDirectoryMarkerQuietly(key);
         return new NativeS3OutputStream(
                 clientProvider.getS3Client(),
                 bucketName,

--- a/flink-filesystems/flink-s3-fs-native/src/test/java/org/apache/flink/fs/s3native/NativeS3FileSystemTest.java
+++ b/flink-filesystems/flink-s3-fs-native/src/test/java/org/apache/flink/fs/s3native/NativeS3FileSystemTest.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.fs.s3native;
+
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectResponse;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link NativeS3FileSystem}. */
+class NativeS3FileSystemTest {
+
+    @Test
+    void createsEmptyDirectoryMarker() {
+        final StubS3Client s3Client = new StubS3Client();
+
+        NativeS3FileSystem.putDirectoryMarker(
+                s3Client, "test-bucket", "catalog/", S3EncryptionConfig.none());
+
+        assertThat(s3Client.request.bucket()).isEqualTo("test-bucket");
+        assertThat(s3Client.request.key()).isEqualTo("catalog/");
+        assertThat(s3Client.contentLength).isZero();
+    }
+
+    @Test
+    void directoryMarkerKeysAreDetected() {
+        assertThat(NativeS3FileSystem.isDirectoryMarkerKey("")).isTrue();
+        assertThat(NativeS3FileSystem.isDirectoryMarkerKey("dir/")).isTrue();
+        assertThat(NativeS3FileSystem.isDirectoryMarkerKey("a/b/c/")).isTrue();
+    }
+
+    @Test
+    void regularKeysAreNotDirectoryMarkers() {
+        assertThat(NativeS3FileSystem.isDirectoryMarkerKey("chk-1/_metadata")).isFalse();
+        assertThat(NativeS3FileSystem.isDirectoryMarkerKey("empty-file")).isFalse();
+        assertThat(NativeS3FileSystem.isDirectoryMarkerKey("a/b/part-0-0")).isFalse();
+    }
+
+    @Test
+    void parentDirectoryMarkerIsDerivedFromKey() {
+        assertThat(NativeS3FileSystem.parentDirectoryMarkerKey("a/b/part-0-0")).isEqualTo("a/b/");
+        assertThat(NativeS3FileSystem.parentDirectoryMarkerKey("a/b/c/")).isEqualTo("a/b/");
+    }
+
+    @Test
+    void topLevelKeysHaveNoParentDirectoryMarker() {
+        assertThat(NativeS3FileSystem.parentDirectoryMarkerKey("file")).isNull();
+        assertThat(NativeS3FileSystem.parentDirectoryMarkerKey("dir/")).isNull();
+        assertThat(NativeS3FileSystem.parentDirectoryMarkerKey("")).isNull();
+    }
+
+    private static final class StubS3Client implements S3Client {
+        private PutObjectRequest request;
+        private long contentLength;
+
+        @Override
+        public PutObjectResponse putObject(PutObjectRequest request, RequestBody requestBody) {
+            this.request = request;
+            this.contentLength = requestBody.contentLength();
+            return PutObjectResponse.builder().build();
+        }
+
+        @Override
+        public String serviceName() {
+            return "s3";
+        }
+
+        @Override
+        public void close() {}
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

use native s3 fs for e2d tests in codebase 


## Verifying this change

Running the E2E tests successfully 

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change the checkbox below to `[X]` and replace the placeholder in the "Generated-by"
line with the tool name and version. Otherwise remove the "Generated-by" line.
See the ASF Generative Tooling Guidance for details:
https://www.apache.org/legal/generative-tooling.html

You are responsible for the quality and correctness of every change in this PR
regardless of the tooling used. Low-effort AI-generated PRs will be closed. See
AGENTS.md for the full guidance.
-->

- [ ] Yes (please specify the tool below)

Generated-by: [Tool Name and Version]
