### PR TITLE
[FLINK-40356][table] Add new MapFromEntries function

### DIFF
--- a/docs/data/sql_functions.yml
+++ b/docs/data/sql_functions.yml
@@ -933,14 +933,18 @@ collection:
     description: |
       Returns a map created from the given array of entries. Each entry must be a ROW with exactly
       two fields, where the first field becomes the key and the second one the value. If there are
-      duplicate keys, the value of the last entry with that key wins. If the array itself or any
-      of its entries is null, null is returned.
+      duplicate keys, the value of the last entry with that key wins; NULL keys are treated as
+      equal and collapse into a single entry. If the array itself or any of its entries is null,
+      null is returned.
       eg.
         -- {1=one, 2=two}
         MAP_FROM_ENTRIES(ARRAY[ROW(1, 'one'), ROW(2, 'two')])
 
         -- {1=uno, 2=two}
         MAP_FROM_ENTRIES(ARRAY[ROW(1, 'one'), ROW(2, 'two'), ROW(1, 'uno')])
+
+        -- {null=b}
+        MAP_FROM_ENTRIES(ARRAY[ROW(CAST(NULL AS INT), 'a'), ROW(CAST(NULL AS INT), 'b')])
 
         -- NULL
         MAP_FROM_ENTRIES(ARRAY[ROW(1, 'one'), CAST(NULL AS ROW(k INT, v STRING))])

--- a/docs/data/sql_functions.yml
+++ b/docs/data/sql_functions.yml
@@ -932,22 +932,25 @@ collection:
     table: array.mapFromEntries()
     description: |
       Returns a map created from the given array of entries. Each entry must be a ROW with exactly
-      two fields, where the first field becomes the key and the second one the value. If there are
-      duplicate keys, the value of the last entry with that key wins; NULL keys are treated as
-      equal and collapse into a single entry. If the array itself or any of its entries is null,
-      null is returned.
-      eg.
-        -- {1=one, 2=two}
-        MAP_FROM_ENTRIES(ARRAY[ROW(1, 'one'), ROW(2, 'two')])
+      two fields, where the first field becomes the key and the second one the value.
 
-        -- {1=uno, 2=two}
-        MAP_FROM_ENTRIES(ARRAY[ROW(1, 'one'), ROW(2, 'two'), ROW(1, 'uno')])
+      If there are duplicate keys, the value of the last entry with that key wins; NULL keys are
+      treated as equal and collapse into a single entry. If the array itself or any of its entries
+      is null, null is returned.
 
-        -- {null=b}
-        MAP_FROM_ENTRIES(ARRAY[ROW(CAST(NULL AS INT), 'a'), ROW(CAST(NULL AS INT), 'b')])
+      ```sql
+      -- Returns {1=one, 2=two}
+      MAP_FROM_ENTRIES(ARRAY[ROW(1, 'one'), ROW(2, 'two')])
 
-        -- NULL
-        MAP_FROM_ENTRIES(ARRAY[ROW(1, 'one'), CAST(NULL AS ROW(k INT, v STRING))])
+      -- Returns {1=uno, 2=two}
+      MAP_FROM_ENTRIES(ARRAY[ROW(1, 'one'), ROW(2, 'two'), ROW(1, 'uno')])
+
+      -- Returns {null=b}
+      MAP_FROM_ENTRIES(ARRAY[ROW(CAST(NULL AS INT), 'a'), ROW(CAST(NULL AS INT), 'b')])
+
+      -- Returns NULL
+      MAP_FROM_ENTRIES(ARRAY[ROW(1, 'one'), CAST(NULL AS ROW(k INT, v STRING))])
+      ```
 
   - sql: SPLIT(string, delimiter)
     table: string.split(delimiter)

--- a/docs/data/sql_functions.yml
+++ b/docs/data/sql_functions.yml
@@ -928,6 +928,23 @@ collection:
   - sql: MAP_FROM_ARRAYS(array_of_keys, array_of_values)
     table: mapFromArrays(array_of_keys, array_of_values)
     description: Returns a map created from an arrays of keys and values. Note that the lengths of two arrays should be the same.
+  - sql: MAP_FROM_ENTRIES(array_of_entries)
+    table: array.mapFromEntries()
+    description: |
+      Returns a map created from the given array of entries. Each entry must be a ROW with exactly
+      two fields, where the first field becomes the key and the second one the value. If there are
+      duplicate keys, the value of the last entry with that key wins. If the array itself or any
+      of its entries is null, null is returned.
+      eg.
+        -- {1=one, 2=two}
+        MAP_FROM_ENTRIES(ARRAY[ROW(1, 'one'), ROW(2, 'two')])
+
+        -- {1=uno, 2=two}
+        MAP_FROM_ENTRIES(ARRAY[ROW(1, 'one'), ROW(2, 'two'), ROW(1, 'uno')])
+
+        -- NULL
+        MAP_FROM_ENTRIES(ARRAY[ROW(1, 'one'), CAST(NULL AS ROW(k INT, v STRING))])
+
   - sql: SPLIT(string, delimiter)
     table: string.split(delimiter)
     description: Returns an array of substrings by splitting the input string based on the given delimiter. If the delimiter is not found in the string, the original string is returned as the only element in the array. If the delimiter is empty, every character in the string is split. If the string or delimiter is null, a null value is returned. If the delimiter is found at the beginning or end of the string, or there are contiguous delimiters, then an empty string is added to the array.

--- a/docs/data/sql_functions.yml
+++ b/docs/data/sql_functions.yml
@@ -936,7 +936,7 @@ collection:
 
       If there are duplicate keys, the value of the last entry with that key wins; NULL keys are
       treated as equal and collapse into a single entry. If the array itself or any of its entries
-      is null, null is returned.
+      is NULL, NULL is returned.
 
       ```sql
       -- Returns {1=one, 2=two}
@@ -945,7 +945,7 @@ collection:
       -- Returns {1=uno, 2=two}
       MAP_FROM_ENTRIES(ARRAY[ROW(1, 'one'), ROW(2, 'two'), ROW(1, 'uno')])
 
-      -- Returns {null=b}
+      -- Returns {NULL=b}
       MAP_FROM_ENTRIES(ARRAY[ROW(CAST(NULL AS INT), 'a'), ROW(CAST(NULL AS INT), 'b')])
 
       -- Returns NULL

--- a/docs/data/sql_functions_zh.yml
+++ b/docs/data/sql_functions_zh.yml
@@ -1055,6 +1055,22 @@ collection:
   - sql: MAP_FROM_ARRAYS(array_of_keys, array_of_values)
     table: mapFromArrays(array_of_keys, array_of_values)
     description: 返回由 key 的数组 keys 和 value 的数组 values 创建的 map。请注意两个数组的长度应该相等。
+  - sql: MAP_FROM_ENTRIES(array_of_entries)
+    table: array.mapFromEntries()
+    description: |
+      Returns a map created from the given array of entries. Each entry must be a ROW with exactly
+      two fields, where the first field becomes the key and the second one the value. If there are
+      duplicate keys, the value of the last entry with that key wins. If the array itself or any
+      of its entries is null, null is returned.
+      eg.
+        -- {1=one, 2=two}
+        MAP_FROM_ENTRIES(ARRAY[ROW(1, 'one'), ROW(2, 'two')])
+
+        -- {1=uno, 2=two}
+        MAP_FROM_ENTRIES(ARRAY[ROW(1, 'one'), ROW(2, 'two'), ROW(1, 'uno')])
+
+        -- NULL
+        MAP_FROM_ENTRIES(ARRAY[ROW(1, 'one'), CAST(NULL AS ROW(k INT, v STRING))])
   - sql: MAP_UNION(map1, map2)
     table: map1.mapUnion(map2)
     description: 返回一个通过合并两个图 'map1' 和 'map2' 创建的图。这两个图应该具有共同的图类型。如果有重叠的键，'map2' 的值将覆盖 'map1' 的值。如果任一图为空，则返回 null。

--- a/docs/data/sql_functions_zh.yml
+++ b/docs/data/sql_functions_zh.yml
@@ -1059,22 +1059,25 @@ collection:
     table: array.mapFromEntries()
     description: |
       Returns a map created from the given array of entries. Each entry must be a ROW with exactly
-      two fields, where the first field becomes the key and the second one the value. If there are
-      duplicate keys, the value of the last entry with that key wins; NULL keys are treated as
-      equal and collapse into a single entry. If the array itself or any of its entries is null,
-      null is returned.
-      eg.
-        -- {1=one, 2=two}
-        MAP_FROM_ENTRIES(ARRAY[ROW(1, 'one'), ROW(2, 'two')])
+      two fields, where the first field becomes the key and the second one the value.
 
-        -- {1=uno, 2=two}
-        MAP_FROM_ENTRIES(ARRAY[ROW(1, 'one'), ROW(2, 'two'), ROW(1, 'uno')])
+      If there are duplicate keys, the value of the last entry with that key wins; NULL keys are
+      treated as equal and collapse into a single entry. If the array itself or any of its entries
+      is null, null is returned.
 
-        -- {null=b}
-        MAP_FROM_ENTRIES(ARRAY[ROW(CAST(NULL AS INT), 'a'), ROW(CAST(NULL AS INT), 'b')])
+      ```sql
+      -- Returns {1=one, 2=two}
+      MAP_FROM_ENTRIES(ARRAY[ROW(1, 'one'), ROW(2, 'two')])
 
-        -- NULL
-        MAP_FROM_ENTRIES(ARRAY[ROW(1, 'one'), CAST(NULL AS ROW(k INT, v STRING))])
+      -- Returns {1=uno, 2=two}
+      MAP_FROM_ENTRIES(ARRAY[ROW(1, 'one'), ROW(2, 'two'), ROW(1, 'uno')])
+
+      -- Returns {null=b}
+      MAP_FROM_ENTRIES(ARRAY[ROW(CAST(NULL AS INT), 'a'), ROW(CAST(NULL AS INT), 'b')])
+
+      -- Returns NULL
+      MAP_FROM_ENTRIES(ARRAY[ROW(1, 'one'), CAST(NULL AS ROW(k INT, v STRING))])
+      ```
   - sql: MAP_UNION(map1, map2)
     table: map1.mapUnion(map2)
     description: 返回一个通过合并两个图 'map1' 和 'map2' 创建的图。这两个图应该具有共同的图类型。如果有重叠的键，'map2' 的值将覆盖 'map1' 的值。如果任一图为空，则返回 null。

--- a/docs/data/sql_functions_zh.yml
+++ b/docs/data/sql_functions_zh.yml
@@ -1060,14 +1060,18 @@ collection:
     description: |
       Returns a map created from the given array of entries. Each entry must be a ROW with exactly
       two fields, where the first field becomes the key and the second one the value. If there are
-      duplicate keys, the value of the last entry with that key wins. If the array itself or any
-      of its entries is null, null is returned.
+      duplicate keys, the value of the last entry with that key wins; NULL keys are treated as
+      equal and collapse into a single entry. If the array itself or any of its entries is null,
+      null is returned.
       eg.
         -- {1=one, 2=two}
         MAP_FROM_ENTRIES(ARRAY[ROW(1, 'one'), ROW(2, 'two')])
 
         -- {1=uno, 2=two}
         MAP_FROM_ENTRIES(ARRAY[ROW(1, 'one'), ROW(2, 'two'), ROW(1, 'uno')])
+
+        -- {null=b}
+        MAP_FROM_ENTRIES(ARRAY[ROW(CAST(NULL AS INT), 'a'), ROW(CAST(NULL AS INT), 'b')])
 
         -- NULL
         MAP_FROM_ENTRIES(ARRAY[ROW(1, 'one'), CAST(NULL AS ROW(k INT, v STRING))])

--- a/docs/data/sql_functions_zh.yml
+++ b/docs/data/sql_functions_zh.yml
@@ -1063,7 +1063,7 @@ collection:
 
       If there are duplicate keys, the value of the last entry with that key wins; NULL keys are
       treated as equal and collapse into a single entry. If the array itself or any of its entries
-      is null, null is returned.
+      is NULL, NULL is returned.
 
       ```sql
       -- Returns {1=one, 2=two}
@@ -1072,7 +1072,7 @@ collection:
       -- Returns {1=uno, 2=two}
       MAP_FROM_ENTRIES(ARRAY[ROW(1, 'one'), ROW(2, 'two'), ROW(1, 'uno')])
 
-      -- Returns {null=b}
+      -- Returns {NULL=b}
       MAP_FROM_ENTRIES(ARRAY[ROW(CAST(NULL AS INT), 'a'), ROW(CAST(NULL AS INT), 'b')])
 
       -- Returns NULL

--- a/flink-python/docs/reference/pyflink.table/expressions.rst
+++ b/flink-python/docs/reference/pyflink.table/expressions.rst
@@ -257,6 +257,7 @@ advanced type helper functions
     Expression.array_sort
     Expression.array_union
     Expression.map_entries
+    Expression.map_from_entries
     Expression.map_keys
     Expression.map_union
     Expression.map_values

--- a/flink-python/pyflink/table/expression.py
+++ b/flink-python/pyflink/table/expression.py
@@ -1966,6 +1966,22 @@ class Expression(Generic[T]):
         """
         return _unary_op("mapEntries")(self)
 
+    @property
+    def map_from_entries(self) -> 'Expression':
+        """
+        Returns a map created from the given array of entries. Each entry must be a row with
+        exactly two fields, where the first field becomes the key and the second one the value.
+        If there are duplicate keys, the value of the last entry with that key wins. If the array
+        itself or any of its entries is None, None is returned.
+
+        Examples:
+        ::
+
+            >>> array(row(1, "one"), row(2, "two")).map_from_entries # {1=one, 2=two}
+            >>> array(row(1, "one"), row(2, "two"), row(1, "uno")).map_from_entries # {1=uno, 2=two}
+        """
+        return _unary_op("mapFromEntries")(self)
+
     # ---------------------------- time definition functions -----------------------------
 
     @property

--- a/flink-python/pyflink/table/expression.py
+++ b/flink-python/pyflink/table/expression.py
@@ -1971,8 +1971,9 @@ class Expression(Generic[T]):
         """
         Returns a map created from the given array of entries. Each entry must be a row with
         exactly two fields, where the first field becomes the key and the second one the value.
-        If there are duplicate keys, the value of the last entry with that key wins. If the array
-        itself or any of its entries is None, None is returned.
+        If there are duplicate keys, the value of the last entry with that key wins; None keys are
+        treated as equal and collapse into a single entry. If the array itself or any of its
+        entries is None, None is returned.
 
         Examples:
         ::

--- a/flink-python/pyflink/table/expression.py
+++ b/flink-python/pyflink/table/expression.py
@@ -1971,6 +1971,7 @@ class Expression(Generic[T]):
         """
         Returns a map created from the given array of entries. Each entry must be a row with
         exactly two fields, where the first field becomes the key and the second one the value.
+
         If there are duplicate keys, the value of the last entry with that key wins; None keys are
         treated as equal and collapse into a single entry. If the array itself or any of its
         entries is None, None is returned.

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/BaseExpressions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/BaseExpressions.java
@@ -1970,10 +1970,11 @@ public abstract class BaseExpressions<InType, OutType> {
 
     /**
      * Returns a map created from the given array of entries. Each entry must be a row with exactly
-     * two fields, where the first field becomes the key and the second one the value. If there are
-     * duplicate keys, the value of the last entry with that key wins; null keys are treated as
-     * equal and collapse into a single entry. If the array itself or any of its entries is null,
-     * null is returned.
+     * two fields, where the first field becomes the key and the second one the value.
+     *
+     * <p>If there are duplicate keys, the value of the last entry with that key wins; null keys are
+     * treated as equal and collapse into a single entry. If the array itself or any of its entries
+     * is null, null is returned.
      *
      * <p>Examples:
      *

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/BaseExpressions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/BaseExpressions.java
@@ -161,6 +161,7 @@ import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.LPAD;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.LTRIM;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.MAKE_VALID_UTF8;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.MAP_ENTRIES;
+import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.MAP_FROM_ENTRIES;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.MAP_KEYS;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.MAP_UNION;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.MAP_VALUES;
@@ -1965,6 +1966,23 @@ public abstract class BaseExpressions<InType, OutType> {
     /** Returns an array of all entries in the given map. */
     public OutType mapEntries() {
         return toApiSpecificExpression(unresolvedCall(MAP_ENTRIES, toExpr()));
+    }
+
+    /**
+     * Returns a map created from the given array of entries. Each entry must be a row with exactly
+     * two fields, where the first field becomes the key and the second one the value. If there are
+     * duplicate keys, the value of the last entry with that key wins. If the array itself or any of
+     * its entries is null, null is returned.
+     *
+     * <p>Examples:
+     *
+     * <pre>{@code
+     * array(row(1, "one"), row(2, "two")).mapFromEntries() // {1=one, 2=two}
+     * array(row(1, "one"), row(2, "two"), row(1, "uno")).mapFromEntries() // {1=uno, 2=two}
+     * }</pre>
+     */
+    public OutType mapFromEntries() {
+        return toApiSpecificExpression(unresolvedCall(MAP_FROM_ENTRIES, toExpr()));
     }
 
     /**

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/BaseExpressions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/BaseExpressions.java
@@ -1971,8 +1971,9 @@ public abstract class BaseExpressions<InType, OutType> {
     /**
      * Returns a map created from the given array of entries. Each entry must be a row with exactly
      * two fields, where the first field becomes the key and the second one the value. If there are
-     * duplicate keys, the value of the last entry with that key wins. If the array itself or any of
-     * its entries is null, null is returned.
+     * duplicate keys, the value of the last entry with that key wins; null keys are treated as
+     * equal and collapse into a single entry. If the array itself or any of its entries is null,
+     * null is returned.
      *
      * <p>Examples:
      *

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
@@ -109,6 +109,7 @@ import static org.apache.flink.table.types.inference.TypeStrategies.nullableIfAr
 import static org.apache.flink.table.types.inference.TypeStrategies.varyingString;
 import static org.apache.flink.table.types.inference.strategies.SpecificInputTypeStrategies.ARRAY_ELEMENT_ARG;
 import static org.apache.flink.table.types.inference.strategies.SpecificInputTypeStrategies.ARRAY_FULLY_COMPARABLE;
+import static org.apache.flink.table.types.inference.strategies.SpecificInputTypeStrategies.ARRAY_OF_ENTRIES_ARG;
 import static org.apache.flink.table.types.inference.strategies.SpecificInputTypeStrategies.FROM_CHANGELOG_INPUT_TYPE_STRATEGY;
 import static org.apache.flink.table.types.inference.strategies.SpecificInputTypeStrategies.INDEX;
 import static org.apache.flink.table.types.inference.strategies.SpecificInputTypeStrategies.JSON_ARGUMENT;
@@ -225,6 +226,19 @@ public final class BuiltInFunctionDefinitions {
                     .outputTypeStrategy(nullableIfArgs(SpecificTypeStrategies.MAP_FROM_ARRAYS))
                     .runtimeClass(
                             "org.apache.flink.table.runtime.functions.scalar.MapFromArraysFunction")
+                    .build();
+
+    public static final BuiltInFunctionDefinition MAP_FROM_ENTRIES =
+            BuiltInFunctionDefinition.newBuilder()
+                    .name("MAP_FROM_ENTRIES")
+                    .kind(SCALAR)
+                    .inputTypeStrategy(
+                            sequence(
+                                    new String[] {"input"},
+                                    new ArgumentTypeStrategy[] {ARRAY_OF_ENTRIES_ARG}))
+                    .outputTypeStrategy(SpecificTypeStrategies.MAP_FROM_ENTRIES)
+                    .runtimeClass(
+                            "org.apache.flink.table.runtime.functions.scalar.MapFromEntriesFunction")
                     .build();
 
     public static final BuiltInFunctionDefinition SOURCE_WATERMARK =

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/ArrayOfEntriesArgumentTypeStrategy.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/ArrayOfEntriesArgumentTypeStrategy.java
@@ -57,8 +57,8 @@ public final class ArrayOfEntriesArgumentTypeStrategy implements ArgumentTypeStr
                 || LogicalTypeChecks.getFieldCount(elementType) != 2) {
             return callContext.fail(
                     throwOnFailure,
-                    "The input argument should be ARRAY<ROW<key, value>>, but the array element "
-                            + "type is '%s'. The element must be a ROW with exactly two fields.",
+                    "The 'input' argument must be ARRAY<ROW<key, value>>, but the array element "
+                            + "type was '%s'. The element must be a ROW with exactly two fields.",
                     elementType.asSummaryString());
         }
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/ArrayOfEntriesArgumentTypeStrategy.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/ArrayOfEntriesArgumentTypeStrategy.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.types.inference.strategies;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.functions.FunctionDefinition;
+import org.apache.flink.table.types.CollectionDataType;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.inference.ArgumentTypeStrategy;
+import org.apache.flink.table.types.inference.CallContext;
+import org.apache.flink.table.types.inference.Signature.Argument;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.LogicalTypeRoot;
+import org.apache.flink.table.types.logical.StructuredType.StructuredComparison;
+import org.apache.flink.table.types.logical.utils.LogicalTypeChecks;
+
+import java.util.Optional;
+
+/**
+ * Strategy for an argument that must be an array of map entries, i.e. an {@code ARRAY} whose
+ * element is a {@code ROW} with exactly two fields. The first field becomes the map key, the second
+ * one the map value.
+ */
+@Internal
+public final class ArrayOfEntriesArgumentTypeStrategy implements ArgumentTypeStrategy {
+
+    @Override
+    public Optional<DataType> inferArgumentType(
+            CallContext callContext, int argumentPos, boolean throwOnFailure) {
+        final DataType actualType = callContext.getArgumentDataTypes().get(argumentPos);
+        if (!actualType.getLogicalType().is(LogicalTypeRoot.ARRAY)) {
+            return callContext.fail(
+                    throwOnFailure, "The input argument should be ARRAY<ROW<key, value>>");
+        }
+
+        final LogicalType elementType =
+                ((CollectionDataType) actualType).getElementDataType().getLogicalType();
+        if (!elementType.is(LogicalTypeRoot.ROW)
+                || LogicalTypeChecks.getFieldCount(elementType) != 2) {
+            return callContext.fail(
+                    throwOnFailure,
+                    "The input argument should be ARRAY<ROW<key, value>>, but the array element "
+                            + "type is '%s'. The element must be a ROW with exactly two fields.",
+                    elementType.asSummaryString());
+        }
+
+        // the key field must support equality, otherwise duplicate keys cannot be detected
+        final LogicalType keyType = LogicalTypeChecks.getFieldTypes(elementType).get(0);
+        if (!LogicalTypeChecks.areComparable(keyType, keyType, StructuredComparison.EQUALS)) {
+            return callContext.fail(
+                    throwOnFailure,
+                    "The map key type '%s' does not support equality comparison and therefore "
+                            + "cannot be used as the first field of a map entry.",
+                    keyType.asSummaryString());
+        }
+
+        return Optional.of(actualType);
+    }
+
+    @Override
+    public Argument getExpectedArgument(FunctionDefinition functionDefinition, int argumentPos) {
+        return Argument.of("ARRAY<ROW<key, value>>");
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return this == o || o instanceof ArrayOfEntriesArgumentTypeStrategy;
+    }
+
+    @Override
+    public int hashCode() {
+        return ArrayOfEntriesArgumentTypeStrategy.class.hashCode();
+    }
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/ArrayOfEntriesArgumentTypeStrategy.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/ArrayOfEntriesArgumentTypeStrategy.java
@@ -46,7 +46,9 @@ public final class ArrayOfEntriesArgumentTypeStrategy implements ArgumentTypeStr
         final DataType actualType = callContext.getArgumentDataTypes().get(argumentPos);
         if (!actualType.getLogicalType().is(LogicalTypeRoot.ARRAY)) {
             return callContext.fail(
-                    throwOnFailure, "The input argument should be ARRAY<ROW<key, value>>");
+                    throwOnFailure,
+                    "The 'input' argument must be ARRAY<ROW<key, value>>, but actual type was '%s'.",
+                    actualType.getLogicalType().asSummaryString());
         }
 
         final LogicalType elementType =

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/SpecificInputTypeStrategies.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/SpecificInputTypeStrategies.java
@@ -104,6 +104,10 @@ public final class SpecificInputTypeStrategies {
     public static final ArgumentTypeStrategy ARRAY_FULLY_COMPARABLE =
             new ArrayComparableElementArgumentTypeStrategy(StructuredComparison.FULL);
 
+    /** See {@link ArrayOfEntriesArgumentTypeStrategy}. */
+    public static final ArgumentTypeStrategy ARRAY_OF_ENTRIES_ARG =
+            new ArrayOfEntriesArgumentTypeStrategy();
+
     /**
      * Input strategy for {@link BuiltInFunctionDefinitions#JSON_OBJECT}.
      *

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/SpecificTypeStrategies.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/SpecificTypeStrategies.java
@@ -183,7 +183,7 @@ public final class SpecificTypeStrategies {
                 final DataType arrayDataType = callContext.getArgumentDataTypes().get(0);
                 final DataType entryDataType =
                         ((CollectionDataType) arrayDataType).getElementDataType();
-                final List<DataType> fieldDataTypes = entryDataType.getChildren();
+                final List<DataType> fieldDataTypes = DataType.getFieldDataTypes(entryDataType);
                 final DataType mapDataType =
                         DataTypes.MAP(fieldDataTypes.get(0), fieldDataTypes.get(1));
                 final boolean nullable =

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/SpecificTypeStrategies.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/SpecificTypeStrategies.java
@@ -172,6 +172,27 @@ public final class SpecificTypeStrategies {
                                             .getElementDataType()));
 
     /**
+     * Type strategy specific for {@link BuiltInFunctionDefinitions#MAP_FROM_ENTRIES}.
+     *
+     * <p>Derives {@code MAP<key, value>} from the {@code ROW} element of the {@code ARRAY}
+     * argument. The result is nullable if the array itself is nullable or if its elements are,
+     * since a {@code NULL} entry makes the whole map {@code NULL}.
+     */
+    public static final TypeStrategy MAP_FROM_ENTRIES =
+            callContext -> {
+                final DataType arrayDataType = callContext.getArgumentDataTypes().get(0);
+                final DataType entryDataType =
+                        ((CollectionDataType) arrayDataType).getElementDataType();
+                final List<DataType> fieldDataTypes = entryDataType.getChildren();
+                final DataType mapDataType =
+                        DataTypes.MAP(fieldDataTypes.get(0), fieldDataTypes.get(1));
+                final boolean nullable =
+                        arrayDataType.getLogicalType().isNullable()
+                                || entryDataType.getLogicalType().isNullable();
+                return Optional.of(nullable ? mapDataType.nullable() : mapDataType.notNull());
+            };
+
+    /**
      * Strategy for {@link org.apache.flink.table.functions.BuiltInFunctionDefinitions#LAG} and
      * {@link org.apache.flink.table.functions.BuiltInFunctionDefinitions#LEAD}. Returns a nullable
      * type of arg0, unless the default value is not null. In that case the result will be not null.

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/inference/strategies/ArrayOfEntriesArgumentTypeStrategyTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/inference/strategies/ArrayOfEntriesArgumentTypeStrategyTest.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.types.inference.strategies;
+
+import org.apache.flink.api.common.serialization.SerializerConfigImpl;
+import org.apache.flink.api.java.typeutils.runtime.kryo.KryoSerializer;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
+import org.apache.flink.table.types.inference.ArgumentTypeStrategy;
+import org.apache.flink.table.types.inference.InputTypeStrategiesTestBase;
+import org.apache.flink.table.types.inference.InputTypeStrategy;
+import org.apache.flink.table.types.utils.DataTypeFactoryMock;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link ArrayOfEntriesArgumentTypeStrategy}. */
+class ArrayOfEntriesArgumentTypeStrategyTest extends InputTypeStrategiesTestBase {
+
+    private static final InputTypeStrategy MAP_FROM_ENTRIES_INPUT_STRATEGY =
+            BuiltInFunctionDefinitions.MAP_FROM_ENTRIES
+                    .getTypeInference(new DataTypeFactoryMock())
+                    .getInputTypeStrategy();
+
+    @Override
+    protected Stream<TestSpec> testData() {
+        return Stream.of(
+                TestSpec.forStrategy(
+                                "Array of two-field rows is accepted",
+                                MAP_FROM_ENTRIES_INPUT_STRATEGY)
+                        .calledWithArgumentTypes(
+                                DataTypes.ARRAY(
+                                        DataTypes.ROW(
+                                                DataTypes.FIELD("key", DataTypes.INT()),
+                                                DataTypes.FIELD("value", DataTypes.STRING()))))
+                        .expectSignature("f(input ARRAY<ROW<key, value>>)")
+                        .expectArgumentTypes(
+                                DataTypes.ARRAY(
+                                        DataTypes.ROW(
+                                                DataTypes.FIELD("key", DataTypes.INT()),
+                                                DataTypes.FIELD("value", DataTypes.STRING())))),
+                TestSpec.forStrategy(
+                                "Nested and NOT NULL element types are preserved",
+                                MAP_FROM_ENTRIES_INPUT_STRATEGY)
+                        .calledWithArgumentTypes(
+                                DataTypes.ARRAY(
+                                                DataTypes.ROW(
+                                                                DataTypes.FIELD(
+                                                                        "key", DataTypes.STRING()),
+                                                                DataTypes.FIELD(
+                                                                        "value",
+                                                                        DataTypes.ARRAY(
+                                                                                DataTypes.INT())))
+                                                        .notNull())
+                                        .notNull())
+                        .expectArgumentTypes(
+                                DataTypes.ARRAY(
+                                                DataTypes.ROW(
+                                                                DataTypes.FIELD(
+                                                                        "key", DataTypes.STRING()),
+                                                                DataTypes.FIELD(
+                                                                        "value",
+                                                                        DataTypes.ARRAY(
+                                                                                DataTypes.INT())))
+                                                        .notNull())
+                                        .notNull()),
+                TestSpec.forStrategy(
+                                "Non-array argument is rejected", MAP_FROM_ENTRIES_INPUT_STRATEGY)
+                        .calledWithArgumentTypes(DataTypes.STRING())
+                        .expectErrorMessage("The input argument should be ARRAY<ROW<key, value>>"),
+                TestSpec.forStrategy(
+                                "Array of non-row elements is rejected",
+                                MAP_FROM_ENTRIES_INPUT_STRATEGY)
+                        .calledWithArgumentTypes(DataTypes.ARRAY(DataTypes.INT()))
+                        .expectErrorMessage(
+                                "The input argument should be ARRAY<ROW<key, value>>, but the array "
+                                        + "element type is 'INT'. The element must be a ROW with "
+                                        + "exactly two fields."),
+                TestSpec.forStrategy(
+                                "Array of rows without exactly two fields is rejected",
+                                MAP_FROM_ENTRIES_INPUT_STRATEGY)
+                        .calledWithArgumentTypes(
+                                DataTypes.ARRAY(
+                                        DataTypes.ROW(
+                                                DataTypes.FIELD("key", DataTypes.INT()),
+                                                DataTypes.FIELD("value", DataTypes.STRING()),
+                                                DataTypes.FIELD("extra", DataTypes.BOOLEAN()))))
+                        .expectErrorMessage("The element must be a ROW with exactly two fields."),
+                TestSpec.forStrategy(
+                                "Key type without equality support is rejected",
+                                MAP_FROM_ENTRIES_INPUT_STRATEGY)
+                        .calledWithArgumentTypes(
+                                DataTypes.ARRAY(
+                                        DataTypes.ROW(
+                                                DataTypes.FIELD(
+                                                        "key",
+                                                        DataTypes.RAW(
+                                                                Object.class,
+                                                                new KryoSerializer<>(
+                                                                        Object.class,
+                                                                        new SerializerConfigImpl()))),
+                                                DataTypes.FIELD("value", DataTypes.STRING()))))
+                        .expectErrorMessage(
+                                "does not support equality comparison and therefore cannot be "
+                                        + "used as the first field of a map entry."));
+    }
+
+    @Test
+    void testEqualsAndHashCode() {
+        final ArgumentTypeStrategy strategy = new ArrayOfEntriesArgumentTypeStrategy();
+        assertThat(strategy)
+                .isEqualTo(strategy)
+                .isEqualTo(new ArrayOfEntriesArgumentTypeStrategy())
+                .hasSameHashCodeAs(new ArrayOfEntriesArgumentTypeStrategy())
+                .isNotEqualTo("not a strategy");
+    }
+}

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/inference/strategies/ArrayOfEntriesArgumentTypeStrategyTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/inference/strategies/ArrayOfEntriesArgumentTypeStrategyTest.java
@@ -86,14 +86,14 @@ class ArrayOfEntriesArgumentTypeStrategyTest extends InputTypeStrategiesTestBase
                 TestSpec.forStrategy(
                                 "Non-array argument is rejected", MAP_FROM_ENTRIES_INPUT_STRATEGY)
                         .calledWithArgumentTypes(DataTypes.STRING())
-                        .expectErrorMessage("The input argument should be ARRAY<ROW<key, value>>"),
+                        .expectErrorMessage("The 'input' argument must be ARRAY<ROW<key, value>>"),
                 TestSpec.forStrategy(
                                 "Array of non-row elements is rejected",
                                 MAP_FROM_ENTRIES_INPUT_STRATEGY)
                         .calledWithArgumentTypes(DataTypes.ARRAY(DataTypes.INT()))
                         .expectErrorMessage(
-                                "The input argument should be ARRAY<ROW<key, value>>, but the array "
-                                        + "element type is 'INT'. The element must be a ROW with "
+                                "The 'input' argument must be ARRAY<ROW<key, value>>, but the array "
+                                        + "element type was 'INT'. The element must be a ROW with "
                                         + "exactly two fields."),
                 TestSpec.forStrategy(
                                 "Array of rows without exactly two fields is rejected",

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/inference/strategies/MapFromEntriesTypeStrategyTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/inference/strategies/MapFromEntriesTypeStrategyTest.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.types.inference.strategies;
+
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.inference.TypeStrategiesTestBase;
+
+import java.util.stream.Stream;
+
+/** Tests for {@link SpecificTypeStrategies#MAP_FROM_ENTRIES}. */
+class MapFromEntriesTypeStrategyTest extends TypeStrategiesTestBase {
+
+    private static DataType entry(boolean elementNullable) {
+        final DataType entryType =
+                DataTypes.ROW(
+                        DataTypes.FIELD("key", DataTypes.INT()),
+                        DataTypes.FIELD("value", DataTypes.STRING()));
+        return elementNullable ? entryType.nullable() : entryType.notNull();
+    }
+
+    private static DataType array(boolean arrayNullable, boolean elementNullable) {
+        final DataType arrayType = DataTypes.ARRAY(entry(elementNullable));
+        return arrayNullable ? arrayType.nullable() : arrayType.notNull();
+    }
+
+    private static final DataType MAP_TYPE = DataTypes.MAP(DataTypes.INT(), DataTypes.STRING());
+
+    @Override
+    protected Stream<TestSpec> testData() {
+        return Stream.of(
+                TestSpec.forStrategy(
+                                "A nullable array yields a nullable map",
+                                SpecificTypeStrategies.MAP_FROM_ENTRIES)
+                        .inputTypes(array(true, false))
+                        .expectDataType(MAP_TYPE.nullable()),
+                TestSpec.forStrategy(
+                                "A nullable entry yields a nullable map",
+                                SpecificTypeStrategies.MAP_FROM_ENTRIES)
+                        .inputTypes(array(false, true))
+                        .expectDataType(MAP_TYPE.nullable()),
+                TestSpec.forStrategy(
+                                "NOT NULL array and entries yield a NOT NULL map, "
+                                        + "carrying field nullability into the map",
+                                SpecificTypeStrategies.MAP_FROM_ENTRIES)
+                        .inputTypes(
+                                DataTypes.ARRAY(
+                                                DataTypes.ROW(
+                                                                DataTypes.FIELD(
+                                                                        "key",
+                                                                        DataTypes.INT().notNull()),
+                                                                DataTypes.FIELD(
+                                                                        "value",
+                                                                        DataTypes.STRING()
+                                                                                .notNull()))
+                                                        .notNull())
+                                        .notNull())
+                        .expectDataType(
+                                DataTypes.MAP(
+                                                DataTypes.INT().notNull(),
+                                                DataTypes.STRING().notNull())
+                                        .notNull()),
+                TestSpec.forStrategy(
+                                "Nested value type is preserved",
+                                SpecificTypeStrategies.MAP_FROM_ENTRIES)
+                        .inputTypes(
+                                DataTypes.ARRAY(
+                                        DataTypes.ROW(
+                                                DataTypes.FIELD("key", DataTypes.STRING()),
+                                                DataTypes.FIELD(
+                                                        "value",
+                                                        DataTypes.ARRAY(DataTypes.INT())))))
+                        .expectDataType(
+                                DataTypes.MAP(DataTypes.STRING(), DataTypes.ARRAY(DataTypes.INT()))
+                                        .nullable()));
+    }
+}

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/MapFunctionITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/MapFunctionITCase.java
@@ -431,7 +431,7 @@ public class MapFunctionITCase extends BuiltInFunctionTestBase {
                         .andDataTypes(DataTypes.STRING(), DataTypes.ARRAY(DataTypes.INT()))
                         .testTableApiValidationError(
                                 $("f0").mapFromEntries(),
-                                "The input argument should be ARRAY<ROW<key, value>>")
+                                "The 'input' argument must be ARRAY<ROW<key, value>>")
                         .testSqlValidationError(
                                 "MAP_FROM_ENTRIES(ARRAY[ROW(1, 'a', true)])",
                                 "The element must be a ROW with exactly two fields."),

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/MapFunctionITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/MapFunctionITCase.java
@@ -20,6 +20,7 @@ package org.apache.flink.table.planner.functions;
 
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
+import org.apache.flink.table.types.DataType;
 import org.apache.flink.types.Row;
 import org.apache.flink.util.CollectionUtil;
 
@@ -46,10 +47,13 @@ import static org.apache.flink.table.api.DataTypes.STRING;
 import static org.apache.flink.table.api.DataTypes.TIME;
 import static org.apache.flink.table.api.DataTypes.TIMESTAMP;
 import static org.apache.flink.table.api.Expressions.$;
+import static org.apache.flink.table.api.Expressions.array;
 import static org.apache.flink.table.api.Expressions.call;
 import static org.apache.flink.table.api.Expressions.lit;
 import static org.apache.flink.table.api.Expressions.map;
 import static org.apache.flink.table.api.Expressions.mapFromArrays;
+import static org.apache.flink.table.api.Expressions.nullOf;
+import static org.apache.flink.table.api.Expressions.row;
 import static org.apache.flink.util.CollectionUtil.entry;
 
 /** Test {@link BuiltInFunctionDefinitions#MAP} and its return type. */
@@ -73,6 +77,7 @@ public class MapFunctionITCase extends BuiltInFunctionTestBase {
                         mapValuesTestCases(),
                         mapEntriesTestCases(),
                         mapFromArraysTestCases(),
+                        mapFromEntriesTestCases(),
                         mapUnionTestCases())
                 .flatMap(s -> s);
     }
@@ -404,6 +409,123 @@ public class MapFunctionITCase extends BuiltInFunctionTestBase {
                                         entry("two", new Integer[] {3, 4})),
                                 DataTypes.MAP(
                                         DataTypes.STRING(), DataTypes.ARRAY(DataTypes.INT()))));
+    }
+
+    private Stream<TestSetSpec> mapFromEntriesTestCases() {
+        final DataType entryType =
+                DataTypes.ROW(
+                        DataTypes.FIELD("key", DataTypes.INT()),
+                        DataTypes.FIELD("value", DataTypes.STRING()));
+        final DataType nestedEntryType =
+                DataTypes.ROW(
+                        DataTypes.FIELD("key", DataTypes.STRING()),
+                        DataTypes.FIELD("value", DataTypes.ARRAY(DataTypes.INT())));
+        return Stream.of(
+                TestSetSpec.forFunction(
+                                BuiltInFunctionDefinitions.MAP_FROM_ENTRIES, "Invalid input")
+                        .onFieldsWithData("item", new Integer[] {1, 2})
+                        .andDataTypes(DataTypes.STRING(), DataTypes.ARRAY(DataTypes.INT()))
+                        .testTableApiValidationError(
+                                $("f0").mapFromEntries(),
+                                "The input argument should be ARRAY<ROW<key, value>>")
+                        .testSqlValidationError(
+                                "MAP_FROM_ENTRIES(ARRAY[ROW(1, 'a', true)])",
+                                "The element must be a ROW with exactly two fields."),
+                TestSetSpec.forFunction(BuiltInFunctionDefinitions.MAP_FROM_ENTRIES)
+                        .onFieldsWithData(
+                                new Row[] {Row.of(1, "one"), Row.of(2, "two")},
+                                new Row[] {Row.of(1, "one"), Row.of(1, "uno")},
+                                null,
+                                new Row[] {
+                                    Row.of("one", new Integer[] {1, 2}),
+                                    Row.of("two", new Integer[] {3, 4})
+                                },
+                                new Row[] {Row.of(null, "a"), Row.of(null, "b")})
+                        .andDataTypes(
+                                DataTypes.ARRAY(entryType),
+                                DataTypes.ARRAY(entryType),
+                                DataTypes.ARRAY(entryType),
+                                DataTypes.ARRAY(nestedEntryType),
+                                DataTypes.ARRAY(entryType))
+                        // duplicate keys: the last value wins
+                        .testResult(
+                                $("f1").mapFromEntries(),
+                                "MAP_FROM_ENTRIES(f1)",
+                                CollectionUtil.map(entry(1, "uno")),
+                                DataTypes.MAP(DataTypes.INT(), DataTypes.STRING()))
+                        // an empty array yields an empty map
+                        .testResult(
+                                $("f0").arraySlice(20, 30).mapFromEntries(),
+                                "MAP_FROM_ENTRIES(ARRAY_SLICE(f0, 20, 30))",
+                                Collections.emptyMap(),
+                                DataTypes.MAP(DataTypes.INT(), DataTypes.STRING()))
+                        // NULL array yields NULL
+                        .testResult(
+                                $("f2").mapFromEntries(),
+                                "MAP_FROM_ENTRIES(f2)",
+                                null,
+                                DataTypes.MAP(DataTypes.INT(), DataTypes.STRING()))
+                        // nested value type
+                        .testTableApiResult(
+                                $("f3").mapFromEntries(),
+                                CollectionUtil.map(
+                                        entry("one", new Integer[] {1, 2}),
+                                        entry("two", new Integer[] {3, 4})),
+                                DataTypes.MAP(DataTypes.STRING(), DataTypes.ARRAY(DataTypes.INT())))
+                        // duplicate NULL keys are deduplicated as well
+                        .testResult(
+                                $("f4").mapFromEntries(),
+                                "MAP_FROM_ENTRIES(f4)",
+                                Collections.singletonMap(null, "b"),
+                                DataTypes.MAP(DataTypes.INT(), DataTypes.STRING()))
+                        // round trip with the inverse function
+                        .testResult(
+                                $("f0").mapFromEntries().mapEntries(),
+                                "MAP_ENTRIES(MAP_FROM_ENTRIES(f0))",
+                                new Row[] {Row.of(1, "one"), Row.of(2, "two")},
+                                DataTypes.ARRAY(entryType)),
+                TestSetSpec.forFunction(
+                                BuiltInFunctionDefinitions.MAP_FROM_ENTRIES, "Documented examples")
+                        .onFieldsWithData(1)
+                        .andDataTypes(DataTypes.INT().notNull())
+                        .testResult(
+                                array(row(1, "one"), row(2, "two")).mapFromEntries(),
+                                "MAP_FROM_ENTRIES(ARRAY[ROW(1, 'one'), ROW(2, 'two')])",
+                                CollectionUtil.map(entry(1, "one"), entry(2, "two")),
+                                DataTypes.MAP(
+                                                DataTypes.INT().notNull(),
+                                                DataTypes.CHAR(3).notNull())
+                                        .notNull())
+                        .testResult(
+                                array(row(1, "one"), row(2, "two"), row(1, "uno")).mapFromEntries(),
+                                "MAP_FROM_ENTRIES(ARRAY[ROW(1, 'one'), ROW(2, 'two'), ROW(1, 'uno')])",
+                                CollectionUtil.map(entry(1, "uno"), entry(2, "two")),
+                                DataTypes.MAP(
+                                                DataTypes.INT().notNull(),
+                                                DataTypes.CHAR(3).notNull())
+                                        .notNull())
+                        .testResult(
+                                array(
+                                                row(1, "one"),
+                                                nullOf(
+                                                        DataTypes.ROW(
+                                                                DataTypes.FIELD(
+                                                                        "k", DataTypes.INT()),
+                                                                DataTypes.FIELD(
+                                                                        "v", DataTypes.STRING()))))
+                                        .mapFromEntries(),
+                                "MAP_FROM_ENTRIES(ARRAY[ROW(1, 'one'), CAST(NULL AS ROW(k INT, v STRING))])",
+                                null,
+                                DataTypes.MAP(DataTypes.INT(), DataTypes.STRING()))
+                        // a NOT NULL array of NOT NULL entries yields a NOT NULL map
+                        .testResult(
+                                array(row($("f0"), "a")).mapFromEntries(),
+                                "MAP_FROM_ENTRIES(ARRAY[ROW(f0, 'a')])",
+                                Collections.singletonMap(1, "a"),
+                                DataTypes.MAP(
+                                                DataTypes.INT().notNull(),
+                                                DataTypes.CHAR(1).notNull())
+                                        .notNull()));
     }
 
     private Stream<TestSetSpec> mapUnionTestCases() {

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/MapFunctionITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/MapFunctionITCase.java
@@ -420,6 +420,10 @@ public class MapFunctionITCase extends BuiltInFunctionTestBase {
                 DataTypes.ROW(
                         DataTypes.FIELD("key", DataTypes.STRING()),
                         DataTypes.FIELD("value", DataTypes.ARRAY(DataTypes.INT())));
+        final DataType rowKeyType =
+                DataTypes.ROW(
+                        DataTypes.FIELD("a", DataTypes.INT()),
+                        DataTypes.FIELD("b", DataTypes.STRING()));
         return Stream.of(
                 TestSetSpec.forFunction(
                                 BuiltInFunctionDefinitions.MAP_FROM_ENTRIES, "Invalid input")
@@ -478,6 +482,56 @@ public class MapFunctionITCase extends BuiltInFunctionTestBase {
                                 "MAP_FROM_ENTRIES(f4)",
                                 Collections.singletonMap(null, "b"),
                                 DataTypes.MAP(DataTypes.INT(), DataTypes.STRING()))
+                        // duplicate STRING keys use the generated equality; a NULL value is kept
+                        .testResult(
+                                array(
+                                                row("k", "a"),
+                                                row("k", "b"),
+                                                row("x", nullOf(DataTypes.STRING())))
+                                        .mapFromEntries(),
+                                "MAP_FROM_ENTRIES(ARRAY[ROW('k', 'a'), ROW('k', 'b'), ROW('x', CAST(NULL AS STRING))])",
+                                CollectionUtil.map(entry("k", "b"), entry("x", null)),
+                                DataTypes.MAP(DataTypes.CHAR(1).notNull(), DataTypes.STRING())
+                                        .notNull())
+                        // duplicate ROW keys use the generated equality; a NULL value is kept
+                        .testResult(
+                                array(
+                                                row(row(1, "a").cast(rowKeyType), "x"),
+                                                row(row(1, "a").cast(rowKeyType), "y"),
+                                                row(
+                                                        row(2, "b").cast(rowKeyType),
+                                                        nullOf(DataTypes.STRING())))
+                                        .mapFromEntries(),
+                                "MAP_FROM_ENTRIES(ARRAY["
+                                        + "ROW(CAST(ROW(1, 'a') AS ROW(a INT, b STRING)), 'x'), "
+                                        + "ROW(CAST(ROW(1, 'a') AS ROW(a INT, b STRING)), 'y'), "
+                                        + "ROW(CAST(ROW(2, 'b') AS ROW(a INT, b STRING)), CAST(NULL AS STRING))])",
+                                CollectionUtil.map(
+                                        entry(Row.of(1, "a"), "y"), entry(Row.of(2, "b"), null)),
+                                DataTypes.MAP(rowKeyType.notNull(), DataTypes.STRING()).notNull())
+                        // duplicate ARRAY keys collapse through the generated equality and the
+                        // last entry wins, keeping its NULL value; asserted via CARDINALITY and
+                        // MAP_VALUES because Map#equals cannot compare array-keyed maps
+                        .testResult(
+                                array(
+                                                row(array(1, 2), "x"),
+                                                row(array(1, 2), nullOf(DataTypes.STRING())))
+                                        .mapFromEntries()
+                                        .cardinality(),
+                                "CARDINALITY(MAP_FROM_ENTRIES("
+                                        + "ARRAY[ROW(ARRAY[1, 2], 'x'), ROW(ARRAY[1, 2], CAST(NULL AS STRING))]))",
+                                1,
+                                DataTypes.INT().notNull())
+                        .testResult(
+                                array(
+                                                row(array(1, 2), "x"),
+                                                row(array(1, 2), nullOf(DataTypes.STRING())))
+                                        .mapFromEntries()
+                                        .mapValues(),
+                                "MAP_VALUES(MAP_FROM_ENTRIES("
+                                        + "ARRAY[ROW(ARRAY[1, 2], 'x'), ROW(ARRAY[1, 2], CAST(NULL AS STRING))]))",
+                                new String[] {null},
+                                DataTypes.ARRAY(DataTypes.STRING()).notNull())
                         // round trip with the inverse function
                         .testResult(
                                 $("f0").mapFromEntries().mapEntries(),
@@ -503,6 +557,15 @@ public class MapFunctionITCase extends BuiltInFunctionTestBase {
                                 DataTypes.MAP(
                                                 DataTypes.INT().notNull(),
                                                 DataTypes.CHAR(3).notNull())
+                                        .notNull())
+                        .testResult(
+                                array(
+                                                row(nullOf(DataTypes.INT()), "a"),
+                                                row(nullOf(DataTypes.INT()), "b"))
+                                        .mapFromEntries(),
+                                "MAP_FROM_ENTRIES(ARRAY[ROW(CAST(NULL AS INT), 'a'), ROW(CAST(NULL AS INT), 'b')])",
+                                Collections.singletonMap(null, "b"),
+                                DataTypes.MAP(DataTypes.INT(), DataTypes.CHAR(1).notNull())
                                         .notNull())
                         .testResult(
                                 array(

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/MapFromArraysFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/MapFromArraysFunction.java
@@ -23,6 +23,7 @@ import org.apache.flink.table.data.ArrayData;
 import org.apache.flink.table.data.MapData;
 import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
 import org.apache.flink.table.functions.SpecializedFunction;
+import org.apache.flink.table.runtime.util.MapDataContainer;
 import org.apache.flink.util.FlinkRuntimeException;
 
 import javax.annotation.Nullable;
@@ -47,31 +48,6 @@ public class MapFromArraysFunction extends BuiltInScalarFunction {
                             + " is not equal to the length of the values array "
                             + valuesArray.size());
         }
-        return new MapDataForMapFromArrays(keysArray, valuesArray);
-    }
-
-    private static class MapDataForMapFromArrays implements MapData {
-        private final ArrayData keyArray;
-        private final ArrayData valueArray;
-
-        public MapDataForMapFromArrays(ArrayData keyArray, ArrayData valueArray) {
-            this.keyArray = keyArray;
-            this.valueArray = valueArray;
-        }
-
-        @Override
-        public int size() {
-            return keyArray.size();
-        }
-
-        @Override
-        public ArrayData keyArray() {
-            return keyArray;
-        }
-
-        @Override
-        public ArrayData valueArray() {
-            return valueArray;
-        }
+        return new MapDataContainer(keysArray, valuesArray);
     }
 }

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/MapFromEntriesFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/MapFromEntriesFunction.java
@@ -1,0 +1,139 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.functions.scalar;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.data.ArrayData;
+import org.apache.flink.table.data.GenericArrayData;
+import org.apache.flink.table.data.MapData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
+import org.apache.flink.table.functions.FunctionContext;
+import org.apache.flink.table.functions.SpecializedFunction;
+import org.apache.flink.table.runtime.util.EqualityAndHashcodeProvider;
+import org.apache.flink.table.runtime.util.ObjectContainer;
+import org.apache.flink.table.types.CollectionDataType;
+import org.apache.flink.table.types.DataType;
+
+import javax.annotation.Nullable;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/** Implementation of {@link BuiltInFunctionDefinitions#MAP_FROM_ENTRIES}. */
+@Internal
+public class MapFromEntriesFunction extends BuiltInScalarFunction {
+
+    private final ArrayData.ElementGetter entryElementGetter;
+    private final RowData.FieldGetter keyFieldGetter;
+    private final RowData.FieldGetter valueFieldGetter;
+
+    private final EqualityAndHashcodeProvider keyEqualityAndHashcodeProvider;
+
+    public MapFromEntriesFunction(SpecializedFunction.SpecializedContext context) {
+        super(BuiltInFunctionDefinitions.MAP_FROM_ENTRIES, context);
+        final DataType arrayDataType = context.getCallContext().getArgumentDataTypes().get(0);
+        final DataType entryDataType = ((CollectionDataType) arrayDataType).getElementDataType();
+        final List<DataType> fieldDataTypes = entryDataType.getChildren();
+        final DataType keyDataType = fieldDataTypes.get(0);
+        final DataType valueDataType = fieldDataTypes.get(1);
+
+        entryElementGetter = ArrayData.createElementGetter(entryDataType.getLogicalType());
+        keyFieldGetter = RowData.createFieldGetter(keyDataType.getLogicalType(), 0);
+        valueFieldGetter = RowData.createFieldGetter(valueDataType.getLogicalType(), 1);
+
+        keyEqualityAndHashcodeProvider =
+                new EqualityAndHashcodeProvider(context, keyDataType.toInternal());
+    }
+
+    @Override
+    public void open(FunctionContext context) throws Exception {
+        keyEqualityAndHashcodeProvider.open(context);
+    }
+
+    public @Nullable MapData eval(@Nullable ArrayData input) {
+        if (input == null) {
+            return null;
+        }
+
+        // a duplicate key keeps the position of its first occurrence and the last value wins
+        final Map<ObjectContainer, Object> entries = new LinkedHashMap<>();
+        for (int pos = 0; pos < input.size(); pos++) {
+            final RowData entry = (RowData) entryElementGetter.getElementOrNull(input, pos);
+            if (entry == null) {
+                return null;
+            }
+            entries.put(
+                    wrapKey(keyFieldGetter.getFieldOrNull(entry)),
+                    valueFieldGetter.getFieldOrNull(entry));
+        }
+        return new MapDataForMapFromEntries(
+                new GenericArrayData(
+                        entries.keySet().stream()
+                                .map(key -> key == null ? null : key.getObject())
+                                .toArray()),
+                new GenericArrayData(entries.values().toArray()));
+    }
+
+    /**
+     * Wraps the given key so that it is hashed and compared with the generated hashcode and
+     * equality of the key type, which implement SQL semantics for internal data structures unlike
+     * {@link Object#hashCode()} and {@link Object#equals(Object)}.
+     */
+    private @Nullable ObjectContainer wrapKey(@Nullable Object key) {
+        if (key == null) {
+            return null;
+        }
+        return new ObjectContainer(
+                key,
+                keyEqualityAndHashcodeProvider::equals,
+                keyEqualityAndHashcodeProvider::hashCode);
+    }
+
+    @Override
+    public void close() throws Exception {
+        keyEqualityAndHashcodeProvider.close();
+    }
+
+    private static class MapDataForMapFromEntries implements MapData {
+        private final GenericArrayData keyArray;
+        private final GenericArrayData valueArray;
+
+        MapDataForMapFromEntries(GenericArrayData keyArray, GenericArrayData valueArray) {
+            this.keyArray = keyArray;
+            this.valueArray = valueArray;
+        }
+
+        @Override
+        public int size() {
+            return keyArray.size();
+        }
+
+        @Override
+        public ArrayData keyArray() {
+            return keyArray;
+        }
+
+        @Override
+        public ArrayData valueArray() {
+            return valueArray;
+        }
+    }
+}

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/MapFromEntriesFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/MapFromEntriesFunction.java
@@ -52,7 +52,7 @@ public class MapFromEntriesFunction extends BuiltInScalarFunction {
         super(BuiltInFunctionDefinitions.MAP_FROM_ENTRIES, context);
         final DataType arrayDataType = context.getCallContext().getArgumentDataTypes().get(0);
         final DataType entryDataType = ((CollectionDataType) arrayDataType).getElementDataType();
-        final List<DataType> fieldDataTypes = entryDataType.getChildren();
+        final List<DataType> fieldDataTypes = DataType.getFieldDataTypes(entryDataType);
         final DataType keyDataType = fieldDataTypes.get(0);
         final DataType valueDataType = fieldDataTypes.get(1);
 

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/MapFromEntriesFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/MapFromEntriesFunction.java
@@ -27,6 +27,7 @@ import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
 import org.apache.flink.table.functions.FunctionContext;
 import org.apache.flink.table.functions.SpecializedFunction;
 import org.apache.flink.table.runtime.util.EqualityAndHashcodeProvider;
+import org.apache.flink.table.runtime.util.MapDataContainer;
 import org.apache.flink.table.runtime.util.ObjectContainer;
 import org.apache.flink.table.types.CollectionDataType;
 import org.apache.flink.table.types.DataType;
@@ -36,8 +37,6 @@ import javax.annotation.Nullable;
 
 import java.util.List;
 import java.util.Map;
-import java.util.function.BiFunction;
-import java.util.function.Function;
 
 /** Implementation of {@link BuiltInFunctionDefinitions#MAP_FROM_ENTRIES}. */
 @Internal
@@ -48,9 +47,6 @@ public class MapFromEntriesFunction extends BuiltInScalarFunction {
     private final RowData.FieldGetter valueFieldGetter;
 
     private final EqualityAndHashcodeProvider keyEqualityAndHashcodeProvider;
-
-    private transient BiFunction<Object, Object, Boolean> keyEquality;
-    private transient Function<Object, Integer> keyHashcode;
 
     public MapFromEntriesFunction(SpecializedFunction.SpecializedContext context) {
         super(BuiltInFunctionDefinitions.MAP_FROM_ENTRIES, context);
@@ -71,8 +67,6 @@ public class MapFromEntriesFunction extends BuiltInScalarFunction {
     @Override
     public void open(FunctionContext context) throws Exception {
         keyEqualityAndHashcodeProvider.open(context);
-        keyEquality = keyEqualityAndHashcodeProvider::equals;
-        keyHashcode = keyEqualityAndHashcodeProvider::hashCode;
     }
 
     public @Nullable MapData eval(@Nullable ArrayData input) {
@@ -104,49 +98,26 @@ public class MapFromEntriesFunction extends BuiltInScalarFunction {
             values[pos] = entry.getValue();
             pos++;
         }
-        return new MapDataForMapFromEntries(
-                new GenericArrayData(keys), new GenericArrayData(values));
+        return new MapDataContainer(new GenericArrayData(keys), new GenericArrayData(values));
     }
 
     /**
-     * Wraps the given key so that it is hashed and compared with the generated hashcode and
-     * equality of the key type, which implement SQL semantics for internal data structures unlike
-     * {@link Object#hashCode()} and {@link Object#equals(Object)}.
+     * Hashes and compares the key with SQL semantics instead of {@link Object#equals}. A {@code
+     * null} key is returned unwrapped, so all {@code null} keys are treated as equal and collapse
+     * into a single entry.
      */
     private @Nullable ObjectContainer wrapKey(@Nullable Object key) {
         if (key == null) {
             return null;
         }
-        return new ObjectContainer(key, keyEquality, keyHashcode);
+        return new ObjectContainer(
+                key,
+                keyEqualityAndHashcodeProvider::equals,
+                keyEqualityAndHashcodeProvider::hashCode);
     }
 
     @Override
     public void close() throws Exception {
         keyEqualityAndHashcodeProvider.close();
-    }
-
-    private static class MapDataForMapFromEntries implements MapData {
-        private final GenericArrayData keyArray;
-        private final GenericArrayData valueArray;
-
-        MapDataForMapFromEntries(GenericArrayData keyArray, GenericArrayData valueArray) {
-            this.keyArray = keyArray;
-            this.valueArray = valueArray;
-        }
-
-        @Override
-        public int size() {
-            return keyArray.size();
-        }
-
-        @Override
-        public ArrayData keyArray() {
-            return keyArray;
-        }
-
-        @Override
-        public ArrayData valueArray() {
-            return valueArray;
-        }
     }
 }

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/MapFromEntriesFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/MapFromEntriesFunction.java
@@ -30,12 +30,14 @@ import org.apache.flink.table.runtime.util.EqualityAndHashcodeProvider;
 import org.apache.flink.table.runtime.util.ObjectContainer;
 import org.apache.flink.table.types.CollectionDataType;
 import org.apache.flink.table.types.DataType;
+import org.apache.flink.util.CollectionUtil;
 
 import javax.annotation.Nullable;
 
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.BiFunction;
+import java.util.function.Function;
 
 /** Implementation of {@link BuiltInFunctionDefinitions#MAP_FROM_ENTRIES}. */
 @Internal
@@ -46,6 +48,9 @@ public class MapFromEntriesFunction extends BuiltInScalarFunction {
     private final RowData.FieldGetter valueFieldGetter;
 
     private final EqualityAndHashcodeProvider keyEqualityAndHashcodeProvider;
+
+    private transient BiFunction<Object, Object, Boolean> keyEquality;
+    private transient Function<Object, Integer> keyHashcode;
 
     public MapFromEntriesFunction(SpecializedFunction.SpecializedContext context) {
         super(BuiltInFunctionDefinitions.MAP_FROM_ENTRIES, context);
@@ -66,6 +71,8 @@ public class MapFromEntriesFunction extends BuiltInScalarFunction {
     @Override
     public void open(FunctionContext context) throws Exception {
         keyEqualityAndHashcodeProvider.open(context);
+        keyEquality = keyEqualityAndHashcodeProvider::equals;
+        keyHashcode = keyEqualityAndHashcodeProvider::hashCode;
     }
 
     public @Nullable MapData eval(@Nullable ArrayData input) {
@@ -73,9 +80,11 @@ public class MapFromEntriesFunction extends BuiltInScalarFunction {
             return null;
         }
 
+        final int size = input.size();
         // a duplicate key keeps the position of its first occurrence and the last value wins
-        final Map<ObjectContainer, Object> entries = new LinkedHashMap<>();
-        for (int pos = 0; pos < input.size(); pos++) {
+        final Map<ObjectContainer, Object> entries =
+                CollectionUtil.newLinkedHashMapWithExpectedSize(size);
+        for (int pos = 0; pos < size; pos++) {
             final RowData entry = (RowData) entryElementGetter.getElementOrNull(input, pos);
             if (entry == null) {
                 return null;
@@ -84,12 +93,19 @@ public class MapFromEntriesFunction extends BuiltInScalarFunction {
                     wrapKey(keyFieldGetter.getFieldOrNull(entry)),
                     valueFieldGetter.getFieldOrNull(entry));
         }
+        final int distinctKeyCount = entries.size();
+
+        final Object[] keys = new Object[distinctKeyCount];
+        final Object[] values = new Object[distinctKeyCount];
+        int pos = 0;
+        for (Map.Entry<ObjectContainer, Object> entry : entries.entrySet()) {
+            final ObjectContainer key = entry.getKey();
+            keys[pos] = key == null ? null : key.getObject();
+            values[pos] = entry.getValue();
+            pos++;
+        }
         return new MapDataForMapFromEntries(
-                new GenericArrayData(
-                        entries.keySet().stream()
-                                .map(key -> key == null ? null : key.getObject())
-                                .toArray()),
-                new GenericArrayData(entries.values().toArray()));
+                new GenericArrayData(keys), new GenericArrayData(values));
     }
 
     /**
@@ -101,10 +117,7 @@ public class MapFromEntriesFunction extends BuiltInScalarFunction {
         if (key == null) {
             return null;
         }
-        return new ObjectContainer(
-                key,
-                keyEqualityAndHashcodeProvider::equals,
-                keyEqualityAndHashcodeProvider::hashCode);
+        return new ObjectContainer(key, keyEquality, keyHashcode);
     }
 
     @Override

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/MapUnionFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/MapUnionFunction.java
@@ -26,6 +26,7 @@ import org.apache.flink.table.data.MapData;
 import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
 import org.apache.flink.table.functions.FunctionContext;
 import org.apache.flink.table.functions.SpecializedFunction;
+import org.apache.flink.table.runtime.util.MapDataContainer;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.KeyValueDataType;
 import org.apache.flink.util.FlinkRuntimeException;
@@ -88,7 +89,7 @@ public class MapUnionFunction extends BuiltInScalarFunction {
                     return null;
                 }
                 if (map.size() > 0) {
-                    result = new MapDataForMapUnion(result, map);
+                    result = mapUnion(result, map);
                 }
             }
             return result;
@@ -97,70 +98,51 @@ public class MapUnionFunction extends BuiltInScalarFunction {
         }
     }
 
-    private class MapDataForMapUnion implements MapData {
-        private final GenericArrayData keysArray;
-        private final GenericArrayData valuesArray;
-
-        public MapDataForMapUnion(MapData map1, MapData map2) throws Throwable {
-            List<Object> keysList = new ArrayList<>();
-            List<Object> valuesList = new ArrayList<>();
-            boolean isKeyNullExist = false;
-            ArrayData keyArray2 = map2.keyArray();
-            ArrayData valueArray2 = map2.valueArray();
-            for (int i = 0; i < map2.size(); i++) {
-                Object key = keyElementGetter.getElementOrNull(keyArray2, i);
-                if (key == null) {
-                    isKeyNullExist = true;
-                }
-                keysList.add(key);
-                valuesList.add(valueElementGetter.getElementOrNull(valueArray2, i));
+    private MapData mapUnion(MapData map1, MapData map2) throws Throwable {
+        List<Object> keysList = new ArrayList<>();
+        List<Object> valuesList = new ArrayList<>();
+        boolean isKeyNullExist = false;
+        ArrayData keyArray2 = map2.keyArray();
+        ArrayData valueArray2 = map2.valueArray();
+        for (int i = 0; i < map2.size(); i++) {
+            Object key = keyElementGetter.getElementOrNull(keyArray2, i);
+            if (key == null) {
+                isKeyNullExist = true;
             }
-            ArrayData keyArray1 = map1.keyArray();
-            ArrayData valueArray1 = map1.valueArray();
-            for (int i = 0; i < map1.size(); i++) {
-                final Object key1 = keyElementGetter.getElementOrNull(keyArray1, i);
+            keysList.add(key);
+            valuesList.add(valueElementGetter.getElementOrNull(valueArray2, i));
+        }
+        ArrayData keyArray1 = map1.keyArray();
+        ArrayData valueArray1 = map1.valueArray();
+        for (int i = 0; i < map1.size(); i++) {
+            final Object key1 = keyElementGetter.getElementOrNull(keyArray1, i);
 
-                boolean keyExists = false;
-                if (key1 != null) {
-                    for (int j = 0; j < keysList.size(); j++) {
-                        final Object key2 = keysList.get(j);
-                        if (key2 != null && (boolean) keyEqualityHandle.invoke(key1, key2)) {
-                            // If key exists in map2, skip this key-value pair
-                            keyExists = true;
-                            break;
-                        }
+            boolean keyExists = false;
+            if (key1 != null) {
+                for (int j = 0; j < keysList.size(); j++) {
+                    final Object key2 = keysList.get(j);
+                    if (key2 != null && (boolean) keyEqualityHandle.invoke(key1, key2)) {
+                        // If key exists in map2, skip this key-value pair
+                        keyExists = true;
+                        break;
                     }
                 }
-
-                if (isKeyNullExist && key1 == null) {
-                    continue;
-                }
-
-                // If key doesn't exist in map2, add the key-value pair from map1
-                if (!keyExists) {
-                    final Object value1 = valueElementGetter.getElementOrNull(valueArray1, i);
-                    keysList.add(key1);
-                    valuesList.add(value1);
-                }
             }
-            this.keysArray = new GenericArrayData(keysList.toArray());
-            this.valuesArray = new GenericArrayData(valuesList.toArray());
-        }
 
-        @Override
-        public int size() {
-            return keysArray.size();
-        }
+            if (isKeyNullExist && key1 == null) {
+                continue;
+            }
 
-        @Override
-        public ArrayData keyArray() {
-            return keysArray;
+            // If key doesn't exist in map2, add the key-value pair from map1
+            if (!keyExists) {
+                final Object value1 = valueElementGetter.getElementOrNull(valueArray1, i);
+                keysList.add(key1);
+                valuesList.add(value1);
+            }
         }
-
-        @Override
-        public ArrayData valueArray() {
-            return valuesArray;
-        }
+        return new MapDataContainer(
+                new GenericArrayData(keysList.toArray()),
+                new GenericArrayData(valuesList.toArray()));
     }
 
     @Override

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/util/MapDataContainer.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/util/MapDataContainer.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.flink.table.runtime.util;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.data.ArrayData;
+import org.apache.flink.table.data.GenericArrayData;
+import org.apache.flink.table.data.MapData;
+
+/** A {@link MapData} backed directly by a key array and a value array. */
+@Internal
+public class MapDataContainer implements MapData {
+    private final GenericArrayData keyArray;
+    private final GenericArrayData valueArray;
+
+    public MapDataContainer(GenericArrayData keyArray, GenericArrayData valueArray) {
+        this.keyArray = keyArray;
+        this.valueArray = valueArray;
+    }
+
+    @Override
+    public int size() {
+        return keyArray.size();
+    }
+
+    @Override
+    public ArrayData keyArray() {
+        return keyArray;
+    }
+
+    @Override
+    public ArrayData valueArray() {
+        return valueArray;
+    }
+}

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/util/MapDataContainer.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/util/MapDataContainer.java
@@ -21,16 +21,15 @@ package org.apache.flink.table.runtime.util;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.table.data.ArrayData;
-import org.apache.flink.table.data.GenericArrayData;
 import org.apache.flink.table.data.MapData;
 
 /** A {@link MapData} backed directly by a key array and a value array. */
 @Internal
 public class MapDataContainer implements MapData {
-    private final GenericArrayData keyArray;
-    private final GenericArrayData valueArray;
+    private final ArrayData keyArray;
+    private final ArrayData valueArray;
 
-    public MapDataContainer(GenericArrayData keyArray, GenericArrayData valueArray) {
+    public MapDataContainer(ArrayData keyArray, ArrayData valueArray) {
         this.keyArray = keyArray;
         this.valueArray = valueArray;
     }


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).



**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

The Purpose of this change was to add a new builtin function, MapFromEntries Function to Flink


## Brief change log

-Added mapFromEntries functionality
-Wired mapFromEntries function to flink


## Verifying this change

Please make sure both new and modified tests in this PR follow [the conventions for tests defined in our code quality guide](https://flink.apache.org/how-to-contribute/code-style-and-quality-common/#7-testing).

*(Please pick either of the following options)*


This change is already covered by existing tests, such as the ones located in 

to run test you need to run this command:
./mvnw -o -pl flink-table/flink-table-planner -Dtest='JsonFunctionsITCase'  -Dsurefire.failIfNoSpecifiedTests=false -Dcheckstyle.skip=true -Dspotless.check.skip=true -Drat.skip=true -e -Denforcer.skip=true test

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (don't know)
  - The runtime per-record code paths (performance sensitive): (don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (sql_fuunctions.yml,javadocs,pythonDocs)

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change the checkbox below to `[X]` and replace the placeholder in the "Generated-by"
line with the tool name and version. Otherwise remove the "Generated-by" line.
See the ASF Generative Tooling Guidance for details:
https://www.apache.org/legal/generative-tooling.html

You are responsible for the quality and correctness of every change in this PR
regardless of the tooling used. Low-effort AI-generated PRs will be closed. See
AGENTS.md for the full guidance.
-->

- [X] Yes (please specify the tool below)

Generated-by: Claude Opus 4.8
