### PR TITLE
[FLINK-40172][table-runtime] Support processing-time early fire on a row-time interval join

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecIntervalJoin.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecIntervalJoin.java
@@ -430,7 +430,11 @@ public class StreamExecIntervalJoin extends ExecNodeBase<RowData>
                         joinFunction,
                         windowBounds.getLeftTimeIdx(),
                         windowBounds.getRightTimeIdx(),
-                        earlyFireDelay == null ? -1L : earlyFireDelay);
+                        earlyFireDelay == null ? -1L : earlyFireDelay,
+                        // Cross-domain flag: an event-time interval join early-fires on the wall
+                        // clock while keeping its event-time cleanup. The operator only acts on it
+                        // once early-firing is enabled (earlyFireDelay >= 0).
+                        earlyFireTimeMode == EarlyFireJoinHintOptions.TimeMode.PROCTIME);
         // TODO: add async version rowJoinFunc to use AsyncKeyedCoProcessOperator
         return ExecNodeUtil.createTwoInputTransformation(
                 leftInputTransform,

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/physical/stream/StreamPhysicalIntervalJoinRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/physical/stream/StreamPhysicalIntervalJoinRule.java
@@ -187,12 +187,6 @@ public class StreamPhysicalIntervalJoinRule
                     "EARLY_FIRE hint requested row-time triggering on a processing-time interval"
                             + " join. Row-time triggering requires a row-time interval join.");
         }
-        if (isEventTime && timeMode == TimeMode.PROCTIME) {
-            // Processing-time triggering on an event-time interval join is not supported.
-            throw new TableException(
-                    "EARLY_FIRE hint requested processing-time triggering on a row-time interval"
-                            + " join, which is not yet supported.");
-        }
 
         return new EarlyFire(delay == null ? null : delay.toMillis(), timeMode);
     }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/hints/stream/EarlyFireJoinHintTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/hints/stream/EarlyFireJoinHintTest.java
@@ -202,7 +202,7 @@ class EarlyFireJoinHintTest extends TableTestBase {
                         + "FROM MyTable t1 LEFT OUTER JOIN MyTable2 t2 ON\n"
                         + "  t1.a = t2.a AND\n"
                         + "  t1.rowtime BETWEEN t2.rowtime - INTERVAL '10' SECOND AND t2.rowtime + INTERVAL '1' HOUR";
-        assertThatThrownBy(() -> verify(sql)).hasStackTraceContaining("not yet supported");
+        verify(sql);
     }
 
     @Test

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/hints/stream/EarlyFireJoinHintTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/hints/stream/EarlyFireJoinHintTest.xml
@@ -244,4 +244,36 @@ Calc(select=[a, b], changelogMode=[I,UA])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testEarlyFireProcTimeOnRowTimeJoin">
+    <Resource name="sql">
+      <![CDATA[SELECT /*+ EARLY_FIRE('delay'='5s', 'time-mode'='proctime') */ t1.a, t2.b
+FROM MyTable t1 LEFT OUTER JOIN MyTable2 t2 ON
+  t1.a = t2.a AND
+  t1.rowtime BETWEEN t2.rowtime - INTERVAL '10' SECOND AND t2.rowtime + INTERVAL '1' HOUR]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$6])
++- LogicalJoin(condition=[AND(=($0, $5), >=($4, -($9, 10000:INTERVAL SECOND)), <=($4, +($9, 3600000:INTERVAL HOUR)))], joinType=[left], joinHints=[[[EARLY_FIRE inheritPath:[0] options:{delay=5s, time-mode=proctime}]]])
+   :- LogicalWatermarkAssigner(rowtime=[rowtime], watermark=[$4])
+   :  +- LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[PROCTIME()], rowtime=[$3])
+   :     +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+   +- LogicalWatermarkAssigner(rowtime=[rowtime], watermark=[$4])
+      +- LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[PROCTIME()], rowtime=[$3])
+         +- LogicalTableScan(table=[[default_catalog, default_database, MyTable2]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[a, b])
++- IntervalJoin(joinType=[LeftOuterJoin], windowBounds=[isRowTime=true, leftLowerBound=-10000, leftUpperBound=3600000, leftTimeIndex=1, rightTimeIndex=2], where=[((a = a0) AND (rowtime >= (rowtime0 - 10000:INTERVAL SECOND)) AND (rowtime <= (rowtime0 + 3600000:INTERVAL HOUR)))], select=[a, rowtime, a0, b, rowtime0], earlyFireDelay=[5000], earlyFireTimeMode=[PROCTIME])
+   :- Exchange(distribution=[hash[a]])
+   :  +- WatermarkAssigner(rowtime=[rowtime], watermark=[rowtime])
+   :     +- TableSourceScan(table=[[default_catalog, default_database, MyTable, project=[a, rowtime], metadata=[]]], fields=[a, rowtime])
+   +- Exchange(distribution=[hash[a]])
+      +- WatermarkAssigner(rowtime=[rowtime], watermark=[rowtime])
+         +- TableSourceScan(table=[[default_catalog, default_database, MyTable2, project=[a, b, rowtime], metadata=[]]], fields=[a, b, rowtime])
+]]>
+    </Resource>
+  </TestCase>
 </Root>

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/interval/ProcTimeIntervalJoin.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/interval/ProcTimeIntervalJoin.java
@@ -45,7 +45,9 @@ public final class ProcTimeIntervalJoin extends TimeIntervalJoin {
                 leftType,
                 rightType,
                 genJoinFunc,
-                earlyFireDelay);
+                earlyFireDelay,
+                // A proctime join's early fire shares the cleanup domain; never cross-domain.
+                false);
     }
 
     @Override

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/interval/RowTimeIntervalJoin.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/interval/RowTimeIntervalJoin.java
@@ -41,7 +41,8 @@ public final class RowTimeIntervalJoin extends TimeIntervalJoin {
             IntervalJoinFunction joinFunc,
             int leftTimeIdx,
             int rightTimeIdx,
-            long earlyFireDelay) {
+            long earlyFireDelay,
+            boolean earlyFireCrossDomain) {
         super(
                 joinType,
                 leftLowerBound,
@@ -51,7 +52,8 @@ public final class RowTimeIntervalJoin extends TimeIntervalJoin {
                 leftType,
                 rightType,
                 joinFunc,
-                earlyFireDelay);
+                earlyFireDelay,
+                earlyFireCrossDomain);
         this.leftTimeIdx = leftTimeIdx;
         this.rightTimeIdx = rightTimeIdx;
     }

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/interval/TimeIntervalJoin.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/interval/TimeIntervalJoin.java
@@ -29,6 +29,7 @@ import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.typeutils.ListTypeInfo;
 import org.apache.flink.api.java.typeutils.TupleTypeInfo;
 import org.apache.flink.configuration.ReadableConfig;
+import org.apache.flink.streaming.api.TimeDomain;
 import org.apache.flink.streaming.api.functions.co.KeyedCoProcessFunction;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.runtime.operators.join.FlinkJoinType;
@@ -71,6 +72,10 @@ abstract class TimeIntervalJoin extends KeyedCoProcessFunction<RowData, RowData,
     private final long earlyFireDelay;
     // True only for an outer join with a non-negative window span and a non-negative delay.
     private final boolean earlyFireEnabled;
+    // True when the early-fire timer fires on the wall clock while cleanup stays on event time
+    // (an event-time interval join early-firing in processing-time mode). The two timer kinds then
+    // live in different domains and onTimer discriminates them by timeDomain().
+    private final boolean earlyFireCrossDomain;
 
     private transient EmitAwareCollector joinCollector;
 
@@ -87,6 +92,14 @@ abstract class TimeIntervalJoin extends KeyedCoProcessFunction<RowData, RowData,
     // on a later match (only a row that was speculatively padded needs correcting).
     private transient MapState<Long, List<Boolean>> leftFiredState;
     private transient MapState<Long, List<Boolean>> rightFiredState;
+
+    // Cross-domain early fire only: maps a firing processing-time to the event-time bucket keys
+    // whose unmatched outer rows are due to be speculatively padded at that wall-clock instant.
+    // The event-time bucket key cannot be recovered from a processing-time firing timestamp alone,
+    // so this index records it at registration and recovers it when the timer fires. Allocated only
+    // when earlyFireCrossDomain is true.
+    private transient MapState<Long, List<Long>> leftEarlyFireSchedule;
+    private transient MapState<Long, List<Long>> rightEarlyFireSchedule;
 
     // state to record the timer on the left stream. 0 means no timer set
     private transient ValueState<Long> leftTimerState;
@@ -110,7 +123,8 @@ abstract class TimeIntervalJoin extends KeyedCoProcessFunction<RowData, RowData,
             InternalTypeInfo<RowData> leftType,
             InternalTypeInfo<RowData> rightType,
             IntervalJoinFunction joinFunc,
-            long earlyFireDelay) {
+            long earlyFireDelay,
+            boolean earlyFireCrossDomain) {
         this.joinType = joinType;
         this.leftRelativeSize = -leftLowerBound;
         this.rightRelativeSize = leftUpperBound;
@@ -130,6 +144,7 @@ abstract class TimeIntervalJoin extends KeyedCoProcessFunction<RowData, RowData,
                 earlyFireDelay >= 0
                         && joinType.isOuter()
                         && (leftRelativeSize + rightRelativeSize) >= 0;
+        this.earlyFireCrossDomain = earlyFireCrossDomain;
     }
 
     @Override
@@ -174,6 +189,25 @@ abstract class TimeIntervalJoin extends KeyedCoProcessFunction<RowData, RowData,
                                             "IntervalJoinRightFired",
                                             BasicTypeInfo.LONG_TYPE_INFO,
                                             firedListTypeInfo));
+
+            if (earlyFireCrossDomain) {
+                ListTypeInfo<Long> bucketListTypeInfo =
+                        new ListTypeInfo<>(BasicTypeInfo.LONG_TYPE_INFO);
+                leftEarlyFireSchedule =
+                        getRuntimeContext()
+                                .getMapState(
+                                        new MapStateDescriptor<>(
+                                                "IntervalJoinLeftEarlyFireSchedule",
+                                                BasicTypeInfo.LONG_TYPE_INFO,
+                                                bucketListTypeInfo));
+                rightEarlyFireSchedule =
+                        getRuntimeContext()
+                                .getMapState(
+                                        new MapStateDescriptor<>(
+                                                "IntervalJoinRightEarlyFireSchedule",
+                                                BasicTypeInfo.LONG_TYPE_INFO,
+                                                bucketListTypeInfo));
+            }
         }
 
         // Initialize the timer states.
@@ -303,7 +337,7 @@ abstract class TimeIntervalJoin extends KeyedCoProcessFunction<RowData, RowData,
                 appendFired(leftFiredState, timeForLeftRow);
                 if (!emitted) {
                     // Schedule a speculative pad of this unmatched left row after the delay.
-                    registerTimer(ctx, timeForLeftRow + earlyFireDelay);
+                    scheduleEarlyFire(ctx, leftEarlyFireSchedule, timeForLeftRow);
                 }
             }
             if (rightTimerState.value() == null) {
@@ -419,7 +453,7 @@ abstract class TimeIntervalJoin extends KeyedCoProcessFunction<RowData, RowData,
                 appendFired(rightFiredState, timeForRightRow);
                 if (!emitted) {
                     // Schedule a speculative pad of this unmatched right row after the delay.
-                    registerTimer(ctx, timeForRightRow + earlyFireDelay);
+                    scheduleEarlyFire(ctx, rightEarlyFireSchedule, timeForRightRow);
                 }
             }
             if (leftTimerState.value() == null) {
@@ -439,12 +473,30 @@ abstract class TimeIntervalJoin extends KeyedCoProcessFunction<RowData, RowData,
         joinCollector.setInnerCollector(out);
         updateOperatorTime(ctx);
 
-        // Early fire runs before cleanup at a shared timestamp so a row that is both due to fire
-        // and
-        // due to expire emits its speculative pad here; the cleanup branch's fired-bit gate then
-        // suppresses a second pad. A cleanup-only timestamp finds no live unfired-unmatched row at
-        // timestamp - earlyFireDelay and is a cheap no-op.
-        if (earlyFireEnabled) {
+        if (earlyFireEnabled && earlyFireCrossDomain) {
+            // Cross-domain: early-fire timers are processing-time, cleanup timers are event-time.
+            // timeDomain() is the authoritative discriminator (a processing-time value can
+            // numerically equal an event-time cleanup value, so timestamp arithmetic is unsafe).
+            if (ctx.timeDomain() == TimeDomain.PROCESSING_TIME) {
+                if (joinType.isLeftOuter()) {
+                    fireScheduled(
+                            leftCache, leftFiredState, leftEarlyFireSchedule, timestamp, true);
+                }
+                if (joinType.isRightOuter()) {
+                    fireScheduled(
+                            rightCache, rightFiredState, rightEarlyFireSchedule, timestamp, false);
+                }
+                // Cleanup is event-time; there is nothing else to do at a processing-time firing.
+                return;
+            }
+            // EVENT_TIME falls through to the cleanup branches below; no early fire in this domain.
+        } else if (earlyFireEnabled) {
+            // Natural pairing: the early-fire timer shares its domain with cleanup and fires at
+            // rowTime + delay, so the bucket key is recovered as timestamp - delay. Early fire runs
+            // before cleanup at a shared timestamp so a row that is both due to fire and due to
+            // expire emits its speculative pad here; the cleanup branch's fired-bit gate then
+            // suppresses a second pad. A cleanup-only timestamp finds no live unfired-unmatched row
+            // and is a cheap no-op.
             long rowTime = timestamp - earlyFireDelay;
             if (joinType.isLeftOuter()) {
                 earlyFire(leftCache, leftFiredState, rowTime, true);
@@ -513,6 +565,53 @@ abstract class TimeIntervalJoin extends KeyedCoProcessFunction<RowData, RowData,
         if (changed) {
             firedState.put(rowTime, fired);
         }
+    }
+
+    /**
+     * Register the early-fire timer for an unmatched outer row. For the natural pairing the timer
+     * shares the cleanup domain and fires at {@code bucketKey + earlyFireDelay}, recoverable later
+     * as {@code timestamp - earlyFireDelay}. For the cross-domain case the timer is a
+     * processing-time timer at {@code currentProcessingTime() + earlyFireDelay}, and the event-time
+     * bucket key is recorded in the schedule under that firing time so it can be recovered when the
+     * processing-time timer fires.
+     */
+    private void scheduleEarlyFire(Context ctx, MapState<Long, List<Long>> schedule, long bucketKey)
+            throws Exception {
+        if (earlyFireCrossDomain) {
+            long firingTime = ctx.timerService().currentProcessingTime() + earlyFireDelay;
+            List<Long> buckets = schedule.get(firingTime);
+            if (buckets == null) {
+                buckets = new ArrayList<>(1);
+            }
+            buckets.add(bucketKey);
+            schedule.put(firingTime, buckets);
+            ctx.timerService().registerProcessingTimeTimer(firingTime);
+        } else {
+            registerTimer(ctx, bucketKey + earlyFireDelay);
+        }
+    }
+
+    /**
+     * Recover the event-time buckets scheduled to fire at the given processing-time and early-fire
+     * each one, then drop the schedule entry. A missing entry is a no-op; a bucket already cleaned
+     * by event-time expiry resolves to an empty cache lookup inside {@link #earlyFire} and is
+     * likewise a no-op.
+     */
+    private void fireScheduled(
+            MapState<Long, List<Tuple2<RowData, Boolean>>> rowCache,
+            MapState<Long, List<Boolean>> firedState,
+            MapState<Long, List<Long>> schedule,
+            long firingTime,
+            boolean padLeft)
+            throws Exception {
+        List<Long> buckets = schedule.get(firingTime);
+        if (buckets == null) {
+            return;
+        }
+        for (Long bucketKey : buckets) {
+            earlyFire(rowCache, firedState, bucketKey, padLeft);
+        }
+        schedule.remove(firingTime);
     }
 
     /**

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/join/interval/RowTimeIntervalJoinTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/join/interval/RowTimeIntervalJoinTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.table.runtime.operators.join.interval;
 
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.core.execution.CheckpointingMode;
+import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
 import org.apache.flink.streaming.api.operators.co.KeyedCoProcessOperator;
 import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.runtime.tasks.StreamTaskActionExecutor;
@@ -72,7 +73,8 @@ class RowTimeIntervalJoinTest extends TimeIntervalStreamJoinTestBase {
                         joinFunction,
                         0,
                         0,
-                        -1L);
+                        -1L,
+                        false);
 
         KeyedTwoInputStreamOperatorTestHarness<RowData, RowData, RowData, RowData> testHarness =
                 createTestHarness(joinProcessFunc);
@@ -147,7 +149,8 @@ class RowTimeIntervalJoinTest extends TimeIntervalStreamJoinTestBase {
                         joinFunction,
                         0,
                         0,
-                        -1L);
+                        -1L,
+                        false);
 
         KeyedTwoInputStreamOperatorTestHarness<RowData, RowData, RowData, RowData> testHarness =
                 createTestHarness(joinProcessFunc);
@@ -202,7 +205,18 @@ class RowTimeIntervalJoinTest extends TimeIntervalStreamJoinTestBase {
     void testRowTimeInnerJoinRealtimeCleanUp() throws Exception {
         RowTimeIntervalJoin joinProcessFunc =
                 new RowTimeIntervalJoin(
-                        FlinkJoinType.LEFT, -5, 9, 0, 0, rowType, rowType, joinFunction, 0, 0, -1L);
+                        FlinkJoinType.LEFT,
+                        -5,
+                        9,
+                        0,
+                        0,
+                        rowType,
+                        rowType,
+                        joinFunction,
+                        0,
+                        0,
+                        -1L,
+                        false);
         KeyedTwoInputStreamOperatorTestHarness<RowData, RowData, RowData, RowData> testHarness =
                 createTestHarness(joinProcessFunc);
 
@@ -231,7 +245,18 @@ class RowTimeIntervalJoinTest extends TimeIntervalStreamJoinTestBase {
     void testRowTimeLeftOuterJoin() throws Exception {
         RowTimeIntervalJoin joinProcessFunc =
                 new RowTimeIntervalJoin(
-                        FlinkJoinType.LEFT, -5, 9, 0, 7, rowType, rowType, joinFunction, 0, 0, -1L);
+                        FlinkJoinType.LEFT,
+                        -5,
+                        9,
+                        0,
+                        7,
+                        rowType,
+                        rowType,
+                        joinFunction,
+                        0,
+                        0,
+                        -1L,
+                        false);
 
         KeyedTwoInputStreamOperatorTestHarness<RowData, RowData, RowData, RowData> testHarness =
                 createTestHarness(joinProcessFunc);
@@ -311,7 +336,8 @@ class RowTimeIntervalJoinTest extends TimeIntervalStreamJoinTestBase {
                         joinFunction,
                         0,
                         0,
-                        -1L);
+                        -1L,
+                        false);
 
         KeyedTwoInputStreamOperatorTestHarness<RowData, RowData, RowData, RowData> testHarness =
                 createTestHarness(joinProcessFunc);
@@ -382,7 +408,18 @@ class RowTimeIntervalJoinTest extends TimeIntervalStreamJoinTestBase {
     void testRowTimeFullOuterJoin() throws Exception {
         RowTimeIntervalJoin joinProcessFunc =
                 new RowTimeIntervalJoin(
-                        FlinkJoinType.FULL, -5, 9, 0, 7, rowType, rowType, joinFunction, 0, 0, -1L);
+                        FlinkJoinType.FULL,
+                        -5,
+                        9,
+                        0,
+                        7,
+                        rowType,
+                        rowType,
+                        joinFunction,
+                        0,
+                        0,
+                        -1L,
+                        false);
 
         KeyedTwoInputStreamOperatorTestHarness<RowData, RowData, RowData, RowData> testHarness =
                 createTestHarness(joinProcessFunc);
@@ -472,7 +509,8 @@ class RowTimeIntervalJoinTest extends TimeIntervalStreamJoinTestBase {
                         joinFunction,
                         0,
                         0,
-                        -1L);
+                        -1L,
+                        false);
 
         KeyedTwoInputStreamOperatorTestHarness<RowData, RowData, RowData, RowData> testHarness =
                 createTestHarness(joinProcessFunc);
@@ -550,7 +588,18 @@ class RowTimeIntervalJoinTest extends TimeIntervalStreamJoinTestBase {
     void testRowTimeLeftOuterEarlyFire() throws Exception {
         RowTimeIntervalJoin joinProcessFunc =
                 new RowTimeIntervalJoin(
-                        FlinkJoinType.LEFT, -5, 9, 0, 0, rowType, rowType, joinFunction, 0, 0, 3L);
+                        FlinkJoinType.LEFT,
+                        -5,
+                        9,
+                        0,
+                        0,
+                        rowType,
+                        rowType,
+                        joinFunction,
+                        0,
+                        0,
+                        3L,
+                        false);
         KeyedTwoInputStreamOperatorTestHarness<RowData, RowData, RowData, RowData> testHarness =
                 createTestHarness(joinProcessFunc);
         testHarness.open();
@@ -580,7 +629,18 @@ class RowTimeIntervalJoinTest extends TimeIntervalStreamJoinTestBase {
     void testRowTimeLeftOuterEarlyFireThenMatch() throws Exception {
         RowTimeIntervalJoin joinProcessFunc =
                 new RowTimeIntervalJoin(
-                        FlinkJoinType.LEFT, -5, 9, 0, 0, rowType, rowType, joinFunction, 0, 0, 3L);
+                        FlinkJoinType.LEFT,
+                        -5,
+                        9,
+                        0,
+                        0,
+                        rowType,
+                        rowType,
+                        joinFunction,
+                        0,
+                        0,
+                        3L,
+                        false);
         KeyedTwoInputStreamOperatorTestHarness<RowData, RowData, RowData, RowData> testHarness =
                 createTestHarness(joinProcessFunc);
         testHarness.open();
@@ -612,7 +672,18 @@ class RowTimeIntervalJoinTest extends TimeIntervalStreamJoinTestBase {
     void testRowTimeRightOuterEarlyFireThenMatch() throws Exception {
         RowTimeIntervalJoin joinProcessFunc =
                 new RowTimeIntervalJoin(
-                        FlinkJoinType.RIGHT, -5, 9, 0, 0, rowType, rowType, joinFunction, 0, 0, 3L);
+                        FlinkJoinType.RIGHT,
+                        -5,
+                        9,
+                        0,
+                        0,
+                        rowType,
+                        rowType,
+                        joinFunction,
+                        0,
+                        0,
+                        3L,
+                        false);
         KeyedTwoInputStreamOperatorTestHarness<RowData, RowData, RowData, RowData> testHarness =
                 createTestHarness(joinProcessFunc);
         testHarness.open();
@@ -642,7 +713,18 @@ class RowTimeIntervalJoinTest extends TimeIntervalStreamJoinTestBase {
     void testRowTimeFullOuterEarlyFireOneMatches() throws Exception {
         RowTimeIntervalJoin joinProcessFunc =
                 new RowTimeIntervalJoin(
-                        FlinkJoinType.FULL, -5, 9, 0, 0, rowType, rowType, joinFunction, 0, 0, 3L);
+                        FlinkJoinType.FULL,
+                        -5,
+                        9,
+                        0,
+                        0,
+                        rowType,
+                        rowType,
+                        joinFunction,
+                        0,
+                        0,
+                        3L,
+                        false);
         KeyedTwoInputStreamOperatorTestHarness<RowData, RowData, RowData, RowData> testHarness =
                 createTestHarness(joinProcessFunc);
         testHarness.open();
@@ -686,7 +768,18 @@ class RowTimeIntervalJoinTest extends TimeIntervalStreamJoinTestBase {
     void testRowTimeInnerJoinIgnoresEarlyFire() throws Exception {
         RowTimeIntervalJoin joinProcessFunc =
                 new RowTimeIntervalJoin(
-                        FlinkJoinType.INNER, -5, 9, 0, 0, rowType, rowType, joinFunction, 0, 0, 3L);
+                        FlinkJoinType.INNER,
+                        -5,
+                        9,
+                        0,
+                        0,
+                        rowType,
+                        rowType,
+                        joinFunction,
+                        0,
+                        0,
+                        3L,
+                        false);
         KeyedTwoInputStreamOperatorTestHarness<RowData, RowData, RowData, RowData> testHarness =
                 createTestHarness(joinProcessFunc);
         testHarness.open();
@@ -713,7 +806,18 @@ class RowTimeIntervalJoinTest extends TimeIntervalStreamJoinTestBase {
         // Window span is 5 + 9 = 14; the delay exceeds it so cleanup may reach the row first.
         RowTimeIntervalJoin joinProcessFunc =
                 new RowTimeIntervalJoin(
-                        FlinkJoinType.LEFT, -5, 9, 0, 0, rowType, rowType, joinFunction, 0, 0, 20L);
+                        FlinkJoinType.LEFT,
+                        -5,
+                        9,
+                        0,
+                        0,
+                        rowType,
+                        rowType,
+                        joinFunction,
+                        0,
+                        0,
+                        20L,
+                        false);
         KeyedTwoInputStreamOperatorTestHarness<RowData, RowData, RowData, RowData> testHarness =
                 createTestHarness(joinProcessFunc);
         testHarness.open();
@@ -735,7 +839,18 @@ class RowTimeIntervalJoinTest extends TimeIntervalStreamJoinTestBase {
     void testRowTimeEarlyFireRowKindIsolation() throws Exception {
         RowTimeIntervalJoin joinProcessFunc =
                 new RowTimeIntervalJoin(
-                        FlinkJoinType.LEFT, -5, 9, 0, 0, rowType, rowType, joinFunction, 0, 0, 3L);
+                        FlinkJoinType.LEFT,
+                        -5,
+                        9,
+                        0,
+                        0,
+                        rowType,
+                        rowType,
+                        joinFunction,
+                        0,
+                        0,
+                        3L,
+                        false);
         KeyedTwoInputStreamOperatorTestHarness<RowData, RowData, RowData, RowData> testHarness =
                 createTestHarness(joinProcessFunc);
         testHarness.open();
@@ -768,7 +883,18 @@ class RowTimeIntervalJoinTest extends TimeIntervalStreamJoinTestBase {
     void testRowTimeLeftOuterEarlyFireMultiMatch() throws Exception {
         RowTimeIntervalJoin joinProcessFunc =
                 new RowTimeIntervalJoin(
-                        FlinkJoinType.LEFT, -5, 9, 0, 0, rowType, rowType, joinFunction, 0, 0, 3L);
+                        FlinkJoinType.LEFT,
+                        -5,
+                        9,
+                        0,
+                        0,
+                        rowType,
+                        rowType,
+                        joinFunction,
+                        0,
+                        0,
+                        3L,
+                        false);
         KeyedTwoInputStreamOperatorTestHarness<RowData, RowData, RowData, RowData> testHarness =
                 createTestHarness(joinProcessFunc);
         testHarness.open();
@@ -793,6 +919,255 @@ class RowTimeIntervalJoinTest extends TimeIntervalStreamJoinTestBase {
         expectedOutput.add(insertRecord(10L, "k1", 14L, "k1"));
         expectedOutput.add(new Watermark(30 - 9));
         assertor.assertOutputEquals("output wrong.", expectedOutput, testHarness.getOutput());
+        testHarness.close();
+    }
+
+    /**
+     * Cross-domain early fire: an event-time interval join firing speculative pads on the wall
+     * clock. The early-fire timer is a processing-time timer while cleanup stays an event-time
+     * timer, so the pad fires on a processing-time advance with the watermark unchanged.
+     */
+    @Test
+    void testRowTimeCrossDomainEarlyFireOnWallClock() throws Exception {
+        RowTimeIntervalJoin joinProcessFunc =
+                new RowTimeIntervalJoin(
+                        FlinkJoinType.LEFT,
+                        -5,
+                        9,
+                        0,
+                        0,
+                        rowType,
+                        rowType,
+                        joinFunction,
+                        0,
+                        0,
+                        3L,
+                        true);
+        KeyedTwoInputStreamOperatorTestHarness<RowData, RowData, RowData, RowData> testHarness =
+                createTestHarness(joinProcessFunc);
+        testHarness.open();
+        testHarness.setProcessingTime(0L);
+
+        testHarness.processElement1(insertRecord(10L, "k1"));
+        // The early-fire timer is processing-time (fires at now + delay = 3); the cleanup timer is
+        // event-time. The cross-domain split is visible in the per-domain timer counts.
+        assertThat(testHarness.numProcessingTimeTimers()).isEqualTo(1);
+        assertThat(testHarness.numEventTimeTimers()).isEqualTo(1);
+
+        // Advance the wall clock past the firing time without advancing the watermark: the pad
+        // fires purely on processing time.
+        testHarness.setProcessingTime(3L);
+
+        List<Object> expectedOutput = new ArrayList<>();
+        expectedOutput.add(insertRecord(10L, "k1", null, null));
+        assertor.assertOutputEquals("output wrong.", expectedOutput, testHarness.getOutput());
+        testHarness.close();
+    }
+
+    /**
+     * Cross-domain early fire followed by an in-window event-time match: the wall-clock pad is
+     * retracted via -U/+U and the later event-time cleanup emits nothing.
+     */
+    @Test
+    void testRowTimeCrossDomainEarlyFireThenMatch() throws Exception {
+        RowTimeIntervalJoin joinProcessFunc =
+                new RowTimeIntervalJoin(
+                        FlinkJoinType.LEFT,
+                        -5,
+                        9,
+                        0,
+                        0,
+                        rowType,
+                        rowType,
+                        joinFunction,
+                        0,
+                        0,
+                        3L,
+                        true);
+        KeyedTwoInputStreamOperatorTestHarness<RowData, RowData, RowData, RowData> testHarness =
+                createTestHarness(joinProcessFunc);
+        testHarness.open();
+        testHarness.setProcessingTime(0L);
+
+        testHarness.processElement1(insertRecord(10L, "k1"));
+        // Wall-clock pad fires.
+        testHarness.setProcessingTime(3L);
+
+        // A right row arrives in window (10 in [12 - 5, 12 + 9]) and matches the padded left row.
+        testHarness.processElement2(insertRecord(12L, "k1"));
+
+        // Cross cleanup on the event-time clock: no further pad, the row already matched.
+        testHarness.processWatermark1(new Watermark(30));
+        testHarness.processWatermark2(new Watermark(30));
+
+        List<Object> expectedOutput = new ArrayList<>();
+        expectedOutput.add(insertRecord(10L, "k1", null, null));
+        expectedOutput.add(updateBeforeRecord(10L, "k1", null, null));
+        expectedOutput.add(updateAfterRecord(10L, "k1", 12L, "k1"));
+        expectedOutput.add(new Watermark(30 - 9));
+        assertor.assertOutputEquals("output wrong.", expectedOutput, testHarness.getOutput());
+        testHarness.close();
+    }
+
+    /**
+     * Cross-domain restore safety: snapshot after the early-fire timer is registered but before it
+     * fires, then restore and advance the wall clock. Exactly one pad is emitted after restore -
+     * none lost, none duplicated.
+     */
+    @Test
+    void testRowTimeCrossDomainSnapshotBeforeFire() throws Exception {
+        RowTimeIntervalJoin joinProcessFunc =
+                new RowTimeIntervalJoin(
+                        FlinkJoinType.LEFT,
+                        -5,
+                        9,
+                        0,
+                        0,
+                        rowType,
+                        rowType,
+                        joinFunction,
+                        0,
+                        0,
+                        3L,
+                        true);
+        KeyedTwoInputStreamOperatorTestHarness<RowData, RowData, RowData, RowData> testHarness =
+                createTestHarness(joinProcessFunc);
+        testHarness.open();
+        testHarness.setProcessingTime(0L);
+
+        testHarness.processElement1(insertRecord(10L, "k1"));
+        // Snapshot with the processing-time early-fire timer pending (firing time is 3).
+        testHarness.prepareSnapshotPreBarrier(0L);
+        OperatorSubtaskState snapshot = testHarness.snapshot(0L, 0);
+        testHarness.close();
+
+        // Nothing was emitted before the snapshot.
+        assertThat(testHarness.getOutput()).isEmpty();
+
+        RowTimeIntervalJoin restoredFunc =
+                new RowTimeIntervalJoin(
+                        FlinkJoinType.LEFT,
+                        -5,
+                        9,
+                        0,
+                        0,
+                        rowType,
+                        rowType,
+                        newJoinFunction(),
+                        0,
+                        0,
+                        3L,
+                        true);
+        testHarness = createTestHarness(restoredFunc);
+        testHarness.setup();
+        testHarness.initializeState(snapshot);
+        testHarness.open();
+
+        // The restored processing-time timer fires once on the wall-clock advance.
+        testHarness.setProcessingTime(3L);
+
+        List<Object> expectedOutput = new ArrayList<>();
+        expectedOutput.add(insertRecord(10L, "k1", null, null));
+        assertor.assertOutputEquals("output wrong.", expectedOutput, testHarness.getOutput());
+        testHarness.close();
+    }
+
+    /**
+     * Cross-domain restore safety: snapshot after the pad has already been emitted, then restore
+     * and let a match arrive. The positional fired bit survives the restore so the post-restore
+     * match still retracts the pad via -U/+U.
+     */
+    @Test
+    void testRowTimeCrossDomainSnapshotAfterFire() throws Exception {
+        RowTimeIntervalJoin joinProcessFunc =
+                new RowTimeIntervalJoin(
+                        FlinkJoinType.LEFT,
+                        -5,
+                        9,
+                        0,
+                        0,
+                        rowType,
+                        rowType,
+                        joinFunction,
+                        0,
+                        0,
+                        3L,
+                        true);
+        KeyedTwoInputStreamOperatorTestHarness<RowData, RowData, RowData, RowData> testHarness =
+                createTestHarness(joinProcessFunc);
+        testHarness.open();
+        testHarness.setProcessingTime(0L);
+
+        testHarness.processElement1(insertRecord(10L, "k1"));
+        // Fire the wall-clock pad before snapshotting.
+        testHarness.setProcessingTime(3L);
+        testHarness.prepareSnapshotPreBarrier(0L);
+        OperatorSubtaskState snapshot = testHarness.snapshot(0L, 0);
+        testHarness.close();
+
+        RowTimeIntervalJoin restoredFunc =
+                new RowTimeIntervalJoin(
+                        FlinkJoinType.LEFT,
+                        -5,
+                        9,
+                        0,
+                        0,
+                        rowType,
+                        rowType,
+                        newJoinFunction(),
+                        0,
+                        0,
+                        3L,
+                        true);
+        testHarness = createTestHarness(restoredFunc);
+        testHarness.setup();
+        testHarness.initializeState(snapshot);
+        testHarness.open();
+        testHarness.setProcessingTime(3L);
+
+        // A match arrives after restore; the restored fired bit drives the -U/+U correction.
+        testHarness.processElement2(insertRecord(12L, "k1"));
+        testHarness.processWatermark1(new Watermark(30));
+        testHarness.processWatermark2(new Watermark(30));
+
+        List<Object> expectedOutput = new ArrayList<>();
+        expectedOutput.add(updateBeforeRecord(10L, "k1", null, null));
+        expectedOutput.add(updateAfterRecord(10L, "k1", 12L, "k1"));
+        expectedOutput.add(new Watermark(30 - 9));
+        assertor.assertOutputEquals("output wrong.", expectedOutput, testHarness.getOutput());
+        testHarness.close();
+    }
+
+    /** An inner join with the cross-domain hint must not early-fire: the no-op guard holds. */
+    @Test
+    void testRowTimeCrossDomainInnerJoinIgnoresEarlyFire() throws Exception {
+        RowTimeIntervalJoin joinProcessFunc =
+                new RowTimeIntervalJoin(
+                        FlinkJoinType.INNER,
+                        -5,
+                        9,
+                        0,
+                        0,
+                        rowType,
+                        rowType,
+                        joinFunction,
+                        0,
+                        0,
+                        3L,
+                        true);
+        KeyedTwoInputStreamOperatorTestHarness<RowData, RowData, RowData, RowData> testHarness =
+                createTestHarness(joinProcessFunc);
+        testHarness.open();
+        testHarness.setProcessingTime(0L);
+
+        testHarness.processElement1(insertRecord(10L, "k1"));
+        // No early-fire processing-time timer for an inner join: only the event-time cleanup timer.
+        assertThat(testHarness.numProcessingTimeTimers()).isEqualTo(0);
+        assertThat(testHarness.numEventTimeTimers()).isEqualTo(1);
+
+        testHarness.setProcessingTime(3L);
+
+        assertThat(testHarness.getOutput()).isEmpty();
         testHarness.close();
     }
 

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/join/interval/TimeIntervalStreamJoinTestBase.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/join/interval/TimeIntervalStreamJoinTestBase.java
@@ -50,10 +50,15 @@ abstract class TimeIntervalStreamJoinTestBase {
                     + "        return true;\n"
                     + "    }\n"
                     + "}\n";
-    protected IntervalJoinFunction joinFunction =
-            new IntervalJoinFunction(
-                    new GeneratedJoinCondition(
-                            "TestIntervalJoinCondition", funcCode, new Object[0]),
-                    outputRowType,
-                    new boolean[] {true});
+    protected IntervalJoinFunction joinFunction = newJoinFunction();
+
+    // IntervalJoinFunction.open() consumes its generated-code field (sets it to null), so a single
+    // instance cannot be opened twice. Restore tests that open a second operator must build a fresh
+    // function for the restored harness.
+    protected IntervalJoinFunction newJoinFunction() {
+        return new IntervalJoinFunction(
+                new GeneratedJoinCondition("TestIntervalJoinCondition", funcCode, new Object[0]),
+                outputRowType,
+                new boolean[] {true});
+    }
 }


### PR DESCRIPTION
Part of the FLIP-497 implementation stack under umbrella [FLINK-36953](https://issues.apache.org/jira/browse/FLINK-36953). Landing order:

| Step | Sub-task | Scope |
| --- | --- | --- |
| PR-1a | [FLINK-40167](https://issues.apache.org/jira/browse/FLINK-40167) | EARLY_FIRE hint surface + option validation (#28353, merged) |
| PR-1b | [FLINK-40168](https://issues.apache.org/jira/browse/FLINK-40168) | Thread the hint into the interval join (#28796, merged) |
| PR-2 | [FLINK-40169](https://issues.apache.org/jira/browse/FLINK-40169) | `target` option (#28827, merged) |
| PR-3 | [FLINK-40170](https://issues.apache.org/jira/browse/FLINK-40170) | Update-producing changelog mode + insert-only guard (#28877, merged) |
| PR-4 | [FLINK-40171](https://issues.apache.org/jira/browse/FLINK-40171) | Runtime early-fire emit + retraction (#28952, merged) |
| **PR-5 (this PR)** | [FLINK-40172](https://issues.apache.org/jira/browse/FLINK-40172) | Processing-time early fire on an event-time join |
| PR-6 | [FLINK-40173](https://issues.apache.org/jira/browse/FLINK-40173) | State restore coverage |
| PR-7 | [FLINK-40174](https://issues.apache.org/jira/browse/FLINK-40174) | User-facing documentation |

## What is the purpose of the change

Allows a processing-time early-fire delay on an event-time interval join. That pairing was previously rejected at planning with a "not yet supported" error. The join still matches on event time; only the early-fire trigger runs on processing time, so a speculative row can be emitted on a wall-clock delay even when watermarks are sparse or stalled.

## Brief change log

  - Drop the planning guard that rejected a processing-time delay on an event-time join.
  - When the hint asks for it, register the early-fire timer on the processing-time timer service, computing the firing time as `currentProcessingTime() + delay`. The join's matching and its state cleanup stay on event time.
  - Track the row's event time as a bucket key in new per-side schedule state, since a processing-time firing timestamp cannot be mapped back to an event-time bucket.
  - A single `onTimer` serves both domains and dispatches on `ctx.timeDomain()`.
  - `StreamExecIntervalJoin` passes the resolved time mode through to the operator.

## Verifying this change

This change added tests and can be verified as follows:

  - `EarlyFireJoinHintTest.testEarlyFireProcTimeOnRowTimeJoin` flips from asserting the old rejection to a golden plan, which records `earlyFireTimeMode=[PROCTIME]` on a join whose bounds are `isRowTime=true`. The opposite pairing stays rejected, covered by `testEarlyFireRowTimeOnProcTimeJoin`.
  - Harness tests in `RowTimeIntervalJoinTest` drive the two clocks independently. One case fires the pad on a wall-clock advance with the watermark untouched. Together they cover the speculative emit, its `-U`/`+U` correction, an inner join correctly ignoring the hint, and snapshot/restore on both sides of the firing.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): yes, the interval join record path. The behavior is gated on the hint and off by default.
  - Anything that affects deployment or recovery: yes. This adds per-side early-fire schedule state alongside the bookkeeping `MapState` introduced in PR-4. Restore is covered by tests taking a snapshot both before and after the speculative row fires.
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no (extends the FLIP-497 hint to a time-domain pairing that was previously rejected)
  - If yes, how is the feature documented? not applicable

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: Claude Code (Anthropic)
