### PR TITLE
[hotfix][ci] Bump github-script to v9 in action.yml

### DIFF
--- a/.github/actions/last_workflow_run/action.yml
+++ b/.github/actions/last_workflow_run/action.yml
@@ -40,7 +40,7 @@ runs:
   steps:
     - name: "Query workflow runs"
       id: resolve
-      uses: actions/github-script@v7
+      uses: actions/github-script@v9
       with:
         script: |
           const workflowId = "${{ inputs.workflow_id }}";


### PR DESCRIPTION

## What is the purpose of the change
The PR bumps github-script to v9 to fix warnings like at https://github.com/apache/flink/actions/runs/31820639896

## Brief change log

GHA

## Verifying this change
GHA warnings
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: ( no)
  - The runtime per-record code paths (performance sensitive): (no )
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: ( no )
  - The S3 file system connector: (no )

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable)

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change the checkbox below to `[X]` and replace the placeholder in the "Generated-by"
line with the tool name and version. Otherwise remove the "Generated-by" line.
See the ASF Generative Tooling Guidance for details:
https://www.apache.org/legal/generative-tooling.html

You are responsible for the quality and correctness of every change in this PR
regardless of the tooling used. Low-effort AI-generated PRs will be closed. See
AGENTS.md for the full guidance.
-->

- [ ] Yes (please specify the tool below)

Generated-by: [Tool Name and Version]
