### PR TITLE
[FLINK-40373][table] `JSON_VALUE` might fail on code gen for null input

### DIFF
--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/calls/JsonParseReuse.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/calls/JsonParseReuse.scala
@@ -57,7 +57,7 @@ object JsonParseReuse {
         val lastInputName = CodeGenUtils.newName(ctx, "jsonParsedInput")
         val methodName = CodeGenUtils.newName(ctx, "parseJson")
         val typeName = classOf[SqlJsonUtils.JsonValueContext].getName
-        val inputType = CodeGenUtils.BINARY_STRING
+        val inputType = CodeGenUtils.boxedTypeTermForType(input.resultType)
         ctx.addReusableMember(s"$typeName $varName;")
         ctx.addReusableMember(s"$inputType $lastInputName;")
 

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/JsonFunctionsITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/JsonFunctionsITCase.java
@@ -530,9 +530,12 @@ class JsonFunctionsITCase extends BuiltInFunctionTestBase {
                         List.of("account", "42"),
                         List.of(STRING(), STRING()))
                 .testSqlResult(
-                        "JSON_VALUE(f1, '$.type'), JSON_VALUE(f2, '$.type')",
-                        Arrays.asList(null, null),
-                        List.of(STRING(), STRING()));
+                        "JSON_VALUE(f1, '$.type'), "
+                                + "JSON_VALUE(f2, '$.type'), "
+                                + "JSON_VALUE(CAST(NULL AS INT), '$.type'), "
+                                + "JSON_VALUE(CAST(NULL AS DATE), '$.type')",
+                        Arrays.asList(null, null, null, null),
+                        List.of(STRING(), STRING(), STRING(), STRING()));
     }
 
     private static List<TestSetSpec> isJsonSpec() {

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/JsonFunctionsITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/JsonFunctionsITCase.java
@@ -41,6 +41,7 @@ import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -407,8 +408,8 @@ class JsonFunctionsITCase extends BuiltInFunctionTestBase {
     private static TestSetSpec jsonValueSpec() {
         final String jsonValue = getJsonFromResource("/json/json-value.json");
         return TestSetSpec.forFunction(BuiltInFunctionDefinitions.JSON_VALUE)
-                .onFieldsWithData(jsonValue)
-                .andDataTypes(STRING())
+                .onFieldsWithData(jsonValue, jsonValue.getBytes(StandardCharsets.UTF_8), Row.of(jsonValue))
+                .andDataTypes(STRING(), VARBINARY(Integer.MAX_VALUE), ROW(FIELD("json", STRING())))
 
                 // NULL and invalid types
                 .testResult(
@@ -525,6 +526,10 @@ class JsonFunctionsITCase extends BuiltInFunctionTestBase {
                 .testSqlResult(
                         "JSON_VALUE(f0, '$.type'), JSON_VALUE(f0, '$.age')",
                         List.of("account", "42"),
+                        List.of(STRING(), STRING()))
+                .testSqlResult(
+                        "JSON_VALUE(f1, '$.type'), JSON_VALUE(f2, '$.type')",
+                        Arrays.asList(null, null),
                         List.of(STRING(), STRING()));
     }
 

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/JsonFunctionsITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/JsonFunctionsITCase.java
@@ -51,6 +51,7 @@ import java.util.stream.Stream;
 import static org.apache.flink.table.api.DataTypes.ARRAY;
 import static org.apache.flink.table.api.DataTypes.BINARY;
 import static org.apache.flink.table.api.DataTypes.BOOLEAN;
+import static org.apache.flink.table.api.DataTypes.BYTES;
 import static org.apache.flink.table.api.DataTypes.DECIMAL;
 import static org.apache.flink.table.api.DataTypes.DOUBLE;
 import static org.apache.flink.table.api.DataTypes.FIELD;
@@ -408,8 +409,9 @@ class JsonFunctionsITCase extends BuiltInFunctionTestBase {
     private static TestSetSpec jsonValueSpec() {
         final String jsonValue = getJsonFromResource("/json/json-value.json");
         return TestSetSpec.forFunction(BuiltInFunctionDefinitions.JSON_VALUE)
-                .onFieldsWithData(jsonValue, jsonValue.getBytes(StandardCharsets.UTF_8), Row.of(jsonValue))
-                .andDataTypes(STRING(), VARBINARY(Integer.MAX_VALUE), ROW(FIELD("json", STRING())))
+                .onFieldsWithData(
+                        jsonValue, jsonValue.getBytes(StandardCharsets.UTF_8), Row.of(jsonValue))
+                .andDataTypes(STRING(), BYTES(), ROW(FIELD("json", STRING())))
 
                 // NULL and invalid types
                 .testResult(


### PR DESCRIPTION

## What is the purpose of the change

The problem is the query like
```sql
SELECT json_value(null, '$.type'), json_value(null, '$.type');
```
## Brief change log

json

## Verifying this change

test is provided
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change the checkbox below to `[X]` and replace the placeholder in the "Generated-by"
line with the tool name and version. Otherwise remove the "Generated-by" line.
See the ASF Generative Tooling Guidance for details:
https://www.apache.org/legal/generative-tooling.html

You are responsible for the quality and correctness of every change in this PR
regardless of the tooling used. Low-effort AI-generated PRs will be closed. See
AGENTS.md for the full guidance.
-->

- [ ] Yes (please specify the tool below)

Generated-by: [Tool Name and Version]
