### PR TITLE
[FLINK-40376][formats] Support `VARIANT` type in `flink-json` converters

### DIFF
--- a/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/JsonParserToRowDataConverters.java
+++ b/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/JsonParserToRowDataConverters.java
@@ -37,6 +37,8 @@ import org.apache.flink.table.types.logical.MapType;
 import org.apache.flink.table.types.logical.MultisetType;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.logical.utils.LogicalTypeUtils;
+import org.apache.flink.types.variant.BinaryVariant;
+import org.apache.flink.types.variant.BinaryVariantInternalBuilder;
 
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonParser;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonToken;
@@ -167,6 +169,8 @@ public class JsonParserToRowDataConverters implements Serializable {
             case BINARY:
             case VARBINARY:
                 return JsonParser::getBinaryValue;
+            case VARIANT:
+                return this::convertToVariant;
             case DECIMAL:
                 return createDecimalConverter((DecimalType) type);
             case ARRAY:
@@ -321,6 +325,10 @@ public class JsonParserToRowDataConverters implements Serializable {
         } else {
             return StringData.fromString(jp.getText());
         }
+    }
+
+    private BinaryVariant convertToVariant(JsonParser jp) throws IOException {
+        return BinaryVariantInternalBuilder.parseJson(jp.readValueAsTree().toString(), false);
     }
 
     private JsonParserToRowDataConverter createDecimalConverter(DecimalType decimalType) {

--- a/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/JsonToRowDataConverters.java
+++ b/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/JsonToRowDataConverters.java
@@ -37,6 +37,8 @@ import org.apache.flink.table.types.logical.MapType;
 import org.apache.flink.table.types.logical.MultisetType;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.logical.utils.LogicalTypeUtils;
+import org.apache.flink.types.variant.BinaryVariant;
+import org.apache.flink.types.variant.BinaryVariantInternalBuilder;
 
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.JsonNode;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.node.ArrayNode;
@@ -137,6 +139,8 @@ public class JsonToRowDataConverters implements Serializable {
             case BINARY:
             case VARBINARY:
                 return this::convertToBytes;
+            case VARIANT:
+                return this::convertToVariant;
             case DECIMAL:
                 return createDecimalConverter((DecimalType) type);
             case ARRAY:
@@ -267,6 +271,14 @@ public class JsonToRowDataConverters implements Serializable {
             return StringData.fromString(jsonNode.toString());
         } else {
             return StringData.fromString(jsonNode.asText());
+        }
+    }
+
+    private BinaryVariant convertToVariant(JsonNode jsonNode) {
+        try {
+            return BinaryVariantInternalBuilder.parseJson(jsonNode.toString(), false);
+        } catch (IOException e) {
+            throw new JsonParseException("Unable to deserialize VARIANT value.", e);
         }
     }
 

--- a/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/RowDataToJsonConverters.java
+++ b/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/RowDataToJsonConverters.java
@@ -33,12 +33,14 @@ import org.apache.flink.table.types.logical.LogicalTypeFamily;
 import org.apache.flink.table.types.logical.MapType;
 import org.apache.flink.table.types.logical.MultisetType;
 import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.types.variant.Variant;
 
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.JsonNode;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.node.ArrayNode;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.node.ObjectNode;
 
+import java.io.IOException;
 import java.io.Serializable;
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -149,6 +151,8 @@ public class RowDataToJsonConverters implements Serializable {
                         new IntType());
             case ROW:
                 return createRowConverter((RowType) type);
+            case VARIANT:
+                return this::convertVariant;
             case RAW:
             default:
                 throw new UnsupportedOperationException("Not support to parse type: " + type);
@@ -164,6 +168,14 @@ public class RowDataToJsonConverters implements Serializable {
                                     ? bd
                                     : bd.stripTrailingZeros());
         };
+    }
+
+    private JsonNode convertVariant(ObjectMapper mapper, JsonNode reuse, Object value) {
+        try {
+            return mapper.readTree(((Variant) value).toJson());
+        } catch (IOException e) {
+            throw new JsonParseException("Unable to serialize VARIANT value.", e);
+        }
     }
 
     private RowDataToJsonConverter createDateConverter() {

--- a/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/JsonRowDataSerDeSchemaTest.java
+++ b/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/JsonRowDataSerDeSchemaTest.java
@@ -36,6 +36,7 @@ import org.apache.flink.testutils.junit.extensions.parameterized.ParameterizedTe
 import org.apache.flink.testutils.junit.extensions.parameterized.Parameters;
 import org.apache.flink.testutils.logging.LoggerAuditingExtension;
 import org.apache.flink.types.Row;
+import org.apache.flink.types.variant.BinaryVariantBuilder;
 import org.apache.flink.util.Collector;
 import org.apache.flink.util.jackson.JacksonMapperFactory;
 
@@ -87,6 +88,7 @@ import static org.apache.flink.table.api.DataTypes.TIME;
 import static org.apache.flink.table.api.DataTypes.TIMESTAMP;
 import static org.apache.flink.table.api.DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE;
 import static org.apache.flink.table.api.DataTypes.TINYINT;
+import static org.apache.flink.table.api.DataTypes.VARIANT;
 import static org.apache.flink.table.types.utils.TypeConversions.fromLogicalToDataType;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -237,6 +239,113 @@ public class JsonRowDataSerDeSchemaTest {
 
         byte[] actualBytes = serializationSchema.serialize(rowData);
         assertThat(serializedJson).containsExactly(actualBytes);
+    }
+
+    @TestTemplate
+    void testVariantScalarsAndNestedTypes() throws Exception {
+        String json =
+                "{\"string\":\"Flink\",\"boolean\":true,\"integer\":42,\"decimal\":3.14,"
+                        + "\"array\":[1,{\"nested\":\"value\"}],\"nestedArray\":[\"array\"],"
+                        + "\"nestedMap\":{\"key\":\"map\"},\"nestedRow\":{\"field\":\"row\"}}";
+        DataType dataType =
+                ROW(
+                        FIELD("string", VARIANT()),
+                        FIELD("boolean", VARIANT()),
+                        FIELD("integer", VARIANT()),
+                        FIELD("decimal", VARIANT()),
+                        FIELD("array", VARIANT()),
+                        FIELD("nestedArray", ARRAY(VARIANT())),
+                        FIELD("nestedMap", MAP(STRING(), VARIANT())),
+                        FIELD("nestedRow", ROW(FIELD("field", VARIANT()))));
+        RowType rowType = (RowType) dataType.getLogicalType();
+
+        DeserializationSchema<RowData> deserializationSchema =
+                createDeserializationSchema(
+                        isJsonParser, rowType, false, false, TimestampFormat.ISO_8601);
+        open(deserializationSchema);
+
+        RowData rowData = deserializationSchema.deserialize(json.getBytes());
+        assertThat(rowData.getVariant(0).toJson()).isEqualTo("\"Flink\"");
+        assertThat(rowData.getVariant(1).toJson()).isEqualTo("true");
+        assertThat(rowData.getVariant(2).toJson()).isEqualTo("42");
+        assertThat(rowData.getVariant(3).toJson()).isEqualTo("3.14");
+        assertThat(rowData.getVariant(4).toJson()).isEqualTo("[1,{\"nested\":\"value\"}]");
+        assertThat(rowData.getArray(5).getVariant(0).toJson()).isEqualTo("\"array\"");
+        assertThat(rowData.getMap(6).valueArray().getVariant(0).toJson()).isEqualTo("\"map\"");
+        assertThat(rowData.getRow(7, 1).getVariant(0).toJson()).isEqualTo("\"row\"");
+
+        JsonRowDataSerializationSchema serializationSchema =
+                new JsonRowDataSerializationSchema(
+                        rowType,
+                        TimestampFormat.ISO_8601,
+                        JsonFormatOptions.MapNullKeyMode.LITERAL,
+                        "null",
+                        true,
+                        false);
+        open(serializationSchema);
+
+        assertThat(OBJECT_MAPPER.readTree(serializationSchema.serialize(rowData)))
+                .isEqualTo(OBJECT_MAPPER.readTree(json));
+    }
+
+    @TestTemplate
+    void testVariantDuplicateKeysUseLastValue() throws Exception {
+        byte[] json = "{\"variant\":{\"key\":1,\"key\":2}}".getBytes();
+        RowType rowType = (RowType) ROW(FIELD("variant", VARIANT())).getLogicalType();
+
+        DeserializationSchema<RowData> deserializationSchema =
+                createDeserializationSchema(
+                        isJsonParser, rowType, false, false, TimestampFormat.ISO_8601);
+        open(deserializationSchema);
+        assertThat(deserializationSchema.deserialize(json).getVariant(0).toJson())
+                .isEqualTo("{\"key\":2}");
+    }
+
+    @TestTemplate
+    void testVariantJsonNullIsDeserializedAsSqlNull() throws Exception {
+        byte[] json = "{\"variant\":null}".getBytes();
+        RowType rowType = (RowType) ROW(FIELD("variant", VARIANT())).getLogicalType();
+
+        DeserializationSchema<RowData> deserializationSchema =
+                createDeserializationSchema(
+                        isJsonParser, rowType, false, false, TimestampFormat.ISO_8601);
+        open(deserializationSchema);
+        assertThat(deserializationSchema.deserialize(json).isNullAt(0)).isTrue();
+
+        JsonRowDataSerializationSchema serializationSchema =
+                new JsonRowDataSerializationSchema(
+                        rowType,
+                        TimestampFormat.ISO_8601,
+                        JsonFormatOptions.MapNullKeyMode.LITERAL,
+                        "null",
+                        true,
+                        false);
+        open(serializationSchema);
+        assertThat(
+                        serializationSchema.serialize(
+                                GenericRowData.of(new BinaryVariantBuilder().ofNull())))
+                .containsExactly(json);
+    }
+
+    @Test
+    void testVariantSerializationRejectsNonFiniteNumbers() {
+        RowType rowType = (RowType) ROW(FIELD("variant", VARIANT())).getLogicalType();
+        JsonRowDataSerializationSchema serializationSchema =
+                new JsonRowDataSerializationSchema(
+                        rowType,
+                        TimestampFormat.ISO_8601,
+                        JsonFormatOptions.MapNullKeyMode.LITERAL,
+                        "null",
+                        true,
+                        false);
+        open(serializationSchema);
+
+        assertThatThrownBy(
+                        () ->
+                                serializationSchema.serialize(
+                                        GenericRowData.of(
+                                                new BinaryVariantBuilder().of(Double.NaN))))
+                .hasMessage("Non-finite value NaN cannot be serialized to JSON.");
     }
 
     @Test


### PR DESCRIPTION
## What is the purpose of the change

Integrate `VARIANT` handling to `flink-json` converters.

## Brief change log

- Added `VARIANT` deserialization support to both JSON tree and streaming converters.
- Added `VARIANT` serialization support in the JSON row-data converter.

## Verifying this change

This change added tests and can be verified as follows:

- Added round-trip tests for nested `VARIANT` objects and arrays through both JSON deserializers.
- Added coverage for scalar `VARIANT` values and variants nested in arrays, maps, and rows.
- Added tests for duplicate JSON keys, JSON-null behavior, and rejection of non-finite variant values during serialization.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable

---

##### Was generative AI tooling used to co-author this PR?

- [x] Yes

Generated-by: openai/gpt-5.6-terra
