### PR TITLE
[FLINK-40209][checkpoint] Introduce Regional Checkpoint core mechanism and notification dispatch

### DIFF
--- a/docs/layouts/shortcodes/generated/checkpointing_configuration.html
+++ b/docs/layouts/shortcodes/generated/checkpointing_configuration.html
@@ -141,6 +141,24 @@
             <td>The maximum number of completed checkpoints to retain.</td>
         </tr>
         <tr>
+            <td><h5>execution.checkpointing.region.enabled</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>Global switch for Regional Checkpoint. When enabled, partial region failures during checkpoint will not abort the entire checkpoint. Historical state will be used for failed regions.</td>
+        </tr>
+        <tr>
+            <td><h5>execution.checkpointing.region.max-consecutive-failures</h5></td>
+            <td style="word-wrap: break-word;">2</td>
+            <td>Integer</td>
+            <td>Maximum number of consecutive checkpoints that may reference historical checkpoint state.</td>
+        </tr>
+        <tr>
+            <td><h5>execution.checkpointing.region.max-failure-ratio</h5></td>
+            <td style="word-wrap: break-word;">0.3</td>
+            <td>Double</td>
+            <td>Maximum ratio of regions that may fail within a single checkpoint and still allow commit.</td>
+        </tr>
+        <tr>
             <td><h5>execution.checkpointing.savepoint-dir</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>String</td>

--- a/docs/layouts/shortcodes/generated/expert_checkpointing_section.html
+++ b/docs/layouts/shortcodes/generated/expert_checkpointing_section.html
@@ -21,6 +21,24 @@
             <td>The minimum size of state data files. All state chunks smaller than that are stored inline in the root checkpoint metadata file. The max memory threshold for this configuration is 1MB.</td>
         </tr>
         <tr>
+            <td><h5>execution.checkpointing.region.enabled</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>Global switch for Regional Checkpoint. When enabled, partial region failures during checkpoint will not abort the entire checkpoint. Historical state will be used for failed regions.</td>
+        </tr>
+        <tr>
+            <td><h5>execution.checkpointing.region.max-consecutive-failures</h5></td>
+            <td style="word-wrap: break-word;">2</td>
+            <td>Integer</td>
+            <td>Maximum number of consecutive checkpoints that may reference historical checkpoint state.</td>
+        </tr>
+        <tr>
+            <td><h5>execution.checkpointing.region.max-failure-ratio</h5></td>
+            <td style="word-wrap: break-word;">0.3</td>
+            <td>Double</td>
+            <td>Maximum ratio of regions that may fail within a single checkpoint and still allow commit.</td>
+        </tr>
+        <tr>
             <td><h5>execution.checkpointing.write-buffer-size</h5></td>
             <td style="word-wrap: break-word;">4096</td>
             <td>Integer</td>

--- a/flink-core/src/main/java/org/apache/flink/api/common/state/CheckpointListener.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/state/CheckpointListener.java
@@ -19,6 +19,7 @@
 package org.apache.flink.api.common.state;
 
 import org.apache.flink.annotation.Public;
+import org.apache.flink.annotation.PublicEvolving;
 
 /**
  * This interface is typically only needed for transactional interaction with the "outside world",
@@ -120,6 +121,60 @@ public interface CheckpointListener {
      *     the task. Note that this will NOT lead to the checkpoint being revoked.
      */
     void notifyCheckpointComplete(long checkpointId) throws Exception;
+
+    /**
+     * Notifies the listener that the checkpoint with the given {@code checkpointId} completed and
+     * was committed, providing additional context about whether this is a regional checkpoint.
+     *
+     * <p>This method is called instead of {@link #notifyCheckpointComplete(long)} when the
+     * framework has Regional Checkpoint information available. The default implementation delegates
+     * to {@link #notifyCheckpointComplete(long)}, so existing implementations are unaffected.
+     *
+     * <p>Implementations that need to distinguish between global checkpoints (all tasks
+     * acknowledged) and regional checkpoints (some tasks fell back to historical state) can
+     * override this method to inspect the {@link RegionalCheckpointInfo}.
+     *
+     * <p>Per FLIP-600, this method is called on <b>healthy-region tasks</b> only. Tasks in failed
+     * regions receive {@link #notifyRegionalCheckpointFallback(long, long)} instead.
+     *
+     * @param checkpointId The ID of the checkpoint that has been completed.
+     * @param regionalCheckpointInfo Context about which subtasks used historical state. Use {@link
+     *     RegionalCheckpointInfo#isGlobalCheckpoint()} to check if all tasks acknowledged.
+     * @throws Exception This method can propagate exceptions, which leads to a failure/recovery for
+     *     the task. Note that this will NOT lead to the checkpoint being revoked.
+     */
+    @PublicEvolving
+    default void notifyRegionalCheckpointComplete(
+            long checkpointId, RegionalCheckpointInfo regionalCheckpointInfo) throws Exception {
+        notifyCheckpointComplete(checkpointId);
+    }
+
+    /**
+     * Notifies the listener that a regional checkpoint has completed but this task's region fell
+     * back to a historical checkpoint. Sent to tasks in failed regions so they can clean up stale
+     * local state from the aborted attempt.
+     *
+     * <p>Per FLIP-600, this method is called on <b>failed-region tasks</b> only. Tasks in healthy
+     * regions receive {@link #notifyRegionalCheckpointComplete(long, RegionalCheckpointInfo)}
+     * instead.
+     *
+     * <p>When a regional checkpoint completes, the framework may have already cancelled/restarted
+     * the failed-region tasks (decline path) or they may still be running but did not finish the
+     * checkpoint (timeout path). This notification is delivered via the same task-side
+     * checkpoint-complete RPC path so that it survives task restarts and is applied after the task
+     * is recovered. Implementations that maintain local checkpoint state (e.g. {@code
+     * TaskLocalStateStore}) should override this method to discard the stale local state of the
+     * failed checkpoint attempt.
+     *
+     * <p>Default: no-op for backward compatibility.
+     *
+     * @param checkpointId the completed regional checkpoint id
+     * @param fallbackCheckpointId the historical checkpoint this task fell back to
+     */
+    @PublicEvolving
+    default void notifyRegionalCheckpointFallback(long checkpointId, long fallbackCheckpointId) {
+        // no-op for backward compatibility
+    }
 
     /**
      * This method is called as a notification once a distributed checkpoint has been aborted.

--- a/flink-core/src/main/java/org/apache/flink/api/common/state/RegionalCheckpointInfo.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/state/RegionalCheckpointInfo.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.common.state;
+
+import org.apache.flink.annotation.PublicEvolving;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Provides context about a completed checkpoint, allowing {@link CheckpointListener}
+ * implementations to distinguish between a global checkpoint and a regional checkpoint.
+ *
+ * <p>A <b>global checkpoint</b> is one where all tasks acknowledged successfully. A <b>regional
+ * checkpoint</b> is one where some tasks failed to acknowledge and their state was replaced by
+ * state from a previous successful checkpoint.
+ *
+ * <p>This class provides:
+ *
+ * <ul>
+ *   <li>{@link #isGlobalCheckpoint()} — whether all tasks contributed current state
+ *   <li>{@link #getFallbackCheckpointSubtasks()} — which subtasks (by operator name and subtask
+ *       index) used historical state, grouped by the fallback checkpoint ID they reference
+ * </ul>
+ *
+ * <p>For a global checkpoint, {@link #isGlobalCheckpoint()} returns {@code true} and the fallback
+ * map is empty.
+ */
+@PublicEvolving
+public class RegionalCheckpointInfo {
+
+    /** Singleton instance representing a global checkpoint (no fallback subtasks). */
+    private static final RegionalCheckpointInfo GLOBAL =
+            new RegionalCheckpointInfo(Collections.emptyMap());
+
+    /**
+     * Mapping from fallback checkpointId to the set of operator-subtask identifiers whose state
+     * originates from that historical checkpoint rather than the current one.
+     *
+     * <p>Each entry in the set is formatted as "operatorName#subtaskIndex" (e.g., "Source:
+     * my_source -> Sink: my_sink#0"). In practice, implementations typically only need to check
+     * {@link #isGlobalCheckpoint()} or use {@link #getFallbackCheckpointIds()} to determine which
+     * historical checkpoints are referenced.
+     */
+    private final Map<Long, Set<String>> fallbackCheckpointSubtasks;
+
+    public RegionalCheckpointInfo(Map<Long, Set<String>> fallbackCheckpointSubtasks) {
+        this.fallbackCheckpointSubtasks = Collections.unmodifiableMap(fallbackCheckpointSubtasks);
+    }
+
+    /** Returns a {@link RegionalCheckpointInfo} representing a global checkpoint. */
+    public static RegionalCheckpointInfo globalCheckpoint() {
+        return GLOBAL;
+    }
+
+    /**
+     * Returns {@code true} if this is a global checkpoint where all tasks acknowledged
+     * successfully.
+     */
+    public boolean isGlobalCheckpoint() {
+        return fallbackCheckpointSubtasks.isEmpty();
+    }
+
+    /**
+     * Returns the set of fallback checkpoint IDs referenced by this regional checkpoint.
+     *
+     * <p>For a global checkpoint, this returns an empty set. For a regional checkpoint, each ID in
+     * the returned set represents a historical checkpoint whose state is used by some subtasks in
+     * this completed checkpoint.
+     */
+    public Set<Long> getFallbackCheckpointIds() {
+        return fallbackCheckpointSubtasks.keySet();
+    }
+
+    /**
+     * Returns the full mapping from fallback checkpoint IDs to the set of subtask identifiers whose
+     * state originates from that historical checkpoint.
+     *
+     * <p>Each subtask identifier is a string in the format "operatorName#subtaskIndex".
+     *
+     * <p>For a global checkpoint, this returns an empty map.
+     */
+    public Map<Long, Set<String>> getFallbackCheckpointSubtasks() {
+        return fallbackCheckpointSubtasks;
+    }
+}

--- a/flink-core/src/main/java/org/apache/flink/configuration/CheckpointingOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/CheckpointingOptions.java
@@ -287,6 +287,41 @@ public class CheckpointingOptions {
                                     + "covers keyed state backends (including both the EmbeddedRocksDBStateBackend and the HashMapStateBackend).");
 
     // ------------------------------------------------------------------------
+    //  Options related to regional checkpoint
+    // ------------------------------------------------------------------------
+
+    @Experimental
+    @Documentation.Section(Documentation.Sections.EXPERT_CHECKPOINTING)
+    public static final ConfigOption<Boolean> REGIONAL_CHECKPOINT_ENABLED =
+            ConfigOptions.key("execution.checkpointing.region.enabled")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription(
+                            "Global switch for Regional Checkpoint. When enabled, partial "
+                                    + "region failures during checkpoint will not abort the entire "
+                                    + "checkpoint. Historical state will be used for failed regions.");
+
+    @Experimental
+    @Documentation.Section(Documentation.Sections.EXPERT_CHECKPOINTING)
+    public static final ConfigOption<Double> REGIONAL_CHECKPOINT_MAX_FAILURE_RATIO =
+            ConfigOptions.key("execution.checkpointing.region.max-failure-ratio")
+                    .doubleType()
+                    .defaultValue(0.3)
+                    .withDescription(
+                            "Maximum ratio of regions that may fail within a single checkpoint "
+                                    + "and still allow commit.");
+
+    @Experimental
+    @Documentation.Section(Documentation.Sections.EXPERT_CHECKPOINTING)
+    public static final ConfigOption<Integer> REGIONAL_CHECKPOINT_MAX_CONSECUTIVE_FAILURES =
+            ConfigOptions.key("execution.checkpointing.region.max-consecutive-failures")
+                    .intType()
+                    .defaultValue(2)
+                    .withDescription(
+                            "Maximum number of consecutive checkpoints that may reference "
+                                    + "historical checkpoint state.");
+
+    // ------------------------------------------------------------------------
     //  Options related to file merging
     // ------------------------------------------------------------------------
 

--- a/flink-core/src/test/java/org/apache/flink/api/common/state/CheckpointListenerRegionalTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/state/CheckpointListenerRegionalTest.java
@@ -1,0 +1,153 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.common.state;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class CheckpointListenerRegionalTest {
+
+    @Test
+    void testGlobalCheckpointInfoIsGlobal() {
+        RegionalCheckpointInfo info = RegionalCheckpointInfo.globalCheckpoint();
+        assertThat(info.isGlobalCheckpoint()).isTrue();
+        assertThat(info.getFallbackCheckpointSubtasks()).isEmpty();
+        assertThat(info.getFallbackCheckpointIds()).isEmpty();
+    }
+
+    @Test
+    void testRegionalCheckpointInfoNotGlobal() {
+        Map<Long, Set<String>> fallback = new HashMap<>();
+        fallback.put(99L, Set.of("Source: kafka_source#0", "Map#0", "Sink#0"));
+        RegionalCheckpointInfo info = new RegionalCheckpointInfo(fallback);
+
+        assertThat(info.isGlobalCheckpoint()).isFalse();
+        assertThat(info.getFallbackCheckpointIds()).containsExactly(99L);
+        assertThat(info.getFallbackCheckpointSubtasks().get(99L))
+                .containsExactlyInAnyOrder("Source: kafka_source#0", "Map#0", "Sink#0");
+    }
+
+    @Test
+    void testDefaultMethodDelegatesToOriginal() throws Exception {
+        AtomicLong receivedId = new AtomicLong(-1);
+
+        CheckpointListener listener =
+                new CheckpointListener() {
+                    @Override
+                    public void notifyCheckpointComplete(long checkpointId) {
+                        receivedId.set(checkpointId);
+                    }
+                };
+
+        Map<Long, Set<String>> fallback = new HashMap<>();
+        fallback.put(99L, Set.of("Source#0"));
+        RegionalCheckpointInfo info = new RegionalCheckpointInfo(fallback);
+
+        listener.notifyRegionalCheckpointComplete(100L, info);
+        assertThat(receivedId.get()).isEqualTo(100L);
+    }
+
+    @Test
+    void testOverriddenMethodReceivesRegionalInfo() throws Exception {
+        AtomicBoolean wasRegional = new AtomicBoolean(false);
+
+        CheckpointListener listener =
+                new CheckpointListener() {
+                    @Override
+                    public void notifyCheckpointComplete(long checkpointId) {}
+
+                    @Override
+                    public void notifyRegionalCheckpointComplete(
+                            long checkpointId, RegionalCheckpointInfo info) {
+                        wasRegional.set(!info.isGlobalCheckpoint());
+                    }
+                };
+
+        Map<Long, Set<String>> fallback = new HashMap<>();
+        fallback.put(99L, Set.of("Source#0"));
+        listener.notifyRegionalCheckpointComplete(100L, new RegionalCheckpointInfo(fallback));
+        assertThat(wasRegional.get()).isTrue();
+
+        listener.notifyRegionalCheckpointComplete(101L, RegionalCheckpointInfo.globalCheckpoint());
+        assertThat(wasRegional.get()).isFalse();
+    }
+
+    @Test
+    void testNotifyRegionalCheckpointFallbackDefaultNoOp() {
+        // Default implementation should be no-op and not throw
+        CheckpointListener listener =
+                new CheckpointListener() {
+                    @Override
+                    public void notifyCheckpointComplete(long checkpointId) {}
+                };
+        listener.notifyRegionalCheckpointFallback(100L, 99L);
+    }
+
+    @Test
+    void testNotifyRegionalCheckpointFallbackOverridden() {
+        AtomicLong receivedCheckpointId = new AtomicLong(-1);
+        AtomicLong receivedFallbackId = new AtomicLong(-1);
+
+        CheckpointListener listener =
+                new CheckpointListener() {
+                    @Override
+                    public void notifyCheckpointComplete(long checkpointId) {}
+
+                    @Override
+                    public void notifyRegionalCheckpointFallback(
+                            long checkpointId, long fallbackCheckpointId) {
+                        receivedCheckpointId.set(checkpointId);
+                        receivedFallbackId.set(fallbackCheckpointId);
+                    }
+                };
+
+        listener.notifyRegionalCheckpointFallback(100L, 99L);
+        assertThat(receivedCheckpointId.get()).isEqualTo(100L);
+        assertThat(receivedFallbackId.get()).isEqualTo(99L);
+    }
+
+    @Test
+    void testFallbackMapIsUnmodifiable() {
+        Map<Long, Set<String>> fallback = new HashMap<>();
+        fallback.put(99L, Set.of("Source#0"));
+        RegionalCheckpointInfo info = new RegionalCheckpointInfo(fallback);
+
+        assertThatThrownBy(() -> info.getFallbackCheckpointSubtasks().put(98L, Set.of("Map#1")))
+                .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    void testMultipleFallbackCheckpoints() {
+        Map<Long, Set<String>> fallback = new HashMap<>();
+        fallback.put(99L, Set.of("Source#0", "Map#0"));
+        fallback.put(98L, Set.of("Source#1"));
+        RegionalCheckpointInfo info = new RegionalCheckpointInfo(fallback);
+
+        assertThat(info.isGlobalCheckpoint()).isFalse();
+        assertThat(info.getFallbackCheckpointIds()).containsExactlyInAnyOrder(99L, 98L);
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
@@ -39,6 +39,7 @@ import org.apache.flink.runtime.messages.checkpoint.DeclineCheckpoint;
 import org.apache.flink.runtime.operators.coordination.OperatorCoordinator;
 import org.apache.flink.runtime.operators.coordination.OperatorInfo;
 import org.apache.flink.runtime.persistence.PossibleInconsistentStateException;
+import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
 import org.apache.flink.runtime.state.CheckpointStorage;
 import org.apache.flink.runtime.state.CheckpointStorageCoordinatorView;
 import org.apache.flink.runtime.state.CheckpointStorageLocation;
@@ -82,7 +83,9 @@ import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiFunction;
+import java.util.function.Function;
 import java.util.function.Predicate;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -261,6 +264,18 @@ public class CheckpointCoordinator {
 
     private long triggerDelay;
 
+    /** Whether regional checkpoint is enabled. */
+    private final boolean regionalCheckpointEnabled;
+
+    /** Maximum ratio of regions that may fail within a single checkpoint. */
+    private final double regionalMaxFailureRatio;
+
+    /** Maximum consecutive checkpoints that may reference historical state. */
+    private final int regionalMaxConsecutiveFailures;
+
+    /** Handles regional checkpoint logic (FLIP-600). */
+    private final RegionalCheckpointHandler regionalCheckpointHandler;
+
     // --------------------------------------------------------------------------------------------
 
     public CheckpointCoordinator(
@@ -380,11 +395,39 @@ public class CheckpointCoordinator {
         this.vertexFinishedStateCheckerFactory = checkNotNull(vertexFinishedStateCheckerFactory);
         this.initialTriggeringDelay = chkConfig.getInitialTriggeringDelay();
         this.triggerDelay = initialTriggeringDelay;
+        this.regionalCheckpointEnabled = chkConfig.isRegionalCheckpointEnabled();
+        this.regionalMaxFailureRatio = chkConfig.getRegionalMaxFailureRatio();
+        this.regionalMaxConsecutiveFailures = chkConfig.getRegionalMaxConsecutiveFailures();
+        this.regionalCheckpointHandler =
+                new RegionalCheckpointHandler(
+                        this,
+                        lock,
+                        this.completedCheckpointStore,
+                        this.coordinatorsToCheckpoint,
+                        this.statsTracker,
+                        this.regionalCheckpointEnabled,
+                        this.regionalMaxFailureRatio,
+                        this.regionalMaxConsecutiveFailures);
     }
 
     // --------------------------------------------------------------------------------------------
     //  Configuration
     // --------------------------------------------------------------------------------------------
+
+    /** Returns whether regional checkpoint is enabled. */
+    public boolean isRegionalCheckpointEnabled() {
+        return regionalCheckpointHandler.isRegionalCheckpointEnabled();
+    }
+
+    /** Sets the region ID provider for regional checkpoint support. */
+    public void setRegionIdProvider(Function<ExecutionVertexID, Object> regionIdProvider) {
+        regionalCheckpointHandler.setRegionIdProvider(regionIdProvider);
+    }
+
+    /** Sets the all-sources-finished checker (FLIP-600 Section 9). */
+    public void setAllSourcesFinishedChecker(Supplier<Boolean> allSourcesFinishedChecker) {
+        regionalCheckpointHandler.setAllSourcesFinishedChecker(allSourcesFinishedChecker);
+    }
 
     /**
      * Adds the given master hook to the checkpoint coordinator. This method does nothing, if the
@@ -647,9 +690,9 @@ public class CheckpointCoordinator {
                             .thenApplyAsync(
                                     plan -> {
                                         try {
-                                            // this must happen outside the coordinator-wide lock,
-                                            // because it communicates with external services
-                                            // (in HA mode) and may block for a while.
+                                            regionalCheckpointHandler
+                                                    .checkAllSourcesFinishedAndForceGlobal(
+                                                            request.props);
                                             long checkpointID =
                                                     checkpointIdCounter.getAndIncrement();
                                             return new Tuple2<>(plan, checkpointID);
@@ -1164,8 +1207,17 @@ public class CheckpointCoordinator {
                         job,
                         taskManagerLocationInfo,
                         checkpointException.getCause());
-                abortPendingCheckpoint(
-                        checkpoint, checkpointException, message.getTaskExecutionId());
+
+                if (regionalCheckpointEnabled && !checkpoint.getProps().isSavepoint()) {
+                    checkpoint.recordDecline(message.getTaskExecutionId(), checkpointException);
+
+                    if (checkpoint.areAllTasksResponded()) {
+                        regionalCheckpointHandler.tryCompleteRegionalCheckpoint(checkpoint);
+                    }
+                } else {
+                    abortPendingCheckpoint(
+                            checkpoint, checkpointException, message.getTaskExecutionId());
+                }
             } else if (LOG.isDebugEnabled()) {
                 if (recentExpiredCheckpoints.contains(checkpointId)) {
                     // message is for an expired checkpoint
@@ -1260,6 +1312,10 @@ public class CheckpointCoordinator {
 
                         if (checkpoint.isFullyAcknowledged()) {
                             completePendingCheckpoint(checkpoint);
+                        } else if (regionalCheckpointEnabled
+                                && checkpoint.hasDeclines()
+                                && checkpoint.areAllTasksResponded()) {
+                            regionalCheckpointHandler.tryCompleteRegionalCheckpoint(checkpoint);
                         }
                         break;
                     case DUPLICATE:
@@ -1392,11 +1448,15 @@ public class CheckpointCoordinator {
             scheduleTriggerRequest();
         }
 
+        // A fully acknowledged checkpoint resets the consecutive regional counter and the
+        // force-global flag (per FLIP-600 two-tier max-consecutive-failures semantics).
+        regionalCheckpointHandler.resetOnGlobalSuccess();
+
         cleanupAfterCompletedCheckpoint(
                 pendingCheckpoint, checkpointId, completedCheckpoint, lastSubsumed, props);
     }
 
-    private void reportCompletedCheckpoint(CompletedCheckpoint completedCheckpoint) {
+    void reportCompletedCheckpoint(CompletedCheckpoint completedCheckpoint) {
         failureManager.handleCheckpointSuccess(completedCheckpoint.getCheckpointID());
         CompletedCheckpointStats completedCheckpointStats = completedCheckpoint.getStatistic();
         if (completedCheckpointStats != null) {
@@ -1439,7 +1499,7 @@ public class CheckpointCoordinator {
         }
     }
 
-    private void logCheckpointInfo(CompletedCheckpoint completedCheckpoint) {
+    void logCheckpointInfo(CompletedCheckpoint completedCheckpoint) {
         LOG.info(
                 "Completed checkpoint {} for job {} ({} bytes, checkpointDuration={} ms, finalizationTime={} ms).",
                 completedCheckpoint.getCheckpointID(),
@@ -1492,7 +1552,7 @@ public class CheckpointCoordinator {
         }
     }
 
-    private long extractIdIfDiscardedOnSubsumed(CompletedCheckpoint lastSubsumed) {
+    long extractIdIfDiscardedOnSubsumed(CompletedCheckpoint lastSubsumed) {
         final long lastSubsumedCheckpointId;
         if (lastSubsumed != null && lastSubsumed.getProperties().discardOnSubsumed()) {
             lastSubsumedCheckpointId = lastSubsumed.getCheckpointID();
@@ -1502,7 +1562,7 @@ public class CheckpointCoordinator {
         return lastSubsumedCheckpointId;
     }
 
-    private CompletedCheckpoint addCompletedCheckpointToStoreAndSubsumeOldest(
+    CompletedCheckpoint addCompletedCheckpointToStoreAndSubsumeOldest(
             long checkpointId,
             CompletedCheckpoint completedCheckpoint,
             PendingCheckpoint pendingCheckpoint)
@@ -1628,7 +1688,7 @@ public class CheckpointCoordinator {
         recentExpiredCheckpoints.addLast(id);
     }
 
-    private void dropSubsumedCheckpoints(long checkpointId) {
+    void dropSubsumedCheckpoints(long checkpointId) {
         abortPendingCheckpoints(
                 checkpoint ->
                         checkpoint.getCheckpointID() < checkpointId && checkpoint.canBeSubsumed(),
@@ -1980,12 +2040,44 @@ public class CheckpointCoordinator {
         return recentExpiredCheckpoints;
     }
 
+    @VisibleForTesting
+    int getConsecutiveRegionalCheckpointCount() {
+        return regionalCheckpointHandler.getConsecutiveRegionalCheckpointCount();
+    }
+
+    @VisibleForTesting
+    boolean getForceGlobalNextCheckpoint() {
+        return regionalCheckpointHandler.getForceGlobalNextCheckpoint();
+    }
+
     public CheckpointStorageCoordinatorView getCheckpointStorage() {
         return checkpointStorageView;
     }
 
     public CompletedCheckpointStore getCheckpointStore() {
         return completedCheckpointStore;
+    }
+
+    // Package-private accessors for RegionalCheckpointHandler
+
+    CheckpointsCleaner getCheckpointsCleaner() {
+        return checkpointsCleaner;
+    }
+
+    Executor getExecutor() {
+        return executor;
+    }
+
+    Clock getClock() {
+        return clock;
+    }
+
+    void removePendingCheckpoint(long checkpointId) {
+        pendingCheckpoints.remove(checkpointId);
+    }
+
+    void setLastCheckpointCompletionRelativeTime(long time) {
+        lastCheckpointCompletionRelativeTime = time;
     }
 
     /**
@@ -2275,13 +2367,13 @@ public class CheckpointCoordinator {
         }
     }
 
-    private void abortPendingCheckpoint(
+    void abortPendingCheckpoint(
             PendingCheckpoint pendingCheckpoint, CheckpointException exception) {
 
         abortPendingCheckpoint(pendingCheckpoint, exception, null);
     }
 
-    private void abortPendingCheckpoint(
+    void abortPendingCheckpoint(
             PendingCheckpoint pendingCheckpoint,
             CheckpointException exception,
             @Nullable final ExecutionAttemptID executionAttemptID) {
@@ -2356,17 +2448,32 @@ public class CheckpointCoordinator {
         @Override
         public void run() {
             synchronized (lock) {
-                // only do the work if the checkpoint is not discarded anyways
-                // note that checkpoint completion discards the pending checkpoint object
                 if (!pendingCheckpoint.isDisposed()) {
                     LOG.info(
                             "Checkpoint {} of job {} expired before completing.",
                             pendingCheckpoint.getCheckpointID(),
                             job);
-
-                    abortPendingCheckpoint(
-                            pendingCheckpoint,
-                            new CheckpointException(CheckpointFailureReason.CHECKPOINT_EXPIRED));
+                    // Per FLIP-600 Per-Region Timeout Handling: when regional checkpoint is
+                    // enabled and this is not a savepoint, treat unacknowledged tasks as
+                    // failed regions and attempt regional checkpoint completion instead of
+                    // directly aborting.
+                    if (regionalCheckpointEnabled && !pendingCheckpoint.getProps().isSavepoint()) {
+                        final int marked =
+                                pendingCheckpoint.markUnacknowledgedTasksAsDeclined(
+                                        new CheckpointException(
+                                                CheckpointFailureReason.CHECKPOINT_EXPIRED));
+                        LOG.info(
+                                "Regional checkpoint {} timed out. Marked {} unacknowledged "
+                                        + "task(s) as failed for regional evaluation.",
+                                pendingCheckpoint.getCheckpointID(),
+                                marked);
+                        regionalCheckpointHandler.tryCompleteRegionalCheckpoint(pendingCheckpoint);
+                    } else {
+                        abortPendingCheckpoint(
+                                pendingCheckpoint,
+                                new CheckpointException(
+                                        CheckpointFailureReason.CHECKPOINT_EXPIRED));
+                    }
                 }
             }
         }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointStatsTracker.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointStatsTracker.java
@@ -58,6 +58,13 @@ public interface CheckpointStatsTracker {
      */
     void reportCompletedCheckpoint(CompletedCheckpointStats completed);
 
+    /**
+     * Callback when a regional checkpoint completes (i.e. a checkpoint that reused historical state
+     * from failed regions). The actual metric reporting is implemented in the metrics PR; this
+     * no-op default ensures the core logic compiles independently.
+     */
+    default void reportRegionalCheckpointCompleted() {}
+
     @Nullable
     PendingCheckpointStats getPendingCheckpointStats(long checkpointId);
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointSubsumeHelper.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointSubsumeHelper.java
@@ -20,9 +20,11 @@ package org.apache.flink.runtime.checkpoint;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Collections;
 import java.util.Deque;
 import java.util.Iterator;
 import java.util.Optional;
+import java.util.Set;
 
 /**
  * Encapsulates the logic to subsume older checkpoints by {@link CompletedCheckpointStore checkpoint
@@ -49,6 +51,23 @@ class CheckpointSubsumeHelper {
     public static Optional<CompletedCheckpoint> subsume(
             Deque<CompletedCheckpoint> checkpoints, int numRetain, SubsumeAction subsumeAction)
             throws Exception {
+        return subsume(checkpoints, numRetain, subsumeAction, Collections.emptySet());
+    }
+
+    /**
+     * Subsumes older checkpoints, respecting a set of protected checkpoint IDs that must not be
+     * subsumed. Protected checkpoints are those transitively referenced via ref_checkpoint_id by
+     * retained checkpoints (regional checkpoint reference protection).
+     *
+     * @param protectedCheckpointIds checkpoint IDs that must not be subsumed because they are
+     *     transitively referenced by retained checkpoints.
+     */
+    public static Optional<CompletedCheckpoint> subsume(
+            Deque<CompletedCheckpoint> checkpoints,
+            int numRetain,
+            SubsumeAction subsumeAction,
+            Set<Long> protectedCheckpointIds)
+            throws Exception {
         if (checkpoints.isEmpty() || checkpoints.size() <= numRetain) {
             return Optional.empty();
         }
@@ -58,6 +77,11 @@ class CheckpointSubsumeHelper {
         Iterator<CompletedCheckpoint> iterator = checkpoints.iterator();
         while (checkpoints.size() > numRetain && iterator.hasNext()) {
             CompletedCheckpoint next = iterator.next();
+            if (protectedCheckpointIds.contains(next.getCheckpointID())) {
+                // This checkpoint is transitively referenced by a retained checkpoint;
+                // it must not be subsumed.
+                continue;
+            }
             if (canSubsume(next, latest, latestNotSavepoint)) {
                 // always return the subsumed checkpoint with larger checkpoint id.
                 if (!lastSubsumedCheckpoint.isPresent()

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/Checkpoints.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/Checkpoints.java
@@ -25,7 +25,7 @@ import org.apache.flink.runtime.OperatorIDPair;
 import org.apache.flink.runtime.checkpoint.metadata.CheckpointMetadata;
 import org.apache.flink.runtime.checkpoint.metadata.MetadataSerializer;
 import org.apache.flink.runtime.checkpoint.metadata.MetadataSerializers;
-import org.apache.flink.runtime.checkpoint.metadata.MetadataV6Serializer;
+import org.apache.flink.runtime.checkpoint.metadata.MetadataV7Serializer;
 import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobgraph.OperatorID;
@@ -124,7 +124,7 @@ public class Checkpoints {
         storeCheckpointMetadata(
                 checkpointMetadata,
                 dos,
-                MetadataV6Serializer.INSTANCE,
+                MetadataV7Serializer.INSTANCE,
                 out.getExclusiveCheckpointDir());
     }
 
@@ -135,7 +135,7 @@ public class Checkpoints {
     public static void storeCheckpointMetadataWithoutExclusiveDir(
             CheckpointMetadata checkpointMetadata, DataOutputStream out) throws IOException {
         storeCheckpointMetadataWithoutExclusiveDir(
-                checkpointMetadata, out, MetadataV6Serializer.INSTANCE);
+                checkpointMetadata, out, MetadataV7Serializer.INSTANCE);
     }
 
     public static void storeCheckpointMetadata(
@@ -144,7 +144,7 @@ public class Checkpoints {
             @Nullable Path exclusiveDir)
             throws IOException {
         storeCheckpointMetadata(
-                checkpointMetadata, out, MetadataV6Serializer.INSTANCE, exclusiveDir);
+                checkpointMetadata, out, MetadataV7Serializer.INSTANCE, exclusiveDir);
     }
 
     public static void storeCheckpointMetadataWithoutExclusiveDir(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/DefaultCompletedCheckpointStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/DefaultCompletedCheckpointStore.java
@@ -31,10 +31,16 @@ import org.slf4j.LoggerFactory;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.OptionalLong;
+import java.util.Set;
 import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
 
 import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -137,6 +143,12 @@ public class DefaultCompletedCheckpointStore<R extends ResourceVersion<R>>
 
         completedCheckpoints.addLast(checkpoint);
 
+        // Compute the set of checkpoint IDs that are transitively referenced via
+        // refCheckpointId by the retained checkpoints. These must not be subsumed.
+        Set<Long> protectedIds =
+                computeReferencedCheckpointIds(
+                        completedCheckpoints, maxNumberOfCheckpointsToRetain);
+
         // Remove completed checkpoint from queue and checkpointStateHandleStore, not discard.
         Optional<CompletedCheckpoint> subsume =
                 CheckpointSubsumeHelper.subsume(
@@ -145,7 +157,8 @@ public class DefaultCompletedCheckpointStore<R extends ResourceVersion<R>>
                         completedCheckpoint -> {
                             tryRemove(completedCheckpoint.getCheckpointID());
                             checkpointsCleaner.addSubsumedCheckpoint(completedCheckpoint);
-                        });
+                        },
+                        protectedIds);
 
         findLowest(completedCheckpoints)
                 .ifPresent(
@@ -246,5 +259,77 @@ public class DefaultCompletedCheckpointStore<R extends ResourceVersion<R>>
     private boolean tryRemove(long checkpointId) throws Exception {
         return checkpointStateHandleStore.releaseAndTryRemove(
                 completedCheckpointStoreUtil.checkpointIDToName(checkpointId));
+    }
+
+    /**
+     * Computes the set of checkpoint IDs that are transitively referenced via {@code
+     * refCheckpointId} by the checkpoints that would be retained (the last {@code numRetain}
+     * checkpoints in the deque). Only returns IDs that are NOT among the retained checkpoints
+     * themselves (since those are already protected by the retention count).
+     */
+    static Set<Long> computeReferencedCheckpointIds(
+            ArrayDeque<CompletedCheckpoint> checkpoints, int numRetain) {
+        if (checkpoints.size() <= numRetain) {
+            return Collections.emptySet();
+        }
+
+        // Build a map of checkpointId -> checkpoint for quick lookup
+        Map<Long, CompletedCheckpoint> checkpointById =
+                checkpoints.stream()
+                        .collect(
+                                Collectors.toMap(
+                                        CompletedCheckpoint::getCheckpointID,
+                                        cp -> cp,
+                                        (a, b) -> b));
+
+        // The retained checkpoints are the last numRetain in the deque
+        Set<Long> retainedIds = new HashSet<>();
+        int skipCount = Math.max(0, checkpoints.size() - numRetain);
+        int idx = 0;
+        for (CompletedCheckpoint cp : checkpoints) {
+            if (idx >= skipCount) {
+                retainedIds.add(cp.getCheckpointID());
+            }
+            idx++;
+        }
+
+        // Transitively follow refCheckpointId links starting from retained checkpoints
+        Set<Long> protectedIds = new HashSet<>();
+        Set<Long> toProcess = new HashSet<>(retainedIds);
+        while (!toProcess.isEmpty()) {
+            Set<Long> nextToProcess = new HashSet<>();
+            for (Long cpId : toProcess) {
+                CompletedCheckpoint cp = checkpointById.get(cpId);
+                if (cp == null) {
+                    continue;
+                }
+                Set<Long> refs = extractReferencedCheckpointIds(cp);
+                for (Long refId : refs) {
+                    if (!retainedIds.contains(refId) && protectedIds.add(refId)) {
+                        nextToProcess.add(refId);
+                    }
+                }
+            }
+            toProcess = nextToProcess;
+        }
+
+        return protectedIds;
+    }
+
+    /**
+     * Extracts all distinct refCheckpointId values from all OperatorSubtaskStates within the given
+     * checkpoint.
+     */
+    static Set<Long> extractReferencedCheckpointIds(CompletedCheckpoint checkpoint) {
+        Set<Long> refIds = new HashSet<>();
+        for (OperatorState operatorState : checkpoint.getOperatorStates().values()) {
+            for (OperatorSubtaskState subtaskState : operatorState.getStates()) {
+                OptionalLong refId = subtaskState.getRefCheckpointId();
+                if (refId.isPresent()) {
+                    refIds.add(refId.getAsLong());
+                }
+            }
+        }
+        return refIds;
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/OperatorCoordinatorCheckpointContext.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/OperatorCoordinatorCheckpointContext.java
@@ -19,11 +19,13 @@
 package org.apache.flink.runtime.checkpoint;
 
 import org.apache.flink.api.common.state.CheckpointListener;
+import org.apache.flink.api.common.state.RegionalCheckpointInfo;
 import org.apache.flink.runtime.operators.coordination.OperatorCoordinator;
 import org.apache.flink.runtime.operators.coordination.OperatorInfo;
 
 import javax.annotation.Nullable;
 
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -44,6 +46,27 @@ public interface OperatorCoordinatorCheckpointContext extends OperatorInfo, Chec
      */
     @Override
     void notifyCheckpointComplete(long checkpointId);
+
+    /**
+     * Notifies the coordinator that a regional checkpoint has completed, providing context about
+     * which subtasks used historical state. Default implementation delegates to {@link
+     * #notifyCheckpointComplete(long)}.
+     */
+    @Override
+    default void notifyRegionalCheckpointComplete(
+            long checkpointId, RegionalCheckpointInfo regionalCheckpointInfo) throws Exception {
+        notifyCheckpointComplete(checkpointId);
+    }
+
+    /**
+     * Notifies the coordinator that a regional checkpoint has completed but some subtasks fell back
+     * to a historical checkpoint. Default is no-op; coordinators that maintain local state should
+     * override to clean up stale state for the fallback subtasks.
+     */
+    @Override
+    default void notifyRegionalCheckpointFallback(long checkpointId, long fallbackCheckpointId) {
+        // no-op for backward compatibility
+    }
 
     /**
      * We override the method here to remove the checked exception. Please check the Java docs of
@@ -78,4 +101,32 @@ public interface OperatorCoordinatorCheckpointContext extends OperatorInfo, Chec
      * recovered.
      */
     void subtaskReset(int subtask, long checkpointId);
+
+    /**
+     * Returns whether this coordinator supports regional checkpoints. When {@code true}, the
+     * framework may call {@link #checkpointCoordinatorForRegionFallback} instead of aborting the
+     * checkpoint when some subtasks decline.
+     */
+    default boolean supportsRegionCheckpoint() {
+        return false;
+    }
+
+    /**
+     * Takes a region-aware snapshot of the coordinator. Called when a regional checkpoint is being
+     * completed and some subtasks' state will fall back to a previous checkpoint.
+     *
+     * @param checkpointId the id of the ongoing checkpoint
+     * @param fallbackCheckpointId the id of the previous checkpoint for fallback subtasks
+     * @param fallbackSubtaskIds subtask indices whose state will be replaced
+     * @param resultFuture future to complete with the serialized coordinator state
+     */
+    default void checkpointCoordinatorForRegionFallback(
+            long checkpointId,
+            long fallbackCheckpointId,
+            Set<Integer> fallbackSubtaskIds,
+            CompletableFuture<byte[]> resultFuture)
+            throws Exception {
+        throw new UnsupportedOperationException(
+                "This coordinator does not support region checkpoints.");
+    }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/OperatorState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/OperatorState.java
@@ -150,6 +150,18 @@ public class OperatorState implements CompositeStateHandle {
         this.coordinatorState = coordinatorState;
     }
 
+    /**
+     * Overwrites the coordinator state, replacing any previously set value.
+     *
+     * <p>Unlike {@link #setCoordinatorState}, this does not require the current value to be {@code
+     * null}. It is used by regional checkpoint fallback, where the coordinator state recovered from
+     * the historical checkpoint must replace any coordinator state that was already collected
+     * during the failed regional checkpoint attempt.
+     */
+    public void overwriteCoordinatorState(@Nullable ByteStreamStateHandle coordinatorState) {
+        this.coordinatorState = coordinatorState;
+    }
+
     @Nullable
     public ByteStreamStateHandle getCoordinatorState() {
         return coordinatorState;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/OperatorSubtaskState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/OperatorSubtaskState.java
@@ -36,9 +36,12 @@ import org.apache.flink.runtime.state.filemerging.FileMergingOperatorStreamState
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nullable;
+
 import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
+import java.util.OptionalLong;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -120,6 +123,12 @@ public class OperatorSubtaskState implements CompositeStateHandle {
 
     private final long checkpointedSize;
 
+    /**
+     * The checkpoint ID from which this subtask's state originates. Null if the state was produced
+     * by the current checkpoint (not reused from a previous one).
+     */
+    @Nullable private final Long refCheckpointId;
+
     private OperatorSubtaskState(
             StateObjectCollection<OperatorStateHandle> managedOperatorState,
             StateObjectCollection<OperatorStateHandle> rawOperatorState,
@@ -129,7 +138,8 @@ public class OperatorSubtaskState implements CompositeStateHandle {
             StateObjectCollection<InputChannelStateHandle> upstreamOutputBufferState,
             StateObjectCollection<OutputStateHandle> resultSubpartitionState,
             InflightDataRescalingDescriptor inputRescalingDescriptor,
-            InflightDataRescalingDescriptor outputRescalingDescriptor) {
+            InflightDataRescalingDescriptor outputRescalingDescriptor,
+            @Nullable Long refCheckpointId) {
 
         this.managedOperatorState = checkNotNull(managedOperatorState);
         this.rawOperatorState = checkNotNull(rawOperatorState);
@@ -140,6 +150,7 @@ public class OperatorSubtaskState implements CompositeStateHandle {
         this.resultSubpartitionState = checkNotNull(resultSubpartitionState);
         this.inputRescalingDescriptor = checkNotNull(inputRescalingDescriptor);
         this.outputRescalingDescriptor = checkNotNull(outputRescalingDescriptor);
+        this.refCheckpointId = refCheckpointId;
 
         this.stateSize = streamSubCollections().mapToLong(StateObject::getStateSize).sum();
         this.checkpointedSize =
@@ -172,7 +183,8 @@ public class OperatorSubtaskState implements CompositeStateHandle {
                 StateObjectCollection.empty(),
                 StateObjectCollection.empty(),
                 InflightDataRescalingDescriptor.NO_RESCALE,
-                InflightDataRescalingDescriptor.NO_RESCALE);
+                InflightDataRescalingDescriptor.NO_RESCALE,
+                null);
     }
 
     // --------------------------------------------------------------------------------------------
@@ -211,6 +223,10 @@ public class OperatorSubtaskState implements CompositeStateHandle {
 
     public InflightDataRescalingDescriptor getOutputRescalingDescriptor() {
         return outputRescalingDescriptor;
+    }
+
+    public OptionalLong getRefCheckpointId() {
+        return refCheckpointId == null ? OptionalLong.empty() : OptionalLong.of(refCheckpointId);
     }
 
     public List<StateObject> getDiscardables() {
@@ -376,16 +392,21 @@ public class OperatorSubtaskState implements CompositeStateHandle {
     }
 
     public Builder toBuilder() {
-        return builder()
-                .setManagedKeyedState(managedKeyedState)
-                .setManagedOperatorState(managedOperatorState)
-                .setRawOperatorState(rawOperatorState)
-                .setRawKeyedState(rawKeyedState)
-                .setInputChannelState(inputChannelState)
-                .setUpstreamOutputBufferState(upstreamOutputBufferState)
-                .setResultSubpartitionState(resultSubpartitionState)
-                .setInputRescalingDescriptor(inputRescalingDescriptor)
-                .setOutputRescalingDescriptor(outputRescalingDescriptor);
+        Builder b =
+                builder()
+                        .setManagedKeyedState(managedKeyedState)
+                        .setManagedOperatorState(managedOperatorState)
+                        .setRawOperatorState(rawOperatorState)
+                        .setRawKeyedState(rawKeyedState)
+                        .setInputChannelState(inputChannelState)
+                        .setUpstreamOutputBufferState(upstreamOutputBufferState)
+                        .setResultSubpartitionState(resultSubpartitionState)
+                        .setInputRescalingDescriptor(inputRescalingDescriptor)
+                        .setOutputRescalingDescriptor(outputRescalingDescriptor);
+        if (refCheckpointId != null) {
+            b.setRefCheckpointId(refCheckpointId);
+        }
+        return b;
     }
 
     public static Builder builder() {
@@ -415,6 +436,7 @@ public class OperatorSubtaskState implements CompositeStateHandle {
                 InflightDataRescalingDescriptor.NO_RESCALE;
         private InflightDataRescalingDescriptor outputRescalingDescriptor =
                 InflightDataRescalingDescriptor.NO_RESCALE;
+        @Nullable private Long refCheckpointId;
 
         private Builder() {}
 
@@ -490,6 +512,11 @@ public class OperatorSubtaskState implements CompositeStateHandle {
             return this;
         }
 
+        public Builder setRefCheckpointId(long refCheckpointId) {
+            this.refCheckpointId = refCheckpointId;
+            return this;
+        }
+
         public OperatorSubtaskState build() {
             return new OperatorSubtaskState(
                     managedOperatorState,
@@ -500,7 +527,8 @@ public class OperatorSubtaskState implements CompositeStateHandle {
                     upstreamOutputBufferState,
                     resultSubpartitionState,
                     inputRescalingDescriptor,
-                    outputRescalingDescriptor);
+                    outputRescalingDescriptor,
+                    refCheckpointId);
         }
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/PendingCheckpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/PendingCheckpoint.java
@@ -24,6 +24,7 @@ import org.apache.flink.runtime.checkpoint.metadata.CheckpointMetadata;
 import org.apache.flink.runtime.executiongraph.Execution;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.executiongraph.ExecutionVertex;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.operators.coordination.OperatorInfo;
 import org.apache.flink.runtime.state.CheckpointMetadataOutputStream;
@@ -52,6 +53,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.OptionalLong;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
@@ -108,6 +110,12 @@ public class PendingCheckpoint implements Checkpoint {
 
     /** Set of acknowledged tasks. */
     private final Set<ExecutionAttemptID> acknowledgedTasks;
+
+    /**
+     * Map of declined tasks to their failure causes (used for deferred abort in regional
+     * checkpoint).
+     */
+    private final Map<ExecutionAttemptID, CheckpointException> declinedTasks;
 
     /** The checkpoint properties. */
     private final CheckpointProperties props;
@@ -179,6 +187,7 @@ public class PendingCheckpoint implements Checkpoint {
         this.acknowledgedTasks =
                 CollectionUtil.newHashSetWithExpectedSize(
                         checkpointPlan.getTasksToWaitFor().size());
+        this.declinedTasks = new HashMap<>();
         this.onCompletionPromise = checkNotNull(onCompletionPromise);
         this.pendingCheckpointStats = pendingCheckpointStats;
         this.masterTriggerCompletionPromise = checkNotNull(masterTriggerCompletionPromise);
@@ -251,6 +260,72 @@ public class PendingCheckpoint implements Checkpoint {
 
     boolean areTasksFullyAcknowledged() {
         return notYetAcknowledgedTasks.isEmpty() && !disposed;
+    }
+
+    /**
+     * Records a decline from a task for deferred abort in regional checkpoint mode. The decline is
+     * buffered instead of immediately aborting the checkpoint.
+     */
+    public void recordDecline(ExecutionAttemptID attemptId, CheckpointException cause) {
+        synchronized (lock) {
+            declinedTasks.put(attemptId, cause);
+        }
+    }
+
+    /** Returns the map of declined tasks and their failure causes. */
+    public Map<ExecutionAttemptID, CheckpointException> getDeclinedTasks() {
+        synchronized (lock) {
+            return Collections.unmodifiableMap(new HashMap<>(declinedTasks));
+        }
+    }
+
+    /** Returns whether any tasks have declined this checkpoint. */
+    public boolean hasDeclines() {
+        synchronized (lock) {
+            return !declinedTasks.isEmpty();
+        }
+    }
+
+    /**
+     * Marks all tasks that have neither acknowledged nor declined as declined with the given cause.
+     * This is used in regional checkpoint mode when a checkpoint timeout fires: unacknowledged
+     * tasks are treated as failed (their regions become failed regions) so that {@link
+     * CheckpointCoordinator#tryCompleteRegionalCheckpoint} can evaluate whether a regional
+     * checkpoint is still possible per FLIP-600 Per-Region Timeout Handling.
+     *
+     * @param cause the exception to associate with each newly-declined task
+     * @return the number of tasks that were marked as declined by this call
+     */
+    public int markUnacknowledgedTasksAsDeclined(CheckpointException cause) {
+        synchronized (lock) {
+            int marked = 0;
+            for (ExecutionAttemptID remaining : notYetAcknowledgedTasks.keySet()) {
+                if (!declinedTasks.containsKey(remaining)) {
+                    declinedTasks.put(remaining, cause);
+                    marked++;
+                }
+            }
+            return marked;
+        }
+    }
+
+    /**
+     * Returns true if every task in this checkpoint has either acknowledged or declined. This is
+     * used in regional checkpoint mode to determine when to evaluate the checkpoint.
+     */
+    public boolean areAllTasksResponded() {
+        synchronized (lock) {
+            if (disposed) {
+                return false;
+            }
+            // All tasks responded if every remaining not-yet-acknowledged task has declined
+            for (ExecutionAttemptID remaining : notYetAcknowledgedTasks.keySet()) {
+                if (!declinedTasks.containsKey(remaining)) {
+                    return false;
+                }
+            }
+            return true;
+        }
     }
 
     public boolean isAcknowledgedBy(ExecutionAttemptID executionAttemptId) {
@@ -364,6 +439,56 @@ public class PendingCheckpoint implements Checkpoint {
         }
     }
 
+    /**
+     * Finalizes a regional checkpoint where some tasks have declined. Unlike {@link
+     * #finalizeCheckpoint}, this does not require all tasks to have acknowledged. The caller is
+     * responsible for ensuring that the operator states have been properly assembled (healthy
+     * subtasks from current checkpoint, failed subtasks from a fallback checkpoint).
+     */
+    public CompletedCheckpoint finalizeRegionalCheckpoint(
+            CheckpointsCleaner checkpointsCleaner, Runnable postCleanup, Executor executor)
+            throws IOException {
+
+        synchronized (lock) {
+            checkState(!isDisposed(), "checkpoint is discarded");
+
+            try {
+                checkpointPlan.fulfillFinishedTaskStatus(operatorStates);
+
+                final CheckpointMetadata savepoint =
+                        new CheckpointMetadata(
+                                checkpointId, operatorStates.values(), masterStates, props);
+                final CompletedCheckpointStorageLocation finalizedLocation;
+
+                try (CheckpointMetadataOutputStream out =
+                        targetLocation.createMetadataOutputStream()) {
+                    Checkpoints.storeCheckpointMetadata(savepoint, out);
+                    finalizedLocation = out.closeAndFinalizeCheckpoint();
+                }
+
+                CompletedCheckpoint completed =
+                        new CompletedCheckpoint(
+                                jobId,
+                                checkpointId,
+                                checkpointTimestamp,
+                                System.currentTimeMillis(),
+                                operatorStates,
+                                masterStates,
+                                props,
+                                finalizedLocation,
+                                toCompletedCheckpointStats(finalizedLocation));
+
+                dispose(false, checkpointsCleaner, postCleanup, executor);
+
+                return completed;
+            } catch (Throwable t) {
+                onCompletionPromise.completeExceptionally(t);
+                ExceptionUtils.rethrowIOException(t);
+                return null;
+            }
+        }
+    }
+
     @Nullable
     private CompletedCheckpointStats toCompletedCheckpointStats(
             CompletedCheckpointStorageLocation finalizedLocation) {
@@ -427,6 +552,10 @@ public class PendingCheckpoint implements Checkpoint {
                 long checkpointStartDelayMillis =
                         metrics.getCheckpointStartDelayNanos() / 1_000_000;
 
+                // Extract the regional-checkpoint reference id if this acknowledged state was
+                // reused from a historical checkpoint (normally empty for a regular acknowledge).
+                Long refCheckpointId = extractRefCheckpointId(operatorSubtaskStates);
+
                 SubtaskStateStats subtaskStateStats =
                         new SubtaskStateStats(
                                 vertex.getParallelSubtaskIndex(),
@@ -440,7 +569,8 @@ public class PendingCheckpoint implements Checkpoint {
                                 alignmentDurationMillis,
                                 checkpointStartDelayMillis,
                                 metrics.getUnalignedCheckpoint(),
-                                true);
+                                true,
+                                refCheckpointId);
 
                 LOG.trace(
                         "Checkpoint {} stats for {}: size={}Kb, duration={}ms, sync part={}ms, async part={}ms",
@@ -459,6 +589,62 @@ public class PendingCheckpoint implements Checkpoint {
 
             return TaskAcknowledgeResult.SUCCESS;
         }
+    }
+
+    /**
+     * Reports statistics for a subtask in a failed region of a regional checkpoint, whose state was
+     * reused from the historical checkpoint {@code refCheckpointId}. Such subtasks neither
+     * acknowledge nor decline into the stats, so their stats must be reported explicitly when the
+     * regional checkpoint completes, in order to surface the reference id through the REST API.
+     *
+     * @param jobVertexId the job vertex the subtask belongs to
+     * @param subtaskIndex the parallel subtask index
+     * @param ackTimestamp the completion timestamp of the regional checkpoint
+     * @param refCheckpointId the historical checkpoint id the subtask's state originates from
+     */
+    public void reportFallbackSubtaskStats(
+            JobVertexID jobVertexId, int subtaskIndex, long ackTimestamp, long refCheckpointId) {
+        synchronized (lock) {
+            if (pendingCheckpointStats == null) {
+                return;
+            }
+            SubtaskStateStats subtaskStateStats =
+                    new SubtaskStateStats(
+                            subtaskIndex,
+                            ackTimestamp,
+                            0,
+                            0,
+                            0,
+                            0,
+                            0,
+                            0,
+                            0,
+                            0,
+                            false,
+                            true,
+                            refCheckpointId);
+            pendingCheckpointStats.reportSubtaskStats(jobVertexId, subtaskStateStats);
+        }
+    }
+
+    /**
+     * Extracts the regional-checkpoint reference id from the given task state snapshot, i.e. the
+     * historical checkpoint id this state was reused from. Returns {@code null} if no operator
+     * subtask state carries a reference id (the regular case).
+     */
+    private static Long extractRefCheckpointId(TaskStateSnapshot operatorSubtaskStates) {
+        if (operatorSubtaskStates == null) {
+            return null;
+        }
+        Long oldest = null;
+        for (Map.Entry<OperatorID, OperatorSubtaskState> entry :
+                operatorSubtaskStates.getSubtaskStateMappings()) {
+            OptionalLong refId = entry.getValue().getRefCheckpointId();
+            if (refId.isPresent()) {
+                oldest = oldest == null ? refId.getAsLong() : Math.min(oldest, refId.getAsLong());
+            }
+        }
+        return oldest;
     }
 
     private void updateOperatorState(
@@ -590,6 +776,7 @@ public class PendingCheckpoint implements Checkpoint {
                 disposed = true;
                 notYetAcknowledgedTasks.clear();
                 acknowledgedTasks.clear();
+                declinedTasks.clear();
                 cancelCanceller();
             }
         }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/RegionalCheckpointHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/RegionalCheckpointHandler.java
@@ -1,0 +1,619 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF)
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.flink.runtime.checkpoint;
+
+import org.apache.flink.api.common.state.RegionalCheckpointInfo;
+import org.apache.flink.runtime.OperatorIDPair;
+import org.apache.flink.runtime.executiongraph.Execution;
+import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
+import org.apache.flink.runtime.executiongraph.ExecutionVertex;
+import org.apache.flink.runtime.jobgraph.OperatorID;
+import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
+import org.apache.flink.runtime.state.memory.ByteStreamStateHandle;
+import org.apache.flink.util.Preconditions;
+import org.apache.flink.util.concurrent.FutureUtils;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+/**
+ * Encapsulates regional checkpoint logic for {@link CheckpointCoordinator}, per FLIP-600.
+ *
+ * <p>This handler owns the mutable regional checkpoint state (consecutive counter, force-global
+ * flag, region ID provider, all-sources-finished checker) and implements the core evaluation
+ * ({@link #tryCompleteRegionalCheckpoint}), completion ({@link #completeRegionalCheckpoint}), and
+ * state recombination ({@link #referenceFallbackState}) logic.
+ *
+ * <p>Thread-safety: all methods assume the caller holds the {@code CheckpointCoordinator}'s {@code
+ * lock} (asserted via {@code Thread.holdsLock}).
+ */
+class RegionalCheckpointHandler {
+
+    private static final Logger LOG = LoggerFactory.getLogger(RegionalCheckpointHandler.class);
+
+    private final CheckpointCoordinator coordinator;
+    private final Object lock;
+    private final CompletedCheckpointStore completedCheckpointStore;
+    private final Collection<OperatorCoordinatorCheckpointContext> coordinatorsToCheckpoint;
+    private final CheckpointStatsTracker statsTracker;
+    private final double regionalMaxFailureRatio;
+    private final int regionalMaxConsecutiveFailures;
+    private final boolean regionalCheckpointEnabled;
+
+    // Mutable state — all access must be under coordinator.lock
+    private int consecutiveRegionalCheckpointCount = 0;
+    private boolean forceGlobalNextCheckpoint = false;
+    private Supplier<Boolean> allSourcesFinishedChecker = () -> false;
+    @Nullable private Function<ExecutionVertexID, Object> regionIdProvider;
+
+    RegionalCheckpointHandler(
+            CheckpointCoordinator coordinator,
+            Object lock,
+            CompletedCheckpointStore completedCheckpointStore,
+            Collection<OperatorCoordinatorCheckpointContext> coordinatorsToCheckpoint,
+            CheckpointStatsTracker statsTracker,
+            boolean regionalCheckpointEnabled,
+            double regionalMaxFailureRatio,
+            int regionalMaxConsecutiveFailures) {
+        this.coordinator = coordinator;
+        this.lock = lock;
+        this.completedCheckpointStore = completedCheckpointStore;
+        this.coordinatorsToCheckpoint = coordinatorsToCheckpoint;
+        this.statsTracker = statsTracker;
+        this.regionalCheckpointEnabled = regionalCheckpointEnabled;
+        this.regionalMaxFailureRatio = regionalMaxFailureRatio;
+        this.regionalMaxConsecutiveFailures = regionalMaxConsecutiveFailures;
+    }
+
+    // --------------------------------------------------------------------------------------------
+    //  Public API (delegated from CheckpointCoordinator)
+    // --------------------------------------------------------------------------------------------
+
+    boolean isRegionalCheckpointEnabled() {
+        return regionalCheckpointEnabled;
+    }
+
+    void setRegionIdProvider(Function<ExecutionVertexID, Object> regionIdProvider) {
+        this.regionIdProvider = regionIdProvider;
+    }
+
+    void setAllSourcesFinishedChecker(Supplier<Boolean> allSourcesFinishedChecker) {
+        this.allSourcesFinishedChecker = allSourcesFinishedChecker;
+    }
+
+    int getConsecutiveRegionalCheckpointCount() {
+        return consecutiveRegionalCheckpointCount;
+    }
+
+    boolean getForceGlobalNextCheckpoint() {
+        return forceGlobalNextCheckpoint;
+    }
+
+    /**
+     * Checks if all sources are finished and, if so, forces the next checkpoint to be global. Per
+     * FLIP-600 Section 9 "Bounded Source (Finished Operators)".
+     */
+    void checkAllSourcesFinishedAndForceGlobal(CheckpointProperties props) {
+        if (regionalCheckpointEnabled && !props.isSavepoint() && allSourcesFinishedChecker.get()) {
+            LOG.info("All sources finished; forcing next checkpoint to be global.");
+            forceGlobalNextCheckpoint = true;
+        }
+    }
+
+    /** Resets consecutive counter and force-global flag on successful global checkpoint. */
+    void resetOnGlobalSuccess() {
+        consecutiveRegionalCheckpointCount = 0;
+        forceGlobalNextCheckpoint = false;
+    }
+
+    // --------------------------------------------------------------------------------------------
+    //  Core regional checkpoint logic
+    // --------------------------------------------------------------------------------------------
+
+    /**
+     * Evaluates a regional checkpoint after all tasks have responded with a mix of acknowledgements
+     * and declines. Determines which pipeline regions have failed tasks, checks limits, assembles
+     * state from the last completed checkpoint for failed regions, and completes the checkpoint
+     * with only healthy regions being notified.
+     *
+     * <p>Important: This method should only be called in the checkpoint lock scope.
+     */
+    void tryCompleteRegionalCheckpoint(PendingCheckpoint checkpoint) {
+        assert (Thread.holdsLock(lock));
+        final long checkpointId = checkpoint.getCheckpointID();
+        LOG.info("Regional Checkpoint evaluation triggered for checkpoint {}", checkpointId);
+
+        // 1. Build mapping from ExecutionAttemptID to ExecutionVertex for declined tasks
+        final Map<ExecutionAttemptID, CheckpointException> declinedTasks =
+                checkpoint.getDeclinedTasks();
+        final List<Execution> tasksToWaitFor = checkpoint.getCheckpointPlan().getTasksToWaitFor();
+        final Map<ExecutionAttemptID, ExecutionVertex> attemptToVertex = new HashMap<>();
+        for (Execution execution : tasksToWaitFor) {
+            attemptToVertex.put(execution.getAttemptId(), execution.getVertex());
+        }
+
+        // 2. Check regionIdProvider availability
+        if (regionIdProvider == null) {
+            LOG.warn("Aborting regional checkpoint {} - regionIdProvider not set", checkpointId);
+            coordinator.abortPendingCheckpoint(
+                    checkpoint,
+                    new CheckpointException(
+                            "RegionIdProvider not set - cannot compute pipeline regions",
+                            CheckpointFailureReason.CHECKPOINT_DECLINED));
+            return;
+        }
+
+        // 3. Compute region membership for all vertices using subtask-level region objects
+        final Map<Object, Set<ExecutionVertex>> regionToVertices = new IdentityHashMap<>();
+        for (Execution execution : tasksToWaitFor) {
+            ExecutionVertex ev = execution.getVertex();
+            Object region = regionIdProvider.apply(ev.getID());
+            regionToVertices.computeIfAbsent(region, k -> new HashSet<>()).add(ev);
+        }
+        final int totalRegions = regionToVertices.size();
+
+        // 4. If single region → abort (ALL_TO_ALL topology, regional checkpoint not applicable)
+        if (totalRegions <= 1) {
+            LOG.info(
+                    "Aborting regional checkpoint {} - job has only {} pipeline region(s)",
+                    checkpointId,
+                    totalRegions);
+            coordinator.abortPendingCheckpoint(
+                    checkpoint,
+                    new CheckpointException(
+                            "Single pipeline region - regional checkpoint not applicable",
+                            CheckpointFailureReason.CHECKPOINT_DECLINED));
+            return;
+        }
+
+        // 5. Determine failed regions (regions containing at least one declined task)
+        final Set<Object> failedRegions = Collections.newSetFromMap(new IdentityHashMap<>());
+        for (ExecutionAttemptID declinedAttemptId : declinedTasks.keySet()) {
+            ExecutionVertex vertex = attemptToVertex.get(declinedAttemptId);
+            if (vertex != null) {
+                failedRegions.add(regionIdProvider.apply(vertex.getID()));
+            }
+        }
+
+        // 6. Check failure ratio
+        final double failureRatio = (double) failedRegions.size() / totalRegions;
+        if (failureRatio > regionalMaxFailureRatio) {
+            LOG.info(
+                    "Aborting regional checkpoint {} - failure ratio {}/{} = {} exceeds max {}",
+                    checkpointId,
+                    failedRegions.size(),
+                    totalRegions,
+                    failureRatio,
+                    regionalMaxFailureRatio);
+            coordinator.abortPendingCheckpoint(
+                    checkpoint,
+                    new CheckpointException(
+                            "Regional checkpoint failure ratio exceeded: "
+                                    + failedRegions.size()
+                                    + "/"
+                                    + totalRegions,
+                            CheckpointFailureReason.CHECKPOINT_DECLINED));
+            return;
+        }
+
+        // 7. Tier 2: if the next checkpoint was forced to be global but still has declined
+        //    tasks, abort and reset (per FLIP-600 two-tier max-consecutive-failures).
+        if (forceGlobalNextCheckpoint) {
+            LOG.info(
+                    "Aborting checkpoint {} - forced global checkpoint still has declined tasks "
+                            + "(Tier 2). Resetting consecutive count and force flag.",
+                    checkpointId);
+            forceGlobalNextCheckpoint = false;
+            consecutiveRegionalCheckpointCount = 0;
+            coordinator.abortPendingCheckpoint(
+                    checkpoint,
+                    new CheckpointException(
+                            "Forced global checkpoint failed (Tier 2): "
+                                    + declinedTasks.size()
+                                    + " tasks declined",
+                            CheckpointFailureReason.CHECKPOINT_DECLINED));
+            return;
+        }
+        // FLIP-600 two-tier: current regional checkpoint completes; next is forced global.
+        // 8. Get last completed checkpoint for fallback state
+        final CompletedCheckpoint lastCompleted = completedCheckpointStore.getLatestCheckpoint();
+        if (lastCompleted == null) {
+            LOG.info(
+                    "Aborting regional checkpoint {} - no historical checkpoint available",
+                    checkpointId);
+            coordinator.abortPendingCheckpoint(
+                    checkpoint,
+                    new CheckpointException(
+                            "No historical checkpoint for regional fallback",
+                            CheckpointFailureReason.CHECKPOINT_DECLINED));
+            return;
+        }
+        final long fallbackCheckpointId = lastCompleted.getCheckpointID();
+
+        // 9. Collect all vertices in failed regions
+        final Set<ExecutionVertex> failedVertices = new HashSet<>();
+        for (Object failedRegion : failedRegions) {
+            Set<ExecutionVertex> regionVertices = regionToVertices.get(failedRegion);
+            if (regionVertices != null) {
+                failedVertices.addAll(regionVertices);
+            }
+        }
+
+        // 10. Collect operator IDs in failed regions and check coordinator support
+        final Set<OperatorID> failedRegionOperatorIds = new HashSet<>();
+        for (ExecutionVertex ev : failedVertices) {
+            ev.getJobVertex()
+                    .getOperatorIDs()
+                    .forEach(pair -> failedRegionOperatorIds.add(pair.getGeneratedOperatorID()));
+        }
+
+        for (OperatorCoordinatorCheckpointContext coordCtx : coordinatorsToCheckpoint) {
+            if (failedRegionOperatorIds.contains(coordCtx.operatorId())) {
+                if (!coordCtx.supportsRegionCheckpoint()) {
+                    LOG.info(
+                            "Aborting regional checkpoint {} - coordinator {} does not support "
+                                    + "regional checkpoint",
+                            checkpointId,
+                            coordCtx.operatorId());
+                    coordinator.abortPendingCheckpoint(
+                            checkpoint,
+                            new CheckpointException(
+                                    "Coordinator "
+                                            + coordCtx.operatorId()
+                                            + " does not support regional checkpoint",
+                                    CheckpointFailureReason.CHECKPOINT_DECLINED));
+                    return;
+                }
+            }
+        }
+
+        // 11. Assemble state: for failed region subtasks use state from lastCompleted
+        final Map<OperatorID, OperatorState> currentStates = checkpoint.getOperatorStates();
+        final Map<OperatorID, OperatorState> lastCompletedStates =
+                lastCompleted.getOperatorStates();
+
+        // Build set of failed subtask indices per operator
+        final Map<OperatorID, Set<Integer>> failedSubtasksByOperator = new HashMap<>();
+        for (ExecutionVertex failedVertex : failedVertices) {
+            final int subtaskIndex = failedVertex.getParallelSubtaskIndex();
+            failedVertex
+                    .getJobVertex()
+                    .getOperatorIDs()
+                    .forEach(
+                            pair ->
+                                    failedSubtasksByOperator
+                                            .computeIfAbsent(
+                                                    pair.getGeneratedOperatorID(),
+                                                    k -> new HashSet<>())
+                                            .add(subtaskIndex));
+        }
+
+        // Merge states: healthy subtask state from current checkpoint,
+        // failed subtask state from last completed checkpoint
+        for (Map.Entry<OperatorID, Set<Integer>> entry : failedSubtasksByOperator.entrySet()) {
+            final OperatorID opId = entry.getKey();
+            final Set<Integer> failedSubtasks = entry.getValue();
+            final OperatorState lastState = lastCompletedStates.get(opId);
+            final OperatorState currentState = currentStates.get(opId);
+
+            if (lastState != null && currentState != null) {
+                for (int subtaskIdx : failedSubtasks) {
+                    OperatorSubtaskState fallbackState = lastState.getState(subtaskIdx);
+                    if (fallbackState != null) {
+                        currentState.putState(
+                                subtaskIdx,
+                                referenceFallbackState(
+                                        fallbackState, fallbackCheckpointId, checkpointId));
+                    }
+                }
+            } else if (lastState != null && currentState == null) {
+                OperatorState newState =
+                        new OperatorState(
+                                null,
+                                null,
+                                opId,
+                                lastState.getParallelism(),
+                                lastState.getMaxParallelism());
+                for (int subtaskIdx : failedSubtasks) {
+                    OperatorSubtaskState fallbackState = lastState.getState(subtaskIdx);
+                    if (fallbackState != null) {
+                        newState.putState(
+                                subtaskIdx,
+                                referenceFallbackState(
+                                        fallbackState, fallbackCheckpointId, checkpointId));
+                    }
+                }
+                currentStates.put(opId, newState);
+            }
+        }
+
+        // 12. Call checkpointCoordinatorForRegionFallback on coordinators in failed regions
+        final List<CompletableFuture<Void>> coordinatorFutures = new ArrayList<>();
+        for (OperatorCoordinatorCheckpointContext coordCtx : coordinatorsToCheckpoint) {
+            if (failedRegionOperatorIds.contains(coordCtx.operatorId())) {
+                Set<Integer> subtasksForCoordinator =
+                        failedSubtasksByOperator.getOrDefault(
+                                coordCtx.operatorId(), Collections.emptySet());
+                if (!subtasksForCoordinator.isEmpty()) {
+                    CompletableFuture<byte[]> resultFuture = new CompletableFuture<>();
+                    try {
+                        coordCtx.checkpointCoordinatorForRegionFallback(
+                                checkpointId,
+                                fallbackCheckpointId,
+                                subtasksForCoordinator,
+                                resultFuture);
+                    } catch (Exception e) {
+                        LOG.warn(
+                                "Failed to invoke checkpointCoordinatorForRegionFallback on {}",
+                                coordCtx.operatorId(),
+                                e);
+                        coordinator.abortPendingCheckpoint(
+                                checkpoint,
+                                new CheckpointException(
+                                        "Region fallback coordinator call failed",
+                                        CheckpointFailureReason.CHECKPOINT_DECLINED,
+                                        e));
+                        return;
+                    }
+
+                    final OperatorID opId = coordCtx.operatorId();
+                    final int coordParallelism = coordCtx.currentParallelism();
+                    final int coordMaxParallelism = coordCtx.maxParallelism();
+                    coordinatorFutures.add(
+                            resultFuture.thenAccept(
+                                    bytes -> {
+                                        synchronized (lock) {
+                                            final ByteStreamStateHandle coordinatorStateHandle =
+                                                    new ByteStreamStateHandle(
+                                                            "regionFallback-" + opId, bytes);
+                                            OperatorState state = currentStates.get(opId);
+                                            if (state == null) {
+                                                state =
+                                                        new OperatorState(
+                                                                null,
+                                                                null,
+                                                                opId,
+                                                                coordParallelism,
+                                                                coordMaxParallelism);
+                                                currentStates.put(opId, state);
+                                            }
+                                            state.overwriteCoordinatorState(coordinatorStateHandle);
+                                        }
+                                    }));
+                }
+            }
+        }
+
+        // 13. Complete the checkpoint
+        if (coordinatorFutures.isEmpty()) {
+            completeRegionalCheckpoint(checkpoint, failedVertices, fallbackCheckpointId);
+        } else {
+            final PendingCheckpoint capturedCheckpoint = checkpoint;
+            FutureUtils.combineAll(coordinatorFutures)
+                    .thenAccept(
+                            ignored -> {
+                                synchronized (lock) {
+                                    if (!capturedCheckpoint.isDisposed()) {
+                                        completeRegionalCheckpoint(
+                                                capturedCheckpoint,
+                                                failedVertices,
+                                                fallbackCheckpointId);
+                                    }
+                                }
+                            })
+                    .exceptionally(
+                            t -> {
+                                synchronized (lock) {
+                                    if (!capturedCheckpoint.isDisposed()) {
+                                        coordinator.abortPendingCheckpoint(
+                                                capturedCheckpoint,
+                                                new CheckpointException(
+                                                        "Region fallback future failed",
+                                                        CheckpointFailureReason.CHECKPOINT_DECLINED,
+                                                        t));
+                                    }
+                                }
+                                return null;
+                            });
+        }
+    }
+
+    /**
+     * Marks a fallback subtask state as referencing the historical checkpoint it originates from,
+     * and registers its shared state under the new checkpoint id.
+     */
+    private OperatorSubtaskState referenceFallbackState(
+            OperatorSubtaskState fallbackState, long fallbackCheckpointId, long checkpointId) {
+        assert (Thread.holdsLock(lock));
+        final OperatorSubtaskState referencedState =
+                fallbackState.toBuilder().setRefCheckpointId(fallbackCheckpointId).build();
+        referencedState.registerSharedStates(
+                completedCheckpointStore.getSharedStateRegistry(), checkpointId);
+        return referencedState;
+    }
+
+    /** Completes a regional checkpoint by finalizing it and notifying only healthy region tasks. */
+    private void completeRegionalCheckpoint(
+            PendingCheckpoint checkpoint,
+            Set<ExecutionVertex> failedVertices,
+            long fallbackCheckpointId) {
+        assert (Thread.holdsLock(lock));
+        try {
+            final long checkpointId = checkpoint.getCheckpointID();
+
+            // Report stats for subtasks in failed regions
+            final long fallbackStatsTimestamp = System.currentTimeMillis();
+            for (ExecutionVertex failedVertex : failedVertices) {
+                checkpoint.reportFallbackSubtaskStats(
+                        failedVertex.getJobvertexId(),
+                        failedVertex.getParallelSubtaskIndex(),
+                        fallbackStatsTimestamp,
+                        fallbackCheckpointId);
+            }
+
+            completedCheckpointStore.getSharedStateRegistry().checkpointCompleted(checkpointId);
+
+            final CompletedCheckpoint completedCheckpoint =
+                    checkpoint.finalizeRegionalCheckpoint(
+                            coordinator.getCheckpointsCleaner(),
+                            coordinator::scheduleTriggerRequest,
+                            coordinator.getExecutor());
+            Preconditions.checkState(checkpoint.isDisposed() && completedCheckpoint != null);
+
+            final CompletedCheckpoint lastSubsumed =
+                    coordinator.addCompletedCheckpointToStoreAndSubsumeOldest(
+                            checkpointId, completedCheckpoint, checkpoint);
+
+            coordinator.reportCompletedCheckpoint(completedCheckpoint);
+            checkpoint.getCompletionFuture().complete(completedCheckpoint);
+
+            coordinator.removePendingCheckpoint(checkpointId);
+            coordinator.scheduleTriggerRequest();
+
+            // Increment consecutive regional checkpoint counter
+            consecutiveRegionalCheckpointCount++;
+            statsTracker.reportRegionalCheckpointCompleted();
+
+            // Tier 1: if consecutive count reaches the limit, force the NEXT checkpoint
+            // to be global.
+            if (consecutiveRegionalCheckpointCount >= regionalMaxConsecutiveFailures
+                    && !forceGlobalNextCheckpoint) {
+                LOG.info(
+                        "Regional checkpoint {} completed. Consecutive count {} reached max {}. "
+                                + "Next checkpoint will be forced global (Tier 1).",
+                        checkpointId,
+                        consecutiveRegionalCheckpointCount,
+                        regionalMaxConsecutiveFailures);
+                forceGlobalNextCheckpoint = true;
+            }
+
+            coordinator.setLastCheckpointCompletionRelativeTime(
+                    coordinator.getClock().relativeTimeMillis());
+            coordinator.logCheckpointInfo(completedCheckpoint);
+
+            // Drop subsumed checkpoints
+            coordinator.dropSubsumedCheckpoints(checkpointId);
+
+            // Notify only healthy region tasks
+            final List<ExecutionVertex> healthyTasks =
+                    checkpoint.getCheckpointPlan().getTasksToCommitTo().stream()
+                            .filter(ev -> !failedVertices.contains(ev))
+                            .collect(Collectors.toList());
+
+            // Build RegionalCheckpointInfo for coordinators
+            final Set<String> fallbackSubtaskIdentifiers = new HashSet<>();
+            for (ExecutionVertex ev : failedVertices) {
+                fallbackSubtaskIdentifiers.add(ev.getTaskNameWithSubtaskIndex());
+            }
+            final Map<Long, Set<String>> fallbackMap = new HashMap<>();
+            fallbackMap.put(fallbackCheckpointId, fallbackSubtaskIdentifiers);
+            final RegionalCheckpointInfo regionalInfo = new RegionalCheckpointInfo(fallbackMap);
+
+            // Send ack to healthy region tasks only
+            final long lastSubsumedId = coordinator.extractIdIfDiscardedOnSubsumed(lastSubsumed);
+            sendAcknowledgeMessagesToTasks(
+                    healthyTasks, checkpointId, completedCheckpoint.getTimestamp(), lastSubsumedId);
+
+            // Notify failed-region tasks with fallbackCheckpointId
+            for (ExecutionVertex ev :
+                    checkpoint.getCheckpointPlan().getTasksToCommitTo().stream()
+                            .filter(failedVertices::contains)
+                            .collect(Collectors.toList())) {
+                Execution ee = ev.getCurrentExecutionAttempt();
+                if (ee != null) {
+                    ee.notifyCheckpointOnComplete(
+                            checkpointId,
+                            completedCheckpoint.getTimestamp(),
+                            lastSubsumedId,
+                            fallbackCheckpointId);
+                }
+            }
+
+            // Notify coordinators: healthy → notifyRegionalCheckpointComplete, failed →
+            // notifyRegionalCheckpointFallback
+            final Set<OperatorID> failedRegionOps =
+                    failedVertices.stream()
+                            .flatMap(
+                                    ev ->
+                                            ev.getJobVertex().getOperatorIDs().stream()
+                                                    .map(OperatorIDPair::getGeneratedOperatorID))
+                            .collect(Collectors.toSet());
+            for (OperatorCoordinatorCheckpointContext coordinatorContext :
+                    coordinatorsToCheckpoint) {
+                if (failedRegionOps.contains(coordinatorContext.operatorId())) {
+                    coordinatorContext.notifyRegionalCheckpointFallback(
+                            checkpointId, fallbackCheckpointId);
+                } else {
+                    coordinatorContext.notifyRegionalCheckpointComplete(checkpointId, regionalInfo);
+                }
+            }
+
+            LOG.info(
+                    "Regional checkpoint {} completed successfully. "
+                            + "Notified {} healthy tasks, {} tasks in failed regions.",
+                    checkpointId,
+                    healthyTasks.size(),
+                    failedVertices.size());
+
+        } catch (Exception e) {
+            checkpoint.getCompletionFuture().completeExceptionally(e);
+            if (!checkpoint.isDisposed()) {
+                coordinator.abortPendingCheckpoint(
+                        checkpoint,
+                        new CheckpointException(
+                                CheckpointFailureReason.FINALIZE_CHECKPOINT_FAILURE, e));
+            }
+        }
+    }
+
+    /**
+     * Sends checkpoint-complete notifications to the given tasks (without coordinator
+     * notification).
+     */
+    private void sendAcknowledgeMessagesToTasks(
+            List<ExecutionVertex> tasksToCommit,
+            long completedCheckpointId,
+            long completedTimestamp,
+            long lastSubsumedCheckpointId) {
+        for (ExecutionVertex ev : tasksToCommit) {
+            Execution ee = ev.getCurrentExecutionAttempt();
+            if (ee != null) {
+                ee.notifyCheckpointOnComplete(
+                        completedCheckpointId, completedTimestamp, lastSubsumedCheckpointId);
+            }
+        }
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/SubtaskStateStats.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/SubtaskStateStats.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.checkpoint;
 
 import java.io.Serializable;
+import java.util.OptionalLong;
 
 import static org.apache.flink.util.Preconditions.checkArgument;
 
@@ -66,8 +67,15 @@ public class SubtaskStateStats implements Serializable {
     /** Is the checkpoint completed by this subtask. */
     private final boolean completed;
 
+    /**
+     * The checkpoint id this subtask's state originates from when it was reused by a regional
+     * checkpoint (i.e. this subtask belonged to a failed region). {@code null} if the state was
+     * produced by the current checkpoint.
+     */
+    private final Long refCheckpointId;
+
     SubtaskStateStats(int subtaskIndex, long ackTimestamp) {
-        this(subtaskIndex, ackTimestamp, 0, 0, 0, 0, 0, 0, 0, 0, false, true);
+        this(subtaskIndex, ackTimestamp, 0, 0, 0, 0, 0, 0, 0, 0, false, true, null);
     }
 
     SubtaskStateStats(
@@ -83,6 +91,36 @@ public class SubtaskStateStats implements Serializable {
             long checkpointStartDelay,
             boolean unalignedCheckpoint,
             boolean completed) {
+        this(
+                subtaskIndex,
+                ackTimestamp,
+                checkpointedSize,
+                stateSize,
+                syncCheckpointDuration,
+                asyncCheckpointDuration,
+                processedData,
+                persistedData,
+                alignmentDuration,
+                checkpointStartDelay,
+                unalignedCheckpoint,
+                completed,
+                null);
+    }
+
+    SubtaskStateStats(
+            int subtaskIndex,
+            long ackTimestamp,
+            long checkpointedSize,
+            long stateSize,
+            long syncCheckpointDuration,
+            long asyncCheckpointDuration,
+            long processedData,
+            long persistedData,
+            long alignmentDuration,
+            long checkpointStartDelay,
+            boolean unalignedCheckpoint,
+            boolean completed,
+            Long refCheckpointId) {
 
         checkArgument(subtaskIndex >= 0, "Negative subtask index");
         this.subtaskIndex = subtaskIndex;
@@ -99,6 +137,7 @@ public class SubtaskStateStats implements Serializable {
         this.checkpointStartDelay = checkpointStartDelay;
         this.unalignedCheckpoint = unalignedCheckpoint;
         this.completed = completed;
+        this.refCheckpointId = refCheckpointId;
     }
 
     public int getSubtaskIndex() {
@@ -193,5 +232,14 @@ public class SubtaskStateStats implements Serializable {
 
     public boolean isCompleted() {
         return completed;
+    }
+
+    /**
+     * Returns the checkpoint id this subtask's state originates from when it was reused by a
+     * regional checkpoint, or {@link OptionalLong#empty()} if the state was produced by the current
+     * checkpoint.
+     */
+    public OptionalLong getRefCheckpointId() {
+        return refCheckpointId == null ? OptionalLong.empty() : OptionalLong.of(refCheckpointId);
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/TaskStateStats.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/TaskStateStats.java
@@ -190,6 +190,12 @@ public class TaskStateStats implements Serializable {
         private StatsSummary alignmentDuration = new StatsSummary();
         private StatsSummary checkpointStartDelay = new StatsSummary();
 
+        /**
+         * The oldest (minimum) regional-checkpoint reference id across all subtasks of this task,
+         * or {@code null} if no subtask referenced a historical checkpoint.
+         */
+        private Long oldestRefCheckpointId = null;
+
         void updateSummary(SubtaskStateStats subtaskStats) {
             checkpointedSize.add(subtaskStats.getCheckpointedSize());
             stateSize.add(subtaskStats.getStateSize());
@@ -202,6 +208,14 @@ public class TaskStateStats implements Serializable {
             persistedData.add(subtaskStats.getPersistedData());
             alignmentDuration.add(subtaskStats.getAlignmentDuration());
             checkpointStartDelay.add(subtaskStats.getCheckpointStartDelay());
+            subtaskStats
+                    .getRefCheckpointId()
+                    .ifPresent(
+                            refId ->
+                                    oldestRefCheckpointId =
+                                            oldestRefCheckpointId == null
+                                                    ? refId
+                                                    : Math.min(oldestRefCheckpointId, refId));
         }
 
         public StatsSummary getCheckpointedSize() {
@@ -238,6 +252,14 @@ public class TaskStateStats implements Serializable {
 
         public StatsSummary getCheckpointStartDelayStats() {
             return checkpointStartDelay;
+        }
+
+        /**
+         * Returns the oldest (minimum) regional-checkpoint reference id across all subtasks of this
+         * task, or {@code null} if no subtask referenced a historical checkpoint.
+         */
+        public Long getOldestRefCheckpointId() {
+            return oldestRefCheckpointId;
         }
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/metadata/MetadataSerializers.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/metadata/MetadataSerializers.java
@@ -30,7 +30,7 @@ import java.util.Map;
 public class MetadataSerializers {
 
     private static final Map<Integer, MetadataSerializer> SERIALIZERS =
-            CollectionUtil.newHashMapWithExpectedSize(6);
+            CollectionUtil.newHashMapWithExpectedSize(7);
 
     static {
         registerSerializer(MetadataV1Serializer.INSTANCE);
@@ -39,6 +39,7 @@ public class MetadataSerializers {
         registerSerializer(MetadataV4Serializer.INSTANCE);
         registerSerializer(MetadataV5Serializer.INSTANCE);
         registerSerializer(MetadataV6Serializer.INSTANCE);
+        registerSerializer(MetadataV7Serializer.INSTANCE);
     }
 
     private static void registerSerializer(MetadataSerializer serializer) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/metadata/MetadataV7Serializer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/metadata/MetadataV7Serializer.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.checkpoint.metadata;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
+
+import javax.annotation.Nullable;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.util.OptionalLong;
+
+/**
+ * V7 serializer that additionally persists the Regional Checkpoint reference id ({@code
+ * refCheckpointId}) of each {@link OperatorSubtaskState}.
+ *
+ * <p>The reference id identifies the historical checkpoint a subtask's state originates from when
+ * it was reused by a regional checkpoint (i.e. the subtask belonged to a failed region). It is
+ * required by the checkpoint cleaner to protect referenced historical checkpoints from being
+ * subsumed.
+ *
+ * <p><b>Format compatibility:</b> the {@code refCheckpointId} is written as an optional trailing
+ * field after the V2/V3 subtask state layout (a presence byte, optionally followed by a {@code
+ * long}). This keeps the layout strictly additive: older serializers (V3–V6) never read this field,
+ * and their metadata is read back with an empty reference id. Savepoints use {@link
+ * MetadataV2Serializer} which does not go through this serializer, so savepoint metadata never
+ * contains the reference id.
+ */
+@Internal
+public class MetadataV7Serializer extends MetadataV6Serializer {
+
+    public static final MetadataSerializer INSTANCE = new MetadataV7Serializer();
+
+    public static final int VERSION = 7;
+
+    /** Marker indicating that a {@code refCheckpointId} value follows. */
+    private static final byte HAS_REF_CHECKPOINT_ID = 1;
+
+    /** Marker indicating that no {@code refCheckpointId} is present. */
+    private static final byte NO_REF_CHECKPOINT_ID = 0;
+
+    @Override
+    public int getVersion() {
+        return VERSION;
+    }
+
+    @Override
+    protected void serializeSubtaskState(
+            OperatorSubtaskState subtaskState, DataOutputStream dos, SerializationContext context)
+            throws IOException {
+        super.serializeSubtaskState(subtaskState, dos, context);
+
+        // Optional trailing field: the regional checkpoint reference id.
+        final OptionalLong refCheckpointId = subtaskState.getRefCheckpointId();
+        if (refCheckpointId.isPresent()) {
+            dos.writeByte(HAS_REF_CHECKPOINT_ID);
+            dos.writeLong(refCheckpointId.getAsLong());
+        } else {
+            dos.writeByte(NO_REF_CHECKPOINT_ID);
+        }
+    }
+
+    @Override
+    protected OperatorSubtaskState deserializeSubtaskState(
+            DataInputStream dis, @Nullable DeserializationContext context) throws IOException {
+        final OperatorSubtaskState subtaskState = super.deserializeSubtaskState(dis, context);
+
+        // Optional trailing field: the regional checkpoint reference id.
+        final byte marker = dis.readByte();
+        if (marker == HAS_REF_CHECKPOINT_ID) {
+            final long refCheckpointId = dis.readLong();
+            return subtaskState.toBuilder().setRefCheckpointId(refCheckpointId).build();
+        }
+        return subtaskState;
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
@@ -27,6 +27,7 @@ import org.apache.flink.runtime.accumulators.StringifiedAccumulatorResult;
 import org.apache.flink.runtime.blob.BlobWriter;
 import org.apache.flink.runtime.blob.PermanentBlobKey;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
+import org.apache.flink.runtime.checkpoint.CheckpointStoreUtil;
 import org.apache.flink.runtime.checkpoint.JobManagerTaskRestore;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
@@ -1018,6 +1019,29 @@ public class Execution
      */
     public void notifyCheckpointOnComplete(
             long completedCheckpointId, long completedTimestamp, long lastSubsumedCheckpointId) {
+        notifyCheckpointOnComplete(
+                completedCheckpointId,
+                completedTimestamp,
+                lastSubsumedCheckpointId,
+                CheckpointStoreUtil.INVALID_CHECKPOINT_ID);
+    }
+
+    /**
+     * Notify the task of this execution about a completed checkpoint, optionally indicating that
+     * this task's region fell back to a historical checkpoint.
+     *
+     * @param completedCheckpointId of the completed checkpoint
+     * @param completedTimestamp of the completed checkpoint
+     * @param lastSubsumedCheckpointId of the last subsumed checkpoint
+     * @param fallbackCheckpointId the historical checkpoint id this task fell back to, or {@link
+     *     org.apache.flink.runtime.checkpoint.CheckpointStoreUtil#INVALID_CHECKPOINT_ID} for normal
+     *     completion
+     */
+    public void notifyCheckpointOnComplete(
+            long completedCheckpointId,
+            long completedTimestamp,
+            long lastSubsumedCheckpointId,
+            long fallbackCheckpointId) {
         final LogicalSlot slot = assignedResource;
 
         if (slot != null) {
@@ -1028,7 +1052,8 @@ public class Execution
                     getVertex().getJobId(),
                     completedCheckpointId,
                     completedTimestamp,
-                    lastSubsumedCheckpointId);
+                    lastSubsumedCheckpointId,
+                    fallbackCheckpointId);
         } else {
             LOG.debug(
                     "The execution has no slot assigned. This indicates that the execution is "

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/tasks/CheckpointCoordinatorConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/tasks/CheckpointCoordinatorConfiguration.java
@@ -76,6 +76,12 @@ public class CheckpointCoordinatorConfiguration implements Serializable {
 
     private final boolean pauseSourcesUntilFirstCheckpoint;
 
+    private final boolean regionalCheckpointEnabled;
+
+    private final double regionalMaxFailureRatio;
+
+    private final int regionalMaxConsecutiveFailures;
+
     /**
      * @deprecated use {@link #builder()}.
      */
@@ -105,7 +111,10 @@ public class CheckpointCoordinatorConfiguration implements Serializable {
                 checkpointIdOfIgnoredInFlightData,
                 false,
                 false,
-                false);
+                false,
+                false,
+                0.3,
+                2);
     }
 
     private CheckpointCoordinatorConfiguration(
@@ -122,7 +131,10 @@ public class CheckpointCoordinatorConfiguration implements Serializable {
             long checkpointIdOfIgnoredInFlightData,
             boolean enableCheckpointsAfterTasksFinish,
             boolean recoverOutputOnDownstreamTask,
-            boolean pauseSourcesUntilFirstCheckpoint) {
+            boolean pauseSourcesUntilFirstCheckpoint,
+            boolean regionalCheckpointEnabled,
+            double regionalMaxFailureRatio,
+            int regionalMaxConsecutiveFailures) {
 
         if (checkpointIntervalDuringBacklog < MINIMAL_CHECKPOINT_TIME) {
             // interval of max value means disable periodic checkpoint
@@ -164,6 +176,9 @@ public class CheckpointCoordinatorConfiguration implements Serializable {
         this.enableCheckpointsAfterTasksFinish = enableCheckpointsAfterTasksFinish;
         this.recoverOutputOnDownstreamTask = recoverOutputOnDownstreamTask;
         this.pauseSourcesUntilFirstCheckpoint = pauseSourcesUntilFirstCheckpoint;
+        this.regionalCheckpointEnabled = regionalCheckpointEnabled;
+        this.regionalMaxFailureRatio = regionalMaxFailureRatio;
+        this.regionalMaxConsecutiveFailures = regionalMaxConsecutiveFailures;
     }
 
     public long getCheckpointInterval() {
@@ -222,6 +237,18 @@ public class CheckpointCoordinatorConfiguration implements Serializable {
         return recoverOutputOnDownstreamTask;
     }
 
+    public boolean isRegionalCheckpointEnabled() {
+        return regionalCheckpointEnabled;
+    }
+
+    public double getRegionalMaxFailureRatio() {
+        return regionalMaxFailureRatio;
+    }
+
+    public int getRegionalMaxConsecutiveFailures() {
+        return regionalMaxConsecutiveFailures;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -242,7 +269,10 @@ public class CheckpointCoordinatorConfiguration implements Serializable {
                 && tolerableCheckpointFailureNumber == that.tolerableCheckpointFailureNumber
                 && checkpointIdOfIgnoredInFlightData == that.checkpointIdOfIgnoredInFlightData
                 && enableCheckpointsAfterTasksFinish == that.enableCheckpointsAfterTasksFinish
-                && recoverOutputOnDownstreamTask == that.recoverOutputOnDownstreamTask;
+                && recoverOutputOnDownstreamTask == that.recoverOutputOnDownstreamTask
+                && regionalCheckpointEnabled == that.regionalCheckpointEnabled
+                && Double.compare(regionalMaxFailureRatio, that.regionalMaxFailureRatio) == 0
+                && regionalMaxConsecutiveFailures == that.regionalMaxConsecutiveFailures;
     }
 
     @Override
@@ -259,7 +289,10 @@ public class CheckpointCoordinatorConfiguration implements Serializable {
                 tolerableCheckpointFailureNumber,
                 checkpointIdOfIgnoredInFlightData,
                 enableCheckpointsAfterTasksFinish,
-                recoverOutputOnDownstreamTask);
+                recoverOutputOnDownstreamTask,
+                regionalCheckpointEnabled,
+                regionalMaxFailureRatio,
+                regionalMaxConsecutiveFailures);
     }
 
     @Override
@@ -289,6 +322,12 @@ public class CheckpointCoordinatorConfiguration implements Serializable {
                 + enableCheckpointsAfterTasksFinish
                 + ", recoverOutputOnDownstreamTask="
                 + recoverOutputOnDownstreamTask
+                + ", regionalCheckpointEnabled="
+                + regionalCheckpointEnabled
+                + ", regionalMaxFailureRatio="
+                + regionalMaxFailureRatio
+                + ", regionalMaxConsecutiveFailures="
+                + regionalMaxConsecutiveFailures
                 + '}';
     }
 
@@ -332,6 +371,9 @@ public class CheckpointCoordinatorConfiguration implements Serializable {
         private boolean enableCheckpointsAfterTasksFinish;
         private boolean recoverOutputOnDownstreamTask;
         private boolean pauseSourcesUntilFirstCheckpoint;
+        private boolean regionalCheckpointEnabled = false;
+        private double regionalMaxFailureRatio = 0.3;
+        private int regionalMaxConsecutiveFailures = 2;
 
         public CheckpointCoordinatorConfiguration build() {
             return new CheckpointCoordinatorConfiguration(
@@ -348,7 +390,10 @@ public class CheckpointCoordinatorConfiguration implements Serializable {
                     checkpointIdOfIgnoredInFlightData,
                     enableCheckpointsAfterTasksFinish,
                     recoverOutputOnDownstreamTask,
-                    pauseSourcesUntilFirstCheckpoint);
+                    pauseSourcesUntilFirstCheckpoint,
+                    regionalCheckpointEnabled,
+                    regionalMaxFailureRatio,
+                    regionalMaxConsecutiveFailures);
         }
 
         public CheckpointCoordinatorConfigurationBuilder setCheckpointInterval(
@@ -431,6 +476,24 @@ public class CheckpointCoordinatorConfiguration implements Serializable {
         public CheckpointCoordinatorConfigurationBuilder setRecoverOutputOnDownstreamTask(
                 boolean recoverOutputOnDownstreamTask) {
             this.recoverOutputOnDownstreamTask = recoverOutputOnDownstreamTask;
+            return this;
+        }
+
+        public CheckpointCoordinatorConfigurationBuilder setRegionalCheckpointEnabled(
+                boolean regionalCheckpointEnabled) {
+            this.regionalCheckpointEnabled = regionalCheckpointEnabled;
+            return this;
+        }
+
+        public CheckpointCoordinatorConfigurationBuilder setRegionalMaxFailureRatio(
+                double regionalMaxFailureRatio) {
+            this.regionalMaxFailureRatio = regionalMaxFailureRatio;
+            return this;
+        }
+
+        public CheckpointCoordinatorConfigurationBuilder setRegionalMaxConsecutiveFailures(
+                int regionalMaxConsecutiveFailures) {
+            this.regionalMaxConsecutiveFailures = regionalMaxConsecutiveFailures;
             return this;
         }
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/tasks/CheckpointableTask.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/tasks/CheckpointableTask.java
@@ -77,6 +77,20 @@ public interface CheckpointableTask {
     Future<Void> notifyCheckpointCompleteAsync(long checkpointId);
 
     /**
+     * Invoked when a regional checkpoint has completed but this task's region fell back to a
+     * historical checkpoint. The task should clean up stale local state from the failed checkpoint
+     * attempt.
+     *
+     * @param checkpointId The ID of the completed regional checkpoint.
+     * @param fallbackCheckpointId The ID of the historical checkpoint this task fell back to.
+     * @return future that completes when the notification has been processed by the task.
+     */
+    default Future<Void> notifyRegionalCheckpointFallbackAsync(
+            long checkpointId, long fallbackCheckpointId) {
+        return CompletableFuture.completedFuture(null);
+    }
+
+    /**
      * Invoked when a checkpoint has been aborted, i.e., when the checkpoint coordinator has
      * received a decline message from one task and try to abort the targeted checkpoint by
      * notification.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/slots/TaskManagerGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/slots/TaskManagerGateway.java
@@ -90,18 +90,27 @@ public interface TaskManagerGateway extends TaskExecutorOperatorEventGateway {
      * Notify the given task about a completed checkpoint and the last subsumed checkpoint id if
      * possible.
      *
+     * <p>When {@code fallbackCheckpointId} is not {@link
+     * org.apache.flink.runtime.checkpoint.CheckpointStoreUtil#INVALID_CHECKPOINT_ID}, this
+     * notification indicates a regional checkpoint completion where this task's region fell back to
+     * the given historical checkpoint.
+     *
      * @param executionAttemptID identifying the task
      * @param jobId identifying the job to which the task belongs
      * @param completedCheckpointId of the completed checkpoint
      * @param completedTimestamp of the completed checkpoint
-     * @param lastSubsumedCheckpointId of the last subsumed checkpoint id,
+     * @param lastSubsumedCheckpointId of the last subsumed checkpoint id
+     * @param fallbackCheckpointId the historical checkpoint id this task fell back to, or {@link
+     *     org.apache.flink.runtime.checkpoint.CheckpointStoreUtil#INVALID_CHECKPOINT_ID} for normal
+     *     completion
      */
     void notifyCheckpointOnComplete(
             ExecutionAttemptID executionAttemptID,
             JobID jobId,
             long completedCheckpointId,
             long completedTimestamp,
-            long lastSubsumedCheckpointId);
+            long lastSubsumedCheckpointId,
+            long fallbackCheckpointId);
 
     /**
      * Notify the given task about a aborted checkpoint.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/RpcTaskManagerGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/RpcTaskManagerGateway.java
@@ -85,12 +85,14 @@ public class RpcTaskManagerGateway implements TaskManagerGateway {
             JobID jobId,
             long completedCheckpointId,
             long completedTimestamp,
-            long lastSubsumedCheckpointId) {
+            long lastSubsumedCheckpointId,
+            long fallbackCheckpointId) {
         taskExecutorGateway.confirmCheckpoint(
                 executionAttemptID,
                 completedCheckpointId,
                 completedTimestamp,
-                lastSubsumedCheckpointId);
+                lastSubsumedCheckpointId,
+                fallbackCheckpointId);
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/OperatorCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/OperatorCoordinator.java
@@ -250,6 +250,98 @@ public interface OperatorCoordinator extends CheckpointListener, AutoCloseable {
         return false;
     }
 
+    /**
+     * Indicates whether this coordinator supports being checkpointed in a "region checkpoint" mode,
+     * where some subtasks of the operator may have failed to acknowledge the checkpoint and their
+     * state is replaced by state from the previous successful checkpoint.
+     *
+     * <p>When this returns {@code true}, the framework will invoke {@link
+     * #checkpointCoordinatorForRegionFallback} after all task responses are collected (instead of
+     * aborting the checkpoint), allowing the coordinator to produce a state snapshot that is
+     * <em>consistent</em> with the mixed view (some subtasks at checkpoint N, some at checkpoint
+     * N-1).
+     *
+     * <p>This method follows the same opt-in pattern as {@link #supportsBatchSnapshot()}.
+     */
+    default boolean supportsRegionCheckpoint() {
+        return false;
+    }
+
+    /**
+     * Takes a "region-aware" snapshot of the coordinator. Called <em>instead of</em> completing the
+     * checkpoint with the bytes produced by {@link #checkpointCoordinator} when the framework has
+     * decided to complete the checkpoint as a region checkpoint, i.e. when some subtasks failed to
+     * acknowledge and their state will be replaced by state from {@code fallbackCheckpointId}.
+     *
+     * <p>The coordinator MUST produce a state snapshot whose view is consistent with the following
+     * task-side reality:
+     *
+     * <ul>
+     *   <li>Subtasks NOT in {@code fallbackSubtaskIds} are at checkpoint {@code checkpointId}.
+     *   <li>Subtasks in {@code fallbackSubtaskIds} are effectively at checkpoint {@code
+     *       fallbackCheckpointId}.
+     * </ul>
+     *
+     * <p>Typical implementations will:
+     *
+     * <ol>
+     *   <li>Roll back any in-memory bookkeeping that pertains to the fallback subtasks since
+     *       checkpoint {@code fallbackCheckpointId} (e.g. split assignments, pending work, etc.).
+     *   <li>Persist any "to-be-replayed" information into the returned bytes so that recovery is
+     *       fully self-contained — i.e. recovery does NOT need any extra reconciliation step.
+     *   <li>Serialize and complete {@code resultFuture}.
+     * </ol>
+     *
+     * <p>After this method completes, the coordinator's in-memory state should reflect the
+     * post-rollback view, identical to what would be restored from the produced bytes.
+     *
+     * <p>The framework guarantees the following invariants when invoking this method:
+     *
+     * <ol>
+     *   <li>INVOKED AFTER {@link #checkpointCoordinator}: This method is only called after {@code
+     *       checkpointCoordinator(checkpointId, ...)} has already completed successfully for the
+     *       same {@code checkpointId}. The coordinator's in-memory state at the time of this call
+     *       reflects the view AT {@code checkpointId}.
+     *   <li>INVOKED AFTER ALL TASK RESPONSES: This method is only called after every task in the
+     *       checkpoint has either acknowledged or declined. The {@code fallbackSubtaskIds} set is
+     *       therefore final and complete.
+     *   <li>INVOKED BEFORE {@link #notifyCheckpointComplete}: This method is called before {@code
+     *       notifyCheckpointComplete(checkpointId)} for the same id. The coordinator can therefore
+     *       safely reorganize state that would normally be cleaned up on checkpoint completion.
+     *   <li>INVOKED BEFORE METADATA PERSISTENCE: The bytes produced by this method replace the
+     *       bytes produced by the original {@link #checkpointCoordinator} call in the persisted
+     *       checkpoint metadata.
+     *   <li>SERIALIZED WITH EVENT HANDLING: This method runs on the coordinator's main executor,
+     *       serially with {@link #handleEventFromOperator}, guaranteeing no concurrent event
+     *       processing.
+     * </ol>
+     *
+     * <p>The default implementation throws {@link UnsupportedOperationException}; coordinators that
+     * declare {@link #supportsRegionCheckpoint()} {@code = true} MUST override this method.
+     *
+     * @param checkpointId the id of the ongoing checkpoint (the "new" one)
+     * @param fallbackCheckpointId the id of the previous checkpoint that the failed subtasks will
+     *     effectively be restored from; {@link #NO_CHECKPOINT} if there is no prior successful
+     *     checkpoint
+     * @param fallbackSubtaskIds the subtask indices whose state will be replaced by state from
+     *     {@code fallbackCheckpointId}; never null and never empty when this method is invoked
+     * @param resultFuture the future to complete with the serialized coordinator state, or complete
+     *     exceptionally to abort the region checkpoint
+     * @throws Exception any exception thrown by this method causes the region checkpoint to be
+     *     aborted and falls back to a normal checkpoint abort
+     */
+    default void checkpointCoordinatorForRegionFallback(
+            long checkpointId,
+            long fallbackCheckpointId,
+            java.util.Set<Integer> fallbackSubtaskIds,
+            CompletableFuture<byte[]> resultFuture)
+            throws Exception {
+        throw new UnsupportedOperationException(
+                "This OperatorCoordinator does not support region checkpoints. "
+                        + "Override supportsRegionCheckpoint() to return true and implement "
+                        + "checkpointCoordinatorForRegionFallback() to enable it.");
+    }
+
     // ------------------------------------------------------------------------
     // ------------------------------------------------------------------------
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/OperatorCoordinatorHolder.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/OperatorCoordinatorHolder.java
@@ -23,6 +23,7 @@ import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.JobInfo;
 import org.apache.flink.api.common.JobInfoImpl;
+import org.apache.flink.api.common.state.RegionalCheckpointInfo;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.metrics.groups.OperatorCoordinatorMetricGroup;
 import org.apache.flink.runtime.checkpoint.CheckpointCoordinator;
@@ -243,6 +244,32 @@ public class OperatorCoordinatorHolder
     }
 
     @Override
+    public boolean supportsRegionCheckpoint() {
+        return coordinator.supportsRegionCheckpoint();
+    }
+
+    @Override
+    public void checkpointCoordinatorForRegionFallback(
+            long checkpointId,
+            long fallbackCheckpointId,
+            Set<Integer> fallbackSubtaskIds,
+            CompletableFuture<byte[]> resultFuture)
+            throws Exception {
+        mainThreadExecutor.execute(
+                () -> {
+                    try {
+                        coordinator.checkpointCoordinatorForRegionFallback(
+                                checkpointId,
+                                fallbackCheckpointId,
+                                fallbackSubtaskIds,
+                                resultFuture);
+                    } catch (Exception e) {
+                        resultFuture.completeExceptionally(e);
+                    }
+                });
+    }
+
+    @Override
     public void checkpointCoordinator(long checkpointId, CompletableFuture<byte[]> result) {
         // unfortunately, this method does not run in the scheduler executor, but in the
         // checkpoint coordinator time thread.
@@ -263,6 +290,36 @@ public class OperatorCoordinatorHolder
                             .values()
                             .forEach(x -> x.openGatewayAndUnmarkCheckpoint(checkpointId));
                     coordinator.notifyCheckpointComplete(checkpointId);
+                });
+    }
+
+    @Override
+    public void notifyRegionalCheckpointComplete(long checkpointId, RegionalCheckpointInfo info) {
+        mainThreadExecutor.execute(
+                () -> {
+                    subtaskGatewayMap
+                            .values()
+                            .forEach(x -> x.openGatewayAndUnmarkCheckpoint(checkpointId));
+                    try {
+                        coordinator.notifyRegionalCheckpointComplete(checkpointId, info);
+                    } catch (Exception e) {
+                        throw new RuntimeException(
+                                "Exception in notifyRegionalCheckpointComplete", e);
+                    }
+                });
+    }
+
+    @Override
+    public void notifyRegionalCheckpointFallback(long checkpointId, long fallbackCheckpointId) {
+        mainThreadExecutor.execute(
+                () -> {
+                    try {
+                        coordinator.notifyRegionalCheckpointFallback(
+                                checkpointId, fallbackCheckpointId);
+                    } catch (Exception e) {
+                        throw new RuntimeException(
+                                "Exception in notifyRegionalCheckpointFallback", e);
+                    }
                 });
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/source/coordinator/SourceCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/source/coordinator/SourceCoordinator.java
@@ -416,6 +416,61 @@ public class SourceCoordinator<SplitT extends SourceSplit, EnumChkT>
     }
 
     @Override
+    public boolean supportsRegionCheckpoint() {
+        return true;
+    }
+
+    @Override
+    public void checkpointCoordinatorForRegionFallback(
+            long checkpointId,
+            long fallbackCheckpointId,
+            Set<Integer> fallbackSubtaskIds,
+            CompletableFuture<byte[]> resultFuture)
+            throws Exception {
+        runInEventLoop(
+                () -> {
+                    LOG.info(
+                            "Region checkpoint fallback for source {} at checkpoint {}, "
+                                    + "rolling back subtasks {} to checkpoint {}.",
+                            operatorName,
+                            checkpointId,
+                            fallbackSubtaskIds,
+                            fallbackCheckpointId);
+                    try {
+                        // Remove splits assigned to fallback subtasks after the fallback checkpoint
+                        final Map<Integer, List<SplitT>> removedAssignments =
+                                context.getAssignmentTracker()
+                                        .removeAssignmentsAfterCheckpoint(
+                                                fallbackCheckpointId, fallbackSubtaskIds);
+
+                        // Return removed splits to the enumerator
+                        for (Map.Entry<Integer, List<SplitT>> entry :
+                                removedAssignments.entrySet()) {
+                            LOG.debug(
+                                    "Adding splits back to enumerator of source {} for subtask {}: {}",
+                                    operatorName,
+                                    entry.getKey(),
+                                    entry.getValue());
+                            enumerator.addSplitsBack(entry.getValue(), entry.getKey());
+                        }
+
+                        // Serialize the corrected coordinator state
+                        resultFuture.complete(toBytes(checkpointId));
+                    } catch (Throwable e) {
+                        ExceptionUtils.rethrowIfFatalErrorOrOOM(e);
+                        resultFuture.completeExceptionally(
+                                new CompletionException(
+                                        String.format(
+                                                "Failed to perform region checkpoint fallback for source %s",
+                                                operatorName),
+                                        e));
+                    }
+                },
+                "performing region checkpoint fallback for checkpoint %d",
+                checkpointId);
+    }
+
+    @Override
     public void checkpointCoordinator(long checkpointId, CompletableFuture<byte[]> result) {
         runInEventLoop(
                 () -> {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorSerdeUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorSerdeUtils.java
@@ -30,6 +30,8 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.Map;
+import java.util.SortedMap;
+import java.util.TreeMap;
 
 /** A serialization util class for the {@link SourceCoordinator}. */
 public class SourceCoordinatorSerdeUtils {
@@ -39,6 +41,20 @@ public class SourceCoordinatorSerdeUtils {
 
     /** The current source coordinator serde version. */
     private static final int CURRENT_VERSION = VERSION_1;
+
+    /**
+     * Magic number marking the assignment-tracker snapshot format that also persists the
+     * per-checkpoint assignment history ({@code assignmentsByCheckpointId}).
+     *
+     * <p>The legacy format produced by {@link #serializeAssignments} starts with the (non-negative)
+     * split serializer version, so a negative magic unambiguously distinguishes the new format from
+     * a legacy snapshot, allowing {@link #deserializeAssignmentTracker} to remain backwards
+     * compatible with state written before regional checkpoint support was added.
+     */
+    private static final int ASSIGNMENT_TRACKER_MAGIC = -1;
+
+    /** The current version of the assignment-tracker snapshot format. */
+    private static final int ASSIGNMENT_TRACKER_VERSION = 1;
 
     /** Private constructor for utility class. */
     private SourceCoordinatorSerdeUtils() {}
@@ -115,6 +131,106 @@ public class SourceCoordinatorSerdeUtils {
             }
 
             return assignments;
+        }
+    }
+
+    /**
+     * Serializes the full state of a {@link SplitAssignmentTracker}, including both the
+     * uncheckpointed assignments and the per-checkpoint assignment history ({@code
+     * assignmentsByCheckpointId}).
+     *
+     * <p>The latter is required by regional checkpoint to precisely roll back the splits assigned
+     * after a given checkpoint, so it must survive coordinator (JM) restarts rather than living
+     * only in memory.
+     */
+    static <SplitT> byte[] serializeAssignmentTracker(
+            Map<Integer, LinkedHashSet<SplitT>> uncheckpointedAssignments,
+            SortedMap<Long, Map<Integer, LinkedHashSet<SplitT>>> assignmentsByCheckpointId,
+            SimpleVersionedSerializer<SplitT> splitSerializer)
+            throws IOException {
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream();
+                DataOutputStream out = new DataOutputViewStreamWrapper(baos)) {
+            out.writeInt(ASSIGNMENT_TRACKER_MAGIC);
+            out.writeInt(ASSIGNMENT_TRACKER_VERSION);
+
+            // Uncheckpointed assignments.
+            byte[] uncheckpointed =
+                    serializeAssignments(uncheckpointedAssignments, splitSerializer);
+            out.writeInt(uncheckpointed.length);
+            out.write(uncheckpointed);
+
+            // Per-checkpoint assignment history.
+            out.writeInt(assignmentsByCheckpointId.size());
+            for (Map.Entry<Long, Map<Integer, LinkedHashSet<SplitT>>> entry :
+                    assignmentsByCheckpointId.entrySet()) {
+                out.writeLong(entry.getKey());
+                byte[] assignments = serializeAssignments(entry.getValue(), splitSerializer);
+                out.writeInt(assignments.length);
+                out.write(assignments);
+            }
+
+            out.flush();
+            return baos.toByteArray();
+        }
+    }
+
+    /**
+     * Deserializes the state written by {@link #serializeAssignmentTracker}, populating both the
+     * uncheckpointed assignments and the per-checkpoint history.
+     *
+     * <p>Remains backwards compatible with the legacy format (which only contained the
+     * uncheckpointed assignments): when the leading int is not {@link #ASSIGNMENT_TRACKER_MAGIC}
+     * the whole payload is interpreted as a legacy {@link #serializeAssignments} blob and the
+     * history is left empty.
+     */
+    static <SplitT> AssignmentTrackerState<SplitT> deserializeAssignmentTracker(
+            byte[] data, SimpleVersionedSerializer<SplitT> splitSerializer) throws IOException {
+        try (ByteArrayInputStream bais = new ByteArrayInputStream(data);
+                DataInputStream in = new DataInputViewStreamWrapper(bais)) {
+            int magic = in.readInt();
+            if (magic != ASSIGNMENT_TRACKER_MAGIC) {
+                // Legacy format: the whole blob is a plain serializeAssignments() payload.
+                return new AssignmentTrackerState<>(
+                        deserializeAssignments(data, splitSerializer), new TreeMap<>());
+            }
+
+            int version = in.readInt();
+            if (version > ASSIGNMENT_TRACKER_VERSION) {
+                throw new IOException(
+                        "Unsupported split assignment tracker serde version " + version);
+            }
+
+            int uncheckpointedLength = in.readInt();
+            byte[] uncheckpointedBytes = readBytes(in, uncheckpointedLength);
+            Map<Integer, LinkedHashSet<SplitT>> uncheckpointedAssignments =
+                    deserializeAssignments(uncheckpointedBytes, splitSerializer);
+
+            int numCheckpoints = in.readInt();
+            SortedMap<Long, Map<Integer, LinkedHashSet<SplitT>>> assignmentsByCheckpointId =
+                    new TreeMap<>();
+            for (int i = 0; i < numCheckpoints; i++) {
+                long checkpointId = in.readLong();
+                int length = in.readInt();
+                byte[] assignmentBytes = readBytes(in, length);
+                assignmentsByCheckpointId.put(
+                        checkpointId, deserializeAssignments(assignmentBytes, splitSerializer));
+            }
+
+            return new AssignmentTrackerState<>(
+                    uncheckpointedAssignments, assignmentsByCheckpointId);
+        }
+    }
+
+    /** Holder for the deserialized state of a {@link SplitAssignmentTracker}. */
+    static final class AssignmentTrackerState<SplitT> {
+        final Map<Integer, LinkedHashSet<SplitT>> uncheckpointedAssignments;
+        final SortedMap<Long, Map<Integer, LinkedHashSet<SplitT>>> assignmentsByCheckpointId;
+
+        AssignmentTrackerState(
+                Map<Integer, LinkedHashSet<SplitT>> uncheckpointedAssignments,
+                SortedMap<Long, Map<Integer, LinkedHashSet<SplitT>>> assignmentsByCheckpointId) {
+            this.uncheckpointedAssignments = uncheckpointedAssignments;
+            this.assignmentsByCheckpointId = assignmentsByCheckpointId;
         }
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/source/coordinator/SplitAssignmentTracker.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/source/coordinator/SplitAssignmentTracker.java
@@ -69,8 +69,8 @@ public class SplitAssignmentTracker<SplitT extends SourceSplit> {
     /** Take a snapshot of the split assignments. */
     public byte[] snapshotState(SimpleVersionedSerializer<SplitT> splitSerializer)
             throws Exception {
-        return SourceCoordinatorSerdeUtils.serializeAssignments(
-                uncheckpointedAssignments, splitSerializer);
+        return SourceCoordinatorSerdeUtils.serializeAssignmentTracker(
+                uncheckpointedAssignments, assignmentsByCheckpointId, splitSerializer);
     }
 
     /**
@@ -83,8 +83,12 @@ public class SplitAssignmentTracker<SplitT extends SourceSplit> {
     public void restoreState(
             SimpleVersionedSerializer<SplitT> splitSerializer, byte[] assignmentData)
             throws Exception {
-        uncheckpointedAssignments =
-                SourceCoordinatorSerdeUtils.deserializeAssignments(assignmentData, splitSerializer);
+        final SourceCoordinatorSerdeUtils.AssignmentTrackerState<SplitT> state =
+                SourceCoordinatorSerdeUtils.deserializeAssignmentTracker(
+                        assignmentData, splitSerializer);
+        uncheckpointedAssignments = state.uncheckpointedAssignments;
+        assignmentsByCheckpointId.clear();
+        assignmentsByCheckpointId.putAll(state.assignmentsByCheckpointId);
     }
 
     /**
@@ -104,6 +108,68 @@ public class SplitAssignmentTracker<SplitT extends SourceSplit> {
      */
     public void recordSplitAssignment(SplitsAssignment<SplitT> splitsAssignment) {
         addSplitAssignment(splitsAssignment, uncheckpointedAssignments);
+    }
+
+    /**
+     * Get all splits assigned to the given subtasks after the given checkpointId without removing
+     * them. This is used for Regional Checkpoint to determine which splits need to be rolled back
+     * when a region falls back to a historical checkpoint.
+     *
+     * @param checkpointId the checkpoint ID to look after.
+     * @param subtaskIds the set of subtask IDs to query.
+     * @return a map from subtask ID to the list of splits assigned after the given checkpoint.
+     */
+    public Map<Integer, List<SplitT>> getAssignmentsAfterCheckpoint(
+            long checkpointId, Set<Integer> subtaskIds) {
+        final Map<Integer, List<SplitT>> result = new HashMap<>();
+        for (int subtaskId : subtaskIds) {
+            final List<SplitT> splits = new ArrayList<>();
+            for (Map.Entry<Long, Map<Integer, LinkedHashSet<SplitT>>> entry :
+                    assignmentsByCheckpointId.entrySet()) {
+                if (entry.getKey() > checkpointId) {
+                    LinkedHashSet<SplitT> assigned = entry.getValue().get(subtaskId);
+                    if (assigned != null) {
+                        splits.addAll(assigned);
+                    }
+                }
+            }
+            LinkedHashSet<SplitT> uncheckpointed = uncheckpointedAssignments.get(subtaskId);
+            if (uncheckpointed != null) {
+                splits.addAll(uncheckpointed);
+            }
+            if (!splits.isEmpty()) {
+                result.put(subtaskId, splits);
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Remove and return all splits assigned to the given subtasks after the given checkpointId.
+     * This is used for Regional Checkpoint rollback: when a region falls back to a historical
+     * checkpoint, the splits assigned after that checkpoint must be returned to the enumerator.
+     *
+     * @param checkpointId the checkpoint ID to look after.
+     * @param subtaskIds the set of subtask IDs whose assignments should be removed.
+     * @return a map from subtask ID to the list of splits removed.
+     */
+    public Map<Integer, List<SplitT>> removeAssignmentsAfterCheckpoint(
+            long checkpointId, Set<Integer> subtaskIds) {
+        final Map<Integer, List<SplitT>> result = new HashMap<>();
+        for (int subtaskId : subtaskIds) {
+            final List<SplitT> splits = new ArrayList<>();
+            for (Map.Entry<Long, Map<Integer, LinkedHashSet<SplitT>>> entry :
+                    assignmentsByCheckpointId.entrySet()) {
+                if (entry.getKey() > checkpointId) {
+                    removeFromAssignment(subtaskId, entry.getValue(), splits);
+                }
+            }
+            removeFromAssignment(subtaskId, uncheckpointedAssignments, splits);
+            if (!splits.isEmpty()) {
+                result.put(subtaskId, splits);
+            }
+        }
+        return result;
     }
 
     /**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/TaskStateManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/TaskStateManager.java
@@ -128,4 +128,13 @@ public interface TaskStateManager extends CheckpointListener, AutoCloseable {
 
     @Nullable
     FileMergingSnapshotManager getFileMergingSnapshotManager();
+
+    /**
+     * Prune (discard) any local state held for the given checkpoint id. Called when a regional
+     * checkpoint completes but this task's region fell back to a historical checkpoint, so the
+     * stale local state from the failed attempt must not be reused on recovery.
+     *
+     * @param checkpointId the id of the failed checkpoint whose local state should be pruned
+     */
+    default void pruneStateForCheckpoint(long checkpointId) {}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/TaskStateManagerImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/TaskStateManagerImpl.java
@@ -315,6 +315,17 @@ public class TaskStateManagerImpl implements TaskStateManager {
         localStateStore.abortCheckpoint(checkpointId);
     }
 
+    /**
+     * Prunes local state for the given checkpoint id. Called when a regional checkpoint completes
+     * but this task's region fell back to a historical checkpoint, so the stale local state from
+     * the failed attempt must not be reused on recovery. Per FLIP-600 Section 9 "Local Recovery
+     * Cleanup".
+     */
+    @Override
+    public void pruneStateForCheckpoint(long checkpointId) {
+        localStateStore.pruneMatchingCheckpoints(id -> id == checkpointId);
+    }
+
     @Override
     public void close() throws Exception {
         sequentialChannelStateReader.close();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
@@ -35,6 +35,7 @@ import org.apache.flink.runtime.blob.TransientBlobService;
 import org.apache.flink.runtime.checkpoint.CheckpointException;
 import org.apache.flink.runtime.checkpoint.CheckpointFailureReason;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
+import org.apache.flink.runtime.checkpoint.CheckpointStoreUtil;
 import org.apache.flink.runtime.checkpoint.JobManagerTaskRestore;
 import org.apache.flink.runtime.checkpoint.filemerging.FileMergingSnapshotManager;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
@@ -1125,19 +1126,28 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
             ExecutionAttemptID executionAttemptID,
             long completedCheckpointId,
             long completedCheckpointTimestamp,
-            long lastSubsumedCheckpointId) {
+            long lastSubsumedCheckpointId,
+            long fallbackCheckpointId) {
         final Task task = taskSlotTable.getTask(executionAttemptID);
         if (task != null) {
             try (MdcCloseable ignored =
                     MdcUtils.withContext(MdcUtils.asContextData(task.getJobID()))) {
                 log.debug(
-                        "Confirm completed checkpoint {}@{} and last subsumed checkpoint {} for {}.",
+                        "Confirm completed checkpoint {}@{} and last subsumed checkpoint {} for {} "
+                                + "(fallbackCheckpointId={}).",
                         completedCheckpointId,
                         completedCheckpointTimestamp,
                         lastSubsumedCheckpointId,
-                        executionAttemptID);
-                task.notifyCheckpointComplete(completedCheckpointId);
-
+                        executionAttemptID,
+                        fallbackCheckpointId);
+                if (fallbackCheckpointId != CheckpointStoreUtil.INVALID_CHECKPOINT_ID) {
+                    // Regional checkpoint fallback notification: this task's region fell back to
+                    // the historical checkpoint. Notify the task to clean up stale local state.
+                    task.notifyRegionalCheckpointFallback(
+                            completedCheckpointId, fallbackCheckpointId);
+                } else {
+                    task.notifyCheckpointComplete(completedCheckpointId);
+                }
                 task.notifyCheckpointSubsumed(lastSubsumedCheckpointId);
                 return CompletableFuture.completedFuture(Acknowledge.get());
             }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutorGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutorGateway.java
@@ -154,17 +154,28 @@ public interface TaskExecutorGateway
      * Confirm a checkpoint for the given task. The checkpoint is identified by the checkpoint ID
      * and the checkpoint timestamp.
      *
+     * <p>When {@code fallbackCheckpointId} is not {@link
+     * org.apache.flink.runtime.checkpoint.CheckpointStoreUtil#INVALID_CHECKPOINT_ID}, this
+     * notification indicates that a regional checkpoint has completed but this task's region fell
+     * back to the given historical checkpoint. The task should invoke {@code
+     * notifyRegionalCheckpointFallback} to clean up stale local state, instead of the normal {@code
+     * notifyCheckpointComplete} path.
+     *
      * @param executionAttemptID identifying the task
      * @param completedCheckpointId unique id for the completed checkpoint
      * @param completedCheckpointTimestamp is the timestamp when the checkpoint has been initiated
      * @param lastSubsumedCheckpointId unique id for the checkpoint to be subsumed
+     * @param fallbackCheckpointId the historical checkpoint id this task fell back to, or {@link
+     *     org.apache.flink.runtime.checkpoint.CheckpointStoreUtil#INVALID_CHECKPOINT_ID} if this is
+     *     a normal (non-regional-fallback) completion
      * @return Future acknowledge if the checkpoint has been successfully confirmed
      */
     CompletableFuture<Acknowledge> confirmCheckpoint(
             ExecutionAttemptID executionAttemptID,
             long completedCheckpointId,
             long completedCheckpointTimestamp,
-            long lastSubsumedCheckpointId);
+            long lastSubsumedCheckpointId,
+            long fallbackCheckpointId);
 
     /**
      * Abort a checkpoint for the given task. The checkpoint is identified by the checkpoint ID and

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutorGatewayDecoratorBase.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutorGatewayDecoratorBase.java
@@ -142,12 +142,14 @@ public class TaskExecutorGatewayDecoratorBase implements TaskExecutorGateway {
             ExecutionAttemptID executionAttemptID,
             long completedCheckpointId,
             long completedCheckpointTimestamp,
-            long lastSubsumedCheckpointId) {
+            long lastSubsumedCheckpointId,
+            long fallbackCheckpointId) {
         return originalGateway.confirmCheckpoint(
                 executionAttemptID,
                 completedCheckpointId,
                 completedCheckpointTimestamp,
-                lastSubsumedCheckpointId);
+                lastSubsumedCheckpointId,
+                fallbackCheckpointId);
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
@@ -1490,6 +1490,21 @@ public class Task
                 NotifyCheckpointOperation.SUBSUME);
     }
 
+    /**
+     * Notifies the task that a regional checkpoint has completed but this task's region fell back
+     * to a historical checkpoint. Used by {@link
+     * org.apache.flink.runtime.taskexecutor.TaskExecutor#confirmCheckpoint} when {@code
+     * fallbackCheckpointId != INVALID_CHECKPOINT_ID}.
+     *
+     * @param checkpointId the completed regional checkpoint id
+     * @param fallbackCheckpointId the historical checkpoint this task fell back to
+     */
+    public void notifyRegionalCheckpointFallback(
+            final long checkpointId, final long fallbackCheckpointId) {
+        notifyCheckpoint(
+                checkpointId, fallbackCheckpointId, NotifyCheckpointOperation.REGIONAL_FALLBACK);
+    }
+
     private void notifyCheckpoint(
             long checkpointId,
             long latestCompletedCheckpointId,
@@ -1509,6 +1524,11 @@ public class Task
                         ((CheckpointableTask) invokable)
                                 .notifyCheckpointCompleteAsync(checkpointId);
                         break;
+                    case REGIONAL_FALLBACK:
+                        ((CheckpointableTask) invokable)
+                                .notifyRegionalCheckpointFallbackAsync(
+                                        checkpointId, latestCompletedCheckpointId);
+                        break;
                     case SUBSUME:
                         ((CheckpointableTask) invokable)
                                 .notifyCheckpointSubsumedAsync(checkpointId);
@@ -1526,6 +1546,7 @@ public class Task
                 switch (notifyCheckpointOperation) {
                     case ABORT:
                     case COMPLETE:
+                    case REGIONAL_FALLBACK:
                         if (getExecutionState() == ExecutionState.RUNNING) {
                             failExternally(
                                     new RuntimeException(
@@ -1902,6 +1923,7 @@ public class Task
     public enum NotifyCheckpointOperation {
         ABORT,
         COMPLETE,
+        REGIONAL_FALLBACK,
         SUBSUME
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/api/graph/StreamGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/api/graph/StreamGraph.java
@@ -401,6 +401,16 @@ public class StreamGraph implements Pipeline, ExecutionPlan {
                                                 .UNALIGNED_RECOVER_OUTPUT_ON_DOWNSTREAM))
                         .setPauseSourcesUntilFirstCheckpoint(
                                 cfg.isPauseSourcesUntilFirstCheckpoint())
+                        .setRegionalCheckpointEnabled(
+                                jobConfiguration.get(
+                                        CheckpointingOptions.REGIONAL_CHECKPOINT_ENABLED))
+                        .setRegionalMaxFailureRatio(
+                                jobConfiguration.get(
+                                        CheckpointingOptions.REGIONAL_CHECKPOINT_MAX_FAILURE_RATIO))
+                        .setRegionalMaxConsecutiveFailures(
+                                jobConfiguration.get(
+                                        CheckpointingOptions
+                                                .REGIONAL_CHECKPOINT_MAX_CONSECUTIVE_FAILURES))
                         .build(),
                 serializedStateBackend,
                 getJobConfiguration()

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/api/operators/AbstractUdfStreamOperator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/api/operators/AbstractUdfStreamOperator.java
@@ -145,6 +145,28 @@ public abstract class AbstractUdfStreamOperator<OUT, F extends Function>
     }
 
     @Override
+    public void notifyRegionalCheckpointComplete(
+            long checkpointId, org.apache.flink.api.common.state.RegionalCheckpointInfo info)
+            throws Exception {
+        super.notifyRegionalCheckpointComplete(checkpointId, info);
+
+        if (userFunction instanceof CheckpointListener) {
+            ((CheckpointListener) userFunction)
+                    .notifyRegionalCheckpointComplete(checkpointId, info);
+        }
+    }
+
+    @Override
+    public void notifyRegionalCheckpointFallback(long checkpointId, long fallbackCheckpointId) {
+        super.notifyRegionalCheckpointFallback(checkpointId, fallbackCheckpointId);
+
+        if (userFunction instanceof CheckpointListener) {
+            ((CheckpointListener) userFunction)
+                    .notifyRegionalCheckpointFallback(checkpointId, fallbackCheckpointId);
+        }
+    }
+
+    @Override
     public void notifyCheckpointAborted(long checkpointId) throws Exception {
         super.notifyCheckpointAborted(checkpointId);
 

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/tasks/FinishedOperatorChain.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/tasks/FinishedOperatorChain.java
@@ -87,6 +87,10 @@ public class FinishedOperatorChain<OUT, OP extends StreamOperator<OUT>>
     public void notifyCheckpointAborted(long checkpointId) throws Exception {}
 
     @Override
+    public void notifyRegionalCheckpointFallback(long checkpointId, long fallbackCheckpointId)
+            throws Exception {}
+
+    @Override
     public void notifyCheckpointSubsumed(long checkpointId) throws Exception {}
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/tasks/OperatorChain.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/tasks/OperatorChain.java
@@ -352,6 +352,14 @@ public abstract class OperatorChain<OUT, OP extends StreamOperator<OUT>>
 
     public abstract void notifyCheckpointSubsumed(long checkpointId) throws Exception;
 
+    /**
+     * Propagates {@link
+     * org.apache.flink.api.common.state.CheckpointListener#notifyRegionalCheckpointFallback(long,
+     * long)} to all operators in the chain.
+     */
+    public abstract void notifyRegionalCheckpointFallback(
+            long checkpointId, long fallbackCheckpointId) throws Exception;
+
     public abstract void snapshotState(
             Map<OperatorID, OperatorSnapshotFutures> operatorSnapshotsInProgress,
             CheckpointMetaData checkpointMetaData,

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/tasks/RegularOperatorChain.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/tasks/RegularOperatorChain.java
@@ -164,6 +164,22 @@ public class RegularOperatorChain<OUT, OP extends StreamOperator<OUT>>
     }
 
     @Override
+    public void notifyRegionalCheckpointFallback(long checkpointId, long fallbackCheckpointId)
+            throws Exception {
+        Exception previousException = null;
+        for (StreamOperatorWrapper<?, ?> operatorWrapper : getAllOperators(true)) {
+            try {
+                operatorWrapper
+                        .getStreamOperator()
+                        .notifyRegionalCheckpointFallback(checkpointId, fallbackCheckpointId);
+            } catch (Exception e) {
+                previousException = ExceptionUtils.firstOrSuppressed(e, previousException);
+            }
+        }
+        ExceptionUtils.tryRethrowException(previousException);
+    }
+
+    @Override
     public void notifyCheckpointSubsumed(long checkpointId) throws Exception {
         Exception previousException = null;
         for (StreamOperatorWrapper<?, ?> operatorWrapper : getAllOperators(true)) {

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -1814,6 +1814,29 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
                 String.format("checkpoint %d subsumed", checkpointId));
     }
 
+    @Override
+    public Future<Void> notifyRegionalCheckpointFallbackAsync(
+            long checkpointId, long fallbackCheckpointId) {
+        return notifyCheckpointOperation(
+                () -> notifyRegionalCheckpointFallback(checkpointId, fallbackCheckpointId),
+                String.format(
+                        "regional checkpoint %d fallback to %d",
+                        checkpointId, fallbackCheckpointId));
+    }
+
+    private void notifyRegionalCheckpointFallback(long checkpointId, long fallbackCheckpointId)
+            throws Exception {
+        LOG.debug(
+                "Notify regional checkpoint {} fallback to {} on task {}",
+                checkpointId,
+                fallbackCheckpointId,
+                getName());
+        // Propagate to subtask checkpoint coordinator which handles local state cleanup
+        // and operator chain notification.
+        subtaskCheckpointCoordinator.notifyRegionalCheckpointFallback(
+                checkpointId, fallbackCheckpointId, operatorChain, this::isRunning);
+    }
+
     private Future<Void> notifyCheckpointOperation(
             RunnableWithException runnable, String description) {
         CompletableFuture<Void> result = new CompletableFuture<>();

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/tasks/SubtaskCheckpointCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/tasks/SubtaskCheckpointCoordinator.java
@@ -98,6 +98,23 @@ public interface SubtaskCheckpointCoordinator extends Closeable {
             long checkpointId, OperatorChain<?, ?> operatorChain, Supplier<Boolean> isRunning)
             throws Exception;
 
+    /**
+     * Notified on the task side when a regional checkpoint has completed but this task's region
+     * fell back to a historical checkpoint. Triggers cleanup of stale local state from the failed
+     * checkpoint attempt and propagates the notification to operators in the chain.
+     *
+     * @param checkpointId The completed regional checkpoint id.
+     * @param fallbackCheckpointId The historical checkpoint id this task fell back to.
+     * @param operatorChain The chain of operators executed by the task.
+     * @param isRunning Whether the task is running.
+     */
+    default void notifyRegionalCheckpointFallback(
+            long checkpointId,
+            long fallbackCheckpointId,
+            OperatorChain<?, ?> operatorChain,
+            Supplier<Boolean> isRunning)
+            throws Exception {}
+
     /** Waits for all the pending checkpoints to finish their asynchronous step. */
     void waitForPendingCheckpoints() throws Exception;
 

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/tasks/SubtaskCheckpointCoordinatorImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/tasks/SubtaskCheckpointCoordinatorImpl.java
@@ -449,6 +449,33 @@ class SubtaskCheckpointCoordinatorImpl implements SubtaskCheckpointCoordinator {
                 checkpointId, operatorChain, isRunning, Task.NotifyCheckpointOperation.SUBSUME);
     }
 
+    @Override
+    public void notifyRegionalCheckpointFallback(
+            long checkpointId,
+            long fallbackCheckpointId,
+            OperatorChain<?, ?> operatorChain,
+            Supplier<Boolean> isRunning)
+            throws Exception {
+        // Per FLIP-600 Section 9 "Local Recovery Cleanup": failed-region tasks discard
+        // the failed checkpoint's local state. Cleanup is deferred to the next checkpoint
+        // trigger. Here we propagate the notification to operators (so they can perform
+        // custom cleanup) and to the TaskStateManager / local state store.
+        LOG.debug(
+                "Notification of regional checkpoint {} fallback to {} for task {}",
+                checkpointId,
+                fallbackCheckpointId,
+                taskName);
+        try {
+            if (isRunning.get()) {
+                operatorChain.notifyRegionalCheckpointFallback(checkpointId, fallbackCheckpointId);
+            }
+        } finally {
+            // Discard local state for this failed checkpoint attempt. The local state store
+            // prunes the entry for checkpointId so that recovery does not restore stale state.
+            env.getTaskStateManager().pruneStateForCheckpoint(checkpointId);
+        }
+    }
+
     private void notifyCheckpoint(
             long checkpointId,
             OperatorChain<?, ?> operatorChain,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorRegionalConfigTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorRegionalConfigTest.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.checkpoint;
+
+import org.apache.flink.runtime.jobgraph.tasks.CheckpointCoordinatorConfiguration;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for regional checkpoint configuration in {@link CheckpointCoordinatorConfiguration}. */
+class CheckpointCoordinatorRegionalConfigTest {
+
+    @Test
+    void testRegionalCheckpointDisabledByDefault() {
+        CheckpointCoordinatorConfiguration config =
+                CheckpointCoordinatorConfiguration.builder().build();
+
+        assertThat(config.isRegionalCheckpointEnabled()).isFalse();
+        assertThat(config.getRegionalMaxFailureRatio()).isEqualTo(0.3);
+        assertThat(config.getRegionalMaxConsecutiveFailures()).isEqualTo(2);
+    }
+
+    @Test
+    void testRegionalCheckpointConfigValues() {
+        CheckpointCoordinatorConfiguration config =
+                CheckpointCoordinatorConfiguration.builder()
+                        .setRegionalCheckpointEnabled(true)
+                        .setRegionalMaxFailureRatio(0.5)
+                        .setRegionalMaxConsecutiveFailures(5)
+                        .build();
+
+        assertThat(config.isRegionalCheckpointEnabled()).isTrue();
+        assertThat(config.getRegionalMaxFailureRatio()).isEqualTo(0.5);
+        assertThat(config.getRegionalMaxConsecutiveFailures()).isEqualTo(5);
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTestingUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTestingUtils.java
@@ -564,7 +564,8 @@ public class CheckpointCoordinatorTestingUtils {
                 JobID jobId,
                 long completedCheckpointId,
                 long completedTimestamp,
-                long lastSubsumedCheckpointId) {
+                long lastSubsumedCheckpointId,
+                long fallbackCheckpointId) {
             notifiedCompletedCheckpoints
                     .computeIfAbsent(attemptId, k -> new ArrayList<>())
                     .add(new NotifiedCheckpoint(jobId, completedCheckpointId, completedTimestamp));
@@ -943,6 +944,8 @@ public class CheckpointCoordinatorTestingUtils {
         private BiConsumer<Long, CompletableFuture<byte[]>> onCallingCheckpointCoordinator = null;
         private Runnable onCallingAbortCurrentTriggering = null;
         private OperatorID operatorID = null;
+        private boolean supportsRegionCheckpoint = false;
+        private RegionFallbackHandler onCallingCheckpointCoordinatorForRegionFallback = null;
 
         public MockOperatorCheckpointCoordinatorContextBuilder setOnCallingCheckpointCoordinator(
                 BiConsumer<Long, CompletableFuture<byte[]>> onCallingCheckpointCoordinator) {
@@ -962,10 +965,39 @@ public class CheckpointCoordinatorTestingUtils {
             return this;
         }
 
+        public MockOperatorCheckpointCoordinatorContextBuilder setSupportsRegionCheckpoint(
+                boolean supportsRegionCheckpoint) {
+            this.supportsRegionCheckpoint = supportsRegionCheckpoint;
+            return this;
+        }
+
+        public MockOperatorCheckpointCoordinatorContextBuilder
+                setOnCallingCheckpointCoordinatorForRegionFallback(
+                        RegionFallbackHandler onCallingCheckpointCoordinatorForRegionFallback) {
+            this.onCallingCheckpointCoordinatorForRegionFallback =
+                    onCallingCheckpointCoordinatorForRegionFallback;
+            return this;
+        }
+
         public MockOperatorCoordinatorCheckpointContext build() {
             return new MockOperatorCoordinatorCheckpointContext(
-                    onCallingCheckpointCoordinator, onCallingAbortCurrentTriggering, operatorID);
+                    onCallingCheckpointCoordinator,
+                    onCallingAbortCurrentTriggering,
+                    operatorID,
+                    supportsRegionCheckpoint,
+                    onCallingCheckpointCoordinatorForRegionFallback);
         }
+    }
+
+    /** Callback for the regional fallback path of a mock coordinator context. */
+    @FunctionalInterface
+    public interface RegionFallbackHandler {
+        void handle(
+                long checkpointId,
+                long fallbackCheckpointId,
+                Set<Integer> fallbackSubtaskIds,
+                CompletableFuture<byte[]> resultFuture)
+                throws Exception;
     }
 
     // ----------------- Mock classes --------------------
@@ -979,18 +1011,29 @@ public class CheckpointCoordinatorTestingUtils {
         private final BiConsumer<Long, CompletableFuture<byte[]>> onCallingCheckpointCoordinator;
         private final Runnable onCallingAbortCurrentTriggering;
         private final OperatorID operatorID;
+        private final boolean supportsRegionCheckpoint;
+        private final RegionFallbackHandler onCallingCheckpointCoordinatorForRegionFallback;
         private final List<Long> completedCheckpoints;
         private final List<Long> abortedCheckpoints;
+        private final List<Long> regionalCompletedCheckpoints;
+        private final List<Long> regionalFallbackCheckpoints;
 
         private MockOperatorCoordinatorCheckpointContext(
                 BiConsumer<Long, CompletableFuture<byte[]>> onCallingCheckpointCoordinator,
                 Runnable onCallingAbortCurrentTriggering,
-                OperatorID operatorID) {
+                OperatorID operatorID,
+                boolean supportsRegionCheckpoint,
+                RegionFallbackHandler onCallingCheckpointCoordinatorForRegionFallback) {
             this.onCallingCheckpointCoordinator = onCallingCheckpointCoordinator;
             this.onCallingAbortCurrentTriggering = onCallingAbortCurrentTriggering;
             this.operatorID = operatorID;
+            this.supportsRegionCheckpoint = supportsRegionCheckpoint;
+            this.onCallingCheckpointCoordinatorForRegionFallback =
+                    onCallingCheckpointCoordinatorForRegionFallback;
             this.completedCheckpoints = new ArrayList<>();
             this.abortedCheckpoints = new ArrayList<>();
+            this.regionalCompletedCheckpoints = new ArrayList<>();
+            this.regionalFallbackCheckpoints = new ArrayList<>();
         }
 
         @Override
@@ -1014,6 +1057,18 @@ public class CheckpointCoordinatorTestingUtils {
         }
 
         @Override
+        public void notifyRegionalCheckpointComplete(
+                long checkpointId, org.apache.flink.api.common.state.RegionalCheckpointInfo info) {
+            regionalCompletedCheckpoints.add(checkpointId);
+            completedCheckpoints.add(checkpointId);
+        }
+
+        @Override
+        public void notifyRegionalCheckpointFallback(long checkpointId, long fallbackCheckpointId) {
+            regionalFallbackCheckpoints.add(checkpointId);
+        }
+
+        @Override
         public void notifyCheckpointAborted(long checkpointId) {
             abortedCheckpoints.add(checkpointId);
         }
@@ -1024,6 +1079,26 @@ public class CheckpointCoordinatorTestingUtils {
 
         @Override
         public void subtaskReset(int subtask, long checkpointId) {}
+
+        @Override
+        public boolean supportsRegionCheckpoint() {
+            return supportsRegionCheckpoint;
+        }
+
+        @Override
+        public void checkpointCoordinatorForRegionFallback(
+                long checkpointId,
+                long fallbackCheckpointId,
+                Set<Integer> fallbackSubtaskIds,
+                CompletableFuture<byte[]> resultFuture)
+                throws Exception {
+            if (onCallingCheckpointCoordinatorForRegionFallback != null) {
+                onCallingCheckpointCoordinatorForRegionFallback.handle(
+                        checkpointId, fallbackCheckpointId, fallbackSubtaskIds, resultFuture);
+            } else {
+                resultFuture.complete(new byte[0]);
+            }
+        }
 
         @Override
         public OperatorID operatorId() {
@@ -1046,6 +1121,14 @@ public class CheckpointCoordinatorTestingUtils {
 
         public List<Long> getAbortedCheckpoints() {
             return abortedCheckpoints;
+        }
+
+        public List<Long> getRegionalCompletedCheckpoints() {
+            return regionalCompletedCheckpoints;
+        }
+
+        public List<Long> getRegionalFallbackCheckpoints() {
+            return regionalFallbackCheckpoints;
         }
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/OperatorStateTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/OperatorStateTest.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.checkpoint;
+
+import org.apache.flink.runtime.jobgraph.OperatorID;
+import org.apache.flink.runtime.state.memory.ByteStreamStateHandle;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Tests for the coordinator-state handling of {@link OperatorState}. */
+class OperatorStateTest {
+
+    private static ByteStreamStateHandle handle(String name) {
+        return new ByteStreamStateHandle(name, new byte[] {1, 2, 3, 4});
+    }
+
+    @Test
+    void testSetCoordinatorStateRejectsOverwrite() {
+        OperatorState operatorState = new OperatorState(null, null, new OperatorID(), 2, 256);
+        ByteStreamStateHandle first = handle("first");
+        operatorState.setCoordinatorState(first);
+
+        assertThat(operatorState.getCoordinatorState()).isSameAs(first);
+        assertThatThrownBy(() -> operatorState.setCoordinatorState(handle("second")))
+                .as("setCoordinatorState must reject overwriting an already-set value")
+                .isInstanceOf(IllegalStateException.class);
+        assertThat(operatorState.getCoordinatorState()).isSameAs(first);
+    }
+
+    @Test
+    void testOverwriteCoordinatorStateReplacesExistingValue() {
+        OperatorState operatorState = new OperatorState(null, null, new OperatorID(), 2, 256);
+        operatorState.setCoordinatorState(handle("from-failed-attempt"));
+
+        // Regional checkpoint fallback replaces the coordinator state collected during the failed
+        // attempt with the historical one. This must not throw, unlike setCoordinatorState.
+        ByteStreamStateHandle fallback = handle("from-historical");
+        operatorState.overwriteCoordinatorState(fallback);
+
+        assertThat(operatorState.getCoordinatorState()).isSameAs(fallback);
+    }
+
+    @Test
+    void testOverwriteCoordinatorStateOnEmptyState() {
+        OperatorState operatorState = new OperatorState(null, null, new OperatorID(), 2, 256);
+        assertThat(operatorState.getCoordinatorState()).isNull();
+
+        ByteStreamStateHandle fallback = handle("from-historical");
+        operatorState.overwriteCoordinatorState(fallback);
+
+        assertThat(operatorState.getCoordinatorState()).isSameAs(fallback);
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/OperatorSubtaskStateRefCheckpointTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/OperatorSubtaskStateRefCheckpointTest.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.checkpoint;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.OptionalLong;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class OperatorSubtaskStateRefCheckpointTest {
+
+    @Test
+    void testDefaultRefCheckpointIdIsEmpty() {
+        OperatorSubtaskState state = OperatorSubtaskState.builder().build();
+        assertThat(state.getRefCheckpointId()).isEqualTo(OptionalLong.empty());
+    }
+
+    @Test
+    void testSetRefCheckpointId() {
+        OperatorSubtaskState state = OperatorSubtaskState.builder().setRefCheckpointId(99L).build();
+        assertThat(state.getRefCheckpointId()).isEqualTo(OptionalLong.of(99L));
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/RegionalCheckpointCleanerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/RegionalCheckpointCleanerTest.java
@@ -1,0 +1,253 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.checkpoint;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.core.execution.RecoveryClaimMode;
+import org.apache.flink.runtime.jobgraph.OperatorID;
+import org.apache.flink.runtime.persistence.TestingStateHandleStore;
+import org.apache.flink.runtime.state.SharedStateRegistry;
+import org.apache.flink.runtime.state.testutils.TestCompletedCheckpointStorageLocation;
+import org.apache.flink.util.concurrent.ExecutorThreadFactory;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayDeque;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static java.util.Collections.emptyList;
+import static org.apache.flink.runtime.checkpoint.CheckpointRetentionPolicy.NEVER_RETAIN_AFTER_TERMINATION;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for regional checkpoint reference protection in the checkpoint cleaner. Verifies that
+ * checkpoints transitively referenced via {@code refCheckpointId} are not subsumed.
+ */
+class RegionalCheckpointCleanerTest {
+
+    private TestingStateHandleStore.Builder<CompletedCheckpoint> builder;
+    private ExecutorService executorService;
+
+    @BeforeEach
+    void setup() {
+        builder = TestingStateHandleStore.newBuilder();
+        executorService = Executors.newFixedThreadPool(2, new ExecutorThreadFactory("IO-Executor"));
+    }
+
+    @AfterEach
+    void after() {
+        executorService.shutdownNow();
+    }
+
+    @Test
+    void testReferencedCheckpointNotCleaned() throws Exception {
+        // numRetained = 1, ckp102 references ckp101
+        // Effective retention set = {102, 101} — ckp101 must not be subsumed
+        final TestingStateHandleStore<CompletedCheckpoint> stateHandleStore = builder.build();
+        final CompletedCheckpointStore store = createStore(stateHandleStore, 1);
+
+        CompletedCheckpoint ckp101 = createCheckpointWithRef(101L, null);
+        CompletedCheckpoint ckp102 = createCheckpointWithRef(102L, 101L);
+
+        store.addCheckpointAndSubsumeOldestOne(ckp101, new CheckpointsCleaner(), () -> {});
+        store.addCheckpointAndSubsumeOldestOne(ckp102, new CheckpointsCleaner(), () -> {});
+
+        List<CompletedCheckpoint> retained = store.getAllCheckpoints();
+        assertThat(retained)
+                .extracting(CompletedCheckpoint::getCheckpointID)
+                .containsExactly(101L, 102L);
+    }
+
+    @Test
+    void testTransitiveReferenceProtection() throws Exception {
+        // numRetained = 1
+        // ckp102 refs ckp101, ckp101 refs ckp99
+        // Effective retention set = {102, 101, 99}
+        final TestingStateHandleStore<CompletedCheckpoint> stateHandleStore = builder.build();
+        final CompletedCheckpointStore store = createStore(stateHandleStore, 1);
+
+        CompletedCheckpoint ckp99 = createCheckpointWithRef(99L, null);
+        CompletedCheckpoint ckp101 = createCheckpointWithRef(101L, 99L);
+        CompletedCheckpoint ckp102 = createCheckpointWithRef(102L, 101L);
+
+        store.addCheckpointAndSubsumeOldestOne(ckp99, new CheckpointsCleaner(), () -> {});
+        store.addCheckpointAndSubsumeOldestOne(ckp101, new CheckpointsCleaner(), () -> {});
+        store.addCheckpointAndSubsumeOldestOne(ckp102, new CheckpointsCleaner(), () -> {});
+
+        List<CompletedCheckpoint> retained = store.getAllCheckpoints();
+        assertThat(retained)
+                .extracting(CompletedCheckpoint::getCheckpointID)
+                .containsExactly(99L, 101L, 102L);
+    }
+
+    @Test
+    void testReferenceChainBrokenAfterGlobalCheckpoint() throws Exception {
+        // numRetained = 1
+        // ckp102 refs ckp101, ckp101 refs ckp99
+        // Then ckp103 arrives with NO refs (global checkpoint)
+        // After ckp103: effective set = {103} — all others can be subsumed
+        final TestingStateHandleStore<CompletedCheckpoint> stateHandleStore = builder.build();
+        final CompletedCheckpointStore store = createStore(stateHandleStore, 1);
+
+        CompletedCheckpoint ckp99 = createCheckpointWithRef(99L, null);
+        CompletedCheckpoint ckp101 = createCheckpointWithRef(101L, 99L);
+        CompletedCheckpoint ckp102 = createCheckpointWithRef(102L, 101L);
+        CompletedCheckpoint ckp103 = createCheckpointWithRef(103L, null);
+
+        store.addCheckpointAndSubsumeOldestOne(ckp99, new CheckpointsCleaner(), () -> {});
+        store.addCheckpointAndSubsumeOldestOne(ckp101, new CheckpointsCleaner(), () -> {});
+        store.addCheckpointAndSubsumeOldestOne(ckp102, new CheckpointsCleaner(), () -> {});
+        store.addCheckpointAndSubsumeOldestOne(ckp103, new CheckpointsCleaner(), () -> {});
+
+        List<CompletedCheckpoint> retained = store.getAllCheckpoints();
+        assertThat(retained).extracting(CompletedCheckpoint::getCheckpointID).containsExactly(103L);
+    }
+
+    @Test
+    void testCheckpointWithoutRefFieldIsTreatedAsGlobal() throws Exception {
+        // All checkpoints have no ref — behavior should be identical to before (standard retention)
+        final TestingStateHandleStore<CompletedCheckpoint> stateHandleStore = builder.build();
+        final CompletedCheckpointStore store = createStore(stateHandleStore, 1);
+
+        CompletedCheckpoint ckp1 = createCheckpointWithRef(1L, null);
+        CompletedCheckpoint ckp2 = createCheckpointWithRef(2L, null);
+        CompletedCheckpoint ckp3 = createCheckpointWithRef(3L, null);
+
+        store.addCheckpointAndSubsumeOldestOne(ckp1, new CheckpointsCleaner(), () -> {});
+        store.addCheckpointAndSubsumeOldestOne(ckp2, new CheckpointsCleaner(), () -> {});
+        store.addCheckpointAndSubsumeOldestOne(ckp3, new CheckpointsCleaner(), () -> {});
+
+        List<CompletedCheckpoint> retained = store.getAllCheckpoints();
+        assertThat(retained).extracting(CompletedCheckpoint::getCheckpointID).containsExactly(3L);
+    }
+
+    @Test
+    void testComputeReferencedCheckpointIdsDirectReference() {
+        // ckp102 references ckp101; numRetain=1; only ckp102 is retained
+        ArrayDeque<CompletedCheckpoint> deque = new ArrayDeque<>();
+        deque.add(createCheckpointWithRef(101L, null));
+        deque.add(createCheckpointWithRef(102L, 101L));
+
+        Set<Long> protectedIds =
+                DefaultCompletedCheckpointStore.computeReferencedCheckpointIds(deque, 1);
+        assertThat(protectedIds).containsExactly(101L);
+    }
+
+    @Test
+    void testComputeReferencedCheckpointIdsTransitive() {
+        // ckp102 refs ckp101, ckp101 refs ckp99; numRetain=1
+        ArrayDeque<CompletedCheckpoint> deque = new ArrayDeque<>();
+        deque.add(createCheckpointWithRef(99L, null));
+        deque.add(createCheckpointWithRef(101L, 99L));
+        deque.add(createCheckpointWithRef(102L, 101L));
+
+        Set<Long> protectedIds =
+                DefaultCompletedCheckpointStore.computeReferencedCheckpointIds(deque, 1);
+        assertThat(protectedIds).containsExactlyInAnyOrder(101L, 99L);
+    }
+
+    @Test
+    void testComputeReferencedCheckpointIdsNoReferences() {
+        // No refs — protected set should be empty
+        ArrayDeque<CompletedCheckpoint> deque = new ArrayDeque<>();
+        deque.add(createCheckpointWithRef(1L, null));
+        deque.add(createCheckpointWithRef(2L, null));
+        deque.add(createCheckpointWithRef(3L, null));
+
+        Set<Long> protectedIds =
+                DefaultCompletedCheckpointStore.computeReferencedCheckpointIds(deque, 1);
+        assertThat(protectedIds).isEmpty();
+    }
+
+    @Test
+    void testComputeReferencedCheckpointIdsRefToExternalCheckpoint() {
+        // ckp102 references ckp50 which is NOT in the deque (already gone)
+        // 50 should still be in protected set (even though we can't follow it further)
+        ArrayDeque<CompletedCheckpoint> deque = new ArrayDeque<>();
+        deque.add(createCheckpointWithRef(101L, null));
+        deque.add(createCheckpointWithRef(102L, 50L));
+
+        Set<Long> protectedIds =
+                DefaultCompletedCheckpointStore.computeReferencedCheckpointIds(deque, 1);
+        assertThat(protectedIds).containsExactly(50L);
+    }
+
+    // --------------------------------------------------------------------------------------------
+    // Helpers
+    // --------------------------------------------------------------------------------------------
+
+    private CompletedCheckpoint createCheckpointWithRef(long checkpointId, Long refId) {
+        OperatorID operatorID = new OperatorID();
+        Map<OperatorID, OperatorState> operatorStates = new HashMap<>();
+        OperatorState operatorState = new OperatorState(null, null, operatorID, 1, 128);
+
+        OperatorSubtaskState.Builder subtaskBuilder = OperatorSubtaskState.builder();
+        if (refId != null) {
+            subtaskBuilder.setRefCheckpointId(refId);
+        }
+        operatorState.putState(0, subtaskBuilder.build());
+        operatorStates.put(operatorID, operatorState);
+
+        return new CompletedCheckpoint(
+                new JobID(),
+                checkpointId,
+                0L,
+                0L,
+                operatorStates,
+                Collections.emptyList(),
+                CheckpointProperties.forCheckpoint(NEVER_RETAIN_AFTER_TERMINATION),
+                new TestCompletedCheckpointStorageLocation(),
+                null);
+    }
+
+    private CompletedCheckpointStore createStore(
+            TestingStateHandleStore<CompletedCheckpoint> stateHandleStore, int numRetain)
+            throws Exception {
+        final CheckpointStoreUtil checkpointStoreUtil =
+                new CheckpointStoreUtil() {
+                    @Override
+                    public String checkpointIDToName(long checkpointId) {
+                        return String.valueOf(checkpointId);
+                    }
+
+                    @Override
+                    public long nameToCheckpointID(String name) {
+                        return Long.parseLong(name);
+                    }
+                };
+        return new DefaultCompletedCheckpointStore<>(
+                numRetain,
+                stateHandleStore,
+                checkpointStoreUtil,
+                emptyList(),
+                SharedStateRegistry.DEFAULT_FACTORY.create(
+                        org.apache.flink.util.concurrent.Executors.directExecutor(),
+                        emptyList(),
+                        RecoveryClaimMode.DEFAULT),
+                executorService);
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/RegionalCheckpointConfigTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/RegionalCheckpointConfigTest.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.checkpoint;
+
+import org.apache.flink.configuration.CheckpointingOptions;
+import org.apache.flink.configuration.Configuration;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class RegionalCheckpointConfigTest {
+
+    @Test
+    void testRegionalCheckpointDefaultDisabled() {
+        Configuration config = new Configuration();
+        assertThat(config.get(CheckpointingOptions.REGIONAL_CHECKPOINT_ENABLED)).isFalse();
+    }
+
+    @Test
+    void testRegionalCheckpointMaxFailureRatioDefault() {
+        Configuration config = new Configuration();
+        assertThat(config.get(CheckpointingOptions.REGIONAL_CHECKPOINT_MAX_FAILURE_RATIO))
+                .isEqualTo(0.3);
+    }
+
+    @Test
+    void testRegionalCheckpointMaxConsecutiveFailuresDefault() {
+        Configuration config = new Configuration();
+        assertThat(config.get(CheckpointingOptions.REGIONAL_CHECKPOINT_MAX_CONSECUTIVE_FAILURES))
+                .isEqualTo(2);
+    }
+
+    @Test
+    void testRegionalCheckpointExplicitEnable() {
+        Configuration config = new Configuration();
+        config.set(CheckpointingOptions.REGIONAL_CHECKPOINT_ENABLED, true);
+        assertThat(config.get(CheckpointingOptions.REGIONAL_CHECKPOINT_ENABLED)).isTrue();
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/RegionalCheckpointConsecutiveLimitTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/RegionalCheckpointConsecutiveLimitTest.java
@@ -1,0 +1,488 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.checkpoint;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.checkpoint.CheckpointCoordinatorTestingUtils.CheckpointCoordinatorBuilder;
+import org.apache.flink.runtime.execution.ExecutionState;
+import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
+import org.apache.flink.runtime.executiongraph.ExecutionGraph;
+import org.apache.flink.runtime.executiongraph.ExecutionGraphTestUtils;
+import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
+import org.apache.flink.runtime.executiongraph.ExecutionVertex;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
+import org.apache.flink.runtime.jobgraph.DistributionPattern;
+import org.apache.flink.runtime.jobgraph.JobVertex;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.jobgraph.OperatorID;
+import org.apache.flink.runtime.jobgraph.tasks.CheckpointCoordinatorConfiguration;
+import org.apache.flink.runtime.jobgraph.tasks.CheckpointCoordinatorConfiguration.CheckpointCoordinatorConfigurationBuilder;
+import org.apache.flink.runtime.messages.checkpoint.AcknowledgeCheckpoint;
+import org.apache.flink.runtime.messages.checkpoint.DeclineCheckpoint;
+import org.apache.flink.runtime.state.testutils.TestCompletedCheckpointStorageLocation;
+import org.apache.flink.runtime.testtasks.NoOpInvokable;
+import org.apache.flink.util.concurrent.ManuallyTriggeredScheduledExecutor;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+
+import static org.apache.flink.runtime.util.JobVertexConnectionUtils.connectNewDataSetAsInput;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for the consecutive regional checkpoint limiting behavior in {@link CheckpointCoordinator}.
+ *
+ * <p>Per FLIP-600 two-tier max-consecutive-failures semantics:
+ *
+ * <ul>
+ *   <li>Tier 1: when {@code consecutiveRegionalCheckpointCount >= maxConsecutiveFailures}, the
+ *       current regional checkpoint still completes, but {@code forceGlobalNextCheckpoint} is set
+ *       so the NEXT checkpoint is forced global.
+ *   <li>Tier 2: if the forced global checkpoint also fails (has declined tasks), it is aborted and
+ *       both the counter and the force flag are reset.
+ *   <li>A successful global checkpoint (all tasks acknowledge) resets both the counter and the
+ *       force flag.
+ * </ul>
+ */
+class RegionalCheckpointConsecutiveLimitTest {
+
+    private static final ScheduledExecutorService EXECUTOR_SERVICE =
+            Executors.newSingleThreadScheduledExecutor();
+
+    private ManuallyTriggeredScheduledExecutor manuallyTriggered;
+
+    @BeforeEach
+    void setUp() {
+        manuallyTriggered = new ManuallyTriggeredScheduledExecutor();
+    }
+
+    /**
+     * With max-consecutive-failures=2, the first regional checkpoint attempt (counter=0) should
+     * pass the consecutive limit check. The checkpoint proceeds past the limit check even though it
+     * may ultimately be aborted for other reasons (e.g., finalization issues in test setup).
+     *
+     * <p>Contrast with {@link #testForcedAbortWhenLimitIsZero} where max=0 causes immediate abort.
+     */
+    @Test
+    void testConsecutiveRegionalCheckpointsWithinLimit() throws Exception {
+        ExecutionGraph graph = createMultiRegionGraph();
+        JobID jobId = graph.getJobID();
+
+        CheckpointCoordinatorConfiguration config =
+                new CheckpointCoordinatorConfigurationBuilder()
+                        .setRegionalCheckpointEnabled(true)
+                        .setRegionalMaxFailureRatio(0.9)
+                        .setRegionalMaxConsecutiveFailures(2)
+                        .setMaxConcurrentCheckpoints(Integer.MAX_VALUE)
+                        .build();
+
+        StandaloneCompletedCheckpointStore store = new StandaloneCompletedCheckpointStore(5);
+        addFakeCompletedCheckpoint(store, jobId, graph);
+
+        CheckpointCoordinator coordinator =
+                new CheckpointCoordinatorBuilder()
+                        .setCheckpointCoordinatorConfiguration(config)
+                        .setCompletedCheckpointStore(store)
+                        .setTimer(manuallyTriggered)
+                        .build(graph);
+
+        coordinator.startCheckpointScheduler();
+
+        // Counter starts at 0, below the limit of 2
+        assertThat(coordinator.getConsecutiveRegionalCheckpointCount()).isZero();
+
+        // Trigger checkpoint — counter is 0 < 2, so the consecutive check passes.
+        // The regional evaluation is triggered but the checkpoint is not blocked by the
+        // consecutive limit. It may be aborted later during finalization.
+        coordinator.triggerCheckpoint(false);
+        manuallyTriggered.triggerAll();
+
+        assertThat(coordinator.getNumberOfPendingCheckpoints()).isEqualTo(1);
+        long checkpointId = coordinator.getPendingCheckpoints().keySet().iterator().next();
+
+        // Source acknowledges, sink declines → triggers regional evaluation
+        declineFromSinkAckFromSource(coordinator, graph, jobId, checkpointId);
+
+        // The key assertion: counter should still be less than 2 (the configured max).
+        // If the regional checkpoint completed, counter would be 1.
+        // If it was aborted during finalization (not at the consecutive check), counter is 0.
+        // Either way, it did NOT hit the consecutive limit.
+        assertThat(coordinator.getConsecutiveRegionalCheckpointCount()).isLessThan(2);
+
+        coordinator.shutdown();
+    }
+
+    /**
+     * With max-consecutive-failures=0, the first regional checkpoint attempt (counter=0) still
+     * completes per Tier 1 semantics. After completion, counter increments to 1 and {@code
+     * forceGlobalNextCheckpoint} is set (1 >= 0). The next checkpoint will be forced global.
+     *
+     * <p>Per FLIP-600 two-tier semantics, the current regional checkpoint is NOT aborted just
+     * because the consecutive limit is reached — only the NEXT checkpoint is forced global.
+     */
+    @Test
+    void testTier1ForcesGlobalAfterLimitReached() throws Exception {
+        ExecutionGraph graph = createMultiRegionGraph();
+        JobID jobId = graph.getJobID();
+
+        CheckpointCoordinatorConfiguration config =
+                new CheckpointCoordinatorConfigurationBuilder()
+                        .setRegionalCheckpointEnabled(true)
+                        .setRegionalMaxFailureRatio(0.9)
+                        .setRegionalMaxConsecutiveFailures(0)
+                        .setMaxConcurrentCheckpoints(Integer.MAX_VALUE)
+                        .build();
+
+        StandaloneCompletedCheckpointStore store = new StandaloneCompletedCheckpointStore(5);
+        addFakeCompletedCheckpoint(store, jobId, graph);
+
+        CheckpointCoordinator coordinator =
+                new CheckpointCoordinatorBuilder()
+                        .setCheckpointCoordinatorConfiguration(config)
+                        .setCompletedCheckpointStore(store)
+                        .setTimer(manuallyTriggered)
+                        .build(graph);
+
+        coordinator.startCheckpointScheduler();
+        coordinator.triggerCheckpoint(false);
+        manuallyTriggered.triggerAll();
+
+        assertThat(coordinator.getNumberOfPendingCheckpoints()).isEqualTo(1);
+        long checkpointId = coordinator.getPendingCheckpoints().keySet().iterator().next();
+
+        declineFromSinkAckFromSource(coordinator, graph, jobId, checkpointId);
+
+        // Per Tier 1: regional checkpoint completed, counter incremented to 1 (1 >= 0 → force
+        // next global). If finalization failed for test-environment reasons, counter is 0 and
+        // force flag is false. Either way, no immediate abort at the consecutive check.
+        assertThat(coordinator.getPendingCheckpoints()).isEmpty();
+        if (coordinator.getConsecutiveRegionalCheckpointCount() > 0) {
+            // Regional checkpoint completed successfully → force flag should be set
+            assertThat(coordinator.getForceGlobalNextCheckpoint()).isTrue();
+        }
+
+        coordinator.shutdown();
+    }
+
+    /**
+     * Tests Tier 2: after {@code forceGlobalNextCheckpoint} is set, a checkpoint with declined
+     * tasks must be aborted (forced global checkpoint failed), and both the counter and force flag
+     * are reset.
+     */
+    @Test
+    void testTier2ForcedGlobalFailureResetsCounterAndFlag() throws Exception {
+        ExecutionGraph graph = createMultiRegionGraph();
+        JobID jobId = graph.getJobID();
+
+        CheckpointCoordinatorConfiguration config =
+                new CheckpointCoordinatorConfigurationBuilder()
+                        .setRegionalCheckpointEnabled(true)
+                        .setRegionalMaxFailureRatio(0.9)
+                        .setRegionalMaxConsecutiveFailures(1)
+                        .setMaxConcurrentCheckpoints(Integer.MAX_VALUE)
+                        .build();
+
+        StandaloneCompletedCheckpointStore store = new StandaloneCompletedCheckpointStore(5);
+        addFakeCompletedCheckpoint(store, jobId, graph);
+
+        CheckpointCoordinator coordinator =
+                new CheckpointCoordinatorBuilder()
+                        .setCheckpointCoordinatorConfiguration(config)
+                        .setCompletedCheckpointStore(store)
+                        .setTimer(manuallyTriggered)
+                        .build(graph);
+
+        coordinator.startCheckpointScheduler();
+
+        // Step 1: trigger first regional checkpoint (counter=0 < 1, passes)
+        coordinator.triggerCheckpoint(false);
+        manuallyTriggered.triggerAll();
+        long cpId1 = coordinator.getPendingCheckpoints().keySet().iterator().next();
+        declineFromSinkAckFromSource(coordinator, graph, jobId, cpId1);
+
+        // If first regional checkpoint completed, force flag should be set (counter=1 >= 1)
+        boolean firstCompleted = coordinator.getConsecutiveRegionalCheckpointCount() > 0;
+        if (firstCompleted) {
+            assertThat(coordinator.getForceGlobalNextCheckpoint()).isTrue();
+
+            // Step 2: trigger second checkpoint — should be forced global. If any task declines,
+            // it must be aborted (Tier 2) and counter/flag reset.
+            coordinator.triggerCheckpoint(false);
+            manuallyTriggered.triggerAll();
+            long cpId2 = coordinator.getPendingCheckpoints().keySet().iterator().next();
+            declineFromSinkAckFromSource(coordinator, graph, jobId, cpId2);
+
+            // Tier 2: forced global failed → abort + reset
+            assertThat(coordinator.getPendingCheckpoints()).isEmpty();
+            assertThat(coordinator.getConsecutiveRegionalCheckpointCount()).isZero();
+            assertThat(coordinator.getForceGlobalNextCheckpoint()).isFalse();
+        }
+
+        coordinator.shutdown();
+    }
+
+    /**
+     * After a successful global checkpoint (all tasks acknowledge), the consecutive regional
+     * checkpoint counter and the force-global flag are reset. This verifies the reset in {@link
+     * CheckpointCoordinator#completePendingCheckpoint}.
+     */
+    @Test
+    void testCountResetAfterGlobalCheckpoint() throws Exception {
+        ExecutionGraph graph = createMultiRegionGraph();
+        JobID jobId = graph.getJobID();
+
+        CheckpointCoordinatorConfiguration config =
+                new CheckpointCoordinatorConfigurationBuilder()
+                        .setRegionalCheckpointEnabled(true)
+                        .setRegionalMaxFailureRatio(0.9)
+                        .setRegionalMaxConsecutiveFailures(10)
+                        .setMaxConcurrentCheckpoints(Integer.MAX_VALUE)
+                        .build();
+
+        StandaloneCompletedCheckpointStore store = new StandaloneCompletedCheckpointStore(5);
+
+        CheckpointCoordinator coordinator =
+                new CheckpointCoordinatorBuilder()
+                        .setCheckpointCoordinatorConfiguration(config)
+                        .setCompletedCheckpointStore(store)
+                        .setTimer(manuallyTriggered)
+                        .build(graph);
+
+        coordinator.startCheckpointScheduler();
+
+        // Counter starts at 0
+        assertThat(coordinator.getConsecutiveRegionalCheckpointCount()).isZero();
+
+        // Complete a global checkpoint (all tasks acknowledge)
+        coordinator.triggerCheckpoint(false);
+        manuallyTriggered.triggerAll();
+
+        assertThat(coordinator.getNumberOfPendingCheckpoints()).isEqualTo(1);
+        long checkpointId = coordinator.getPendingCheckpoints().keySet().iterator().next();
+
+        acknowledgeFromAllTasks(coordinator, graph, jobId, checkpointId);
+
+        // Global checkpoint completed → counter should be 0 (reset)
+        assertThat(coordinator.getConsecutiveRegionalCheckpointCount()).isZero();
+        // The checkpoint should have completed successfully
+        assertThat(coordinator.getNumberOfRetainedSuccessfulCheckpoints()).isEqualTo(1);
+
+        coordinator.shutdown();
+    }
+
+    /**
+     * Verifies that the consecutive limit configuration correctly differentiates between allowed
+     * and force-global-after behaviors. With max=1:
+     *
+     * <ul>
+     *   <li>Counter=0: passes (0 < 1), regional checkpoint completes, counter becomes 1
+     *   <li>Counter=1: 1 >= 1 → forceGlobalNextCheckpoint set, next checkpoint forced global
+     * </ul>
+     *
+     * <p>Per FLIP-600 two-tier semantics, the regional checkpoint is NOT aborted when the counter
+     * reaches the limit — instead the next checkpoint is forced global.
+     */
+    @Test
+    void testLimitConfigDeterminesForceGlobalAfterLimit() throws Exception {
+        ExecutionGraph graph = createMultiRegionGraph();
+        JobID jobId = graph.getJobID();
+
+        StandaloneCompletedCheckpointStore store = new StandaloneCompletedCheckpointStore(5);
+        addFakeCompletedCheckpoint(store, jobId, graph);
+
+        // With max=1, counter=0 < 1 → passes consecutive check
+        CheckpointCoordinatorConfiguration passConfig =
+                new CheckpointCoordinatorConfigurationBuilder()
+                        .setRegionalCheckpointEnabled(true)
+                        .setRegionalMaxFailureRatio(0.9)
+                        .setRegionalMaxConsecutiveFailures(1)
+                        .setMaxConcurrentCheckpoints(Integer.MAX_VALUE)
+                        .build();
+
+        CheckpointCoordinator passCoordinator =
+                new CheckpointCoordinatorBuilder()
+                        .setCheckpointCoordinatorConfiguration(passConfig)
+                        .setCompletedCheckpointStore(store)
+                        .setTimer(manuallyTriggered)
+                        .build(graph);
+
+        passCoordinator.startCheckpointScheduler();
+        passCoordinator.triggerCheckpoint(false);
+        manuallyTriggered.triggerAll();
+
+        long cpId1 = passCoordinator.getPendingCheckpoints().keySet().iterator().next();
+
+        declineFromSinkAckFromSource(passCoordinator, graph, jobId, cpId1);
+
+        // Per Tier 1: regional checkpoint NOT aborted by consecutive limit. If it completed,
+        // counter=1 and forceGlobalNextCheckpoint=true. If finalization failed for test
+        // reasons, counter=0 and flag=false. Either way, not blocked at consecutive check.
+        assertThat(passCoordinator.getConsecutiveRegionalCheckpointCount()).isLessThanOrEqualTo(1);
+        if (passCoordinator.getConsecutiveRegionalCheckpointCount() >= 1) {
+            assertThat(passCoordinator.getForceGlobalNextCheckpoint()).isTrue();
+        }
+
+        passCoordinator.shutdown();
+
+        // Now test with max=0: first regional checkpoint still completes (Tier 1), but
+        // forceGlobalNextCheckpoint is set immediately after (counter=1 >= 0).
+        ExecutionGraph graph2 = createMultiRegionGraph();
+        JobID jobId2 = graph2.getJobID();
+        StandaloneCompletedCheckpointStore store2 = new StandaloneCompletedCheckpointStore(5);
+        addFakeCompletedCheckpoint(store2, jobId2, graph2);
+
+        ManuallyTriggeredScheduledExecutor timer2 = new ManuallyTriggeredScheduledExecutor();
+
+        CheckpointCoordinatorConfiguration blockConfig =
+                new CheckpointCoordinatorConfigurationBuilder()
+                        .setRegionalCheckpointEnabled(true)
+                        .setRegionalMaxFailureRatio(0.9)
+                        .setRegionalMaxConsecutiveFailures(0)
+                        .setMaxConcurrentCheckpoints(Integer.MAX_VALUE)
+                        .build();
+
+        CheckpointCoordinator blockCoordinator =
+                new CheckpointCoordinatorBuilder()
+                        .setCheckpointCoordinatorConfiguration(blockConfig)
+                        .setCompletedCheckpointStore(store2)
+                        .setTimer(timer2)
+                        .build(graph2);
+
+        blockCoordinator.startCheckpointScheduler();
+        blockCoordinator.triggerCheckpoint(false);
+        timer2.triggerAll();
+
+        long cpId2 = blockCoordinator.getPendingCheckpoints().keySet().iterator().next();
+        declineFromSinkAckFromSource(blockCoordinator, graph2, jobId2, cpId2);
+
+        // Per Tier 1: regional checkpoint NOT aborted by consecutive limit. If completed,
+        // forceGlobalNextCheckpoint set. If finalization failed, counter=0 and flag=false.
+        assertThat(blockCoordinator.getPendingCheckpoints()).isEmpty();
+        if (blockCoordinator.getConsecutiveRegionalCheckpointCount() > 0) {
+            assertThat(blockCoordinator.getForceGlobalNextCheckpoint()).isTrue();
+        }
+
+        blockCoordinator.shutdown();
+    }
+
+    // ---- Helper methods ----
+
+    /**
+     * Creates a multi-region execution graph with two job vertices (source and sink) connected by a
+     * BLOCKING edge, resulting in two separate pipelined regions.
+     */
+    private ExecutionGraph createMultiRegionGraph() throws Exception {
+        JobVertex source = new JobVertex("source", new JobVertexID());
+        source.setParallelism(1);
+        source.setMaxParallelism(128);
+        source.setInvokableClass(NoOpInvokable.class);
+
+        JobVertex sink = new JobVertex("sink", new JobVertexID());
+        sink.setParallelism(1);
+        sink.setMaxParallelism(128);
+        sink.setInvokableClass(NoOpInvokable.class);
+
+        // BLOCKING edge → two separate pipelined regions
+        connectNewDataSetAsInput(
+                sink, source, DistributionPattern.ALL_TO_ALL, ResultPartitionType.BLOCKING);
+
+        ExecutionGraph graph =
+                ExecutionGraphTestUtils.createExecutionGraph(EXECUTOR_SERVICE, source, sink);
+        graph.start(
+                org.apache.flink.runtime.concurrent.ComponentMainThreadExecutorServiceAdapter
+                        .forMainThread());
+        graph.transitionToRunning();
+
+        for (ExecutionVertex ev : graph.getAllExecutionVertices()) {
+            ev.getCurrentExecutionAttempt().transitionState(ExecutionState.RUNNING);
+        }
+
+        return graph;
+    }
+
+    /** Adds a fake completed checkpoint to the store so regional checkpoint has fallback state. */
+    private void addFakeCompletedCheckpoint(
+            StandaloneCompletedCheckpointStore store, JobID jobId, ExecutionGraph graph)
+            throws Exception {
+        Map<OperatorID, OperatorState> operatorStates = new HashMap<>();
+        for (ExecutionJobVertex jv : graph.getAllVertices().values()) {
+            OperatorID opId = jv.getOperatorIDs().get(0).getGeneratedOperatorID();
+            OperatorState state = new OperatorState(null, null, opId, 1, 128);
+            operatorStates.put(opId, state);
+        }
+
+        CompletedCheckpoint fakeCheckpoint =
+                new CompletedCheckpoint(
+                        jobId,
+                        1L,
+                        0L,
+                        0L,
+                        operatorStates,
+                        Collections.emptyList(),
+                        CheckpointProperties.forCheckpoint(
+                                CheckpointRetentionPolicy.NEVER_RETAIN_AFTER_TERMINATION),
+                        new TestCompletedCheckpointStorageLocation(),
+                        null);
+
+        store.addCheckpointAndSubsumeOldestOne(fakeCheckpoint, new CheckpointsCleaner(), () -> {});
+    }
+
+    /** Acknowledges from "source" vertex, declines from "sink" vertex. */
+    private void declineFromSinkAckFromSource(
+            CheckpointCoordinator coordinator, ExecutionGraph graph, JobID jobId, long checkpointId)
+            throws Exception {
+        for (ExecutionJobVertex jv : graph.getAllVertices().values()) {
+            for (ExecutionVertex ev : jv.getTaskVertices()) {
+                ExecutionAttemptID attemptId = ev.getCurrentExecutionAttempt().getAttemptId();
+                if (jv.getName().contains("source")) {
+                    coordinator.receiveAcknowledgeMessage(
+                            new AcknowledgeCheckpoint(jobId, attemptId, checkpointId), "test");
+                } else {
+                    coordinator.receiveDeclineMessage(
+                            new DeclineCheckpoint(
+                                    jobId,
+                                    attemptId,
+                                    checkpointId,
+                                    new CheckpointException(
+                                            CheckpointFailureReason.CHECKPOINT_DECLINED)),
+                            "test");
+                }
+            }
+        }
+    }
+
+    /** Acknowledges from all tasks — results in a full global checkpoint completion. */
+    private void acknowledgeFromAllTasks(
+            CheckpointCoordinator coordinator, ExecutionGraph graph, JobID jobId, long checkpointId)
+            throws Exception {
+        for (ExecutionJobVertex jv : graph.getAllVertices().values()) {
+            for (ExecutionVertex ev : jv.getTaskVertices()) {
+                ExecutionAttemptID attemptId = ev.getCurrentExecutionAttempt().getAttemptId();
+                coordinator.receiveAcknowledgeMessage(
+                        new AcknowledgeCheckpoint(jobId, attemptId, checkpointId), "test");
+            }
+        }
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/RegionalCheckpointDeferredAbortTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/RegionalCheckpointDeferredAbortTest.java
@@ -1,0 +1,376 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.checkpoint;
+
+import org.apache.flink.core.execution.SavepointFormatType;
+import org.apache.flink.runtime.checkpoint.CheckpointCoordinatorTestingUtils.CheckpointCoordinatorBuilder;
+import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
+import org.apache.flink.runtime.executiongraph.ExecutionGraph;
+import org.apache.flink.runtime.executiongraph.ExecutionVertex;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.jobgraph.tasks.CheckpointCoordinatorConfiguration;
+import org.apache.flink.runtime.messages.checkpoint.AcknowledgeCheckpoint;
+import org.apache.flink.runtime.messages.checkpoint.DeclineCheckpoint;
+import org.apache.flink.testutils.TestingUtils;
+import org.apache.flink.testutils.executor.TestExecutorExtension;
+import org.apache.flink.util.concurrent.FutureUtils;
+import org.apache.flink.util.concurrent.ManuallyTriggeredScheduledExecutor;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ScheduledExecutorService;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for deferred abort behavior in regional checkpoint mode. */
+class RegionalCheckpointDeferredAbortTest {
+
+    private static final String TASK_MANAGER_LOCATION_INFO = "Unknown location";
+
+    @RegisterExtension
+    static final TestExecutorExtension<ScheduledExecutorService> EXECUTOR_RESOURCE =
+            TestingUtils.defaultExecutorExtension();
+
+    @TempDir Path tmpFolder;
+
+    private ManuallyTriggeredScheduledExecutor manuallyTriggeredScheduledExecutor;
+
+    @BeforeEach
+    void setUp() {
+        manuallyTriggeredScheduledExecutor = new ManuallyTriggeredScheduledExecutor();
+    }
+
+    @Test
+    void testRegionalEnabledSingleDeclineDoesNotImmediatelyAbort() throws Exception {
+        JobVertexID jobVertexID1 = new JobVertexID();
+        JobVertexID jobVertexID2 = new JobVertexID();
+
+        CheckpointCoordinatorTestingUtils.CheckpointRecorderTaskManagerGateway gateway =
+                new CheckpointCoordinatorTestingUtils.CheckpointRecorderTaskManagerGateway();
+
+        ExecutionGraph graph =
+                new CheckpointCoordinatorTestingUtils.CheckpointExecutionGraphBuilder()
+                        .addJobVertex(jobVertexID1)
+                        .addJobVertex(jobVertexID2)
+                        .setTaskManagerGateway(gateway)
+                        .build(EXECUTOR_RESOURCE.getExecutor());
+
+        ExecutionVertex vertex1 = graph.getJobVertex(jobVertexID1).getTaskVertices()[0];
+        ExecutionVertex vertex2 = graph.getJobVertex(jobVertexID2).getTaskVertices()[0];
+
+        ExecutionAttemptID attemptID1 = vertex1.getCurrentExecutionAttempt().getAttemptId();
+
+        CheckpointCoordinator checkpointCoordinator =
+                new CheckpointCoordinatorBuilder()
+                        .setCheckpointCoordinatorConfiguration(
+                                CheckpointCoordinatorConfiguration.builder()
+                                        .setMaxConcurrentCheckpoints(Integer.MAX_VALUE)
+                                        .setRegionalCheckpointEnabled(true)
+                                        .build())
+                        .setTimer(manuallyTriggeredScheduledExecutor)
+                        .build(graph);
+
+        // Trigger checkpoint
+        final CompletableFuture<CompletedCheckpoint> checkpointFuture =
+                checkpointCoordinator.triggerCheckpoint(false);
+        manuallyTriggeredScheduledExecutor.triggerAll();
+        FutureUtils.throwIfCompletedExceptionally(checkpointFuture);
+
+        assertThat(checkpointCoordinator.getNumberOfPendingCheckpoints()).isOne();
+
+        long checkpointId =
+                checkpointCoordinator.getPendingCheckpoints().entrySet().iterator().next().getKey();
+        PendingCheckpoint checkpoint =
+                checkpointCoordinator.getPendingCheckpoints().get(checkpointId);
+
+        // Decline from task 1 — should NOT immediately abort
+        checkpointCoordinator.receiveDeclineMessage(
+                new DeclineCheckpoint(
+                        graph.getJobID(),
+                        attemptID1,
+                        checkpointId,
+                        new CheckpointException(CheckpointFailureReason.CHECKPOINT_DECLINED)),
+                TASK_MANAGER_LOCATION_INFO);
+
+        // Checkpoint should still be pending (not disposed) because task 2 hasn't responded
+        assertThat(checkpoint.isDisposed()).isFalse();
+        assertThat(checkpointCoordinator.getNumberOfPendingCheckpoints()).isOne();
+        assertThat(checkpoint.hasDeclines()).isTrue();
+
+        checkpointCoordinator.shutdown();
+    }
+
+    @Test
+    void testRegionalEnabledAllTasksRespondTriggersEvaluation() throws Exception {
+        JobVertexID jobVertexID1 = new JobVertexID();
+        JobVertexID jobVertexID2 = new JobVertexID();
+
+        CheckpointCoordinatorTestingUtils.CheckpointRecorderTaskManagerGateway gateway =
+                new CheckpointCoordinatorTestingUtils.CheckpointRecorderTaskManagerGateway();
+
+        ExecutionGraph graph =
+                new CheckpointCoordinatorTestingUtils.CheckpointExecutionGraphBuilder()
+                        .addJobVertex(jobVertexID1)
+                        .addJobVertex(jobVertexID2)
+                        .setTaskManagerGateway(gateway)
+                        .build(EXECUTOR_RESOURCE.getExecutor());
+
+        ExecutionVertex vertex1 = graph.getJobVertex(jobVertexID1).getTaskVertices()[0];
+        ExecutionVertex vertex2 = graph.getJobVertex(jobVertexID2).getTaskVertices()[0];
+
+        ExecutionAttemptID attemptID1 = vertex1.getCurrentExecutionAttempt().getAttemptId();
+        ExecutionAttemptID attemptID2 = vertex2.getCurrentExecutionAttempt().getAttemptId();
+
+        CheckpointCoordinator checkpointCoordinator =
+                new CheckpointCoordinatorBuilder()
+                        .setCheckpointCoordinatorConfiguration(
+                                CheckpointCoordinatorConfiguration.builder()
+                                        .setMaxConcurrentCheckpoints(Integer.MAX_VALUE)
+                                        .setRegionalCheckpointEnabled(true)
+                                        .build())
+                        .setTimer(manuallyTriggeredScheduledExecutor)
+                        .build(graph);
+
+        // Trigger checkpoint
+        final CompletableFuture<CompletedCheckpoint> checkpointFuture =
+                checkpointCoordinator.triggerCheckpoint(false);
+        manuallyTriggeredScheduledExecutor.triggerAll();
+        FutureUtils.throwIfCompletedExceptionally(checkpointFuture);
+
+        long checkpointId =
+                checkpointCoordinator.getPendingCheckpoints().entrySet().iterator().next().getKey();
+        PendingCheckpoint checkpoint =
+                checkpointCoordinator.getPendingCheckpoints().get(checkpointId);
+
+        // Decline from task 1
+        checkpointCoordinator.receiveDeclineMessage(
+                new DeclineCheckpoint(
+                        graph.getJobID(),
+                        attemptID1,
+                        checkpointId,
+                        new CheckpointException(CheckpointFailureReason.CHECKPOINT_DECLINED)),
+                TASK_MANAGER_LOCATION_INFO);
+
+        // Still pending
+        assertThat(checkpoint.isDisposed()).isFalse();
+
+        // Acknowledge from task 2 — now all tasks have responded
+        checkpointCoordinator.receiveAcknowledgeMessage(
+                new AcknowledgeCheckpoint(graph.getJobID(), attemptID2, checkpointId),
+                TASK_MANAGER_LOCATION_INFO);
+
+        // After all tasks responded, tryCompleteRegionalCheckpoint should be triggered.
+        // The stub implementation aborts, so the checkpoint should now be disposed.
+        assertThat(checkpoint.isDisposed()).isTrue();
+        assertThat(checkpointCoordinator.getNumberOfPendingCheckpoints()).isZero();
+
+        checkpointCoordinator.shutdown();
+    }
+
+    @Test
+    void testRegionalDisabledDeclineImmediatelyAborts() throws Exception {
+        JobVertexID jobVertexID1 = new JobVertexID();
+        JobVertexID jobVertexID2 = new JobVertexID();
+
+        CheckpointCoordinatorTestingUtils.CheckpointRecorderTaskManagerGateway gateway =
+                new CheckpointCoordinatorTestingUtils.CheckpointRecorderTaskManagerGateway();
+
+        ExecutionGraph graph =
+                new CheckpointCoordinatorTestingUtils.CheckpointExecutionGraphBuilder()
+                        .addJobVertex(jobVertexID1)
+                        .addJobVertex(jobVertexID2)
+                        .setTaskManagerGateway(gateway)
+                        .build(EXECUTOR_RESOURCE.getExecutor());
+
+        ExecutionVertex vertex1 = graph.getJobVertex(jobVertexID1).getTaskVertices()[0];
+
+        ExecutionAttemptID attemptID1 = vertex1.getCurrentExecutionAttempt().getAttemptId();
+
+        // Regional checkpoint DISABLED (default)
+        CheckpointCoordinator checkpointCoordinator =
+                new CheckpointCoordinatorBuilder()
+                        .setCheckpointCoordinatorConfiguration(
+                                CheckpointCoordinatorConfiguration.builder()
+                                        .setMaxConcurrentCheckpoints(Integer.MAX_VALUE)
+                                        .setRegionalCheckpointEnabled(false)
+                                        .build())
+                        .setTimer(manuallyTriggeredScheduledExecutor)
+                        .build(graph);
+
+        // Trigger checkpoint
+        final CompletableFuture<CompletedCheckpoint> checkpointFuture =
+                checkpointCoordinator.triggerCheckpoint(false);
+        manuallyTriggeredScheduledExecutor.triggerAll();
+        FutureUtils.throwIfCompletedExceptionally(checkpointFuture);
+
+        long checkpointId =
+                checkpointCoordinator.getPendingCheckpoints().entrySet().iterator().next().getKey();
+        PendingCheckpoint checkpoint =
+                checkpointCoordinator.getPendingCheckpoints().get(checkpointId);
+
+        // Decline from task 1 — should immediately abort
+        checkpointCoordinator.receiveDeclineMessage(
+                new DeclineCheckpoint(
+                        graph.getJobID(),
+                        attemptID1,
+                        checkpointId,
+                        new CheckpointException(CheckpointFailureReason.CHECKPOINT_DECLINED)),
+                TASK_MANAGER_LOCATION_INFO);
+
+        assertThat(checkpoint.isDisposed()).isTrue();
+        assertThat(checkpointCoordinator.getNumberOfPendingCheckpoints()).isZero();
+
+        checkpointCoordinator.shutdown();
+    }
+
+    @Test
+    void testSavepointDeclineImmediatelyAbortsRegardlessOfRegionalSetting() throws Exception {
+        JobVertexID jobVertexID1 = new JobVertexID();
+        JobVertexID jobVertexID2 = new JobVertexID();
+
+        CheckpointCoordinatorTestingUtils.CheckpointRecorderTaskManagerGateway gateway =
+                new CheckpointCoordinatorTestingUtils.CheckpointRecorderTaskManagerGateway();
+
+        ExecutionGraph graph =
+                new CheckpointCoordinatorTestingUtils.CheckpointExecutionGraphBuilder()
+                        .addJobVertex(jobVertexID1)
+                        .addJobVertex(jobVertexID2)
+                        .setTaskManagerGateway(gateway)
+                        .build(EXECUTOR_RESOURCE.getExecutor());
+
+        ExecutionVertex vertex1 = graph.getJobVertex(jobVertexID1).getTaskVertices()[0];
+
+        ExecutionAttemptID attemptID1 = vertex1.getCurrentExecutionAttempt().getAttemptId();
+
+        // Regional checkpoint ENABLED
+        CheckpointCoordinator checkpointCoordinator =
+                new CheckpointCoordinatorBuilder()
+                        .setCheckpointCoordinatorConfiguration(
+                                CheckpointCoordinatorConfiguration.builder()
+                                        .setMaxConcurrentCheckpoints(Integer.MAX_VALUE)
+                                        .setRegionalCheckpointEnabled(true)
+                                        .build())
+                        .setTimer(manuallyTriggeredScheduledExecutor)
+                        .build(graph);
+
+        // Trigger a savepoint (not a regular checkpoint)
+        final CompletableFuture<CompletedCheckpoint> savepointFuture =
+                checkpointCoordinator.triggerSavepoint(
+                        tmpFolder.toString(), SavepointFormatType.CANONICAL);
+        manuallyTriggeredScheduledExecutor.triggerAll();
+
+        assertThat(checkpointCoordinator.getNumberOfPendingCheckpoints()).isOne();
+
+        long checkpointId =
+                checkpointCoordinator.getPendingCheckpoints().entrySet().iterator().next().getKey();
+        PendingCheckpoint checkpoint =
+                checkpointCoordinator.getPendingCheckpoints().get(checkpointId);
+
+        // Verify it's a savepoint
+        assertThat(checkpoint.getProps().isSavepoint()).isTrue();
+
+        // Decline from task 1 — should immediately abort even with regional enabled
+        checkpointCoordinator.receiveDeclineMessage(
+                new DeclineCheckpoint(
+                        graph.getJobID(),
+                        attemptID1,
+                        checkpointId,
+                        new CheckpointException(CheckpointFailureReason.CHECKPOINT_DECLINED)),
+                TASK_MANAGER_LOCATION_INFO);
+
+        assertThat(checkpoint.isDisposed()).isTrue();
+        assertThat(checkpointCoordinator.getNumberOfPendingCheckpoints()).isZero();
+
+        checkpointCoordinator.shutdown();
+    }
+
+    @Test
+    void testRegionalEnabledDeclineThenDeclineTriggersEvaluation() throws Exception {
+        JobVertexID jobVertexID1 = new JobVertexID();
+        JobVertexID jobVertexID2 = new JobVertexID();
+
+        CheckpointCoordinatorTestingUtils.CheckpointRecorderTaskManagerGateway gateway =
+                new CheckpointCoordinatorTestingUtils.CheckpointRecorderTaskManagerGateway();
+
+        ExecutionGraph graph =
+                new CheckpointCoordinatorTestingUtils.CheckpointExecutionGraphBuilder()
+                        .addJobVertex(jobVertexID1)
+                        .addJobVertex(jobVertexID2)
+                        .setTaskManagerGateway(gateway)
+                        .build(EXECUTOR_RESOURCE.getExecutor());
+
+        ExecutionVertex vertex1 = graph.getJobVertex(jobVertexID1).getTaskVertices()[0];
+        ExecutionVertex vertex2 = graph.getJobVertex(jobVertexID2).getTaskVertices()[0];
+
+        ExecutionAttemptID attemptID1 = vertex1.getCurrentExecutionAttempt().getAttemptId();
+        ExecutionAttemptID attemptID2 = vertex2.getCurrentExecutionAttempt().getAttemptId();
+
+        CheckpointCoordinator checkpointCoordinator =
+                new CheckpointCoordinatorBuilder()
+                        .setCheckpointCoordinatorConfiguration(
+                                CheckpointCoordinatorConfiguration.builder()
+                                        .setMaxConcurrentCheckpoints(Integer.MAX_VALUE)
+                                        .setRegionalCheckpointEnabled(true)
+                                        .build())
+                        .setTimer(manuallyTriggeredScheduledExecutor)
+                        .build(graph);
+
+        // Trigger checkpoint
+        final CompletableFuture<CompletedCheckpoint> checkpointFuture =
+                checkpointCoordinator.triggerCheckpoint(false);
+        manuallyTriggeredScheduledExecutor.triggerAll();
+        FutureUtils.throwIfCompletedExceptionally(checkpointFuture);
+
+        long checkpointId =
+                checkpointCoordinator.getPendingCheckpoints().entrySet().iterator().next().getKey();
+        PendingCheckpoint checkpoint =
+                checkpointCoordinator.getPendingCheckpoints().get(checkpointId);
+
+        // Decline from task 1
+        checkpointCoordinator.receiveDeclineMessage(
+                new DeclineCheckpoint(
+                        graph.getJobID(),
+                        attemptID1,
+                        checkpointId,
+                        new CheckpointException(CheckpointFailureReason.CHECKPOINT_DECLINED)),
+                TASK_MANAGER_LOCATION_INFO);
+
+        assertThat(checkpoint.isDisposed()).isFalse();
+
+        // Decline from task 2 — now all tasks responded (both declined)
+        checkpointCoordinator.receiveDeclineMessage(
+                new DeclineCheckpoint(
+                        graph.getJobID(),
+                        attemptID2,
+                        checkpointId,
+                        new CheckpointException(CheckpointFailureReason.CHECKPOINT_DECLINED)),
+                TASK_MANAGER_LOCATION_INFO);
+
+        // After all tasks responded, the stub triggers abort
+        assertThat(checkpoint.isDisposed()).isTrue();
+        assertThat(checkpointCoordinator.getNumberOfPendingCheckpoints()).isZero();
+
+        checkpointCoordinator.shutdown();
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/RegionalCheckpointStateAssemblyTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/RegionalCheckpointStateAssemblyTest.java
@@ -1,0 +1,405 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.checkpoint;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.checkpoint.CheckpointCoordinatorTestingUtils.CheckpointCoordinatorBuilder;
+import org.apache.flink.runtime.checkpoint.CheckpointCoordinatorTestingUtils.CheckpointExecutionGraphBuilder;
+import org.apache.flink.runtime.execution.ExecutionState;
+import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
+import org.apache.flink.runtime.executiongraph.ExecutionGraph;
+import org.apache.flink.runtime.executiongraph.ExecutionGraphTestUtils;
+import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
+import org.apache.flink.runtime.executiongraph.ExecutionVertex;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
+import org.apache.flink.runtime.jobgraph.DistributionPattern;
+import org.apache.flink.runtime.jobgraph.JobVertex;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.jobgraph.tasks.CheckpointCoordinatorConfiguration;
+import org.apache.flink.runtime.jobgraph.tasks.CheckpointCoordinatorConfiguration.CheckpointCoordinatorConfigurationBuilder;
+import org.apache.flink.runtime.messages.checkpoint.AcknowledgeCheckpoint;
+import org.apache.flink.runtime.messages.checkpoint.DeclineCheckpoint;
+import org.apache.flink.runtime.testtasks.NoOpInvokable;
+import org.apache.flink.util.concurrent.ManuallyTriggeredScheduledExecutor;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+
+import static org.apache.flink.runtime.util.JobVertexConnectionUtils.connectNewDataSetAsInput;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for the regional checkpoint state assembly logic in {@link CheckpointCoordinator},
+ * specifically the {@code tryCompleteRegionalCheckpoint} method.
+ */
+class RegionalCheckpointStateAssemblyTest {
+
+    private static final ScheduledExecutorService EXECUTOR_SERVICE =
+            Executors.newSingleThreadScheduledExecutor();
+
+    private ManuallyTriggeredScheduledExecutor manuallyTriggered;
+
+    @BeforeEach
+    void setUp() {
+        manuallyTriggered = new ManuallyTriggeredScheduledExecutor();
+    }
+
+    /**
+     * When the job has only a single pipelined region (ALL_TO_ALL pipelined connectivity), regional
+     * checkpoint should abort because there's no isolation benefit.
+     */
+    @Test
+    void testSingleRegionJobAborts() throws Exception {
+        JobVertexID sourceId = new JobVertexID();
+        JobVertexID sinkId = new JobVertexID();
+
+        // source -> sink connected by PIPELINED edge = single region
+        ExecutionGraph graph =
+                new CheckpointExecutionGraphBuilder()
+                        .addJobVertex(sourceId, true)
+                        .addJobVertex(sinkId, false)
+                        .build(EXECUTOR_SERVICE);
+
+        CheckpointCoordinatorConfiguration config =
+                new CheckpointCoordinatorConfigurationBuilder()
+                        .setRegionalCheckpointEnabled(true)
+                        .setRegionalMaxFailureRatio(0.5)
+                        .setRegionalMaxConsecutiveFailures(3)
+                        .setMaxConcurrentCheckpoints(Integer.MAX_VALUE)
+                        .build();
+
+        CheckpointCoordinator coordinator =
+                new CheckpointCoordinatorBuilder()
+                        .setCheckpointCoordinatorConfiguration(config)
+                        .setTimer(manuallyTriggered)
+                        .build(graph);
+
+        coordinator.startCheckpointScheduler();
+
+        // Trigger checkpoint
+        coordinator.triggerCheckpoint(false);
+        manuallyTriggered.triggerAll();
+
+        assertThat(coordinator.getNumberOfPendingCheckpoints()).isEqualTo(1);
+        long checkpointId = coordinator.getPendingCheckpoints().keySet().iterator().next();
+
+        ExecutionVertex sourceVertex = graph.getJobVertex(sourceId).getTaskVertices()[0];
+        ExecutionVertex sinkVertex = graph.getJobVertex(sinkId).getTaskVertices()[0];
+
+        // Source acknowledges
+        coordinator.receiveAcknowledgeMessage(
+                new AcknowledgeCheckpoint(
+                        graph.getJobID(),
+                        sourceVertex.getCurrentExecutionAttempt().getAttemptId(),
+                        checkpointId),
+                "test");
+
+        // Sink declines - triggers regional checkpoint evaluation
+        coordinator.receiveDeclineMessage(
+                new DeclineCheckpoint(
+                        graph.getJobID(),
+                        sinkVertex.getCurrentExecutionAttempt().getAttemptId(),
+                        checkpointId,
+                        new CheckpointException(CheckpointFailureReason.CHECKPOINT_DECLINED)),
+                "test");
+
+        // Single region → should be aborted
+        assertThat(coordinator.getPendingCheckpoints()).isEmpty();
+
+        coordinator.shutdown();
+    }
+
+    /** When consecutive regional checkpoint limit is exceeded, the checkpoint should be aborted. */
+    @Test
+    void testConsecutiveLimitExceededAborts() throws Exception {
+        ExecutionGraph graph = createMultiRegionGraph();
+        JobID jobId = graph.getJobID();
+
+        CheckpointCoordinatorConfiguration config =
+                new CheckpointCoordinatorConfigurationBuilder()
+                        .setRegionalCheckpointEnabled(true)
+                        .setRegionalMaxFailureRatio(0.9)
+                        .setRegionalMaxConsecutiveFailures(0) // zero consecutive allowed
+                        .setMaxConcurrentCheckpoints(Integer.MAX_VALUE)
+                        .build();
+
+        CheckpointCoordinator coordinator =
+                new CheckpointCoordinatorBuilder()
+                        .setCheckpointCoordinatorConfiguration(config)
+                        .setTimer(manuallyTriggered)
+                        .build(graph);
+
+        coordinator.startCheckpointScheduler();
+
+        // Trigger checkpoint
+        coordinator.triggerCheckpoint(false);
+        manuallyTriggered.triggerAll();
+
+        assertThat(coordinator.getNumberOfPendingCheckpoints()).isEqualTo(1);
+        long checkpointId = coordinator.getPendingCheckpoints().keySet().iterator().next();
+
+        // Source acknowledges, sink declines
+        declineFromSinkAckFromSource(coordinator, graph, jobId, checkpointId);
+
+        // Consecutive limit 0 → should be aborted
+        assertThat(coordinator.getPendingCheckpoints()).isEmpty();
+
+        coordinator.shutdown();
+    }
+
+    /** When failure ratio exceeds the configured max, the checkpoint should be aborted. */
+    @Test
+    void testFailureRatioExceededAborts() throws Exception {
+        ExecutionGraph graph = createMultiRegionGraph();
+        JobID jobId = graph.getJobID();
+
+        // Max failure ratio of 0.0 means any single region failure exceeds the limit
+        CheckpointCoordinatorConfiguration config =
+                new CheckpointCoordinatorConfigurationBuilder()
+                        .setRegionalCheckpointEnabled(true)
+                        .setRegionalMaxFailureRatio(0.0)
+                        .setRegionalMaxConsecutiveFailures(10)
+                        .setMaxConcurrentCheckpoints(Integer.MAX_VALUE)
+                        .build();
+
+        CheckpointCoordinator coordinator =
+                new CheckpointCoordinatorBuilder()
+                        .setCheckpointCoordinatorConfiguration(config)
+                        .setTimer(manuallyTriggered)
+                        .build(graph);
+
+        coordinator.startCheckpointScheduler();
+
+        coordinator.triggerCheckpoint(false);
+        manuallyTriggered.triggerAll();
+
+        assertThat(coordinator.getNumberOfPendingCheckpoints()).isEqualTo(1);
+        long checkpointId = coordinator.getPendingCheckpoints().keySet().iterator().next();
+
+        declineFromSinkAckFromSource(coordinator, graph, jobId, checkpointId);
+
+        // Failure ratio exceeded → should be aborted
+        assertThat(coordinator.getPendingCheckpoints()).isEmpty();
+
+        coordinator.shutdown();
+    }
+
+    /**
+     * When there is no historical completed checkpoint to use as fallback, regional checkpoint
+     * should abort.
+     */
+    @Test
+    void testNoHistoricalCheckpointAborts() throws Exception {
+        ExecutionGraph graph = createMultiRegionGraph();
+        JobID jobId = graph.getJobID();
+
+        CheckpointCoordinatorConfiguration config =
+                new CheckpointCoordinatorConfigurationBuilder()
+                        .setRegionalCheckpointEnabled(true)
+                        .setRegionalMaxFailureRatio(0.9)
+                        .setRegionalMaxConsecutiveFailures(10)
+                        .setMaxConcurrentCheckpoints(Integer.MAX_VALUE)
+                        .build();
+
+        // Empty completed store → no historical checkpoint
+        CompletedCheckpointStore completedStore = new StandaloneCompletedCheckpointStore(5);
+
+        CheckpointCoordinator coordinator =
+                new CheckpointCoordinatorBuilder()
+                        .setCheckpointCoordinatorConfiguration(config)
+                        .setCompletedCheckpointStore(completedStore)
+                        .setTimer(manuallyTriggered)
+                        .build(graph);
+
+        coordinator.startCheckpointScheduler();
+
+        coordinator.triggerCheckpoint(false);
+        manuallyTriggered.triggerAll();
+
+        assertThat(coordinator.getNumberOfPendingCheckpoints()).isEqualTo(1);
+        long checkpointId = coordinator.getPendingCheckpoints().keySet().iterator().next();
+
+        declineFromSinkAckFromSource(coordinator, graph, jobId, checkpointId);
+
+        // No historical checkpoint → should be aborted
+        assertThat(coordinator.getPendingCheckpoints()).isEmpty();
+
+        coordinator.shutdown();
+    }
+
+    /** When regional checkpoint is disabled, a decline immediately aborts. */
+    @Test
+    void testRegionalCheckpointDisabledAborts() throws Exception {
+        JobVertexID sourceId = new JobVertexID();
+
+        ExecutionGraph graph =
+                new CheckpointExecutionGraphBuilder()
+                        .addJobVertex(sourceId, true)
+                        .build(EXECUTOR_SERVICE);
+
+        CheckpointCoordinatorConfiguration config =
+                new CheckpointCoordinatorConfigurationBuilder()
+                        .setRegionalCheckpointEnabled(false)
+                        .setMaxConcurrentCheckpoints(Integer.MAX_VALUE)
+                        .build();
+
+        CheckpointCoordinator coordinator =
+                new CheckpointCoordinatorBuilder()
+                        .setCheckpointCoordinatorConfiguration(config)
+                        .setTimer(manuallyTriggered)
+                        .build(graph);
+
+        coordinator.startCheckpointScheduler();
+
+        coordinator.triggerCheckpoint(false);
+        manuallyTriggered.triggerAll();
+
+        assertThat(coordinator.getNumberOfPendingCheckpoints()).isEqualTo(1);
+        long checkpointId = coordinator.getPendingCheckpoints().keySet().iterator().next();
+
+        ExecutionVertex vertex = graph.getJobVertex(sourceId).getTaskVertices()[0];
+
+        // Decline immediately aborts when regional checkpoint is disabled
+        coordinator.receiveDeclineMessage(
+                new DeclineCheckpoint(
+                        graph.getJobID(),
+                        vertex.getCurrentExecutionAttempt().getAttemptId(),
+                        checkpointId,
+                        new CheckpointException(CheckpointFailureReason.CHECKPOINT_DECLINED)),
+                "test");
+
+        assertThat(coordinator.getPendingCheckpoints()).isEmpty();
+
+        coordinator.shutdown();
+    }
+
+    /**
+     * Verifies that when regional checkpoint is enabled and a task declines, the checkpoint is not
+     * immediately aborted — it waits for all tasks to respond.
+     */
+    @Test
+    void testDeclineBufferedUntilAllRespond() throws Exception {
+        JobVertexID sourceId = new JobVertexID();
+
+        ExecutionGraph graph =
+                new CheckpointExecutionGraphBuilder()
+                        .addJobVertex(sourceId, 2, 128)
+                        .build(EXECUTOR_SERVICE);
+
+        CheckpointCoordinatorConfiguration config =
+                new CheckpointCoordinatorConfigurationBuilder()
+                        .setRegionalCheckpointEnabled(true)
+                        .setRegionalMaxFailureRatio(0.5)
+                        .setRegionalMaxConsecutiveFailures(3)
+                        .setMaxConcurrentCheckpoints(Integer.MAX_VALUE)
+                        .build();
+
+        CheckpointCoordinator coordinator =
+                new CheckpointCoordinatorBuilder()
+                        .setCheckpointCoordinatorConfiguration(config)
+                        .setTimer(manuallyTriggered)
+                        .build(graph);
+
+        coordinator.startCheckpointScheduler();
+
+        coordinator.triggerCheckpoint(false);
+        manuallyTriggered.triggerAll();
+
+        assertThat(coordinator.getNumberOfPendingCheckpoints()).isEqualTo(1);
+        long checkpointId = coordinator.getPendingCheckpoints().keySet().iterator().next();
+
+        ExecutionVertex vertex0 = graph.getJobVertex(sourceId).getTaskVertices()[0];
+
+        // First task declines — checkpoint should still be pending (waiting for second task)
+        coordinator.receiveDeclineMessage(
+                new DeclineCheckpoint(
+                        graph.getJobID(),
+                        vertex0.getCurrentExecutionAttempt().getAttemptId(),
+                        checkpointId,
+                        new CheckpointException(CheckpointFailureReason.CHECKPOINT_DECLINED)),
+                "test");
+
+        // Checkpoint should still be pending (second task hasn't responded yet)
+        assertThat(coordinator.getPendingCheckpoints()).containsKey(checkpointId);
+
+        coordinator.shutdown();
+    }
+
+    // ---- Helper methods ----
+
+    /**
+     * Creates a multi-region execution graph with two job vertices (source and sink) connected by a
+     * BLOCKING edge, resulting in two separate pipelined regions.
+     */
+    private ExecutionGraph createMultiRegionGraph() throws Exception {
+        JobVertex source = new JobVertex("source", new JobVertexID());
+        source.setParallelism(1);
+        source.setMaxParallelism(128);
+        source.setInvokableClass(NoOpInvokable.class);
+
+        JobVertex sink = new JobVertex("sink", new JobVertexID());
+        sink.setParallelism(1);
+        sink.setMaxParallelism(128);
+        sink.setInvokableClass(NoOpInvokable.class);
+
+        // BLOCKING edge → two separate pipelined regions
+        connectNewDataSetAsInput(
+                sink, source, DistributionPattern.ALL_TO_ALL, ResultPartitionType.BLOCKING);
+
+        ExecutionGraph graph =
+                ExecutionGraphTestUtils.createExecutionGraph(EXECUTOR_SERVICE, source, sink);
+        graph.start(
+                org.apache.flink.runtime.concurrent.ComponentMainThreadExecutorServiceAdapter
+                        .forMainThread());
+        graph.transitionToRunning();
+
+        for (ExecutionVertex ev : graph.getAllExecutionVertices()) {
+            ev.getCurrentExecutionAttempt().transitionState(ExecutionState.RUNNING);
+        }
+
+        return graph;
+    }
+
+    /** Acknowledges from "source" vertex, declines from "sink" vertex. */
+    private void declineFromSinkAckFromSource(
+            CheckpointCoordinator coordinator, ExecutionGraph graph, JobID jobId, long checkpointId)
+            throws Exception {
+        for (ExecutionJobVertex jv : graph.getAllVertices().values()) {
+            for (ExecutionVertex ev : jv.getTaskVertices()) {
+                ExecutionAttemptID attemptId = ev.getCurrentExecutionAttempt().getAttemptId();
+                if (jv.getName().contains("source")) {
+                    coordinator.receiveAcknowledgeMessage(
+                            new AcknowledgeCheckpoint(jobId, attemptId, checkpointId), "test");
+                } else {
+                    coordinator.receiveDeclineMessage(
+                            new DeclineCheckpoint(
+                                    jobId,
+                                    attemptId,
+                                    checkpointId,
+                                    new CheckpointException(
+                                            CheckpointFailureReason.CHECKPOINT_DECLINED)),
+                            "test");
+                }
+            }
+        }
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/RegionalCheckpointSuccessPathTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/RegionalCheckpointSuccessPathTest.java
@@ -1,0 +1,477 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.checkpoint;
+
+import org.apache.flink.runtime.checkpoint.CheckpointCoordinatorTestingUtils.CheckpointCoordinatorBuilder;
+import org.apache.flink.runtime.execution.ExecutionState;
+import org.apache.flink.runtime.executiongraph.ExecutionGraph;
+import org.apache.flink.runtime.executiongraph.ExecutionGraphTestUtils;
+import org.apache.flink.runtime.executiongraph.ExecutionVertex;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
+import org.apache.flink.runtime.jobgraph.DistributionPattern;
+import org.apache.flink.runtime.jobgraph.JobVertex;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.jobgraph.OperatorID;
+import org.apache.flink.runtime.jobgraph.tasks.CheckpointCoordinatorConfiguration;
+import org.apache.flink.runtime.jobgraph.tasks.CheckpointCoordinatorConfiguration.CheckpointCoordinatorConfigurationBuilder;
+import org.apache.flink.runtime.messages.checkpoint.AcknowledgeCheckpoint;
+import org.apache.flink.runtime.messages.checkpoint.DeclineCheckpoint;
+import org.apache.flink.runtime.state.memory.ByteStreamStateHandle;
+import org.apache.flink.runtime.state.testutils.TestCompletedCheckpointStorageLocation;
+import org.apache.flink.runtime.testtasks.NoOpInvokable;
+import org.apache.flink.util.concurrent.ManuallyTriggeredScheduledExecutor;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+
+import static org.apache.flink.runtime.util.JobVertexConnectionUtils.connectNewDataSetAsInput;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests that drive the regional checkpoint <b>success</b> path of {@link CheckpointCoordinator} —
+ * the part that actually computes pipeline regions, merges healthy/failed subtask state, marks the
+ * fallback state with a reference checkpoint id and finalizes the regional checkpoint.
+ *
+ * <p>This complements {@code RegionalCheckpointStateAssemblyTest}, which only exercises the abort
+ * branches. The crucial difference is that these tests install a {@code regionIdProvider} (via
+ * {@link CheckpointCoordinator#setRegionIdProvider}) and acknowledge with real {@link
+ * OperatorSubtaskState}, so the state-assembly and completion logic is genuinely executed rather
+ * than short-circuited at the {@code regionIdProvider == null} guard.
+ */
+class RegionalCheckpointSuccessPathTest {
+
+    private ManuallyTriggeredScheduledExecutor manuallyTriggered;
+
+    @BeforeEach
+    void setUp() {
+        manuallyTriggered = new ManuallyTriggeredScheduledExecutor();
+    }
+
+    /**
+     * A healthy region keeps the freshly acknowledged state; the failed region's subtask state is
+     * taken from the historical checkpoint and tagged with the fallback checkpoint id.
+     */
+    @Test
+    void testRegionalCheckpointCompletesWithStateMerge() throws Exception {
+        final TwoRegionGraph g = new TwoRegionGraph();
+        final long fallbackCheckpointId = 1L;
+        addHistoricalCheckpoint(g, fallbackCheckpointId);
+
+        final CheckpointCoordinator coordinator =
+                buildCoordinator(g, regionalConfig(0.9, 10), g.store);
+        coordinator.setRegionIdProvider(g.regionProvider());
+        coordinator.startCheckpointScheduler();
+
+        final long checkpointId = triggerPending(coordinator);
+
+        // Healthy region (source) acknowledges with fresh state; failed region (sink) declines.
+        ackWithState(coordinator, g, g.sourceVertex(), checkpointId);
+        decline(coordinator, g, g.sinkVertex(), checkpointId);
+
+        // The regional checkpoint must have completed (not aborted).
+        assertThat(coordinator.getPendingCheckpoints()).isEmpty();
+        final CompletedCheckpoint completed = findCompleted(coordinator, checkpointId);
+        assertThat(completed).isNotNull();
+
+        // Healthy region: state present, NOT a reference to a historical checkpoint.
+        final OperatorSubtaskState healthy =
+                completed.getOperatorStates().get(g.sourceOperatorId).getState(0);
+        assertThat(healthy).isNotNull();
+        assertThat(healthy.getRefCheckpointId()).isNotPresent();
+
+        // Failed region: state taken from history and marked with the fallback checkpoint id.
+        final OperatorSubtaskState fellBack =
+                completed.getOperatorStates().get(g.sinkOperatorId).getState(0);
+        assertThat(fellBack).isNotNull();
+        assertThat(fellBack.getRefCheckpointId()).hasValue(fallbackCheckpointId);
+
+        // The consecutive regional checkpoint counter was incremented exactly once.
+        assertThat(coordinator.getConsecutiveRegionalCheckpointCount()).isEqualTo(1);
+
+        coordinator.shutdown();
+    }
+
+    /**
+     * When the failed region's operator has no subtask state in the historical checkpoint, no
+     * fallback state is grafted in (the operator simply has no entry for that subtask), but the
+     * checkpoint still completes for the healthy region.
+     */
+    @Test
+    void testFailedRegionWithoutHistoricalSubtaskStateStillCompletes() throws Exception {
+        final TwoRegionGraph g = new TwoRegionGraph();
+        // Historical checkpoint that contains the sink operator but with NO subtask state.
+        addHistoricalCheckpoint(g, 1L, /* includeSinkSubtaskState= */ false);
+
+        final CheckpointCoordinator coordinator =
+                buildCoordinator(g, regionalConfig(0.9, 10), g.store);
+        coordinator.setRegionIdProvider(g.regionProvider());
+        coordinator.startCheckpointScheduler();
+
+        final long checkpointId = triggerPending(coordinator);
+        ackWithState(coordinator, g, g.sourceVertex(), checkpointId);
+        decline(coordinator, g, g.sinkVertex(), checkpointId);
+
+        assertThat(coordinator.getPendingCheckpoints()).isEmpty();
+        final CompletedCheckpoint completed = findCompleted(coordinator, checkpointId);
+        assertThat(completed).isNotNull();
+        // Healthy region state survived.
+        assertThat(completed.getOperatorStates().get(g.sourceOperatorId).getState(0)).isNotNull();
+
+        coordinator.shutdown();
+    }
+
+    /**
+     * The consecutive regional checkpoint counter increments per successful regional checkpoint and
+     * resets to zero once a full global checkpoint (all tasks acknowledge) completes.
+     */
+    @Test
+    void testConsecutiveCounterIncrementsThenResetsOnGlobalCheckpoint() throws Exception {
+        final TwoRegionGraph g = new TwoRegionGraph();
+        addHistoricalCheckpoint(g, 1L);
+
+        final CheckpointCoordinator coordinator =
+                buildCoordinator(g, regionalConfig(0.9, 10), g.store);
+        coordinator.setRegionIdProvider(g.regionProvider());
+        coordinator.startCheckpointScheduler();
+
+        // First regional checkpoint → counter 1.
+        long cp1 = triggerPending(coordinator);
+        ackWithState(coordinator, g, g.sourceVertex(), cp1);
+        decline(coordinator, g, g.sinkVertex(), cp1);
+        assertThat(coordinator.getConsecutiveRegionalCheckpointCount()).isEqualTo(1);
+
+        // Second regional checkpoint → counter 2.
+        long cp2 = triggerPending(coordinator);
+        ackWithState(coordinator, g, g.sourceVertex(), cp2);
+        decline(coordinator, g, g.sinkVertex(), cp2);
+        assertThat(coordinator.getConsecutiveRegionalCheckpointCount()).isEqualTo(2);
+
+        // A full global checkpoint resets the counter to 0.
+        long cp3 = triggerPending(coordinator);
+        ackWithState(coordinator, g, g.sourceVertex(), cp3);
+        ackWithState(coordinator, g, g.sinkVertex(), cp3);
+        assertThat(coordinator.getConsecutiveRegionalCheckpointCount()).isZero();
+
+        coordinator.shutdown();
+    }
+
+    /**
+     * When the failed region contains an operator coordinator that supports regional checkpoint,
+     * its region-fallback state (the bytes returned via the result future) is written into the
+     * resulting OperatorState and the coordinator is notified of the regional completion.
+     */
+    @Test
+    void testCoordinatorFallbackStateWrittenAndNotified() throws Exception {
+        final TwoRegionGraph g = new TwoRegionGraph();
+        addHistoricalCheckpoint(g, 1L);
+
+        final byte[] fallbackBytes = new byte[] {7, 7, 7};
+        final CheckpointCoordinatorTestingUtils.MockOperatorCoordinatorCheckpointContext coordCtx =
+                new CheckpointCoordinatorTestingUtils
+                                .MockOperatorCheckpointCoordinatorContextBuilder()
+                        .setOperatorID(g.sinkOperatorId)
+                        .setSupportsRegionCheckpoint(true)
+                        .setOnCallingCheckpointCoordinatorForRegionFallback(
+                                (cpId, fallbackId, subtasks, future) ->
+                                        future.complete(fallbackBytes))
+                        .build();
+
+        final CheckpointCoordinator coordinator =
+                buildCoordinator(g, regionalConfig(0.9, 10), g.store, coordCtx);
+        coordinator.setRegionIdProvider(g.regionProvider());
+        coordinator.startCheckpointScheduler();
+
+        final long checkpointId = triggerPending(coordinator);
+        ackWithState(coordinator, g, g.sourceVertex(), checkpointId);
+        decline(coordinator, g, g.sinkVertex(), checkpointId);
+
+        final CompletedCheckpoint completed = findCompleted(coordinator, checkpointId);
+        assertThat(completed).isNotNull();
+
+        // The coordinator fallback bytes were written into the sink operator's coordinator state.
+        final ByteStreamStateHandle coordinatorState =
+                (ByteStreamStateHandle)
+                        completed.getOperatorStates().get(g.sinkOperatorId).getCoordinatorState();
+        assertThat(coordinatorState).isNotNull();
+        assertThat(coordinatorState.getData()).isEqualTo(fallbackBytes);
+
+        // The coordinator was notified via the regional fallback path (it's in the failed region).
+        assertThat(coordCtx.getRegionalFallbackCheckpoints()).contains(checkpointId);
+        // Healthy-region coordinators would receive notifyRegionalCheckpointComplete; the failed
+        // region's coordinator receives notifyRegionalCheckpointFallback instead.
+        assertThat(coordCtx.getRegionalCompletedCheckpoints()).doesNotContain(checkpointId);
+
+        coordinator.shutdown();
+    }
+
+    /**
+     * If the failed region's coordinator does not support regional checkpoint, the regional
+     * checkpoint must abort rather than silently proceed.
+     */
+    @Test
+    void testUnsupportedCoordinatorAbortsRegionalCheckpoint() throws Exception {
+        final TwoRegionGraph g = new TwoRegionGraph();
+        addHistoricalCheckpoint(g, 1L);
+
+        final CheckpointCoordinatorTestingUtils.MockOperatorCoordinatorCheckpointContext coordCtx =
+                new CheckpointCoordinatorTestingUtils
+                                .MockOperatorCheckpointCoordinatorContextBuilder()
+                        .setOperatorID(g.sinkOperatorId)
+                        .setSupportsRegionCheckpoint(false)
+                        .setOnCallingCheckpointCoordinator(
+                                (cpId, future) -> future.complete(new byte[0]))
+                        .build();
+
+        final CheckpointCoordinator coordinator =
+                buildCoordinator(g, regionalConfig(0.9, 10), g.store, coordCtx);
+        coordinator.setRegionIdProvider(g.regionProvider());
+        coordinator.startCheckpointScheduler();
+
+        final long checkpointId = triggerPending(coordinator);
+        ackWithState(coordinator, g, g.sourceVertex(), checkpointId);
+        decline(coordinator, g, g.sinkVertex(), checkpointId);
+
+        // Coordinator in the failed region doesn't support regional checkpoint → abort.
+        assertThat(coordinator.getPendingCheckpoints()).isEmpty();
+        assertThat(findCompleted(coordinator, checkpointId)).isNull();
+
+        coordinator.shutdown();
+    }
+
+    // ------------------------------------------------------------------------
+    //  Helpers
+    // ------------------------------------------------------------------------
+
+    private static CheckpointCoordinatorConfiguration regionalConfig(
+            double maxFailureRatio, int maxConsecutive) {
+        return new CheckpointCoordinatorConfigurationBuilder()
+                .setRegionalCheckpointEnabled(true)
+                .setRegionalMaxFailureRatio(maxFailureRatio)
+                .setRegionalMaxConsecutiveFailures(maxConsecutive)
+                .setMaxConcurrentCheckpoints(Integer.MAX_VALUE)
+                .build();
+    }
+
+    private CheckpointCoordinator buildCoordinator(
+            TwoRegionGraph g,
+            CheckpointCoordinatorConfiguration config,
+            CompletedCheckpointStore store)
+            throws Exception {
+        return buildCoordinator(g, config, store, null);
+    }
+
+    private CheckpointCoordinator buildCoordinator(
+            TwoRegionGraph g,
+            CheckpointCoordinatorConfiguration config,
+            CompletedCheckpointStore store,
+            CheckpointCoordinatorTestingUtils.MockOperatorCoordinatorCheckpointContext coordCtx)
+            throws Exception {
+        // Start triggered checkpoint ids well above the historical fallback id to avoid collisions.
+        final StandaloneCheckpointIDCounter idCounter = new StandaloneCheckpointIDCounter();
+        idCounter.setCount(100L);
+        final CheckpointCoordinatorBuilder builder =
+                new CheckpointCoordinatorBuilder()
+                        .setCheckpointCoordinatorConfiguration(config)
+                        .setCompletedCheckpointStore(store)
+                        .setCheckpointIDCounter(idCounter)
+                        .setTimer(manuallyTriggered);
+        if (coordCtx != null) {
+            builder.setCoordinatorsToCheckpoint(java.util.Collections.singleton(coordCtx));
+        }
+        return builder.build(g.graph);
+    }
+
+    private static CompletedCheckpoint findCompleted(
+            CheckpointCoordinator coordinator, long checkpointId) throws Exception {
+        return coordinator.getSuccessfulCheckpoints().stream()
+                .filter(cp -> cp.getCheckpointID() == checkpointId)
+                .findFirst()
+                .orElse(null);
+    }
+
+    private long triggerPending(CheckpointCoordinator coordinator) {
+        coordinator.triggerCheckpoint(false);
+        manuallyTriggered.triggerAll();
+        assertThat(coordinator.getNumberOfPendingCheckpoints()).isEqualTo(1);
+        return coordinator.getPendingCheckpoints().keySet().iterator().next();
+    }
+
+    private static void ackWithState(
+            CheckpointCoordinator coordinator,
+            TwoRegionGraph g,
+            ExecutionVertex vertex,
+            long checkpointId)
+            throws Exception {
+        final OperatorID opId =
+                vertex.getJobVertex()
+                        .getJobVertex()
+                        .getOperatorIDs()
+                        .get(0)
+                        .getGeneratedOperatorID();
+        final TaskStateSnapshot snapshot = new TaskStateSnapshot();
+        snapshot.putSubtaskStateByOperatorID(
+                opId,
+                OperatorSubtaskState.builder()
+                        .setManagedOperatorState(
+                                new org.apache.flink.runtime.state.OperatorStreamStateHandle(
+                                        Collections.emptyMap(),
+                                        new ByteStreamStateHandle(
+                                                "fresh-" + opId, new byte[] {1, 2, 3})))
+                        .build());
+        coordinator.receiveAcknowledgeMessage(
+                new AcknowledgeCheckpoint(
+                        g.graph.getJobID(),
+                        vertex.getCurrentExecutionAttempt().getAttemptId(),
+                        checkpointId,
+                        new CheckpointMetrics(),
+                        snapshot),
+                "test");
+    }
+
+    private static void decline(
+            CheckpointCoordinator coordinator,
+            TwoRegionGraph g,
+            ExecutionVertex vertex,
+            long checkpointId) {
+        coordinator.receiveDeclineMessage(
+                new DeclineCheckpoint(
+                        g.graph.getJobID(),
+                        vertex.getCurrentExecutionAttempt().getAttemptId(),
+                        checkpointId,
+                        new CheckpointException(CheckpointFailureReason.CHECKPOINT_DECLINED)),
+                "test");
+    }
+
+    private void addHistoricalCheckpoint(TwoRegionGraph g, long checkpointId) throws Exception {
+        addHistoricalCheckpoint(g, checkpointId, true);
+    }
+
+    /**
+     * Seeds the completed checkpoint store with a fallback checkpoint containing operator state.
+     */
+    private void addHistoricalCheckpoint(
+            TwoRegionGraph g, long checkpointId, boolean includeSinkSubtaskState) throws Exception {
+        final Map<OperatorID, OperatorState> operatorStates = new HashMap<>();
+
+        final OperatorState sourceState = new OperatorState(null, null, g.sourceOperatorId, 1, 128);
+        sourceState.putState(0, historicalSubtaskState("hist-source"));
+        operatorStates.put(g.sourceOperatorId, sourceState);
+
+        final OperatorState sinkState = new OperatorState(null, null, g.sinkOperatorId, 1, 128);
+        if (includeSinkSubtaskState) {
+            sinkState.putState(0, historicalSubtaskState("hist-sink"));
+        }
+        operatorStates.put(g.sinkOperatorId, sinkState);
+
+        final CompletedCheckpoint historical =
+                new CompletedCheckpoint(
+                        g.graph.getJobID(),
+                        checkpointId,
+                        0L,
+                        0L,
+                        operatorStates,
+                        Collections.emptyList(),
+                        CheckpointProperties.forCheckpoint(
+                                CheckpointRetentionPolicy.NEVER_RETAIN_AFTER_TERMINATION),
+                        new TestCompletedCheckpointStorageLocation(),
+                        null);
+
+        g.store.addCheckpointAndSubsumeOldestOne(historical, new CheckpointsCleaner(), () -> {});
+    }
+
+    private static OperatorSubtaskState historicalSubtaskState(String name) {
+        return OperatorSubtaskState.builder()
+                .setManagedOperatorState(
+                        new org.apache.flink.runtime.state.OperatorStreamStateHandle(
+                                Collections.emptyMap(),
+                                new ByteStreamStateHandle(name, new byte[] {9, 9, 9})))
+                .build();
+    }
+
+    /**
+     * A two-region execution graph: source and sink connected by a BLOCKING ALL_TO_ALL edge, which
+     * places them in two separate pipelined regions. The region provider maps each vertex to its
+     * owning {@link JobVertexID}, so source and sink belong to distinct regions.
+     */
+    private static final class TwoRegionGraph {
+        private static final java.util.concurrent.ScheduledExecutorService EXECUTOR =
+                java.util.concurrent.Executors.newSingleThreadScheduledExecutor();
+
+        final ExecutionGraph graph;
+        final JobVertexID sourceJvId;
+        final JobVertexID sinkJvId;
+        final OperatorID sourceOperatorId;
+        final OperatorID sinkOperatorId;
+        final CompletedCheckpointStore store = new StandaloneCompletedCheckpointStore(5);
+
+        TwoRegionGraph() throws Exception {
+            final JobVertex source = new JobVertex("source", new JobVertexID());
+            source.setParallelism(1);
+            source.setMaxParallelism(128);
+            source.setInvokableClass(NoOpInvokable.class);
+
+            final JobVertex sink = new JobVertex("sink", new JobVertexID());
+            sink.setParallelism(1);
+            sink.setMaxParallelism(128);
+            sink.setInvokableClass(NoOpInvokable.class);
+
+            connectNewDataSetAsInput(
+                    sink, source, DistributionPattern.ALL_TO_ALL, ResultPartitionType.BLOCKING);
+
+            graph = ExecutionGraphTestUtils.createExecutionGraph(EXECUTOR, source, sink);
+            graph.start(
+                    org.apache.flink.runtime.concurrent.ComponentMainThreadExecutorServiceAdapter
+                            .forMainThread());
+            graph.transitionToRunning();
+            for (ExecutionVertex ev : graph.getAllExecutionVertices()) {
+                ev.getCurrentExecutionAttempt().transitionState(ExecutionState.RUNNING);
+            }
+
+            sourceJvId = source.getID();
+            sinkJvId = sink.getID();
+            sourceOperatorId = operatorIdOf(sourceJvId);
+            sinkOperatorId = operatorIdOf(sinkJvId);
+        }
+
+        private OperatorID operatorIdOf(JobVertexID jvId) {
+            return graph.getJobVertex(jvId).getOperatorIDs().get(0).getGeneratedOperatorID();
+        }
+
+        ExecutionVertex sourceVertex() {
+            return graph.getJobVertex(sourceJvId).getTaskVertices()[0];
+        }
+
+        ExecutionVertex sinkVertex() {
+            return graph.getJobVertex(sinkJvId).getTaskVertices()[0];
+        }
+
+        /**
+         * Maps each execution vertex to its owning JobVertexID, giving one region per job vertex.
+         */
+        Function<org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID, Object>
+                regionProvider() {
+            return id -> id.getJobVertexId();
+        }
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/metadata/MetadataV7SerializerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/metadata/MetadataV7SerializerTest.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.checkpoint.metadata;
+
+import org.apache.flink.core.fs.FileSystem;
+import org.apache.flink.runtime.checkpoint.OperatorState;
+import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
+import org.apache.flink.runtime.state.filesystem.AbstractFsCheckpointStorageAccess;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Collection;
+import java.util.OptionalLong;
+import java.util.Random;
+
+import static java.util.Collections.emptyList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link MetadataV7Serializer}, in particular the (de)serialization of the Regional
+ * Checkpoint reference id ({@code refCheckpointId}) and backward compatibility with V6.
+ */
+class MetadataV7SerializerTest {
+
+    private static final Random RND = new Random();
+
+    private String basePath;
+
+    @BeforeEach
+    void beforeEach(@TempDir Path tempDir) throws IOException {
+        basePath = tempDir.toUri().toString();
+        final org.apache.flink.core.fs.Path metaPath =
+                new org.apache.flink.core.fs.Path(
+                        basePath, AbstractFsCheckpointStorageAccess.METADATA_FILE_NAME);
+        FileSystem.getLocalFileSystem().create(metaPath, FileSystem.WriteMode.OVERWRITE).close();
+    }
+
+    @Test
+    void testRefCheckpointIdRoundTrip() throws IOException {
+        // A subtask state carrying a refCheckpointId should round-trip through V7.
+        final CheckpointMetadata metadata = createMetadataWithRefCheckpointId(99L);
+
+        final CheckpointMetadata deserialized =
+                serializeAndDeserialize(MetadataV7Serializer.INSTANCE, metadata);
+
+        assertThat(firstSubtaskState(deserialized).getRefCheckpointId())
+                .isEqualTo(OptionalLong.of(99L));
+    }
+
+    @Test
+    void testNoRefCheckpointIdRoundTrip() throws IOException {
+        // A subtask state without a refCheckpointId should round-trip as empty through V7.
+        final CheckpointMetadata metadata = createMetadataWithRefCheckpointId(null);
+
+        final CheckpointMetadata deserialized =
+                serializeAndDeserialize(MetadataV7Serializer.INSTANCE, metadata);
+
+        assertThat(firstSubtaskState(deserialized).getRefCheckpointId())
+                .isEqualTo(OptionalLong.empty());
+    }
+
+    @Test
+    void testBackwardCompatibilityV6WrittenReadByV7() throws IOException {
+        // Metadata written by V6 (no refCheckpointId field) must be readable, with an empty
+        // refCheckpointId. V6 is read back with its own serializer based on the version header,
+        // but here we explicitly verify the value is treated as empty.
+        final CheckpointMetadata metadata = createMetadataWithRefCheckpointId(null);
+
+        final CheckpointMetadata deserialized =
+                serializeAndDeserialize(MetadataV6Serializer.INSTANCE, metadata);
+
+        assertThat(firstSubtaskState(deserialized).getRefCheckpointId())
+                .isEqualTo(OptionalLong.empty());
+    }
+
+    private CheckpointMetadata createMetadataWithRefCheckpointId(Long refCheckpointId) {
+        final Collection<OperatorState> operatorStates =
+                CheckpointTestUtils.createOperatorStates(RND, basePath, 1, 0, 0, 1);
+        for (OperatorState operatorState : operatorStates) {
+            final OperatorSubtaskState origin = operatorState.getState(0);
+            final OperatorSubtaskState.Builder builder = origin.toBuilder();
+            if (refCheckpointId != null) {
+                builder.setRefCheckpointId(refCheckpointId);
+            }
+            operatorState.putState(0, builder.build());
+        }
+        return new CheckpointMetadata(1L, operatorStates, emptyList(), null);
+    }
+
+    private CheckpointMetadata serializeAndDeserialize(
+            MetadataSerializer serializer, CheckpointMetadata metadata) throws IOException {
+        try (ByteArrayOutputStream out = new ByteArrayOutputStream();
+                DataOutputStream dos = new DataOutputStream(out)) {
+            serializer.serialize(metadata, dos, null);
+            try (DataInputStream dis =
+                    new DataInputStream(new ByteArrayInputStream(out.toByteArray()))) {
+                return serializer.deserialize(dis, metadata.getClass().getClassLoader(), basePath);
+            }
+        }
+    }
+
+    private OperatorSubtaskState firstSubtaskState(CheckpointMetadata metadata) {
+        final OperatorState operatorState = metadata.getOperatorStates().iterator().next();
+        return operatorState.getState(0);
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/utils/SimpleAckingTaskManagerGateway.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/utils/SimpleAckingTaskManagerGateway.java
@@ -132,7 +132,8 @@ public class SimpleAckingTaskManagerGateway implements TaskManagerGateway {
             JobID jobId,
             long completedCheckpointId,
             long completedTimestamp,
-            long lastSubsumedCheckpointId) {}
+            long lastSubsumedCheckpointId,
+            long fallbackCheckpointId) {}
 
     @Override
     public void notifyCheckpointAborted(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/OperatorCoordinatorRegionalCheckpointTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/OperatorCoordinatorRegionalCheckpointTest.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.operators.coordination;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class OperatorCoordinatorRegionalCheckpointTest {
+
+    @Test
+    void testDefaultSupportsRegionCheckpointReturnsFalse() {
+        OperatorCoordinator coordinator = new TestingOperatorCoordinator();
+        assertThat(coordinator.supportsRegionCheckpoint()).isFalse();
+    }
+
+    @Test
+    void testDefaultCheckpointCoordinatorForRegionFallbackThrows() {
+        OperatorCoordinator coordinator = new TestingOperatorCoordinator();
+        Set<Integer> fallbackSubtaskIds = new HashSet<>();
+        fallbackSubtaskIds.add(0);
+        CompletableFuture<byte[]> resultFuture = new CompletableFuture<>();
+
+        assertThatThrownBy(
+                        () ->
+                                coordinator.checkpointCoordinatorForRegionFallback(
+                                        100L, 99L, fallbackSubtaskIds, resultFuture))
+                .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    // Minimal OperatorCoordinator implementation for testing defaults.
+    private static class TestingOperatorCoordinator implements OperatorCoordinator {
+        @Override
+        public void start() {}
+
+        @Override
+        public void close() {}
+
+        @Override
+        public void handleEventFromOperator(int subtask, int attemptNumber, OperatorEvent event) {}
+
+        @Override
+        public void checkpointCoordinator(long checkpointId, CompletableFuture<byte[]> result) {}
+
+        @Override
+        public void notifyCheckpointComplete(long checkpointId) {}
+
+        @Override
+        public void resetToCheckpoint(long checkpointId, byte[] checkpointData) {}
+
+        @Override
+        public void subtaskReset(int subtask, long checkpointId) {}
+
+        @Override
+        public void executionAttemptFailed(int subtask, int attemptNumber, Throwable reason) {}
+
+        @Override
+        public void executionAttemptReady(int subtask, int attemptNumber, SubtaskGateway gateway) {}
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorRegionalCheckpointTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorRegionalCheckpointTest.java
@@ -1,0 +1,175 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.source.coordinator;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link SourceCoordinator} regional checkpoint support. */
+class SourceCoordinatorRegionalCheckpointTest extends SourceCoordinatorTestBase {
+
+    @Test
+    void testSupportsRegionCheckpoint() throws Exception {
+        sourceReady();
+        assertThat(sourceCoordinator.supportsRegionCheckpoint()).isTrue();
+    }
+
+    @Test
+    void testCheckpointCoordinatorForRegionFallback() throws Exception {
+        sourceReady();
+        addTestingSplitSet(6);
+
+        // Register readers for subtask 0 and 1
+        registerReader(0);
+        registerReader(1);
+
+        // Assign splits: 2 to subtask 0, 1 to subtask 1
+        getEnumerator().executeAssignOneSplit(0);
+        getEnumerator().executeAssignOneSplit(0);
+        getEnumerator().executeAssignOneSplit(1);
+
+        // Take checkpoint 100 - this records the above assignments under checkpoint 100
+        final CompletableFuture<byte[]> checkpoint100Future = new CompletableFuture<>();
+        sourceCoordinator.checkpointCoordinator(100L, checkpoint100Future);
+        waitForCoordinatorToProcessActions();
+        assertThat(checkpoint100Future).isDone();
+
+        // Assign more splits after checkpoint 100
+        getEnumerator().executeAssignOneSplit(0);
+        getEnumerator().executeAssignOneSplit(1);
+
+        // Take checkpoint 101 to record the new assignments
+        final CompletableFuture<byte[]> checkpoint101Future = new CompletableFuture<>();
+        sourceCoordinator.checkpointCoordinator(101L, checkpoint101Future);
+        waitForCoordinatorToProcessActions();
+        assertThat(checkpoint101Future).isDone();
+
+        // Now simulate region fallback: subtask 0 failed, falls back to checkpoint 100
+        final Set<Integer> fallbackSubtaskIds = new HashSet<>(Collections.singletonList(0));
+        final CompletableFuture<byte[]> regionFallbackFuture = new CompletableFuture<>();
+        sourceCoordinator.checkpointCoordinatorForRegionFallback(
+                101L, 100L, fallbackSubtaskIds, regionFallbackFuture);
+        waitForCoordinatorToProcessActions();
+
+        // The future should complete successfully with serialized state
+        assertThat(regionFallbackFuture).isDone();
+        assertThat(regionFallbackFuture).isNotCompletedExceptionally();
+        final byte[] result = regionFallbackFuture.get();
+        assertThat(result).isNotNull();
+        assertThat(result.length).isGreaterThan(0);
+
+        // The split assigned to subtask 0 after checkpoint 100 should be added back
+        // to the enumerator. Originally 6 splits, 5 were assigned (3 before ckpt 100,
+        // 2 after). After rollback, subtask 0's post-ckpt-100 split should return.
+        // So unassigned = original 1 remaining + 1 rolled back = 2
+        assertThat(getEnumerator().getUnassignedSplits()).hasSize(2);
+    }
+
+    @Test
+    void testRegionFallbackWithNoAssignmentsAfterCheckpoint() throws Exception {
+        sourceReady();
+        addTestingSplitSet(4);
+
+        registerReader(0);
+        registerReader(1);
+
+        // Assign splits before checkpoint
+        getEnumerator().executeAssignOneSplit(0);
+        getEnumerator().executeAssignOneSplit(1);
+
+        // Take checkpoint 100
+        final CompletableFuture<byte[]> checkpoint100Future = new CompletableFuture<>();
+        sourceCoordinator.checkpointCoordinator(100L, checkpoint100Future);
+        waitForCoordinatorToProcessActions();
+        assertThat(checkpoint100Future).isDone();
+
+        // No new assignments after checkpoint 100
+        // Take checkpoint 101
+        final CompletableFuture<byte[]> checkpoint101Future = new CompletableFuture<>();
+        sourceCoordinator.checkpointCoordinator(101L, checkpoint101Future);
+        waitForCoordinatorToProcessActions();
+
+        // Region fallback for subtask 0 to checkpoint 100
+        final Set<Integer> fallbackSubtaskIds = new HashSet<>(Collections.singletonList(0));
+        final CompletableFuture<byte[]> regionFallbackFuture = new CompletableFuture<>();
+        sourceCoordinator.checkpointCoordinatorForRegionFallback(
+                101L, 100L, fallbackSubtaskIds, regionFallbackFuture);
+        waitForCoordinatorToProcessActions();
+
+        // Should succeed even when there's nothing to roll back
+        assertThat(regionFallbackFuture).isDone();
+        assertThat(regionFallbackFuture).isNotCompletedExceptionally();
+
+        // Unassigned splits should remain the same (2 remaining from original 4)
+        assertThat(getEnumerator().getUnassignedSplits()).hasSize(2);
+    }
+
+    @Test
+    void testRegionFallbackMultipleSubtasks() throws Exception {
+        sourceReady();
+        addTestingSplitSet(6);
+
+        registerReader(0);
+        registerReader(1);
+        registerReader(2);
+
+        // Assign 2 splits each to subtask 0, 1, 2
+        getEnumerator().executeAssignOneSplit(0);
+        getEnumerator().executeAssignOneSplit(1);
+        getEnumerator().executeAssignOneSplit(2);
+
+        // Take checkpoint 100
+        final CompletableFuture<byte[]> checkpoint100Future = new CompletableFuture<>();
+        sourceCoordinator.checkpointCoordinator(100L, checkpoint100Future);
+        waitForCoordinatorToProcessActions();
+
+        // Assign more splits after checkpoint 100
+        getEnumerator().executeAssignOneSplit(0);
+        getEnumerator().executeAssignOneSplit(1);
+        getEnumerator().executeAssignOneSplit(2);
+
+        // Take checkpoint 101
+        final CompletableFuture<byte[]> checkpoint101Future = new CompletableFuture<>();
+        sourceCoordinator.checkpointCoordinator(101L, checkpoint101Future);
+        waitForCoordinatorToProcessActions();
+
+        // Region fallback: subtasks 0 and 2 fall back to checkpoint 100
+        final Set<Integer> fallbackSubtaskIds = new HashSet<>();
+        fallbackSubtaskIds.add(0);
+        fallbackSubtaskIds.add(2);
+        final CompletableFuture<byte[]> regionFallbackFuture = new CompletableFuture<>();
+        sourceCoordinator.checkpointCoordinatorForRegionFallback(
+                101L, 100L, fallbackSubtaskIds, regionFallbackFuture);
+        waitForCoordinatorToProcessActions();
+
+        assertThat(regionFallbackFuture).isDone();
+        assertThat(regionFallbackFuture).isNotCompletedExceptionally();
+
+        // 6 splits total, 6 assigned (3 before + 3 after ckpt 100).
+        // 0 unassigned originally. After rollback, subtask 0 and 2's post-ckpt-100
+        // splits (1 each) should be returned = 2 back in enumerator.
+        assertThat(getEnumerator().getUnassignedSplits()).hasSize(2);
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/source/coordinator/SplitAssignmentTrackerRegionalCheckpointTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/source/coordinator/SplitAssignmentTrackerRegionalCheckpointTest.java
@@ -1,0 +1,153 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package org.apache.flink.runtime.source.coordinator;
+
+import org.apache.flink.api.connector.source.mocks.MockSourceSplit;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.apache.flink.runtime.source.coordinator.CoordinatorTestUtils.getSplitsAssignment;
+import static org.apache.flink.runtime.source.coordinator.CoordinatorTestUtils.verifyAssignment;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for Regional Checkpoint support in {@link SplitAssignmentTracker}. */
+class SplitAssignmentTrackerRegionalCheckpointTest {
+
+    @Test
+    void testGetAssignmentsAfterCheckpoint() throws Exception {
+        final long checkpointId1 = 99L;
+        final long checkpointId2 = 100L;
+        SplitAssignmentTracker<MockSourceSplit> tracker = new SplitAssignmentTracker<>();
+
+        // Assign splits and checkpoint at 99.
+        // subtask 0: [0], subtask 1: [1, 2]
+        tracker.recordSplitAssignment(getSplitsAssignment(2, 0));
+        tracker.onCheckpoint(checkpointId1);
+
+        // Assign more splits and checkpoint at 100.
+        // subtask 0: [3], subtask 1: [4, 5]
+        tracker.recordSplitAssignment(getSplitsAssignment(2, 3));
+        tracker.onCheckpoint(checkpointId2);
+
+        // Assign uncheckpointed splits.
+        // subtask 0: [6], subtask 1: [7, 8]
+        tracker.recordSplitAssignment(getSplitsAssignment(2, 6));
+
+        // Get assignments after checkpoint 99 for subtask 0.
+        Set<Integer> subtaskIds = new HashSet<>(Arrays.asList(0));
+        Map<Integer, List<MockSourceSplit>> result =
+                tracker.getAssignmentsAfterCheckpoint(checkpointId1, subtaskIds);
+
+        assertThat(result).containsKey(0);
+        verifyAssignment(Arrays.asList("3", "6"), result.get(0));
+
+        // Get assignments after checkpoint 99 for subtask 1.
+        subtaskIds = new HashSet<>(Arrays.asList(1));
+        result = tracker.getAssignmentsAfterCheckpoint(checkpointId1, subtaskIds);
+
+        assertThat(result).containsKey(1);
+        verifyAssignment(Arrays.asList("4", "5", "7", "8"), result.get(1));
+
+        // Get assignments after checkpoint 100 for subtask 0 — only uncheckpointed.
+        subtaskIds = new HashSet<>(Arrays.asList(0));
+        result = tracker.getAssignmentsAfterCheckpoint(checkpointId2, subtaskIds);
+
+        assertThat(result).containsKey(0);
+        verifyAssignment(Arrays.asList("6"), result.get(0));
+    }
+
+    @Test
+    void testRemoveAssignmentsAfterCheckpoint() throws Exception {
+        final long checkpointId1 = 99L;
+        final long checkpointId2 = 100L;
+        SplitAssignmentTracker<MockSourceSplit> tracker = new SplitAssignmentTracker<>();
+
+        // Assign splits and checkpoint at 99.
+        tracker.recordSplitAssignment(getSplitsAssignment(2, 0));
+        tracker.onCheckpoint(checkpointId1);
+
+        // Assign more splits and checkpoint at 100.
+        tracker.recordSplitAssignment(getSplitsAssignment(2, 3));
+        tracker.onCheckpoint(checkpointId2);
+
+        // Assign uncheckpointed splits.
+        tracker.recordSplitAssignment(getSplitsAssignment(2, 6));
+
+        // Remove assignments after checkpoint 99 for subtask 0.
+        Set<Integer> subtaskIds = new HashSet<>(Arrays.asList(0));
+        Map<Integer, List<MockSourceSplit>> removed =
+                tracker.removeAssignmentsAfterCheckpoint(checkpointId1, subtaskIds);
+
+        assertThat(removed).containsKey(0);
+        verifyAssignment(Arrays.asList("3", "6"), removed.get(0));
+
+        // Verify the splits have been removed — getting again should return empty.
+        Map<Integer, List<MockSourceSplit>> afterRemoval =
+                tracker.getAssignmentsAfterCheckpoint(checkpointId1, subtaskIds);
+        assertThat(afterRemoval).doesNotContainKey(0);
+
+        // Verify subtask 1 assignments are still intact.
+        Set<Integer> subtask1 = new HashSet<>(Arrays.asList(1));
+        Map<Integer, List<MockSourceSplit>> subtask1Result =
+                tracker.getAssignmentsAfterCheckpoint(checkpointId1, subtask1);
+        assertThat(subtask1Result).containsKey(1);
+        verifyAssignment(Arrays.asList("4", "5", "7", "8"), subtask1Result.get(1));
+    }
+
+    @Test
+    void testMultipleSubtasksRemoval() throws Exception {
+        final long checkpointId1 = 99L;
+        final long checkpointId2 = 100L;
+        SplitAssignmentTracker<MockSourceSplit> tracker = new SplitAssignmentTracker<>();
+
+        // Assign splits and checkpoint at 99.
+        // subtask 0: [0], subtask 1: [1, 2], subtask 2: [3, 4, 5]
+        tracker.recordSplitAssignment(getSplitsAssignment(3, 0));
+        tracker.onCheckpoint(checkpointId1);
+
+        // Assign more splits and checkpoint at 100.
+        // subtask 0: [6], subtask 1: [7, 8], subtask 2: [9, 10, 11]
+        tracker.recordSplitAssignment(getSplitsAssignment(3, 6));
+        tracker.onCheckpoint(checkpointId2);
+
+        // Remove assignments after checkpoint 99 for subtasks 0 and 2 (a region).
+        Set<Integer> subtaskIds = new HashSet<>(Arrays.asList(0, 2));
+        Map<Integer, List<MockSourceSplit>> removed =
+                tracker.removeAssignmentsAfterCheckpoint(checkpointId1, subtaskIds);
+
+        assertThat(removed).hasSize(2);
+        assertThat(removed).containsKey(0);
+        assertThat(removed).containsKey(2);
+        verifyAssignment(Arrays.asList("6"), removed.get(0));
+        verifyAssignment(Arrays.asList("9", "10", "11"), removed.get(2));
+
+        // Verify subtask 1 is unaffected.
+        Set<Integer> subtask1 = new HashSet<>(Arrays.asList(1));
+        Map<Integer, List<MockSourceSplit>> subtask1Result =
+                tracker.getAssignmentsAfterCheckpoint(checkpointId1, subtask1);
+        assertThat(subtask1Result).containsKey(1);
+        verifyAssignment(Arrays.asList("7", "8"), subtask1Result.get(1));
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/source/coordinator/SplitAssignmentTrackerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/source/coordinator/SplitAssignmentTrackerTest.java
@@ -70,6 +70,70 @@ class SplitAssignmentTrackerTest {
     }
 
     @Test
+    void testSnapshotStateAndRestoreStateWithCheckpointHistory() throws Exception {
+        final long checkpointId1 = 100L;
+        final long checkpointId2 = 101L;
+        SplitAssignmentTracker<MockSourceSplit> tracker = new SplitAssignmentTracker<>();
+
+        // Checkpointed history: ckp100 and ckp101.
+        tracker.recordSplitAssignment(getSplitsAssignment(2, 0));
+        tracker.onCheckpoint(checkpointId1);
+        tracker.recordSplitAssignment(getSplitsAssignment(2, 3));
+        tracker.onCheckpoint(checkpointId2);
+
+        // Plus some uncheckpointed assignments on top.
+        tracker.recordSplitAssignment(getSplitsAssignment(1, 6));
+
+        byte[] snapshotState = tracker.snapshotState(new MockSourceSplitSerializer());
+
+        SplitAssignmentTracker<MockSourceSplit> trackerToRestore = new SplitAssignmentTracker<>();
+        trackerToRestore.restoreState(new MockSourceSplitSerializer(), snapshotState);
+
+        // The per-checkpoint history must survive the round-trip (the core of regional checkpoint
+        // precise rollback support).
+        verifyAssignment(
+                Arrays.asList("0"),
+                trackerToRestore.assignmentsByCheckpointId(checkpointId1).get(0));
+        verifyAssignment(
+                Arrays.asList("1", "2"),
+                trackerToRestore.assignmentsByCheckpointId(checkpointId1).get(1));
+        verifyAssignment(
+                Arrays.asList("3"),
+                trackerToRestore.assignmentsByCheckpointId(checkpointId2).get(0));
+        verifyAssignment(
+                Arrays.asList("4", "5"),
+                trackerToRestore.assignmentsByCheckpointId(checkpointId2).get(1));
+
+        // The uncheckpointed assignments must survive too.
+        verifyAssignment(Arrays.asList("6"), trackerToRestore.uncheckpointedAssignments().get(0));
+
+        // And precise rollback must work after restore: rolling subtask 0 back past ckp100 should
+        // recover the splits assigned in ckp101 and the uncheckpointed ones.
+        List<MockSourceSplit> splitsToPutBack =
+                trackerToRestore.getAndRemoveUncheckpointedAssignment(0, checkpointId1);
+        verifyAssignment(Arrays.asList("3", "6"), splitsToPutBack);
+    }
+
+    @Test
+    void testRestoreFromLegacyFormatLeavesHistoryEmpty() throws Exception {
+        // The legacy snapshot format only contained the uncheckpointed assignments, produced
+        // directly by SourceCoordinatorSerdeUtils.serializeAssignments(...).
+        SplitAssignmentTracker<MockSourceSplit> source = new SplitAssignmentTracker<>();
+        source.recordSplitAssignment(getSplitsAssignment(2, 0));
+        byte[] legacy =
+                SourceCoordinatorSerdeUtils.serializeAssignments(
+                        source.uncheckpointedAssignments(), new MockSourceSplitSerializer());
+
+        SplitAssignmentTracker<MockSourceSplit> trackerToRestore = new SplitAssignmentTracker<>();
+        trackerToRestore.restoreState(new MockSourceSplitSerializer(), legacy);
+
+        verifyAssignment(Arrays.asList("0"), trackerToRestore.uncheckpointedAssignments().get(0));
+        verifyAssignment(
+                Arrays.asList("1", "2"), trackerToRestore.uncheckpointedAssignments().get(1));
+        assertThat(trackerToRestore.assignmentsByCheckpointId()).isEmpty();
+    }
+
+    @Test
     void testOnCheckpoint() throws Exception {
         final long checkpointId = 123L;
         SplitAssignmentTracker<MockSourceSplit> tracker = new SplitAssignmentTracker<>();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TestingTaskExecutorGateway.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TestingTaskExecutorGateway.java
@@ -284,7 +284,8 @@ public class TestingTaskExecutorGateway implements TaskExecutorGateway {
             ExecutionAttemptID executionAttemptID,
             long checkpointId,
             long checkpointTimestamp,
-            long lastSubsumedCheckpointId) {
+            long lastSubsumedCheckpointId,
+            long fallbackCheckpointId) {
         return confirmCheckpointFunction.apply(
                 executionAttemptID, checkpointId, checkpointTimestamp);
     }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/AbstractUdfStreamOperatorLifecycleTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/AbstractUdfStreamOperatorLifecycleTest.java
@@ -104,6 +104,8 @@ class AbstractUdfStreamOperatorLifecycleTest {
                     + "initializeState[interface org.apache.flink.streaming.api.operators.StreamTaskStateInitializer], "
                     + "notifyCheckpointAborted[long], "
                     + "notifyCheckpointComplete[long], "
+                    + "notifyRegionalCheckpointComplete[long, class org.apache.flink.api.common.state.RegionalCheckpointInfo], "
+                    + "notifyRegionalCheckpointFallback[long, long], "
                     + "open[], "
                     + "prepareSnapshotPreBarrier[long], "
                     + "setCurrentKey[class java.lang.Object], "


### PR DESCRIPTION
## Purpose

Implements the core Regional Checkpoint mechanism (FLIP-600 Phase 1-5): when partial pipeline regions fail during a checkpoint, the framework generates a logically complete Completed Checkpoint by combining historical state of failed regions with current state of healthy regions.

## Changes

**Commit 1: Define interfaces, configuration and refCheckpointId infrastructure**
- CheckpointListener: add `notifyRegionalCheckpointComplete` (healthy-region tasks) and `notifyRegionalCheckpointFallback` (failed-region tasks)
- OperatorCoordinator: add `supportsRegionCheckpoint()` and `checkpointCoordinatorForRegionFallback()`
- Add RegionalCheckpointInfo class
- Add 3 config options: `region.enabled`, `region.max-failure-ratio`, `region.max-consecutive-failures`
- Add `refCheckpointId` field to OperatorSubtaskState + MetadataV7Serializer (backward-compatible)
- Add CheckpointSubsumeHelper for reference-aware cleanup

**Commit 2: Implement core logic and SourceCoordinator fallback**
- Add RegionalCheckpointHandler: decline buffering, region failure judgment, state recombination, two-tier max-consecutive-failures (Tier 1: force next global; Tier 2: abort + reset)
- Wire CheckpointCoordinator to delegate to RegionalCheckpointHandler
- Implement SourceCoordinator.checkpointCoordinatorForRegionFallback (split assignment rollback)
- Add DefaultCompletedCheckpointStore.computeReferencedCheckpointIds for cleaner reference protection

**Commit 3: Implement notification dispatch and local state cleanup**
- Extend confirmCheckpoint RPC with `fallbackCheckpointId` parameter (reuses task-side checkpoint-complete RPC path so notification survives task restarts)
- Full notification chain: TaskExecutor → Task → StreamTask → SubtaskCheckpointCoordinator → OperatorChain → AbstractUdfStreamOperator → user function
- Add TaskStateManager.pruneStateForCheckpoint for local state cleanup (FLIP-600 Section 9)

## Testing
- Unit tests: success path, consecutive limit (two-tier), state assembly, deferred abort, cleaner, config, SourceCoordinator fallback, SplitAssignmentTracker
- All tests pass

## Dependencies
- None (base PR for FLIP-600 Regional Checkpoint)

Generated-by: CodeBuddy Code (GLM-5.2)