### PR TITLE
[FLINK-40298][table] Opt-in name-based state schema evolution for RowData

### DIFF
--- a/docs/layouts/shortcodes/generated/execution_config_configuration.html
+++ b/docs/layouts/shortcodes/generated/execution_config_configuration.html
@@ -357,6 +357,12 @@ By default no operator is disabled.</td>
             <td>Whether to compress spilled data. Currently we only support compress spilled data for sort and hash-agg and hash-join operators.</td>
         </tr>
         <tr>
+            <td><h5>table.exec.state.schema-evolution.enabled</h5><br> <span class="label label-primary">Streaming</span></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>When enabled, a RowData keyed-state value whose schema changed in a backward-compatible way (adding nullable fields, reordering fields by name, evolving a nested ROW) is migrated when state is restored, instead of the restore failing. Only a state's own value serializer is covered: a RowData nested below a composite serializer, or a state whose serializer the operator pre-builds, is still rejected. Takes effect only on a state backend that migrates restored values at the object level, currently RocksDB; on other backends the restore still fails. Disabled by default.</td>
+        </tr>
+        <tr>
             <td><h5>table.exec.state.ttl</h5><br> <span class="label label-primary">Streaming</span></td>
             <td style="word-wrap: break-word;">0 ms</td>
             <td>Duration</td>

--- a/flink-core/src/main/java/org/apache/flink/api/common/serialization/SerializerConfig.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/serialization/SerializerConfig.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.api.common.serialization;
 
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.api.common.typeinfo.TypeInfoFactory;
 import org.apache.flink.configuration.PipelineOptions;
@@ -70,6 +71,21 @@ public interface SerializerConfig extends Serializable {
 
     /** Returns whether forces Flink to register Apache Avro classes in Kryo serializer. */
     TernaryBoolean isForceKryoAvroEnabled();
+
+    /**
+     * Whether state schema evolution for {@code RowData} state is enabled. When enabled, a {@code
+     * RowData} state value serializer admits a backward-compatible schema change and migrates the
+     * stored values when state is restored, instead of the restore failing.
+     *
+     * <p>This is a runtime hook rather than user-facing configuration. The option itself is owned
+     * by {@code ExecutionConfigOptions.TABLE_EXEC_STATE_SCHEMA_EVOLUTION_ENABLED} and only mirrored
+     * here by key, because this module cannot depend on the table API. Set the option there, not
+     * through this method.
+     */
+    @Internal
+    default boolean isStateSchemaEvolutionEnabled() {
+        return false;
+    }
 
     /**
      * Sets all relevant options contained in the {@link ReadableConfig} such as e.g. {@link

--- a/flink-core/src/main/java/org/apache/flink/api/common/serialization/SerializerConfigImpl.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/serialization/SerializerConfigImpl.java
@@ -23,6 +23,8 @@ import org.apache.flink.api.common.SerializableSerializer;
 import org.apache.flink.api.common.functions.InvalidTypesException;
 import org.apache.flink.api.common.typeinfo.TypeInfoFactory;
 import org.apache.flink.api.java.typeutils.TypeExtractor;
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.ConfigOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.ConfigurationUtils;
 import org.apache.flink.configuration.PipelineOptions;
@@ -46,6 +48,14 @@ import java.util.stream.Collectors;
 public final class SerializerConfigImpl implements SerializerConfig {
 
     private static final long serialVersionUID = 1L;
+
+    // Mirrors org.apache.flink.table.api.config.ExecutionConfigOptions
+    //   .TABLE_EXEC_STATE_SCHEMA_EVOLUTION_ENABLED by key string, because flink-core cannot depend
+    //   on flink-table-api-java. The value travels in the shared job Configuration.
+    private static final ConfigOption<Boolean> STATE_SCHEMA_EVOLUTION_ENABLED =
+            ConfigOptions.key("table.exec.state.schema-evolution.enabled")
+                    .booleanType()
+                    .defaultValue(false);
 
     private final Configuration configuration;
 
@@ -259,6 +269,11 @@ public final class SerializerConfigImpl implements SerializerConfig {
         configuration.set(PipelineOptions.FORCE_KRYO, forceKryo);
     }
 
+    @Override
+    public boolean isStateSchemaEvolutionEnabled() {
+        return configuration.get(STATE_SCHEMA_EVOLUTION_ENABLED);
+    }
+
     /** Returns whether the Apache Avro is the serializer for POJOs. */
     public boolean isForceAvroEnabled() {
         return configuration.get(PipelineOptions.FORCE_AVRO);
@@ -357,6 +372,10 @@ public final class SerializerConfigImpl implements SerializerConfig {
         configuration
                 .getOptional(PipelineOptions.SERIALIZATION_CONFIG)
                 .ifPresent(c -> parseSerializationConfigWithExceptionHandling(classLoader, c));
+        configuration
+                .getOptional(STATE_SCHEMA_EVOLUTION_ENABLED)
+                .ifPresent(
+                        enabled -> this.configuration.set(STATE_SCHEMA_EVOLUTION_ENABLED, enabled));
     }
 
     @SuppressWarnings("unchecked")

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/StateSchemaEvolvingSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/StateSchemaEvolvingSerializer.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.common.typeutils;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.functions.SerializerFactory;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+
+/**
+ * A {@link TypeSerializer} that can admit a backward-compatible change of the schema of the values
+ * it serializes, provided the state it belongs to will actually have those values migrated.
+ *
+ * <p>Implementations are inert by default: a serializer only starts admitting schema changes once
+ * {@link #withStateSchemaEvolution()} has been called on it, and only if the job configuration
+ * opted in.
+ *
+ * @param <T> the type of the serialized values
+ */
+@Internal
+public interface StateSchemaEvolvingSerializer<T> {
+
+    /**
+     * Returns a serializer that admits a backward-compatible schema change and migrates the stored
+     * values when state is restored, or {@code this} if the job configuration did not opt in.
+     *
+     * <p>This is called only on a state's own value serializer, never on an arbitrary serializer
+     * encountered while walking a type.
+     */
+    TypeSerializer<T> withStateSchemaEvolution();
+
+    /**
+     * Decorates a factory so that the serializer it produces for a state value is armed for schema
+     * evolution.
+     *
+     * <p>Only a caller whose backend migrates restored values through {@link
+     * TypeSerializerSnapshot#migrate} may use this. A caller that does not decorate its factory
+     * keeps today's behavior unchanged.
+     */
+    static SerializerFactory arming(SerializerFactory delegate) {
+        // Not a lambda: SerializerFactory's single method is generic, which a lambda cannot
+        // implement.
+        return new SerializerFactory() {
+            @Override
+            public <T> TypeSerializer<T> createSerializer(TypeInformation<T> typeInformation) {
+                return armStateValueSerializer(delegate.createSerializer(typeInformation));
+            }
+        };
+    }
+
+    /**
+     * Arms the serializer a state holds for its values, if it supports schema evolution at all.
+     *
+     * <p>The serializer passed in is armed, and nothing below it: there is no descent into a
+     * composite, and no recursion. A serializer nested below the state value is not reached by
+     * {@link TypeSerializerSnapshot#migrate}, so arming one would let a compatibility check report
+     * {@code compatibleAfterMigration} for bytes that nothing ever migrates.
+     *
+     * <p>The serializers armed here are therefore a subset of those {@code
+     * TtlAwareSerializer#wrapTtlAwareSerializer} descends into, which are the ones some backend
+     * calls {@code migrate} on. Being a subset is what keeps this sound. Widening the descent to
+     * close the gap is only safe once every caller registering the widened shape is known to reach
+     * such a backend, which is not true of the seam as it stands: operator state and broadcast
+     * state register list and map descriptors through it and never migrate.
+     */
+    @SuppressWarnings("unchecked")
+    static <T> TypeSerializer<T> armStateValueSerializer(TypeSerializer<T> serializer) {
+        return serializer instanceof StateSchemaEvolvingSerializer
+                ? ((StateSchemaEvolvingSerializer<T>) serializer).withStateSchemaEvolution()
+                : serializer;
+    }
+}

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/TypeSerializerSnapshot.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/TypeSerializerSnapshot.java
@@ -150,10 +150,19 @@ public interface TypeSerializerSnapshot<T> {
      * <p>The migration is not applied recursively to nested serializers. The snapshot of a
      * composite type returns its value unchanged unless it overrides this method to decompose the
      * value and migrate each part, so a caller that needs a nested value migrated must reach the
-     * nested snapshot itself.
+     * nested snapshot itself. An implementation that does so should not assume that the old and the
+     * new snapshot expose nested snapshots of the same type: restoring may have replaced those of
+     * the old snapshot with decorators, so nested snapshots are best matched by position or name
+     * rather than by class.
      *
-     * @param oldSerializerSnapshot snapshot of the serializer that wrote the value.
-     * @param value the value, already deserialized with the prior serializer.
+     * @param oldSerializerSnapshot snapshot of the serializer that wrote the value. A caller that
+     *     holds the snapshot persisted with the state should pass that one in preference to a
+     *     snapshot re-derived from a serializer restored from it, because that round trip does not
+     *     always reproduce the schema that was written.
+     * @param value the value, already deserialized with the prior serializer. It may be {@code
+     *     null} wherever the prior serializer can produce {@code null}. An implementation that
+     *     decomposes a composite value may likewise pass {@code null} to a nested snapshot for an
+     *     absent part, even where that part's serializer would reject {@code null} at top level.
      * @return the value adapted to the schema of the current serializer.
      */
     default T migrate(TypeSerializerSnapshot<T> oldSerializerSnapshot, T value) {

--- a/flink-core/src/test/java/org/apache/flink/api/common/serialization/SerializerConfigImplTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/serialization/SerializerConfigImplTest.java
@@ -20,6 +20,8 @@ package org.apache.flink.api.common.serialization;
 
 import org.apache.flink.api.common.typeinfo.TypeInfoFactory;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.ConfigOptions;
 import org.apache.flink.configuration.Configuration;
 
 import com.esotericsoftware.kryo.Kryo;
@@ -42,6 +44,47 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class SerializerConfigImplTest {
+
+    /**
+     * Mirrors {@code ExecutionConfigOptions.TABLE_EXEC_STATE_SCHEMA_EVOLUTION_ENABLED}, which lives
+     * in a module this one cannot depend on.
+     */
+    private static final ConfigOption<Boolean> STATE_SCHEMA_EVOLUTION_ENABLED =
+            ConfigOptions.key("table.exec.state.schema-evolution.enabled")
+                    .booleanType()
+                    .defaultValue(false);
+
+    @Test
+    void testStateSchemaEvolutionFlagSurvivesConstructionAndCopy() {
+        Configuration configuration = new Configuration();
+        configuration.set(STATE_SCHEMA_EVOLUTION_ENABLED, true);
+
+        SerializerConfigImpl serializerConfig = new SerializerConfigImpl(configuration);
+
+        assertThat(serializerConfig.isStateSchemaEvolutionEnabled()).isTrue();
+        assertThat(serializerConfig.copy().isStateSchemaEvolutionEnabled()).isTrue();
+    }
+
+    @Test
+    void testStateSchemaEvolutionFlagDefaultsFalseThroughCopy() {
+        SerializerConfigImpl serializerConfig = new SerializerConfigImpl();
+
+        assertThat(serializerConfig.isStateSchemaEvolutionEnabled()).isFalse();
+        assertThat(serializerConfig.copy().isStateSchemaEvolutionEnabled()).isFalse();
+    }
+
+    @Test
+    void testStateSchemaEvolutionFlagSurvivesConfigure() {
+        Configuration configuration = new Configuration();
+        configuration.set(STATE_SCHEMA_EVOLUTION_ENABLED, true);
+
+        SerializerConfigImpl serializerConfig = new SerializerConfigImpl();
+        serializerConfig.configure(configuration, SerializerConfigImplTest.class.getClassLoader());
+
+        assertThat(serializerConfig.isStateSchemaEvolutionEnabled()).isTrue();
+        assertThat(serializerConfig.copy().isStateSchemaEvolutionEnabled()).isTrue();
+    }
+
     @Test
     void testReadingDefaultConfig() {
         SerializerConfig config = new SerializerConfigImpl();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/AbstractKeyedStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/AbstractKeyedStateBackend.java
@@ -20,9 +20,12 @@ package org.apache.flink.runtime.state;
 
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.functions.SerializerFactory;
 import org.apache.flink.api.common.state.InternalCheckpointListener;
 import org.apache.flink.api.common.state.State;
 import org.apache.flink.api.common.state.StateDescriptor;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeutils.StateSchemaEvolvingSerializer;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.core.fs.CloseableRegistry;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
@@ -387,7 +390,7 @@ public abstract class AbstractKeyedStateBackend<K>
         InternalKvState<K, ?, ?> kvState = keyValueStatesByName.get(stateDescriptor.getName());
         if (kvState == null) {
             if (!stateDescriptor.isSerializerInitialized()) {
-                stateDescriptor.initializeSerializerUnlessSet(executionConfig);
+                stateDescriptor.initializeSerializerUnlessSet(stateValueSerializerFactory());
             }
             kvState =
                     MetricsTrackingStateFactory.createStateAndWrapWithMetricsTrackingIfEnabled(
@@ -401,6 +404,29 @@ public abstract class AbstractKeyedStateBackend<K>
             publishQueryableStateIfEnabled(stateDescriptor, kvState);
         }
         return (S) kvState;
+    }
+
+    /**
+     * The factory a state descriptor registered here uses for its own value serializer. It
+     * reproduces what {@link StateDescriptor#initializeSerializerUnlessSet(ExecutionConfig)}
+     * builds, and arms schema evolution on top of it only when this backend migrates restored
+     * values at the object level.
+     */
+    private SerializerFactory stateValueSerializerFactory() {
+        SerializerFactory factory =
+                new SerializerFactory() {
+                    @Override
+                    public <T> TypeSerializer<T> createSerializer(
+                            TypeInformation<T> typeInformation) {
+                        return typeInformation.createSerializer(
+                                executionConfig == null
+                                        ? null
+                                        : executionConfig.getSerializerConfig());
+                    }
+                };
+        return supportsObjectLevelValueMigration()
+                ? StateSchemaEvolvingSerializer.arming(factory)
+                : factory;
     }
 
     public void publishQueryableStateIfEnabled(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/DefaultKeyedStateStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/DefaultKeyedStateStore.java
@@ -33,6 +33,7 @@ import org.apache.flink.api.common.state.State;
 import org.apache.flink.api.common.state.StateDescriptor;
 import org.apache.flink.api.common.state.ValueState;
 import org.apache.flink.api.common.state.ValueStateDescriptor;
+import org.apache.flink.api.common.typeutils.StateSchemaEvolvingSerializer;
 import org.apache.flink.util.Preconditions;
 
 import javax.annotation.Nonnull;
@@ -51,6 +52,13 @@ public class DefaultKeyedStateStore implements KeyedStateStore {
 
     @Nullable protected final AsyncKeyedStateBackend<?> asyncKeyedStateBackend;
     protected final SerializerFactory serializerFactory;
+
+    /**
+     * The factory used for a state's own value serializer. It arms schema evolution only on a
+     * backend that migrates restored values at the object level; on any other backend it is {@link
+     * #serializerFactory} itself, so those states keep today's behavior.
+     */
+    private final SerializerFactory stateValueSerializerFactory;
 
     protected SupportKeyedStateApiSet supportKeyedStateApiSet;
 
@@ -71,6 +79,10 @@ public class DefaultKeyedStateStore implements KeyedStateStore {
         this.keyedStateBackend = keyedStateBackend;
         this.asyncKeyedStateBackend = asyncKeyedStateBackend;
         this.serializerFactory = Preconditions.checkNotNull(serializerFactory);
+        this.stateValueSerializerFactory =
+                keyedStateBackend != null && keyedStateBackend.supportsObjectLevelValueMigration()
+                        ? StateSchemaEvolvingSerializer.arming(this.serializerFactory)
+                        : this.serializerFactory;
         if (keyedStateBackend != null) {
             // By default, we support state v1
             this.supportKeyedStateApiSet = SupportKeyedStateApiSet.STATE_V1;
@@ -85,7 +97,7 @@ public class DefaultKeyedStateStore implements KeyedStateStore {
     public <T> ValueState<T> getState(ValueStateDescriptor<T> stateProperties) {
         requireNonNull(stateProperties, "The state properties must not be null");
         try {
-            stateProperties.initializeSerializerUnlessSet(serializerFactory);
+            stateProperties.initializeSerializerUnlessSet(stateValueSerializerFactory);
             return getPartitionedState(stateProperties);
         } catch (Exception e) {
             throw new RuntimeException("Error while getting state", e);
@@ -96,7 +108,7 @@ public class DefaultKeyedStateStore implements KeyedStateStore {
     public <T> ListState<T> getListState(ListStateDescriptor<T> stateProperties) {
         requireNonNull(stateProperties, "The state properties must not be null");
         try {
-            stateProperties.initializeSerializerUnlessSet(serializerFactory);
+            stateProperties.initializeSerializerUnlessSet(stateValueSerializerFactory);
             ListState<T> originalState = getPartitionedState(stateProperties);
             return new UserFacingListState<>(originalState);
         } catch (Exception e) {
@@ -108,7 +120,7 @@ public class DefaultKeyedStateStore implements KeyedStateStore {
     public <T> ReducingState<T> getReducingState(ReducingStateDescriptor<T> stateProperties) {
         requireNonNull(stateProperties, "The state properties must not be null");
         try {
-            stateProperties.initializeSerializerUnlessSet(serializerFactory);
+            stateProperties.initializeSerializerUnlessSet(stateValueSerializerFactory);
             return getPartitionedState(stateProperties);
         } catch (Exception e) {
             throw new RuntimeException("Error while getting state", e);
@@ -120,7 +132,7 @@ public class DefaultKeyedStateStore implements KeyedStateStore {
             AggregatingStateDescriptor<IN, ACC, OUT> stateProperties) {
         requireNonNull(stateProperties, "The state properties must not be null");
         try {
-            stateProperties.initializeSerializerUnlessSet(serializerFactory);
+            stateProperties.initializeSerializerUnlessSet(stateValueSerializerFactory);
             return getPartitionedState(stateProperties);
         } catch (Exception e) {
             throw new RuntimeException("Error while getting state", e);
@@ -131,7 +143,7 @@ public class DefaultKeyedStateStore implements KeyedStateStore {
     public <UK, UV> MapState<UK, UV> getMapState(MapStateDescriptor<UK, UV> stateProperties) {
         requireNonNull(stateProperties, "The state properties must not be null");
         try {
-            stateProperties.initializeSerializerUnlessSet(serializerFactory);
+            stateProperties.initializeSerializerUnlessSet(stateValueSerializerFactory);
             MapState<UK, UV> originalState = getPartitionedState(stateProperties);
             return new UserFacingMapState<>(originalState);
         } catch (Exception e) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/KeyedStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/KeyedStateBackend.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.state;
 
 import org.apache.flink.annotation.Experimental;
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.state.State;
 import org.apache.flink.api.common.state.StateDescriptor;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
@@ -180,6 +181,21 @@ public interface KeyedStateBackend<K>
      * @return returns ture if safe to reuse the key-values from the state-backend.
      */
     default boolean isSafeToReuseKVState() {
+        return false;
+    }
+
+    /**
+     * Whether this backend migrates restored values at the object level.
+     *
+     * <p>A backend returning {@code true} guarantees that every value it restores under a {@code
+     * compatibleAfterMigration} verdict passes through {@link
+     * org.apache.flink.api.common.typeutils.TypeSerializerSnapshot#migrate} on the state's own
+     * value serializer. State schema evolution is armed only on such a backend: on any other one
+     * the verdict would be accepted and the stored bytes rewritten under the new schema with
+     * nothing ever converting them.
+     */
+    @Internal
+    default boolean supportsObjectLevelValueMigration() {
         return false;
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/ttl/TtlAwareSerializer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/ttl/TtlAwareSerializer.java
@@ -26,6 +26,8 @@ import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataOutputView;
 import org.apache.flink.util.function.SupplierWithException;
 
+import javax.annotation.Nullable;
+
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
@@ -46,6 +48,13 @@ public class TtlAwareSerializer<T, S extends TypeSerializer<T>> extends TypeSeri
     private final boolean isTtlEnabled;
 
     private final S typeSerializer;
+
+    /**
+     * Snapshot of {@link #bareValueSerializer()}, computed on first use. {@link
+     * #migrateValueFromPriorSerializer} runs once per migrated state value while the serializer
+     * stays the same, and taking a snapshot allocates one object per nested serializer.
+     */
+    private transient TypeSerializerSnapshot<?> bareValueSerializerSnapshot;
 
     public TtlAwareSerializer(S typeSerializer) {
         checkArgument(
@@ -128,29 +137,127 @@ public class TtlAwareSerializer<T, S extends TypeSerializer<T>> extends TypeSeri
         return Objects.hash(isTtlEnabled, typeSerializer);
     }
 
-    @SuppressWarnings("unchecked")
+    /**
+     * Reads one state value written by {@code priorTtlAwareSerializer}, adapts it to this
+     * serializer's TTL setting and value schema, and writes it to {@code target}.
+     *
+     * <p>The value is unwrapped to its bare form, passed through {@link
+     * TypeSerializerSnapshot#migrate}, and re-wrapped. The hook returns the value unchanged unless
+     * the value serializer overrides it, so a value whose schema did not change is written back
+     * byte for byte.
+     *
+     * @param priorSerializerSnapshot the snapshot persisted with the state for {@code
+     *     priorTtlAwareSerializer}, or {@code null} for a state that carries none.
+     */
+    @SuppressWarnings({"unchecked", "rawtypes"})
     public void migrateValueFromPriorSerializer(
             TtlAwareSerializer<T, ?> priorTtlAwareSerializer,
+            @Nullable TypeSerializerSnapshot<T> priorSerializerSnapshot,
             SupplierWithException<T, IOException> inputSupplier,
             DataOutputView target,
             TtlTimeProvider ttlTimeProvider)
             throws IOException {
+        T priorValue = inputSupplier.get();
+        Object bareValue =
+                priorTtlAwareSerializer.wrapsTtlValue()
+                        ? ((TtlValue<?>) priorValue).getUserValue()
+                        : priorValue;
+
+        TypeSerializerSnapshot newSnapshot = bareValueSerializerSnapshot();
+        Object migratedValue =
+                newSnapshot.migrate(
+                        priorBareValueSerializerSnapshot(
+                                priorTtlAwareSerializer, priorSerializerSnapshot),
+                        bareValue);
+
         T outputRecord;
-        if (this.isTtlEnabled()) {
-            outputRecord =
-                    priorTtlAwareSerializer.isTtlEnabled
-                            ? inputSupplier.get()
-                            : (T)
-                                    new TtlValue<>(
-                                            inputSupplier.get(),
-                                            ttlTimeProvider.currentTimestamp());
+        if (this.wrapsTtlValue()) {
+            // Carrying the prior timestamp over keeps the value's expiry where it was; migration
+            // is not a state access.
+            long lastAccessTimestamp =
+                    priorTtlAwareSerializer.wrapsTtlValue()
+                            ? ((TtlValue<?>) priorValue).getLastAccessTimestamp()
+                            : ttlTimeProvider.currentTimestamp();
+            outputRecord = (T) new TtlValue<>(migratedValue, lastAccessTimestamp);
         } else {
-            outputRecord =
-                    priorTtlAwareSerializer.isTtlEnabled
-                            ? ((TtlValue<T>) inputSupplier.get()).getUserValue()
-                            : inputSupplier.get();
+            outputRecord = (T) migratedValue;
         }
         this.serialize(outputRecord, target);
+    }
+
+    /**
+     * The snapshot describing the schema the prior bare value was written with.
+     *
+     * <p>The snapshot persisted with the state is preferred over one re-derived from the prior
+     * serializer, because the prior serializer is itself restored from that snapshot and the round
+     * trip back to a snapshot is not always lossless: a POJO field that no longer exists on the
+     * class returns under a generated placeholder name, which would present a schema that was never
+     * written. Only the absence of a persisted snapshot falls back to the re-derived one: a
+     * persisted snapshot that does not match the prior serializer is an error, not a second reason
+     * to fall back, because re-deriving there would silently reintroduce that lossy round trip.
+     */
+    private static TypeSerializerSnapshot<?> priorBareValueSerializerSnapshot(
+            TtlAwareSerializer<?, ?> priorSerializer,
+            @Nullable TypeSerializerSnapshot<?> priorSerializerSnapshot) {
+        if (priorSerializerSnapshot == null) {
+            return priorSerializer.bareValueSerializerSnapshot();
+        }
+        // TtlAwareSerializerSnapshot is the snapshot counterpart of this class, so the persisted
+        // snapshot carries that layer wherever the serializer carries the wrapper: for a list or
+        // map state it is the element or value snapshot, for a value state the whole snapshot.
+        TypeSerializerSnapshot<?> priorSnapshot =
+                priorSerializerSnapshot instanceof TtlAwareSerializerSnapshot
+                        ? ((TtlAwareSerializerSnapshot<?>) priorSerializerSnapshot)
+                                .getOriginalTypeSerializerSnapshot()
+                        : priorSerializerSnapshot;
+
+        // Thrown rather than checked through Preconditions: this runs once per migrated state
+        // value, so the message must not be built while the check is passing.
+        boolean isTtlSnapshot = priorSnapshot instanceof TtlStateFactory.TtlSerializerSnapshot;
+        if (!priorSerializer.wrapsTtlValue()) {
+            if (isTtlSnapshot) {
+                throw new IllegalArgumentException(
+                        "The prior serializer does not wrap values in TtlValue, but its persisted snapshot is a TtlSerializerSnapshot.");
+            }
+            return priorSnapshot;
+        }
+        if (!isTtlSnapshot) {
+            throw new IllegalArgumentException(
+                    "The prior serializer wraps values in TtlValue, so its persisted snapshot should be a TtlSerializerSnapshot, but was "
+                            + priorSnapshot.getClass().getName()
+                            + ".");
+        }
+        // The persisted snapshot describes the TtlValue envelope, so descend to the user value
+        // the same way bareValueSerializer() descends the serializer.
+        return ((TtlStateFactory.TtlSerializerSnapshot<?>) priorSnapshot)
+                .getValueSerializerSnapshot();
+    }
+
+    private TypeSerializerSnapshot<?> bareValueSerializerSnapshot() {
+        if (bareValueSerializerSnapshot == null) {
+            bareValueSerializerSnapshot = bareValueSerializer().snapshotConfiguration();
+        }
+        return bareValueSerializerSnapshot;
+    }
+
+    /**
+     * The serializer of the bare (non-TTL) value: the user value serializer of a {@link
+     * TtlStateFactory.TtlSerializer}, otherwise the wrapped serializer itself.
+     */
+    private TypeSerializer<?> bareValueSerializer() {
+        return wrapsTtlValue()
+                ? ((TtlStateFactory.TtlSerializer<?>) typeSerializer).getValueSerializer()
+                : typeSerializer;
+    }
+
+    /**
+     * Whether the values this serializer reads and writes are {@link TtlValue} envelopes. Narrower
+     * than {@link #isTtlEnabled()}, which is also true for a list or map serializer whose element
+     * or value serializer is a {@link TtlStateFactory.TtlSerializer}: such a serializer wraps the
+     * collection, not a single {@code TtlValue}.
+     */
+    private boolean wrapsTtlValue() {
+        return typeSerializer instanceof TtlStateFactory.TtlSerializer;
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/api/operators/StreamingRuntimeContext.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/api/operators/StreamingRuntimeContext.java
@@ -203,21 +203,18 @@ public class StreamingRuntimeContext extends AbstractRuntimeUDFContext {
     @Override
     public <T> ValueState<T> getState(ValueStateDescriptor<T> stateProperties) {
         KeyedStateStore keyedStateStore = checkPreconditionsAndGetKeyedStateStore(stateProperties);
-        stateProperties.initializeSerializerUnlessSet(this::createSerializer);
         return keyedStateStore.getState(stateProperties);
     }
 
     @Override
     public <T> ListState<T> getListState(ListStateDescriptor<T> stateProperties) {
         KeyedStateStore keyedStateStore = checkPreconditionsAndGetKeyedStateStore(stateProperties);
-        stateProperties.initializeSerializerUnlessSet(this::createSerializer);
         return keyedStateStore.getListState(stateProperties);
     }
 
     @Override
     public <T> ReducingState<T> getReducingState(ReducingStateDescriptor<T> stateProperties) {
         KeyedStateStore keyedStateStore = checkPreconditionsAndGetKeyedStateStore(stateProperties);
-        stateProperties.initializeSerializerUnlessSet(this::createSerializer);
         return keyedStateStore.getReducingState(stateProperties);
     }
 
@@ -225,14 +222,12 @@ public class StreamingRuntimeContext extends AbstractRuntimeUDFContext {
     public <IN, ACC, OUT> AggregatingState<IN, OUT> getAggregatingState(
             AggregatingStateDescriptor<IN, ACC, OUT> stateProperties) {
         KeyedStateStore keyedStateStore = checkPreconditionsAndGetKeyedStateStore(stateProperties);
-        stateProperties.initializeSerializerUnlessSet(this::createSerializer);
         return keyedStateStore.getAggregatingState(stateProperties);
     }
 
     @Override
     public <UK, UV> MapState<UK, UV> getMapState(MapStateDescriptor<UK, UV> stateProperties) {
         KeyedStateStore keyedStateStore = checkPreconditionsAndGetKeyedStateStore(stateProperties);
-        stateProperties.initializeSerializerUnlessSet(this::createSerializer);
         return keyedStateStore.getMapState(stateProperties);
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateSchemaEvolutionArmingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateSchemaEvolutionArmingTest.java
@@ -1,0 +1,380 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state;
+
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.functions.SerializerFactory;
+import org.apache.flink.api.common.serialization.SerializerConfig;
+import org.apache.flink.api.common.serialization.SerializerConfigImpl;
+import org.apache.flink.api.common.state.ListStateDescriptor;
+import org.apache.flink.api.common.state.MapStateDescriptor;
+import org.apache.flink.api.common.state.State;
+import org.apache.flink.api.common.state.StateDescriptor;
+import org.apache.flink.api.common.state.ValueStateDescriptor;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.ConfigOptions;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.fs.CloseableRegistry;
+import org.apache.flink.runtime.asyncprocessing.StateExecutor;
+import org.apache.flink.runtime.asyncprocessing.StateRequestHandler;
+import org.apache.flink.runtime.checkpoint.CheckpointOptions;
+import org.apache.flink.runtime.state.StateSchemaEvolvingTestSerializer.StateSchemaEvolvingTestTypeInfo;
+import org.apache.flink.runtime.state.StateSnapshotTransformer.StateSnapshotTransformFactory;
+import org.apache.flink.runtime.state.heap.HeapPriorityQueueElement;
+import org.apache.flink.runtime.state.v2.internal.InternalKeyedState;
+
+import org.junit.jupiter.api.Test;
+
+import javax.annotation.Nonnull;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.RunnableFuture;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests the backend capability gate on state schema evolution arming: only a keyed backend that
+ * performs object-level value migration may hand a state its armed value serializer.
+ *
+ * <p>Assertions are made on the serializer object the state descriptor ends up holding, so a gate
+ * that is bypassed shows up as an armed serializer rather than having to be read out of the code
+ * path.
+ */
+class StateSchemaEvolutionArmingTest {
+
+    /**
+     * Mirrors {@code ExecutionConfigOptions.TABLE_EXEC_STATE_SCHEMA_EVOLUTION_ENABLED}, which lives
+     * in a module this one cannot depend on.
+     */
+    private static final ConfigOption<Boolean> STATE_SCHEMA_EVOLUTION_ENABLED =
+            ConfigOptions.key("table.exec.state.schema-evolution.enabled")
+                    .booleanType()
+                    .defaultValue(false);
+
+    @Test
+    void valueStateIsArmedOnAnObjectLevelMigratingBackend() {
+        ValueStateDescriptor<Integer> descriptor =
+                new ValueStateDescriptor<>("value", new StateSchemaEvolvingTestTypeInfo());
+
+        keyedStateStore(true).getState(descriptor);
+
+        assertThat(armedFlagOf(descriptor.getSerializer())).isTrue();
+    }
+
+    @Test
+    void valueStateIsNotArmedOnABackendWithoutObjectLevelMigration() {
+        ValueStateDescriptor<Integer> descriptor =
+                new ValueStateDescriptor<>("value", new StateSchemaEvolvingTestTypeInfo());
+
+        keyedStateStore(false).getState(descriptor);
+
+        assertThat(armedFlagOf(descriptor.getSerializer())).isFalse();
+    }
+
+    @Test
+    void v2ValueStateIsNotArmed() {
+        org.apache.flink.api.common.state.v2.ValueStateDescriptor<Integer> descriptor =
+                new org.apache.flink.api.common.state.v2.ValueStateDescriptor<>(
+                        "value", new StateSchemaEvolvingTestTypeInfo());
+
+        asyncKeyedStateStore().getValueState(descriptor);
+
+        assertThat(armedFlagOf(descriptor.getSerializer())).isFalse();
+    }
+
+    @Test
+    void operatorListStateIsNotArmed() throws Exception {
+        ListStateDescriptor<Integer> descriptor =
+                new ListStateDescriptor<>("list", new StateSchemaEvolvingTestTypeInfo());
+
+        operatorStateBackend().getListState(descriptor);
+
+        assertThat(armedFlagOf(descriptor.getElementSerializer())).isFalse();
+    }
+
+    @Test
+    void broadcastStateIsNotArmed() throws Exception {
+        MapStateDescriptor<Integer, Integer> descriptor =
+                new MapStateDescriptor<>(
+                        "broadcast", Types.INT, new StateSchemaEvolvingTestTypeInfo());
+
+        operatorStateBackend().getBroadcastState(descriptor);
+
+        assertThat(armedFlagOf(descriptor.getValueSerializer())).isFalse();
+    }
+
+    private static boolean armedFlagOf(TypeSerializer<Integer> serializer) {
+        assertThat(serializer).isInstanceOf(StateSchemaEvolvingTestSerializer.class);
+        return ((StateSchemaEvolvingTestSerializer) serializer).isArmed();
+    }
+
+    private static DefaultKeyedStateStore keyedStateStore(boolean objectLevelValueMigration) {
+        return new DefaultKeyedStateStore(
+                new TestKeyedStateBackend(objectLevelValueMigration), serializerFactory());
+    }
+
+    private static DefaultKeyedStateStore asyncKeyedStateStore() {
+        DefaultKeyedStateStore store =
+                new DefaultKeyedStateStore(
+                        new TestKeyedStateBackend(true),
+                        new TestAsyncKeyedStateBackend(),
+                        serializerFactory());
+        store.setSupportKeyedStateApiSetV2();
+        return store;
+    }
+
+    private static DefaultOperatorStateBackend operatorStateBackend() throws Exception {
+        return new DefaultOperatorStateBackendBuilder(
+                        StateSchemaEvolutionArmingTest.class.getClassLoader(),
+                        new ExecutionConfig(configurationWithSchemaEvolutionEnabled()),
+                        false,
+                        Collections.emptyList(),
+                        new CloseableRegistry())
+                .build();
+    }
+
+    private static SerializerFactory serializerFactory() {
+        SerializerConfig config =
+                new SerializerConfigImpl(configurationWithSchemaEvolutionEnabled());
+        return new SerializerFactory() {
+            @Override
+            public <T> TypeSerializer<T> createSerializer(TypeInformation<T> typeInformation) {
+                return typeInformation.createSerializer(config);
+            }
+        };
+    }
+
+    private static Configuration configurationWithSchemaEvolutionEnabled() {
+        Configuration configuration = new Configuration();
+        configuration.set(STATE_SCHEMA_EVOLUTION_ENABLED, true);
+        return configuration;
+    }
+
+    /**
+     * A keyed backend whose object-level value migration capability is fixed per instance. {@link
+     * DefaultKeyedStateStore} only reads that capability and forwards the descriptor to {@link
+     * #getPartitionedState}, so every other method is left unsupported.
+     */
+    private static final class TestKeyedStateBackend implements KeyedStateBackend<Integer> {
+
+        private final boolean objectLevelValueMigration;
+
+        private TestKeyedStateBackend(boolean objectLevelValueMigration) {
+            this.objectLevelValueMigration = objectLevelValueMigration;
+        }
+
+        @Override
+        public boolean supportsObjectLevelValueMigration() {
+            return objectLevelValueMigration;
+        }
+
+        @Override
+        public <N, S extends State> S getPartitionedState(
+                N namespace,
+                TypeSerializer<N> namespaceSerializer,
+                StateDescriptor<S, ?> stateDescriptor) {
+            return null;
+        }
+
+        @Override
+        public String getBackendTypeIdentifier() {
+            return "test";
+        }
+
+        @Override
+        public void setCurrentKey(Integer newKey) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Integer getCurrentKey() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void setCurrentKeyAndKeyGroup(Integer newKey, int newKeyGroupIndex) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public TypeSerializer<Integer> getKeySerializer() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public <N, S extends State, T> void applyToAllKeys(
+                N namespace,
+                TypeSerializer<N> namespaceSerializer,
+                StateDescriptor<S, T> stateDescriptor,
+                KeyedStateFunction<Integer, S> function) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public <N> Stream<Integer> getKeys(String state, N namespace) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public <N> Stream<Integer> getKeys(List<String> states, N namespace) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public <N> Stream<Tuple2<Integer, Integer>> getKeysAndKeyGroups(
+                List<String> states, N namespace) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public <N> Stream<Tuple2<Integer, N>> getKeysAndNamespaces(String state) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public <N, S extends State, T> S getOrCreateKeyedState(
+                TypeSerializer<N> namespaceSerializer, StateDescriptor<S, T> stateDescriptor) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void dispose() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void registerKeySelectionListener(KeySelectionListener<Integer> listener) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean deregisterKeySelectionListener(KeySelectionListener<Integer> listener) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Nonnull
+        @Override
+        public <N, SV, SEV, S extends State, IS extends S> IS createOrUpdateInternalState(
+                @Nonnull TypeSerializer<N> namespaceSerializer,
+                @Nonnull StateDescriptor<S, SV> stateDesc,
+                @Nonnull StateSnapshotTransformFactory<SEV> snapshotTransformFactory) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Nonnull
+        @Override
+        public <T extends HeapPriorityQueueElement & PriorityComparable<? super T> & Keyed<?>>
+                KeyGroupedInternalPriorityQueue<T> create(
+                        @Nonnull String stateName,
+                        @Nonnull TypeSerializer<T> byteOrderedElementSerializer) {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    /**
+     * An async keyed backend that accepts a v2 descriptor and returns no state, so the v2 path
+     * through {@link DefaultKeyedStateStore} can be exercised without a real backend.
+     */
+    private static final class TestAsyncKeyedStateBackend
+            implements AsyncKeyedStateBackend<Integer> {
+
+        @Override
+        public <N, S extends org.apache.flink.api.common.state.v2.State, SV>
+                S getOrCreateKeyedState(
+                        N defaultNamespace,
+                        TypeSerializer<N> namespaceSerializer,
+                        org.apache.flink.api.common.state.v2.StateDescriptor<SV> stateDesc) {
+            return null;
+        }
+
+        @Override
+        public String getBackendTypeIdentifier() {
+            return "test";
+        }
+
+        @Override
+        public void setup(@Nonnull StateRequestHandler stateRequestHandler) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Nonnull
+        @Override
+        public <N, S extends InternalKeyedState, SV> S createStateInternal(
+                @Nonnull N defaultNamespace,
+                @Nonnull TypeSerializer<N> namespaceSerializer,
+                @Nonnull org.apache.flink.api.common.state.v2.StateDescriptor<SV> stateDesc) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Nonnull
+        @Override
+        public StateExecutor createStateExecutor() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public KeyGroupRange getKeyGroupRange() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void dispose() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void close() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void notifyCheckpointSubsumed(long checkpointId) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void notifyCheckpointComplete(long checkpointId) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public RunnableFuture<SnapshotResult<KeyedStateHandle>> snapshot(
+                long checkpointId,
+                long timestamp,
+                CheckpointStreamFactory streamFactory,
+                CheckpointOptions checkpointOptions) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Nonnull
+        @Override
+        public <T extends HeapPriorityQueueElement & PriorityComparable<? super T> & Keyed<?>>
+                KeyGroupedInternalPriorityQueue<T> create(
+                        @Nonnull String stateName,
+                        @Nonnull TypeSerializer<T> byteOrderedElementSerializer) {
+            throw new UnsupportedOperationException();
+        }
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateSchemaEvolvingTestSerializer.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateSchemaEvolvingTestSerializer.java
@@ -1,0 +1,198 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state;
+
+import org.apache.flink.api.common.serialization.SerializerConfig;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeutils.SimpleTypeSerializerSnapshot;
+import org.apache.flink.api.common.typeutils.StateSchemaEvolvingSerializer;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.core.memory.DataOutputView;
+
+import java.io.IOException;
+
+/**
+ * An integer serializer that records whether it was armed for state schema evolution, so a test can
+ * assert arming on the serializer object a state descriptor actually ends up holding.
+ *
+ * <p>Lives here because the production {@link StateSchemaEvolvingSerializer} implementation is a
+ * table-module serializer that flink-runtime cannot see.
+ */
+public class StateSchemaEvolvingTestSerializer extends TypeSerializer<Integer>
+        implements StateSchemaEvolvingSerializer<Integer> {
+
+    private static final long serialVersionUID = 1L;
+
+    private final boolean armed;
+
+    public StateSchemaEvolvingTestSerializer() {
+        this(false);
+    }
+
+    private StateSchemaEvolvingTestSerializer(boolean armed) {
+        this.armed = armed;
+    }
+
+    public boolean isArmed() {
+        return armed;
+    }
+
+    @Override
+    public TypeSerializer<Integer> withStateSchemaEvolution() {
+        return armed ? this : new StateSchemaEvolvingTestSerializer(true);
+    }
+
+    @Override
+    public boolean isImmutableType() {
+        return true;
+    }
+
+    @Override
+    public TypeSerializer<Integer> duplicate() {
+        return new StateSchemaEvolvingTestSerializer(armed);
+    }
+
+    @Override
+    public Integer createInstance() {
+        return 0;
+    }
+
+    @Override
+    public Integer copy(Integer from) {
+        return from;
+    }
+
+    @Override
+    public Integer copy(Integer from, Integer reuse) {
+        return from;
+    }
+
+    @Override
+    public int getLength() {
+        return Integer.BYTES;
+    }
+
+    @Override
+    public void serialize(Integer record, DataOutputView target) throws IOException {
+        target.writeInt(record);
+    }
+
+    @Override
+    public Integer deserialize(DataInputView source) throws IOException {
+        return source.readInt();
+    }
+
+    @Override
+    public Integer deserialize(Integer reuse, DataInputView source) throws IOException {
+        return source.readInt();
+    }
+
+    @Override
+    public void copy(DataInputView source, DataOutputView target) throws IOException {
+        target.writeInt(source.readInt());
+    }
+
+    /** The armed flag is runtime-only state, so it must not perturb serializer equality. */
+    @Override
+    public boolean equals(Object obj) {
+        return obj instanceof StateSchemaEvolvingTestSerializer;
+    }
+
+    @Override
+    public int hashCode() {
+        return StateSchemaEvolvingTestSerializer.class.hashCode();
+    }
+
+    @Override
+    public TypeSerializerSnapshot<Integer> snapshotConfiguration() {
+        return new StateSchemaEvolvingTestSerializerSnapshot();
+    }
+
+    /** Snapshot for {@link StateSchemaEvolvingTestSerializer}. */
+    public static final class StateSchemaEvolvingTestSerializerSnapshot
+            extends SimpleTypeSerializerSnapshot<Integer> {
+
+        public StateSchemaEvolvingTestSerializerSnapshot() {
+            super(StateSchemaEvolvingTestSerializer::new);
+        }
+    }
+
+    /** Type information producing an unarmed {@link StateSchemaEvolvingTestSerializer}. */
+    public static final class StateSchemaEvolvingTestTypeInfo extends TypeInformation<Integer> {
+
+        private static final long serialVersionUID = 1L;
+
+        @Override
+        public boolean isBasicType() {
+            return false;
+        }
+
+        @Override
+        public boolean isTupleType() {
+            return false;
+        }
+
+        @Override
+        public int getArity() {
+            return 1;
+        }
+
+        @Override
+        public int getTotalFields() {
+            return 1;
+        }
+
+        @Override
+        public Class<Integer> getTypeClass() {
+            return Integer.class;
+        }
+
+        @Override
+        public boolean isKeyType() {
+            return false;
+        }
+
+        @Override
+        public TypeSerializer<Integer> createSerializer(SerializerConfig config) {
+            return new StateSchemaEvolvingTestSerializer();
+        }
+
+        @Override
+        public String toString() {
+            return StateSchemaEvolvingTestTypeInfo.class.getSimpleName();
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            return obj instanceof StateSchemaEvolvingTestTypeInfo;
+        }
+
+        @Override
+        public int hashCode() {
+            return StateSchemaEvolvingTestTypeInfo.class.hashCode();
+        }
+
+        @Override
+        public boolean canEqual(Object obj) {
+            return obj instanceof StateSchemaEvolvingTestTypeInfo;
+        }
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateSerializerProviderTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateSerializerProviderTest.java
@@ -21,13 +21,18 @@ package org.apache.flink.runtime.state;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.TypeSerializerSchemaCompatibility;
 import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
+import org.apache.flink.api.common.typeutils.base.ListSerializer;
+import org.apache.flink.api.common.typeutils.base.ListSerializerSnapshot;
+import org.apache.flink.api.common.typeutils.base.StringSerializer;
 import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataOutputView;
+import org.apache.flink.runtime.state.ttl.TtlAwareSerializerSnapshot;
 import org.apache.flink.runtime.testutils.statemigration.TestType;
 
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -309,6 +314,42 @@ class StateSerializerProviderTest {
         // a serializer for the current schema will no longer be accessible
         assertThatThrownBy(testProvider::currentSchemaSerializer)
                 .isInstanceOf(IllegalStateException.class);
+    }
+
+    // --------------------------------------------------------------------------------
+    //  Tests for the ttl-aware wrapping of the previous serializer snapshot
+    // --------------------------------------------------------------------------------
+
+    /**
+     * Registering a new serializer replaces the nested snapshot of the previous snapshot in place,
+     * so the snapshot a caller still holds no longer reports what the checkpoint wrote: its nested
+     * snapshot becomes a {@link TtlAwareSerializerSnapshot} around the original. Anything that
+     * descends a restored composite snapshot has to expect that layer.
+     */
+    @Test
+    void testRegisterNewSerializerWrapsNestedSnapshotOfPreviousSnapshotInPlace() {
+        ListSerializerSnapshot<String> previousSnapshot =
+                (ListSerializerSnapshot<String>)
+                        new ListSerializer<>(StringSerializer.INSTANCE).snapshotConfiguration();
+        TypeSerializerSnapshot<String> elementSnapshotAsWritten =
+                previousSnapshot.getElementSerializerSnapshot();
+
+        StateSerializerProvider<List<String>> testProvider =
+                StateSerializerProvider.fromPreviousSerializerSnapshot(previousSnapshot);
+        testProvider.registerNewSerializerForRestoredState(
+                new ListSerializer<>(StringSerializer.INSTANCE));
+
+        // The same snapshot instance now reports a different element snapshot than it did above.
+        TypeSerializerSnapshot<String> elementSnapshotAfterRestore =
+                previousSnapshot.getElementSerializerSnapshot();
+        assertThat(elementSnapshotAfterRestore).isNotSameAs(elementSnapshotAsWritten);
+        assertThat(elementSnapshotAfterRestore).isInstanceOf(TtlAwareSerializerSnapshot.class);
+        // The original is carried inside the wrapper, not re-derived: a re-derived snapshot would
+        // be an equal instance of the same class but a different object.
+        assertThat(
+                        ((TtlAwareSerializerSnapshot<String>) elementSnapshotAfterRestore)
+                                .getOriginalTypeSerializerSnapshot())
+                .isSameAs(elementSnapshotAsWritten);
     }
 
     // --------------------------------------------------------------------------------

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/TtlAwareSerializerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/TtlAwareSerializerTest.java
@@ -18,18 +18,35 @@
 
 package org.apache.flink.runtime.state.ttl;
 
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.TypeSerializerSchemaCompatibility;
+import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
 import org.apache.flink.api.common.typeutils.base.IntSerializer;
 import org.apache.flink.api.common.typeutils.base.ListSerializer;
 import org.apache.flink.api.common.typeutils.base.ListSerializerSnapshot;
 import org.apache.flink.api.common.typeutils.base.LongSerializer;
 import org.apache.flink.api.common.typeutils.base.MapSerializer;
 import org.apache.flink.api.common.typeutils.base.MapSerializerSnapshot;
+import org.apache.flink.api.common.typeutils.base.StringSerializer;
+import org.apache.flink.api.java.typeutils.runtime.NullableSerializer;
+import org.apache.flink.core.memory.DataInputDeserializer;
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.core.memory.DataOutputSerializer;
+import org.apache.flink.core.memory.DataOutputView;
 
 import org.junit.jupiter.api.Test;
 
+import java.io.IOException;
+
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class TtlAwareSerializerTest {
+
+    private static final String VALUE = "value";
+    private static final long PRIOR_TIMESTAMP = 1_000L;
+    private static final long CURRENT_TIMESTAMP = 9_999L;
+    private static final TtlTimeProvider FIXED_TIME_PROVIDER = () -> CURRENT_TIMESTAMP;
 
     @Test
     void testSerializerTtlEnabled() {
@@ -146,5 +163,386 @@ class TtlAwareSerializerTest {
                         (((MapSerializerSnapshot) mapTtlAwareSerializer.snapshotConfiguration())
                                 .getValueSerializerSnapshot()))
                 .isInstanceOf(TtlAwareSerializerSnapshot.class);
+    }
+
+    @Test
+    void testMigrateValueNoTtlToNoTtl() throws IOException {
+        TtlAwareSerializer<?, ?> prior = stringSerializer(false);
+        TtlAwareSerializer<?, ?> current = stringSerializer(false);
+
+        assertThat(migrate(current, prior, VALUE)).isEqualTo(serialize(current, VALUE));
+    }
+
+    @Test
+    void testMigrateValueNoTtlToTtlStampsCurrentTime() throws IOException {
+        TtlAwareSerializer<?, ?> prior = stringSerializer(false);
+        TtlAwareSerializer<?, ?> current = stringSerializer(true);
+
+        assertThat(migrate(current, prior, VALUE))
+                .isEqualTo(serialize(current, new TtlValue<>(VALUE, CURRENT_TIMESTAMP)));
+    }
+
+    @Test
+    void testMigrateValueTtlToNoTtlUnwraps() throws IOException {
+        TtlAwareSerializer<?, ?> prior = stringSerializer(true);
+        TtlAwareSerializer<?, ?> current = stringSerializer(false);
+
+        assertThat(migrate(current, prior, new TtlValue<>(VALUE, PRIOR_TIMESTAMP)))
+                .isEqualTo(serialize(current, VALUE));
+    }
+
+    @Test
+    void testMigrateValueTtlToTtlKeepsPriorTimestamp() throws IOException {
+        TtlAwareSerializer<?, ?> prior = stringSerializer(true);
+        TtlAwareSerializer<?, ?> current = stringSerializer(true);
+        TtlValue<String> priorValue = new TtlValue<>(VALUE, PRIOR_TIMESTAMP);
+
+        assertThat(migrate(current, prior, priorValue)).isEqualTo(serialize(current, priorValue));
+    }
+
+    @Test
+    void testMigrateValueInvokesHookOnNewSnapshotWithOldSnapshotAsArgument() throws IOException {
+        TtlAwareSerializer<?, ?> prior =
+                TtlAwareSerializer.wrapTtlAwareSerializer(new TaggedStringSerializer("old"));
+        TtlAwareSerializer<?, ?> current =
+                TtlAwareSerializer.wrapTtlAwareSerializer(new TaggedStringSerializer("new"));
+
+        byte[] migrated = migrate(current, prior, VALUE);
+
+        assertThat(current.deserialize(new DataInputDeserializer(migrated)))
+                .isEqualTo(VALUE + "|from=old|to=new");
+    }
+
+    @Test
+    void testMigrateValueInvokesHookOnUnwrappedValueWithInnerSnapshots() throws IOException {
+        TtlAwareSerializer<?, ?> prior = taggedTtlSerializer("old");
+        TtlAwareSerializer<?, ?> current = taggedTtlSerializer("new");
+
+        byte[] migrated = migrate(current, prior, new TtlValue<>(VALUE, PRIOR_TIMESTAMP));
+
+        TtlValue<?> result = (TtlValue<?>) current.deserialize(new DataInputDeserializer(migrated));
+        assertThat(result.getUserValue()).isEqualTo(VALUE + "|from=old|to=new");
+        assertThat(result.getLastAccessTimestamp()).isEqualTo(PRIOR_TIMESTAMP);
+    }
+
+    @Test
+    void testMigrateValueUsesPersistedPriorSnapshotNotOneRederivedFromPriorSerializer()
+            throws IOException {
+        TtlAwareSerializer<?, ?> prior =
+                TtlAwareSerializer.wrapTtlAwareSerializer(new TaggedStringSerializer("rederived"));
+        TtlAwareSerializer<?, ?> current =
+                TtlAwareSerializer.wrapTtlAwareSerializer(new TaggedStringSerializer("new"));
+
+        byte[] migrated = migrate(current, prior, new TaggedSnapshot("persisted"), VALUE);
+
+        assertThat(current.deserialize(new DataInputDeserializer(migrated)))
+                .isEqualTo(VALUE + "|from=persisted|to=new");
+    }
+
+    @Test
+    void testMigrateValueDescendsPersistedTtlSnapshotToItsValueSnapshot() throws IOException {
+        TtlAwareSerializer<?, ?> prior = taggedTtlSerializer("rederived");
+        TtlAwareSerializer<?, ?> current = taggedTtlSerializer("new");
+        // Tagged differently from the prior serializer, so both falling back to a re-derived
+        // snapshot and skipping the descent into the TtlValue envelope change the result.
+        TypeSerializerSnapshot<?> persisted =
+                taggedTtlSerializer("persisted")
+                        .getOriginalTypeSerializer()
+                        .snapshotConfiguration();
+
+        byte[] migrated =
+                migrate(current, prior, persisted, new TtlValue<>(VALUE, PRIOR_TIMESTAMP));
+
+        TtlValue<?> result = (TtlValue<?>) current.deserialize(new DataInputDeserializer(migrated));
+        assertThat(result.getUserValue()).isEqualTo(VALUE + "|from=persisted|to=new");
+    }
+
+    /**
+     * A list or map state persists its element or value snapshot wrapped in a {@link
+     * TtlAwareSerializerSnapshot}, which the descent has to see through to reach the user value
+     * snapshot. Value state persists the unwrapped shape covered by the test above.
+     */
+    @Test
+    void testMigrateValueDescendsPersistedTtlAwareElementSnapshot() throws IOException {
+        ListSerializerSnapshot<?> persistedListSnapshot =
+                (ListSerializerSnapshot<?>)
+                        TtlAwareSerializer.wrapTtlAwareSerializer(
+                                        new ListSerializer<>(rawTaggedTtlSerializer("persisted")))
+                                .snapshotConfiguration();
+        TypeSerializerSnapshot<?> persistedElementSnapshot =
+                persistedListSnapshot.getElementSerializerSnapshot();
+        assertThat(persistedElementSnapshot).isInstanceOf(TtlAwareSerializerSnapshot.class);
+
+        TtlAwareSerializer<?, ?> prior = taggedTtlSerializer("rederived");
+        TtlAwareSerializer<?, ?> current = taggedTtlSerializer("new");
+
+        byte[] migrated =
+                migrate(
+                        current,
+                        prior,
+                        persistedElementSnapshot,
+                        new TtlValue<>(VALUE, PRIOR_TIMESTAMP));
+
+        TtlValue<?> result = (TtlValue<?>) current.deserialize(new DataInputDeserializer(migrated));
+        assertThat(result.getUserValue()).isEqualTo(VALUE + "|from=persisted|to=new");
+    }
+
+    @Test
+    void testMigrateValueRejectsNonTtlSnapshotForTtlPriorSerializer() {
+        TtlAwareSerializer<?, ?> prior = taggedTtlSerializer("old");
+        TtlAwareSerializer<?, ?> current = taggedTtlSerializer("new");
+
+        assertThatThrownBy(
+                        () ->
+                                migrate(
+                                        current,
+                                        prior,
+                                        new TaggedSnapshot("mismatched"),
+                                        new TtlValue<>(VALUE, PRIOR_TIMESTAMP)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("should be a TtlSerializerSnapshot");
+    }
+
+    @Test
+    void testMigrateValueRejectsNonTtlSnapshotBehindTtlAwareLayer() {
+        TtlAwareSerializer<?, ?> prior = taggedTtlSerializer("old");
+        TtlAwareSerializer<?, ?> current = taggedTtlSerializer("new");
+        // The TtlAware layer is seen through, so a mismatch inside it is still caught.
+        TypeSerializerSnapshot<?> wrappedMismatch =
+                new TtlAwareSerializerSnapshot<>(new TaggedSnapshot("mismatched"));
+
+        assertThatThrownBy(
+                        () ->
+                                migrate(
+                                        current,
+                                        prior,
+                                        wrappedMismatch,
+                                        new TtlValue<>(VALUE, PRIOR_TIMESTAMP)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("should be a TtlSerializerSnapshot");
+    }
+
+    @Test
+    void testMigrateValueRejectsTtlSnapshotForNonTtlPriorSerializer() {
+        TtlAwareSerializer<?, ?> prior =
+                TtlAwareSerializer.wrapTtlAwareSerializer(new TaggedStringSerializer("old"));
+        TtlAwareSerializer<?, ?> current =
+                TtlAwareSerializer.wrapTtlAwareSerializer(new TaggedStringSerializer("new"));
+        TypeSerializerSnapshot<?> ttlSnapshot =
+                rawTaggedTtlSerializer("mismatched").snapshotConfiguration();
+
+        assertThatThrownBy(() -> migrate(current, prior, ttlSnapshot, VALUE))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("does not wrap values in TtlValue");
+    }
+
+    @Test
+    void testMigrateValueFallsBackToPriorSerializerSnapshotWhenNonePersisted() throws IOException {
+        TtlAwareSerializer<?, ?> prior =
+                TtlAwareSerializer.wrapTtlAwareSerializer(new TaggedStringSerializer("old"));
+        TtlAwareSerializer<?, ?> current =
+                TtlAwareSerializer.wrapTtlAwareSerializer(new TaggedStringSerializer("new"));
+
+        byte[] migrated = migrate(current, prior, null, VALUE);
+
+        assertThat(current.deserialize(new DataInputDeserializer(migrated)))
+                .isEqualTo(VALUE + "|from=old|to=new");
+    }
+
+    @Test
+    void testMigrateValueTtlToTtlWithNullUserValue() throws IOException {
+        TtlAwareSerializer<?, ?> prior = nullTolerantTtlSerializer();
+        TtlAwareSerializer<?, ?> current = nullTolerantTtlSerializer();
+
+        byte[] migrated = migrate(current, prior, new TtlValue<>(null, PRIOR_TIMESTAMP));
+
+        TtlValue<?> result = (TtlValue<?>) current.deserialize(new DataInputDeserializer(migrated));
+        assertThat(result.getUserValue()).isNull();
+        assertThat(result.getLastAccessTimestamp()).isEqualTo(PRIOR_TIMESTAMP);
+    }
+
+    /** Migrates with the snapshot the state backends would have persisted for {@code prior}. */
+    private static byte[] migrate(
+            TtlAwareSerializer<?, ?> current, TtlAwareSerializer<?, ?> prior, Object priorValue)
+            throws IOException {
+        return migrate(
+                current,
+                prior,
+                prior.getOriginalTypeSerializer().snapshotConfiguration(),
+                priorValue);
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private static byte[] migrate(
+            TtlAwareSerializer<?, ?> current,
+            TtlAwareSerializer<?, ?> prior,
+            TypeSerializerSnapshot<?> priorSnapshot,
+            Object priorValue)
+            throws IOException {
+        DataOutputSerializer output = new DataOutputSerializer(64);
+        ((TtlAwareSerializer) current)
+                .migrateValueFromPriorSerializer(
+                        (TtlAwareSerializer) prior,
+                        priorSnapshot,
+                        () -> priorValue,
+                        output,
+                        FIXED_TIME_PROVIDER);
+        return output.getCopyOfBuffer();
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private static byte[] serialize(TtlAwareSerializer<?, ?> serializer, Object value)
+            throws IOException {
+        DataOutputSerializer output = new DataOutputSerializer(64);
+        ((TtlAwareSerializer) serializer).serialize(value, output);
+        return output.getCopyOfBuffer();
+    }
+
+    private static TtlAwareSerializer<?, ?> stringSerializer(boolean ttlEnabled) {
+        return ttlEnabled
+                ? TtlAwareSerializer.wrapTtlAwareSerializer(
+                        new TtlStateFactory.TtlSerializer<>(
+                                LongSerializer.INSTANCE, StringSerializer.INSTANCE))
+                : TtlAwareSerializer.wrapTtlAwareSerializer(StringSerializer.INSTANCE);
+    }
+
+    private static TtlAwareSerializer<?, ?> taggedTtlSerializer(String tag) {
+        return TtlAwareSerializer.wrapTtlAwareSerializer(rawTaggedTtlSerializer(tag));
+    }
+
+    private static TtlStateFactory.TtlSerializer<String> rawTaggedTtlSerializer(String tag) {
+        return new TtlStateFactory.TtlSerializer<>(
+                LongSerializer.INSTANCE, new TaggedStringSerializer(tag));
+    }
+
+    private static TtlAwareSerializer<?, ?> nullTolerantTtlSerializer() {
+        return TtlAwareSerializer.wrapTtlAwareSerializer(
+                new TtlStateFactory.TtlSerializer<>(
+                        LongSerializer.INSTANCE,
+                        NullableSerializer.wrapIfNullIsNotSupported(
+                                StringSerializer.INSTANCE, false)));
+    }
+
+    /** A string serializer whose snapshot records the schema it belongs to. */
+    private static final class TaggedStringSerializer extends TypeSerializer<String> {
+
+        private final String tag;
+
+        private TaggedStringSerializer(String tag) {
+            this.tag = tag;
+        }
+
+        @Override
+        public boolean isImmutableType() {
+            return true;
+        }
+
+        @Override
+        public TypeSerializer<String> duplicate() {
+            return this;
+        }
+
+        @Override
+        public String createInstance() {
+            return "";
+        }
+
+        @Override
+        public String copy(String from) {
+            return from;
+        }
+
+        @Override
+        public String copy(String from, String reuse) {
+            return from;
+        }
+
+        @Override
+        public int getLength() {
+            return -1;
+        }
+
+        @Override
+        public void serialize(String record, DataOutputView target) throws IOException {
+            StringSerializer.INSTANCE.serialize(record, target);
+        }
+
+        @Override
+        public String deserialize(DataInputView source) throws IOException {
+            return StringSerializer.INSTANCE.deserialize(source);
+        }
+
+        @Override
+        public String deserialize(String reuse, DataInputView source) throws IOException {
+            return deserialize(source);
+        }
+
+        @Override
+        public void copy(DataInputView source, DataOutputView target) throws IOException {
+            StringSerializer.INSTANCE.copy(source, target);
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            return obj instanceof TaggedStringSerializer
+                    && tag.equals(((TaggedStringSerializer) obj).tag);
+        }
+
+        @Override
+        public int hashCode() {
+            return tag.hashCode();
+        }
+
+        @Override
+        public TypeSerializerSnapshot<String> snapshotConfiguration() {
+            return new TaggedSnapshot(tag);
+        }
+    }
+
+    /**
+     * Appends both the argument snapshot's tag and its own tag to the migrated value, so a
+     * migration that swaps receiver and argument produces a different result.
+     */
+    public static final class TaggedSnapshot implements TypeSerializerSnapshot<String> {
+
+        private String tag;
+
+        public TaggedSnapshot() {}
+
+        private TaggedSnapshot(String tag) {
+            this.tag = tag;
+        }
+
+        @Override
+        public int getCurrentVersion() {
+            return 1;
+        }
+
+        @Override
+        public void writeSnapshot(DataOutputView out) throws IOException {
+            out.writeUTF(tag);
+        }
+
+        @Override
+        public void readSnapshot(int readVersion, DataInputView in, ClassLoader userCodeClassLoader)
+                throws IOException {
+            tag = in.readUTF();
+        }
+
+        @Override
+        public TypeSerializer<String> restoreSerializer() {
+            return new TaggedStringSerializer(tag);
+        }
+
+        @Override
+        public TypeSerializerSchemaCompatibility<String> resolveSchemaCompatibility(
+                TypeSerializerSnapshot<String> oldSerializerSnapshot) {
+            return TypeSerializerSchemaCompatibility.compatibleAsIs();
+        }
+
+        @Override
+        public String migrate(TypeSerializerSnapshot<String> oldSerializerSnapshot, String value) {
+            return value + "|from=" + ((TaggedSnapshot) oldSerializerSnapshot).tag + "|to=" + tag;
+        }
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/TtlAwareSerializerUpgradeTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/TtlAwareSerializerUpgradeTest.java
@@ -161,6 +161,7 @@ public class TtlAwareSerializerUpgradeTest
         DataOutputSerializer migratedOut = new DataOutputSerializer(INITIAL_OUTPUT_BUFFER_SIZE);
         writer.migrateValueFromPriorSerializer(
                 reader,
+                reader.getOriginalTypeSerializer().snapshotConfiguration(),
                 () -> reader.deserialize(originalDataInput),
                 migratedOut,
                 TtlTimeProvider.DEFAULT);

--- a/flink-runtime/src/test/java/org/apache/flink/streaming/api/operators/StreamingRuntimeContextTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/streaming/api/operators/StreamingRuntimeContextTest.java
@@ -57,6 +57,8 @@ import org.apache.flink.runtime.state.DefaultKeyedStateStore;
 import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.runtime.state.KeyedStateBackend;
 import org.apache.flink.runtime.state.KeyedStateBackendParametersImpl;
+import org.apache.flink.runtime.state.StateSchemaEvolvingTestSerializer;
+import org.apache.flink.runtime.state.StateSchemaEvolvingTestSerializer.StateSchemaEvolvingTestTypeInfo;
 import org.apache.flink.runtime.state.VoidNamespace;
 import org.apache.flink.runtime.state.VoidNamespaceSerializer;
 import org.apache.flink.runtime.state.hashmap.HashMapStateBackend;
@@ -248,6 +250,26 @@ class StreamingRuntimeContextTest {
     }
 
     @Test
+    void testValueStateSerializerIsArmedForObjectLevelMigratingBackend() throws Exception {
+        final ExecutionConfig config = new ExecutionConfig();
+        final AtomicReference<Object> descriptorCapture = new AtomicReference<>();
+
+        StreamingRuntimeContext context =
+                createRuntimeContext(descriptorCapture, config, false, true);
+        ValueStateDescriptor<Integer> descr =
+                new ValueStateDescriptor<>("name", new StateSchemaEvolvingTestTypeInfo());
+        context.getState(descr);
+
+        StateDescriptor<?, ?> descrIntercepted = (StateDescriptor<?, ?>) descriptorCapture.get();
+        TypeSerializer<?> serializer = descrIntercepted.getSerializer();
+
+        // The keyed state store owns the arming; a serializer initialized before delegating to the
+        // store would win the descriptor's CAS and leave this unarmed.
+        assertThat(serializer).isInstanceOf(StateSchemaEvolvingTestSerializer.class);
+        assertThat(((StateSchemaEvolvingTestSerializer) serializer).isArmed()).isTrue();
+    }
+
+    @Test
     void testV2ValueStateInstantiation() throws Exception {
 
         final ExecutionConfig config = new ExecutionConfig();
@@ -404,11 +426,21 @@ class StreamingRuntimeContextTest {
     private StreamingRuntimeContext createRuntimeContext(
             AtomicReference<Object> descriptorCapture, ExecutionConfig config, boolean stateV2)
             throws Exception {
+        return createRuntimeContext(descriptorCapture, config, stateV2, false);
+    }
+
+    private StreamingRuntimeContext createRuntimeContext(
+            AtomicReference<Object> descriptorCapture,
+            ExecutionConfig config,
+            boolean stateV2,
+            boolean objectLevelValueMigration)
+            throws Exception {
         return createDescriptorCapturingMockOp(
                         descriptorCapture,
                         config,
                         MockEnvironment.builder().setExecutionConfig(config).build(),
-                        stateV2)
+                        stateV2,
+                        objectLevelValueMigration)
                 .getRuntimeContext();
     }
 
@@ -428,7 +460,8 @@ class StreamingRuntimeContextTest {
             final AtomicReference<Object> ref,
             final ExecutionConfig config,
             Environment environment,
-            boolean stateV2)
+            boolean stateV2,
+            boolean objectLevelValueMigration)
             throws Exception {
 
         StreamConfig streamConfig = new StreamConfig(new Configuration());
@@ -457,6 +490,8 @@ class StreamingRuntimeContextTest {
                 new StreamTaskStateInitializerImpl(environment, new HashMapStateBackend());
 
         KeyedStateBackend keyedStateBackend = mock(KeyedStateBackend.class);
+        when(keyedStateBackend.supportsObjectLevelValueMigration())
+                .thenReturn(objectLevelValueMigration);
 
         AsyncKeyedStateBackend asyncKeyedStateBackend = mock(AsyncKeyedStateBackend.class);
 

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/state/rocksdb/AbstractRocksDBState.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/state/rocksdb/AbstractRocksDBState.java
@@ -19,6 +19,7 @@ package org.apache.flink.state.rocksdb;
 
 import org.apache.flink.api.common.state.State;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.core.memory.DataInputDeserializer;
 import org.apache.flink.core.memory.DataOutputSerializer;
@@ -35,6 +36,8 @@ import org.apache.flink.util.StateMigrationException;
 import org.rocksdb.ColumnFamilyHandle;
 import org.rocksdb.RocksDBException;
 import org.rocksdb.WriteOptions;
+
+import javax.annotation.Nullable;
 
 import java.io.IOException;
 
@@ -191,6 +194,7 @@ public abstract class AbstractRocksDBState<K, N, V> implements InternalKvState<K
             DataInputDeserializer serializedOldValueInput,
             DataOutputSerializer serializedMigratedValueOutput,
             TypeSerializer<V> priorSerializer,
+            @Nullable TypeSerializerSnapshot<V> priorSerializerSnapshot,
             TypeSerializer<V> newSerializer,
             TtlTimeProvider ttlTimeProvider)
             throws StateMigrationException {
@@ -203,6 +207,7 @@ public abstract class AbstractRocksDBState<K, N, V> implements InternalKvState<K
         try {
             ttlAwareNewSerializer.migrateValueFromPriorSerializer(
                     ttlAwarePriorSerializer,
+                    priorSerializerSnapshot,
                     () -> ttlAwarePriorSerializer.deserialize(serializedOldValueInput),
                     serializedMigratedValueOutput,
                     ttlTimeProvider);

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/state/rocksdb/RocksDBKeyedStateBackend.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/state/rocksdb/RocksDBKeyedStateBackend.java
@@ -916,9 +916,12 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
             Tuple2<ColumnFamilyHandle, RegisteredKeyValueStateBackendMetaInfo<N, SV>> stateMetaInfo)
             throws Exception {
 
+        // The snapshot the state was written with. Preferred over one re-derived from the previous
+        // serializer, which is itself restored from this snapshot and does not always round trip.
+        TypeSerializerSnapshot<SV> previousSerializerSnapshot =
+                stateMetaInfo.f1.getPreviousStateSerializerSnapshot();
+
         if (stateDesc.getType() == StateDescriptor.Type.MAP) {
-            TypeSerializerSnapshot<SV> previousSerializerSnapshot =
-                    stateMetaInfo.f1.getPreviousStateSerializerSnapshot();
             checkState(
                     previousSerializerSnapshot != null,
                     "the previous serializer snapshot should exist.");
@@ -1003,6 +1006,7 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
                         serializedValueInput,
                         migratedSerializedValueOutput,
                         previousTtlAwareSerializer,
+                        previousSerializerSnapshot,
                         currentTtlAwareSerializer,
                         this.ttlTimeProvider);
 

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/state/rocksdb/RocksDBKeyedStateBackend.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/state/rocksdb/RocksDBKeyedStateBackend.java
@@ -1146,6 +1146,14 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
     }
 
     @Override
+    public boolean supportsObjectLevelValueMigration() {
+        // A compatibleAfterMigration verdict routes every restored entry through
+        // migrateStateValues, whose per-entry migrateSerializedValue call reaches the migrate hook
+        // on the state's own value serializer.
+        return true;
+    }
+
+    @Override
     public String getBackendTypeIdentifier() {
         return StateBackendLoader.ROCKSDB_STATE_BACKEND_NAME;
     }

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/state/rocksdb/RocksDBListState.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/state/rocksdb/RocksDBListState.java
@@ -22,7 +22,9 @@ import org.apache.flink.api.common.state.ListState;
 import org.apache.flink.api.common.state.State;
 import org.apache.flink.api.common.state.StateDescriptor;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
 import org.apache.flink.api.common.typeutils.base.ListSerializer;
+import org.apache.flink.api.common.typeutils.base.ListSerializerSnapshot;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.core.memory.DataInputDeserializer;
 import org.apache.flink.core.memory.DataOutputSerializer;
@@ -200,6 +202,7 @@ class RocksDBListState<K, N, V> extends AbstractRocksDBState<K, N, List<V>>
             DataInputDeserializer serializedOldValueInput,
             DataOutputSerializer serializedMigratedValueOutput,
             TypeSerializer<List<V>> priorSerializer,
+            @Nullable TypeSerializerSnapshot<List<V>> priorSerializerSnapshot,
             TypeSerializer<List<V>> newSerializer,
             TtlTimeProvider ttlTimeProvider)
             throws StateMigrationException {
@@ -214,11 +217,29 @@ class RocksDBListState<K, N, V> extends AbstractRocksDBState<K, N, List<V>>
         TtlAwareSerializer<V, ?> newTtlAwareElementSerializer =
                 ((TtlAwareSerializer.TtlAwareListSerializer<V>) newSerializer)
                         .getElementSerializer();
+        // Descend the persisted snapshot the same way as the serializer, so element migration
+        // sees the schema the elements were written with. A state that carries no persisted
+        // snapshot leaves this null, and the element migration re-derives one instead.
+        TypeSerializerSnapshot<V> priorElementSerializerSnapshot = null;
+        if (priorSerializerSnapshot != null) {
+            // Thrown rather than checked through Preconditions: this method runs once per state
+            // entry, so the message must not be built while the check is passing.
+            if (!(priorSerializerSnapshot instanceof ListSerializerSnapshot)) {
+                throw new IllegalArgumentException(
+                        "The previous serializer snapshot of a list state should be a ListSerializerSnapshot, but was "
+                                + priorSerializerSnapshot.getClass().getName()
+                                + ".");
+            }
+            priorElementSerializerSnapshot =
+                    ((ListSerializerSnapshot<V>) priorSerializerSnapshot)
+                            .getElementSerializerSnapshot();
+        }
 
         try {
             while (serializedOldValueInput.available() > 0) {
                 newTtlAwareElementSerializer.migrateValueFromPriorSerializer(
                         priorTtlAwareElementSerializer,
+                        priorElementSerializerSnapshot,
                         () ->
                                 ListDelimitedSerializer.deserializeNextElement(
                                         serializedOldValueInput, priorTtlAwareElementSerializer),

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/state/rocksdb/RocksDBMapState.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/state/rocksdb/RocksDBMapState.java
@@ -22,7 +22,9 @@ import org.apache.flink.api.common.state.MapState;
 import org.apache.flink.api.common.state.State;
 import org.apache.flink.api.common.state.StateDescriptor;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
 import org.apache.flink.api.common.typeutils.base.MapSerializer;
+import org.apache.flink.api.common.typeutils.base.MapSerializerSnapshot;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.core.memory.DataInputDeserializer;
 import org.apache.flink.core.memory.DataOutputSerializer;
@@ -227,6 +229,7 @@ class RocksDBMapState<K, N, UK, UV> extends AbstractRocksDBState<K, N, Map<UK, U
             DataInputDeserializer serializedOldValueInput,
             DataOutputSerializer serializedMigratedValueOutput,
             TypeSerializer<Map<UK, UV>> priorSerializer,
+            @Nullable TypeSerializerSnapshot<Map<UK, UV>> priorSerializerSnapshot,
             TypeSerializer<Map<UK, UV>> newSerializer,
             TtlTimeProvider ttlTimeProvider)
             throws StateMigrationException {
@@ -240,6 +243,23 @@ class RocksDBMapState<K, N, UK, UV> extends AbstractRocksDBState<K, N, Map<UK, U
         TtlAwareSerializer<UV, ?> newTtlAwareMapValueSerializer =
                 ((TtlAwareSerializer.TtlAwareMapSerializer<UK, UV>) newSerializer)
                         .getValueSerializer();
+        // Descend the persisted snapshot the same way as the serializer, so value migration sees
+        // the schema the map values were written with. A state that carries no persisted
+        // snapshot leaves this null, and the value migration re-derives one instead.
+        TypeSerializerSnapshot<UV> priorMapValueSerializerSnapshot = null;
+        if (priorSerializerSnapshot != null) {
+            // Thrown rather than checked through Preconditions: this method runs once per state
+            // entry, so the message must not be built while the check is passing.
+            if (!(priorSerializerSnapshot instanceof MapSerializerSnapshot)) {
+                throw new IllegalArgumentException(
+                        "The previous serializer snapshot of a map state should be a MapSerializerSnapshot, but was "
+                                + priorSerializerSnapshot.getClass().getName()
+                                + ".");
+            }
+            priorMapValueSerializerSnapshot =
+                    ((MapSerializerSnapshot<UK, UV>) priorSerializerSnapshot)
+                            .getValueSerializerSnapshot();
+        }
 
         try {
             boolean isNull = serializedOldValueInput.readBoolean();
@@ -250,6 +270,7 @@ class RocksDBMapState<K, N, UK, UV> extends AbstractRocksDBState<K, N, Map<UK, U
             } else {
                 newTtlAwareMapValueSerializer.migrateValueFromPriorSerializer(
                         priorTtlAwareMapValueSerializer,
+                        priorMapValueSerializerSnapshot,
                         () -> priorTtlAwareMapValueSerializer.deserialize(serializedOldValueInput),
                         serializedMigratedValueOutput,
                         ttlTimeProvider);

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/config/ExecutionConfigOptions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/config/ExecutionConfigOptions.java
@@ -46,6 +46,23 @@ public class ExecutionConfigOptions {
     // ------------------------------------------------------------------------
 
     @Documentation.TableOption(execMode = Documentation.ExecMode.STREAMING)
+    public static final ConfigOption<Boolean> TABLE_EXEC_STATE_SCHEMA_EVOLUTION_ENABLED =
+            key("table.exec.state.schema-evolution.enabled")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription(
+                            "When enabled, a RowData keyed-state value whose schema changed in a "
+                                    + "backward-compatible way (adding nullable fields, reordering "
+                                    + "fields by name, evolving a nested ROW) is migrated when "
+                                    + "state is restored, instead of the restore failing. Only a "
+                                    + "state's own value serializer is covered: a RowData nested "
+                                    + "below a composite serializer, or a state whose serializer "
+                                    + "the operator pre-builds, is still rejected. Takes effect "
+                                    + "only on a state backend that migrates restored values at "
+                                    + "the object level, currently RocksDB; on other backends the "
+                                    + "restore still fails. Disabled by default.");
+
+    @Documentation.TableOption(execMode = Documentation.ExecMode.STREAMING)
     public static final ConfigOption<Duration> IDLE_STATE_RETENTION =
             key("table.exec.state.ttl")
                     .durationType()

--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/api/config/ExecutionConfigOptionsTest.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/api/config/ExecutionConfigOptionsTest.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.api.config;
+
+import org.apache.flink.api.common.serialization.SerializerConfigImpl;
+import org.apache.flink.configuration.Configuration;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link ExecutionConfigOptions}. */
+class ExecutionConfigOptionsTest {
+
+    /**
+     * {@link SerializerConfigImpl} reads the state schema evolution option by key string, because
+     * flink-core cannot depend on this module. Nothing else ties the two together: if the key here
+     * changed, the option would keep documenting and validating while the runtime read its own
+     * unset key and the feature stayed permanently off. This is the only place both sides are
+     * visible at once.
+     */
+    @Test
+    void stateSchemaEvolutionOptionReachesTheSerializerConfig() {
+        Configuration configuration = new Configuration();
+        configuration.set(ExecutionConfigOptions.TABLE_EXEC_STATE_SCHEMA_EVOLUTION_ENABLED, true);
+
+        assertThat(new SerializerConfigImpl(configuration).isStateSchemaEvolutionEnabled())
+                .isTrue();
+        assertThat(new SerializerConfigImpl(new Configuration()).isStateSchemaEvolutionEnabled())
+                .isFalse();
+    }
+}

--- a/flink-table/flink-table-type-utils/src/main/java/org/apache/flink/table/runtime/typeutils/InternalTypeInfo.java
+++ b/flink-table/flink-table-type-utils/src/main/java/org/apache/flink/table/runtime/typeutils/InternalTypeInfo.java
@@ -194,7 +194,19 @@ public final class InternalTypeInfo<T> extends TypeInformation<T> implements Dat
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public TypeSerializer<T> createSerializer(SerializerConfig config) {
+        if (config != null
+                && config.isStateSchemaEvolutionEnabled()
+                && typeSerializer instanceof RowDataSerializer) {
+            // The cached instance is shared by every use of this type information, so the opt-in
+            // is recorded on a copy rather than in place. The copy goes to every caller, not only
+            // to state registration, so with the option on this method stops handing out the
+            // shared instance for row types; callers compare serializers by equality, which
+            // neither evolution flag affects.
+            return (TypeSerializer<T>)
+                    ((RowDataSerializer) typeSerializer).withSchemaEvolutionAllowed();
+        }
         return typeSerializer;
     }
 

--- a/flink-table/flink-table-type-utils/src/main/java/org/apache/flink/table/runtime/typeutils/RowDataSerializer.java
+++ b/flink-table/flink-table-type-utils/src/main/java/org/apache/flink/table/runtime/typeutils/RowDataSerializer.java
@@ -22,6 +22,7 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.typeutils.CompositeTypeSerializerUtil;
 import org.apache.flink.api.common.typeutils.NestedSerializersSnapshotDelegate;
+import org.apache.flink.api.common.typeutils.StateSchemaEvolvingSerializer;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.TypeSerializerSchemaCompatibility;
 import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
@@ -38,18 +39,23 @@ import org.apache.flink.table.data.binary.NestedRowData;
 import org.apache.flink.table.data.writer.BinaryRowWriter;
 import org.apache.flink.table.data.writer.BinaryWriter;
 import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.LogicalTypeRoot;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.util.InstantiationUtil;
+import org.apache.flink.util.Preconditions;
 
 import javax.annotation.Nullable;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.stream.IntStream;
 
 /** Serializer for {@link RowData}. */
 @Internal
-public class RowDataSerializer extends AbstractRowDataSerializer<RowData> {
+public class RowDataSerializer extends AbstractRowDataSerializer<RowData>
+        implements StateSchemaEvolvingSerializer<RowData> {
     private static final long serialVersionUID = 1L;
 
     private BinaryRowDataSerializer binarySerializer;
@@ -57,6 +63,16 @@ public class RowDataSerializer extends AbstractRowDataSerializer<RowData> {
     private final @Nullable String[] fieldNames;
     private final TypeSerializer[] fieldSerializers;
     private final RowData.FieldGetter[] fieldGetters;
+
+    /** Whether the job configuration opted in to state schema evolution. */
+    private final transient boolean schemaEvolutionAllowed;
+
+    /**
+     * Whether this serializer is the value serializer of a state whose backend migrates restored
+     * values, and may therefore admit a backward-compatible schema change. This is the bit the
+     * snapshot carries into a compatibility check.
+     */
+    private final transient boolean stateSchemaEvolutionEnabled;
 
     private transient BinaryRowData reuseRow;
     private transient BinaryRowWriter reuseWriter;
@@ -86,9 +102,20 @@ public class RowDataSerializer extends AbstractRowDataSerializer<RowData> {
             LogicalType[] types,
             TypeSerializer<?>[] fieldSerializers,
             @Nullable String[] fieldNames) {
+        this(types, fieldSerializers, fieldNames, false, false);
+    }
+
+    private RowDataSerializer(
+            LogicalType[] types,
+            TypeSerializer<?>[] fieldSerializers,
+            @Nullable String[] fieldNames,
+            boolean schemaEvolutionAllowed,
+            boolean stateSchemaEvolutionEnabled) {
         this.types = types;
         this.fieldNames = fieldNames;
         this.fieldSerializers = fieldSerializers;
+        this.schemaEvolutionAllowed = schemaEvolutionAllowed;
+        this.stateSchemaEvolutionEnabled = stateSchemaEvolutionEnabled;
         this.binarySerializer = new BinaryRowDataSerializer(types.length);
         this.fieldGetters =
                 IntStream.range(0, types.length)
@@ -107,13 +134,69 @@ public class RowDataSerializer extends AbstractRowDataSerializer<RowData> {
         return fieldSerializers;
     }
 
+    @VisibleForTesting
+    boolean isSchemaEvolutionAllowed() {
+        return schemaEvolutionAllowed;
+    }
+
+    @VisibleForTesting
+    boolean isStateSchemaEvolutionEnabled() {
+        return stateSchemaEvolutionEnabled;
+    }
+
+    /** Returns a copy that records the job configuration having opted in to schema evolution. */
+    RowDataSerializer withSchemaEvolutionAllowed() {
+        return new RowDataSerializer(
+                types, fieldSerializers, fieldNames, true, stateSchemaEvolutionEnabled);
+    }
+
+    @Override
+    public TypeSerializer<RowData> withStateSchemaEvolution() {
+        return schemaEvolutionAllowed ? enableStateSchemaEvolution() : this;
+    }
+
+    /**
+     * Returns a copy that admits a backward-compatible schema change, recursing down the nested
+     * {@code ROW} spine.
+     *
+     * <p>The opt-in is checked once, by the caller, and never again below: nested field serializers
+     * are built by {@link InternalSerializers} inside this class's constructor, so they never carry
+     * the opt-in flag. Re-checking it one level down would silently no-op and short-circuit every
+     * nested {@code ROW} evolution to incompatible, because an unarmed nested snapshot rejects the
+     * change and that rejection propagates to the whole row.
+     *
+     * <p>The descent stops at anything that is not a {@code ROW}: the migration remap does not
+     * reach inside an ARRAY, MAP, MULTISET, RAW or structured value, so an evolved one is rejected
+     * by the leaf type-equality check instead. A structured type's serializer is a {@code
+     * RowDataSerializer} too, but its type root is not {@code ROW}, so the guard excludes it.
+     */
+    private RowDataSerializer enableStateSchemaEvolution() {
+        TypeSerializer<?>[] evolvingFieldSerializers = new TypeSerializer[fieldSerializers.length];
+        for (int i = 0; i < fieldSerializers.length; i++) {
+            evolvingFieldSerializers[i] =
+                    types[i].getTypeRoot() == LogicalTypeRoot.ROW
+                                    && fieldSerializers[i] instanceof RowDataSerializer
+                            ? ((RowDataSerializer) fieldSerializers[i]).enableStateSchemaEvolution()
+                            : fieldSerializers[i];
+        }
+        return new RowDataSerializer(
+                types, evolvingFieldSerializers, fieldNames, schemaEvolutionAllowed, true);
+    }
+
     @Override
     public TypeSerializer<RowData> duplicate() {
         TypeSerializer<?>[] duplicateFieldSerializers = new TypeSerializer[fieldSerializers.length];
         for (int i = 0; i < fieldSerializers.length; i++) {
             duplicateFieldSerializers[i] = fieldSerializers[i].duplicate();
         }
-        return new RowDataSerializer(types, duplicateFieldSerializers, fieldNames);
+        // Both evolution flags travel with the copy: a state backend registers a duplicate of the
+        // serializer, so a flag dropped here would never reach the snapshot.
+        return new RowDataSerializer(
+                types,
+                duplicateFieldSerializers,
+                fieldNames,
+                schemaEvolutionAllowed,
+                stateSchemaEvolutionEnabled);
     }
 
     @Override
@@ -298,7 +381,8 @@ public class RowDataSerializer extends AbstractRowDataSerializer<RowData> {
 
     @Override
     public TypeSerializerSnapshot<RowData> snapshotConfiguration() {
-        return new RowDataSerializerSnapshot(types, fieldSerializers, fieldNames);
+        return new RowDataSerializerSnapshot(
+                types, fieldSerializers, fieldNames, stateSchemaEvolutionEnabled);
     }
 
     /** {@link TypeSerializerSnapshot} for {@link BinaryRowDataSerializer}. */
@@ -309,15 +393,27 @@ public class RowDataSerializer extends AbstractRowDataSerializer<RowData> {
         private @Nullable String[] fieldNames;
         private NestedSerializersSnapshotDelegate nestedSerializersSnapshotDelegate;
 
+        /**
+         * Whether the serializer this snapshot was taken from admits a backward-compatible schema
+         * change. It is deliberately not part of the snapshot format: a snapshot read back from
+         * bytes describes stored state, not a running job's configuration, so it always resolves
+         * with evolution off.
+         */
+        private boolean stateSchemaEvolutionEnabled;
+
         @SuppressWarnings("unused")
         public RowDataSerializerSnapshot() {
             // this constructor is used when restoring from a checkpoint/savepoint.
         }
 
         RowDataSerializerSnapshot(
-                LogicalType[] types, TypeSerializer[] serializers, @Nullable String[] fieldNames) {
+                LogicalType[] types,
+                TypeSerializer[] serializers,
+                @Nullable String[] fieldNames,
+                boolean stateSchemaEvolutionEnabled) {
             this.types = types;
             this.fieldNames = fieldNames;
+            this.stateSchemaEvolutionEnabled = stateSchemaEvolutionEnabled;
             this.nestedSerializersSnapshotDelegate =
                     new NestedSerializersSnapshotDelegate(serializers);
         }
@@ -387,25 +483,224 @@ public class RowDataSerializer extends AbstractRowDataSerializer<RowData> {
 
             RowDataSerializerSnapshot oldRowDataSerializerSnapshot =
                     (RowDataSerializerSnapshot) oldSerializerSnapshot;
-            if (!Arrays.equals(types, oldRowDataSerializerSnapshot.types)) {
+            // A side that carries no names cannot disagree with anything: without names a reorder
+            // is undetectable, so identical types keep meaning "compatible as is" there, exactly as
+            // they do unarmed.
+            boolean namesDisagree =
+                    stateSchemaEvolutionEnabled
+                            && fieldNames != null
+                            && oldRowDataSerializerSnapshot.fieldNames != null
+                            && !Arrays.equals(fieldNames, oldRowDataSerializerSnapshot.fieldNames);
+
+            // Identical positional layout: the nested composite path. Equal types at equal
+            // positions say nothing about which field is which, so an armed resolution has to see
+            // the names agree as well before it can treat the layout as unchanged -- otherwise a
+            // reorder or a rename among same-typed fields resolves here as needing no migration
+            // and leaves every value sitting under a neighbour's name.
+            if (Arrays.equals(types, oldRowDataSerializerSnapshot.types) && !namesDisagree) {
+                CompositeTypeSerializerUtil.IntermediateCompatibilityResult<RowData>
+                        intermediateResult =
+                                CompositeTypeSerializerUtil
+                                        .constructIntermediateCompatibilityResult(
+                                                nestedSerializersSnapshotDelegate
+                                                        .getNestedSerializerSnapshots(),
+                                                oldRowDataSerializerSnapshot
+                                                        .nestedSerializersSnapshotDelegate
+                                                        .getNestedSerializerSnapshots());
+
+                if (intermediateResult.isCompatibleWithReconfiguredSerializer()) {
+                    RowDataSerializer reconfiguredCompositeSerializer = restoreSerializer();
+                    return TypeSerializerSchemaCompatibility.compatibleWithReconfiguredSerializer(
+                            reconfiguredCompositeSerializer);
+                }
+
+                return intermediateResult.getFinalResult();
+            }
+
+            if (!stateSchemaEvolutionEnabled) {
                 return TypeSerializerSchemaCompatibility.incompatible();
             }
 
-            CompositeTypeSerializerUtil.IntermediateCompatibilityResult<RowData>
-                    intermediateResult =
-                            CompositeTypeSerializerUtil.constructIntermediateCompatibilityResult(
-                                    nestedSerializersSnapshotDelegate
-                                            .getNestedSerializerSnapshots(),
-                                    oldRowDataSerializerSnapshot.nestedSerializersSnapshotDelegate
-                                            .getNestedSerializerSnapshots());
-
-            if (intermediateResult.isCompatibleWithReconfiguredSerializer()) {
-                RowDataSerializer reconfiguredCompositeSerializer = restoreSerializer();
-                return TypeSerializerSchemaCompatibility.compatibleWithReconfiguredSerializer(
-                        reconfiguredCompositeSerializer);
+            // The new side must carry field names. A name-less new serializer is reachable -- a
+            // structured type resolves to one -- and admitting it would open a permanent name-less
+            // evolution channel rather than a ramp for savepoints taken before names were stored.
+            if (fieldNames == null) {
+                return TypeSerializerSchemaCompatibility.incompatible();
             }
 
-            return intermediateResult.getFinalResult();
+            return oldRowDataSerializerSnapshot.fieldNames != null
+                    ? checkNameBasedEvolution(oldRowDataSerializerSnapshot)
+                    : checkPositionalEvolution(oldRowDataSerializerSnapshot);
+        }
+
+        private TypeSerializerSchemaCompatibility<RowData> checkNameBasedEvolution(
+                RowDataSerializerSnapshot oldSnapshot) {
+            int[] oldToNew = buildNameMapping(oldSnapshot.fieldNames, this.fieldNames);
+            int[] newToOld = buildNameMapping(this.fieldNames, oldSnapshot.fieldNames);
+
+            // (A) Every new-only field (no matching old field) must be nullable.
+            for (int newPos = 0; newPos < newToOld.length; newPos++) {
+                if (newToOld[newPos] == -1 && !types[newPos].isNullable()) {
+                    return TypeSerializerSchemaCompatibility.incompatible();
+                }
+            }
+
+            // (B) Every old field must survive with a compatible type, and nested snapshots are
+            //     aligned old->new so nested ROW evolution can recurse. Leaf (non-ROW) fields
+            //     require an exactly equal type; ROW fields defer to the nested recursion in (C).
+            TypeSerializerSnapshot<?>[] newNested =
+                    nestedSerializersSnapshotDelegate.getNestedSerializerSnapshots();
+            TypeSerializerSnapshot<?>[] alignedNewNested =
+                    new TypeSerializerSnapshot<?>[oldSnapshot.types.length];
+            for (int oldPos = 0; oldPos < oldToNew.length; oldPos++) {
+                int newPos = oldToNew[oldPos];
+                if (newPos == -1) {
+                    return TypeSerializerSchemaCompatibility.incompatible(); // field removed
+                }
+                LogicalType oldType = oldSnapshot.types[oldPos];
+                LogicalType newType = types[newPos];
+                if (!bothRow(oldType, newType) && !oldType.equals(newType)) {
+                    return TypeSerializerSchemaCompatibility.incompatible(); // leaf type changed
+                }
+                alignedNewNested[oldPos] = newNested[newPos];
+            }
+
+            // (C) Recurse into the aligned nested snapshot pairs.
+            return resolveAlignedNested(alignedNewNested, oldSnapshot);
+        }
+
+        /**
+         * Resolves against a prior snapshot that carries no field names, matching fields by
+         * position.
+         *
+         * <p>Position is a stable identity only for an append. An insertion in the middle is
+         * indistinguishable from a retype plus an append, and the two demand opposite migrations,
+         * so the old layout has to be a prefix of the new one.
+         */
+        private TypeSerializerSchemaCompatibility<RowData> checkPositionalEvolution(
+                RowDataSerializerSnapshot oldSnapshot) {
+            if (types.length < oldSnapshot.types.length) {
+                return TypeSerializerSchemaCompatibility.incompatible();
+            }
+            for (int i = 0; i < oldSnapshot.types.length; i++) {
+                LogicalType oldType = oldSnapshot.types[i];
+                LogicalType newType = types[i];
+                if (!bothRow(oldType, newType) && !oldType.equals(newType)) {
+                    return TypeSerializerSchemaCompatibility.incompatible();
+                }
+            }
+            for (int i = oldSnapshot.types.length; i < types.length; i++) {
+                if (!types[i].isNullable()) {
+                    return TypeSerializerSchemaCompatibility.incompatible();
+                }
+            }
+
+            // constructIntermediateCompatibilityResult requires both arrays to have the same
+            // length, so only the prefix the old layout covers is handed to it.
+            TypeSerializerSnapshot<?>[] alignedNewNested =
+                    Arrays.copyOf(
+                            nestedSerializersSnapshotDelegate.getNestedSerializerSnapshots(),
+                            oldSnapshot.types.length);
+            return resolveAlignedNested(alignedNewNested, oldSnapshot);
+        }
+
+        private TypeSerializerSchemaCompatibility<RowData> resolveAlignedNested(
+                TypeSerializerSnapshot<?>[] alignedNewNested,
+                RowDataSerializerSnapshot oldSnapshot) {
+            CompositeTypeSerializerUtil.IntermediateCompatibilityResult<RowData> nested =
+                    CompositeTypeSerializerUtil.constructIntermediateCompatibilityResult(
+                            alignedNewNested,
+                            oldSnapshot.nestedSerializersSnapshotDelegate
+                                    .getNestedSerializerSnapshots());
+            // A reconfigured nested serializer is deliberately not propagated here, unlike on the
+            // identical-layout path. Reconfiguration exists so a new serializer can read old bytes;
+            // once the values have been remapped there are no old bytes left, because the migrated
+            // row is re-encoded by the state's own new serializer.
+            return nested.isIncompatible()
+                    ? TypeSerializerSchemaCompatibility.incompatible()
+                    : TypeSerializerSchemaCompatibility.compatibleAfterMigration();
+        }
+
+        private static boolean bothRow(LogicalType oldType, LogicalType newType) {
+            return oldType.getTypeRoot() == LogicalTypeRoot.ROW
+                    && newType.getTypeRoot() == LogicalTypeRoot.ROW;
+        }
+
+        @Override
+        public RowData migrate(
+                TypeSerializerSnapshot<RowData> oldSerializerSnapshot, RowData value) {
+            if (value == null) {
+                return null;
+            }
+            // Runs once per restored entry, so a mismatch would otherwise surface as a bare
+            // ClassCastException from deep inside a migration loop.
+            Preconditions.checkArgument(
+                    oldSerializerSnapshot instanceof RowDataSerializerSnapshot,
+                    "Cannot migrate RowData state from %s.",
+                    oldSerializerSnapshot.getClass().getName());
+            RowDataSerializerSnapshot oldSnapshot =
+                    (RowDataSerializerSnapshot) oldSerializerSnapshot;
+            return getNewRowData(value, oldSnapshot.restoreSerializer(), restoreSerializer());
+        }
+
+        // Remaps oldData into the new layout. Name-based when both serializers carry field names;
+        // otherwise positions map 1:1 up to the common field count. RowKind preserved; added
+        // fields and null sources become null; nested ROW values are remapped recursively.
+        private static GenericRowData getNewRowData(
+                RowData oldData, RowDataSerializer oldSerializer, RowDataSerializer newSerializer) {
+            GenericRowData newData = new GenericRowData(newSerializer.getArity());
+            newData.setRowKind(oldData.getRowKind());
+            int[] positions = buildPositionMapping(oldSerializer, newSerializer);
+            for (int newPos = 0; newPos < newSerializer.getArity(); newPos++) {
+                int oldPos = positions[newPos];
+                if (oldPos != -1 && !oldData.isNullAt(oldPos)) {
+                    Object fieldValue = oldSerializer.fieldGetters[oldPos].getFieldOrNull(oldData);
+                    if (fieldValue instanceof RowData) {
+                        fieldValue =
+                                getNewRowData(
+                                        (RowData) fieldValue,
+                                        (RowDataSerializer) oldSerializer.fieldSerializers[oldPos],
+                                        (RowDataSerializer) newSerializer.fieldSerializers[newPos]);
+                    }
+                    newData.setField(newPos, fieldValue);
+                } else {
+                    newData.setField(newPos, null);
+                }
+            }
+            return newData;
+        }
+
+        // positions[newPos] = matching old position, or -1 for an added field.
+        private static int[] buildPositionMapping(
+                RowDataSerializer oldSerializer, RowDataSerializer newSerializer) {
+            if (oldSerializer.getFieldNames() != null && newSerializer.getFieldNames() != null) {
+                // Already indexed by new position, one entry per new field.
+                return buildNameMapping(
+                        newSerializer.getFieldNames(), oldSerializer.getFieldNames());
+            }
+            // The old arity comes from the serializer, not from the record: the compatibility rule
+            // is a statement about the snapshot's layout, and reading it off the record would make
+            // the remap follow whatever turned up instead. Under the prefix bound the two agree,
+            // which is exactly what would make a divergence invisible.
+            int[] positions = new int[newSerializer.getArity()];
+            int commonFields = Math.min(oldSerializer.getArity(), newSerializer.getArity());
+            for (int i = 0; i < newSerializer.getArity(); i++) {
+                positions[i] = i < commonFields ? i : -1;
+            }
+            return positions;
+        }
+
+        // mapping[i] = index in toNames of the field named fromNames[i], or -1 if absent.
+        private static int[] buildNameMapping(String[] fromNames, String[] toNames) {
+            Map<String, Integer> toIndex = new HashMap<>(toNames.length);
+            for (int i = 0; i < toNames.length; i++) {
+                toIndex.put(toNames[i], i);
+            }
+            int[] mapping = new int[fromNames.length];
+            for (int i = 0; i < fromNames.length; i++) {
+                mapping[i] = toIndex.getOrDefault(fromNames[i], -1);
+            }
+            return mapping;
         }
 
         /** Returns the logical types stored in this snapshot. */

--- a/flink-table/flink-table-type-utils/src/test/java/org/apache/flink/table/runtime/typeutils/RowDataSerializerSchemaEvolutionTest.java
+++ b/flink-table/flink-table-type-utils/src/test/java/org/apache/flink/table/runtime/typeutils/RowDataSerializerSchemaEvolutionTest.java
@@ -1,0 +1,573 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.typeutils;
+
+import org.apache.flink.api.common.serialization.SerializerConfig;
+import org.apache.flink.api.common.serialization.SerializerConfigImpl;
+import org.apache.flink.api.common.typeutils.StateSchemaEvolvingSerializer;
+import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.ConfigOptions;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.memory.DataInputDeserializer;
+import org.apache.flink.core.memory.DataOutputSerializer;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.runtime.typeutils.RowDataSerializer.RowDataSerializerSnapshot;
+import org.apache.flink.table.types.logical.ArrayType;
+import org.apache.flink.table.types.logical.BigIntType;
+import org.apache.flink.table.types.logical.IntType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.types.logical.StructuredType;
+import org.apache.flink.table.types.logical.VarCharType;
+import org.apache.flink.types.RowKind;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+import static org.apache.flink.table.data.StringData.fromString;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests the opt-in state schema evolution carried by {@link RowDataSerializer}: the two evolution
+ * bits on the serializer, and the compatibility verdict plus {@code migrate} remap performed by
+ * {@link RowDataSerializerSnapshot} once the state bit is set.
+ *
+ * <p>Complements {@link RowDataSerializerFieldNamesTest}, which covers the field-name metadata and
+ * the V4 snapshot format that this evolution builds on, and {@link RowDataSerializerTest}, which
+ * covers per-record serialization round trips.
+ */
+class RowDataSerializerSchemaEvolutionTest {
+
+    /**
+     * Mirrors {@code ExecutionConfigOptions.TABLE_EXEC_STATE_SCHEMA_EVOLUTION_ENABLED}, which lives
+     * in a module this one cannot depend on.
+     */
+    private static final ConfigOption<Boolean> STATE_SCHEMA_EVOLUTION_ENABLED =
+            ConfigOptions.key("table.exec.state.schema-evolution.enabled")
+                    .booleanType()
+                    .defaultValue(false);
+
+    // ------------------------------------------------------------------------
+    //  Name-based evolution
+    // ------------------------------------------------------------------------
+
+    @Test
+    void addedNullableFieldAtEndIsMigrated() throws IOException {
+        RowDataSerializerSnapshot oldSnap =
+                oldSnapshot(row(new String[] {"a", "b"}, new IntType(), VarCharType.STRING_TYPE));
+        RowDataSerializerSnapshot newSnap =
+                newSnapshot(
+                        row(
+                                new String[] {"a", "b", "c"},
+                                new IntType(),
+                                VarCharType.STRING_TYPE,
+                                new IntType()));
+
+        assertThat(newSnap.resolveSchemaCompatibility(oldSnap).isCompatibleAfterMigration())
+                .isTrue();
+
+        GenericRowData oldValue = GenericRowData.of(1, fromString("x"));
+        oldValue.setRowKind(RowKind.UPDATE_AFTER);
+        RowData migrated = newSnap.migrate(oldSnap, oldValue);
+
+        assertThat(migrated.getArity()).isEqualTo(3);
+        assertThat(migrated.getInt(0)).isEqualTo(1);
+        assertThat(migrated.getString(1)).isEqualTo(fromString("x"));
+        assertThat(migrated.isNullAt(2)).isTrue();
+        assertThat(migrated.getRowKind()).isEqualTo(RowKind.UPDATE_AFTER);
+    }
+
+    @Test
+    void addedNullableFieldInMiddleIsMigrated() throws IOException {
+        RowDataSerializerSnapshot oldSnap =
+                oldSnapshot(row(new String[] {"a", "c"}, new IntType(), new BigIntType()));
+        RowDataSerializerSnapshot newSnap =
+                newSnapshot(
+                        row(
+                                new String[] {"a", "b", "c"},
+                                new IntType(),
+                                new IntType(),
+                                new BigIntType()));
+
+        assertThat(newSnap.resolveSchemaCompatibility(oldSnap).isCompatibleAfterMigration())
+                .isTrue();
+
+        RowData migrated = newSnap.migrate(oldSnap, GenericRowData.of(1, 99L));
+
+        assertThat(migrated.getInt(0)).isEqualTo(1);
+        assertThat(migrated.isNullAt(1)).isTrue();
+        assertThat(migrated.getLong(2)).isEqualTo(99L);
+    }
+
+    @Test
+    void reorderedFieldsAreMigratedByName() throws IOException {
+        RowDataSerializerSnapshot oldSnap =
+                oldSnapshot(row(new String[] {"a", "b"}, new IntType(), new BigIntType()));
+        RowDataSerializerSnapshot newSnap =
+                newSnapshot(row(new String[] {"b", "a"}, new BigIntType(), new IntType()));
+
+        assertThat(newSnap.resolveSchemaCompatibility(oldSnap).isCompatibleAfterMigration())
+                .isTrue();
+
+        RowData migrated = newSnap.migrate(oldSnap, GenericRowData.of(7, 42L));
+
+        assertThat(migrated.getLong(0)).isEqualTo(42L);
+        assertThat(migrated.getInt(1)).isEqualTo(7);
+    }
+
+    /**
+     * The reorder that {@link #reorderedFieldsAreMigratedByName} cannot catch: with the same type
+     * at every position the {@code LogicalType[]} arrays are equal, so only a name comparison
+     * distinguishes this from an unchanged layout. Resolving it as needing no migration would leave
+     * every value under its neighbour's name.
+     */
+    @Test
+    void sameTypedReorderIsMigratedByName() throws IOException {
+        RowDataSerializerSnapshot oldSnap =
+                oldSnapshot(row(new String[] {"a", "b"}, new IntType(), new IntType()));
+        RowDataSerializerSnapshot newSnap =
+                newSnapshot(row(new String[] {"b", "a"}, new IntType(), new IntType()));
+
+        assertThat(newSnap.resolveSchemaCompatibility(oldSnap).isCompatibleAfterMigration())
+                .isTrue();
+
+        RowData migrated = newSnap.migrate(oldSnap, GenericRowData.of(7, 42));
+
+        assertThat(migrated.getInt(0)).isEqualTo(42);
+        assertThat(migrated.getInt(1)).isEqualTo(7);
+    }
+
+    /** A rename among same-typed fields drops the old field, so it cannot be migrated. */
+    @Test
+    void sameTypedRenameIsIncompatible() throws IOException {
+        RowDataSerializerSnapshot oldSnap = oldSnapshot(row(new String[] {"a"}, new IntType()));
+        RowDataSerializerSnapshot newSnap = newSnapshot(row(new String[] {"x"}, new IntType()));
+
+        assertThat(newSnap.resolveSchemaCompatibility(oldSnap).isIncompatible()).isTrue();
+    }
+
+    /**
+     * With the option off, field names are not consulted at all: an identical positional layout
+     * resolves exactly as it does without this feature, whatever the names did.
+     */
+    @Test
+    void sameTypedReorderIsCompatibleAsIsWhenNotOptedIn() throws IOException {
+        RowDataSerializerSnapshot oldSnap =
+                oldSnapshot(row(new String[] {"a", "b"}, new IntType(), new IntType()));
+        RowDataSerializerSnapshot unarmedNewSnap =
+                (RowDataSerializerSnapshot)
+                        InternalSerializers.create(
+                                        row(new String[] {"b", "a"}, new IntType(), new IntType()))
+                                .snapshotConfiguration();
+
+        assertThat(unarmedNewSnap.resolveSchemaCompatibility(oldSnap).isCompatibleAsIs()).isTrue();
+    }
+
+    /**
+     * A prior snapshot from before field names were persisted names nothing, so a reorder cannot be
+     * detected there and identical types must keep meaning "no migration needed". Reporting a
+     * migration instead would rewrite every entry of an unchanged state on the first restore after
+     * a user opts in, which is the most common path this option will meet.
+     */
+    @Test
+    void nameLessOldSnapshotWithUnchangedLayoutIsCompatibleAsIs() {
+        RowDataSerializerSnapshot oldSnap = nameLessSnapshot(new IntType(), new BigIntType());
+        RowDataSerializerSnapshot newSnap =
+                newSnapshot(row(new String[] {"a", "b"}, new IntType(), new BigIntType()));
+
+        assertThat(newSnap.resolveSchemaCompatibility(oldSnap).isCompatibleAsIs()).isTrue();
+    }
+
+    /**
+     * The mirror case: a name-less new side against a named prior snapshot with identical types.
+     * Opting in must never narrow a restore that succeeds with the option off.
+     */
+    @Test
+    void nameLessNewSnapshotWithUnchangedLayoutIsCompatibleAsIs() throws IOException {
+        RowDataSerializerSnapshot oldSnap =
+                oldSnapshot(row(new String[] {"a", "b"}, new IntType(), new BigIntType()));
+        RowDataSerializer nameLessArmed =
+                (RowDataSerializer)
+                        new RowDataSerializer(new IntType(), new BigIntType())
+                                .withSchemaEvolutionAllowed()
+                                .withStateSchemaEvolution();
+        RowDataSerializerSnapshot newSnap =
+                (RowDataSerializerSnapshot) nameLessArmed.snapshotConfiguration();
+
+        assertThat(nameLessArmed.isStateSchemaEvolutionEnabled()).isTrue();
+        assertThat(newSnap.resolveSchemaCompatibility(oldSnap).isCompatibleAsIs()).isTrue();
+    }
+
+    /**
+     * An unchanged layout can still reach {@code migrate}, because a nested serializer may report
+     * {@code compatibleAfterMigration} on its own. The remap must then reproduce the row exactly.
+     */
+    @Test
+    void migrateReproducesAnUnchangedLayout() throws IOException {
+        RowType rowType = row(new String[] {"a", "b"}, new IntType(), VarCharType.STRING_TYPE);
+
+        RowData migrated =
+                newSnapshot(rowType)
+                        .migrate(oldSnapshot(rowType), GenericRowData.of(1, fromString("x")));
+
+        assertThat(migrated.getArity()).isEqualTo(2);
+        assertThat(migrated.getInt(0)).isEqualTo(1);
+        assertThat(migrated.getString(1)).isEqualTo(fromString("x"));
+    }
+
+    @Test
+    void addedNotNullFieldIsIncompatible() throws IOException {
+        RowDataSerializerSnapshot oldSnap = oldSnapshot(row(new String[] {"a"}, new IntType()));
+        RowDataSerializerSnapshot newSnap =
+                newSnapshot(row(new String[] {"a", "b"}, new IntType(), new IntType(false)));
+
+        assertThat(newSnap.resolveSchemaCompatibility(oldSnap).isIncompatible()).isTrue();
+    }
+
+    @Test
+    void droppedFieldIsIncompatible() throws IOException {
+        RowDataSerializerSnapshot oldSnap =
+                oldSnapshot(row(new String[] {"a", "b"}, new IntType(), new BigIntType()));
+        RowDataSerializerSnapshot newSnap = newSnapshot(row(new String[] {"a"}, new IntType()));
+
+        assertThat(newSnap.resolveSchemaCompatibility(oldSnap).isIncompatible()).isTrue();
+    }
+
+    @Test
+    void changedLeafTypeIsIncompatible() throws IOException {
+        RowDataSerializerSnapshot oldSnap =
+                oldSnapshot(row(new String[] {"a", "b"}, new IntType(), new IntType()));
+        RowDataSerializerSnapshot newSnap =
+                newSnapshot(row(new String[] {"a", "b"}, new IntType(), new BigIntType()));
+
+        assertThat(newSnap.resolveSchemaCompatibility(oldSnap).isIncompatible()).isTrue();
+    }
+
+    @Test
+    void evolvedNestedRowIsMigrated() throws IOException {
+        RowType oldNested = row(new String[] {"x", "y"}, new IntType(), VarCharType.STRING_TYPE);
+        RowType newNested =
+                row(
+                        new String[] {"x", "y", "z"},
+                        new IntType(),
+                        VarCharType.STRING_TYPE,
+                        new IntType());
+        RowType newType = row(new String[] {"id", "nested"}, new IntType(), newNested);
+
+        RowDataSerializer stateSerializer =
+                (RowDataSerializer)
+                        StateSchemaEvolvingSerializer.armStateValueSerializer(optedIn(newType));
+
+        // Nested field serializers are built by InternalSerializers inside the RowDataSerializer
+        // constructor, so they never carry the opt-in bit. The state bit therefore has to be set on
+        // them unconditionally down the ROW spine; re-checking the opt-in bit one level down would
+        // leave the nested snapshot unarmed and short-circuit the whole row to incompatible.
+        RowDataSerializer nestedSerializer =
+                (RowDataSerializer) stateSerializer.fieldSerializers()[1];
+        assertThat(nestedSerializer.isSchemaEvolutionAllowed()).isFalse();
+        assertThat(nestedSerializer.isStateSchemaEvolutionEnabled()).isTrue();
+
+        RowDataSerializerSnapshot newSnap =
+                (RowDataSerializerSnapshot) stateSerializer.snapshotConfiguration();
+        RowDataSerializerSnapshot oldSnap =
+                oldSnapshot(row(new String[] {"id", "nested"}, new IntType(), oldNested));
+
+        assertThat(newSnap.resolveSchemaCompatibility(oldSnap).isCompatibleAfterMigration())
+                .isTrue();
+
+        RowData migrated =
+                newSnap.migrate(
+                        oldSnap, GenericRowData.of(5, GenericRowData.of(8, fromString("hi"))));
+
+        assertThat(migrated.getInt(0)).isEqualTo(5);
+        RowData migratedNested = migrated.getRow(1, 3);
+        assertThat(migratedNested.getInt(0)).isEqualTo(8);
+        assertThat(migratedNested.getString(1)).isEqualTo(fromString("hi"));
+        assertThat(migratedNested.isNullAt(2)).isTrue();
+    }
+
+    @Test
+    void incompatibleNestedRowChangeIsIncompatible() throws IOException {
+        RowDataSerializerSnapshot oldSnap =
+                oldSnapshot(
+                        row(
+                                new String[] {"id", "nested"},
+                                new IntType(),
+                                row(new String[] {"a"}, new IntType())));
+        RowDataSerializerSnapshot newSnap =
+                newSnapshot(
+                        row(
+                                new String[] {"id", "nested"},
+                                new IntType(),
+                                row(new String[] {"a"}, new BigIntType())));
+
+        assertThat(newSnap.resolveSchemaCompatibility(oldSnap).isIncompatible()).isTrue();
+    }
+
+    @Test
+    void changedArrayElementRowIsIncompatible() throws IOException {
+        RowType oldElement = row(new String[] {"a"}, new IntType());
+        RowType newElement = row(new String[] {"a"}, new BigIntType());
+        RowType newType = row(new String[] {"id", "arr"}, new IntType(), new ArrayType(newElement));
+
+        // The recursion descends only into ROW-typed fields, so the ROW nested under the ARRAY is
+        // never reached and the change has to be rejected by the leaf type-equality check instead.
+        RowDataSerializer stateSerializer = armed(newType);
+        ArrayDataSerializer arraySerializer =
+                (ArrayDataSerializer) stateSerializer.fieldSerializers()[1];
+        RowDataSerializer elementSerializer = (RowDataSerializer) arraySerializer.getEleSer();
+        assertThat(elementSerializer.isStateSchemaEvolutionEnabled()).isFalse();
+
+        RowDataSerializerSnapshot newSnap =
+                (RowDataSerializerSnapshot) stateSerializer.snapshotConfiguration();
+        RowDataSerializerSnapshot oldSnap =
+                oldSnapshot(
+                        row(new String[] {"id", "arr"}, new IntType(), new ArrayType(oldElement)));
+
+        assertThat(newSnap.resolveSchemaCompatibility(oldSnap).isIncompatible()).isTrue();
+    }
+
+    // ------------------------------------------------------------------------
+    //  Opt-in semantics
+    // ------------------------------------------------------------------------
+
+    @Test
+    void unarmedNewSnapshotIsIncompatible() throws IOException {
+        RowType newType = row(new String[] {"a", "b"}, new IntType(), new IntType());
+        RowDataSerializer notOptedIn =
+                (RowDataSerializer) InternalTypeInfo.of(newType).createSerializer(config(false));
+        RowDataSerializerSnapshot newSnap =
+                (RowDataSerializerSnapshot)
+                        notOptedIn.withStateSchemaEvolution().snapshotConfiguration();
+
+        assertThat(
+                        newSnap.resolveSchemaCompatibility(
+                                        oldSnapshot(row(new String[] {"a"}, new IntType())))
+                                .isIncompatible())
+                .isTrue();
+    }
+
+    @Test
+    void armedBitIsNotPersisted() throws IOException {
+        RowType oldType = row(new String[] {"a"}, new IntType());
+        RowType newType = row(new String[] {"a", "b"}, new IntType(), new IntType());
+
+        assertThat(
+                        newSnapshot(newType)
+                                .resolveSchemaCompatibility(oldSnapshot(oldType))
+                                .isCompatibleAfterMigration())
+                .isTrue();
+
+        RowDataSerializerSnapshot restored = roundTrip(armed(newType).snapshotConfiguration());
+
+        assertThat(restored.resolveSchemaCompatibility(oldSnapshot(oldType)).isIncompatible())
+                .isTrue();
+    }
+
+    @Test
+    void withStateSchemaEvolutionIsIdentityWhenNotOptedIn() {
+        RowDataSerializer serializer =
+                InternalSerializers.create(
+                        row(new String[] {"a", "b"}, new IntType(), new BigIntType()));
+
+        assertThat(serializer.withStateSchemaEvolution()).isSameAs(serializer);
+    }
+
+    @Test
+    void optingInDoesNotMutateTheCachedSerializer() {
+        InternalTypeInfo<RowData> typeInfo =
+                InternalTypeInfo.of(row(new String[] {"a", "b"}, new IntType(), new BigIntType()));
+        RowDataSerializer cached = typeInfo.toRowSerializer();
+
+        RowDataSerializer optedIn = (RowDataSerializer) typeInfo.createSerializer(config(true));
+
+        assertThat(optedIn).isNotSameAs(cached);
+        assertThat(optedIn.isSchemaEvolutionAllowed()).isTrue();
+        assertThat(cached.isSchemaEvolutionAllowed()).isFalse();
+        assertThat(typeInfo.createSerializer(config(false))).isSameAs(cached);
+    }
+
+    @Test
+    void duplicateCarriesBothEvolutionBits() {
+        RowType rowType = row(new String[] {"a", "b"}, new IntType(), new BigIntType());
+
+        RowDataSerializer armedDuplicate = (RowDataSerializer) armed(rowType).duplicate();
+        assertThat(armedDuplicate.isSchemaEvolutionAllowed()).isTrue();
+        assertThat(armedDuplicate.isStateSchemaEvolutionEnabled()).isTrue();
+
+        RowDataSerializer plainDuplicate =
+                (RowDataSerializer) InternalSerializers.create(rowType).duplicate();
+        assertThat(plainDuplicate.isSchemaEvolutionAllowed()).isFalse();
+        assertThat(plainDuplicate.isStateSchemaEvolutionEnabled()).isFalse();
+    }
+
+    @Test
+    void equalsAndHashCodeIgnoreEvolutionBits() {
+        RowType rowType = row(new String[] {"a", "b"}, new IntType(), new BigIntType());
+        RowDataSerializer plain = InternalSerializers.create(rowType);
+
+        assertThat(armed(rowType)).isEqualTo(plain);
+        assertThat(armed(rowType).hashCode()).isEqualTo(plain.hashCode());
+    }
+
+    // ------------------------------------------------------------------------
+    //  Positional fallback for a prior snapshot written without field names
+    // ------------------------------------------------------------------------
+
+    @Test
+    void positionalAppendedNullableFieldIsMigrated() {
+        RowDataSerializerSnapshot oldSnap = nameLessSnapshot(new IntType(), new BigIntType());
+        RowDataSerializerSnapshot newSnap =
+                newSnapshot(
+                        row(
+                                new String[] {"a", "b", "c"},
+                                new IntType(),
+                                new BigIntType(),
+                                new IntType()));
+
+        assertThat(newSnap.resolveSchemaCompatibility(oldSnap).isCompatibleAfterMigration())
+                .isTrue();
+
+        RowData migrated = newSnap.migrate(oldSnap, GenericRowData.of(1, 2L));
+
+        assertThat(migrated.getArity()).isEqualTo(3);
+        assertThat(migrated.getInt(0)).isEqualTo(1);
+        assertThat(migrated.getLong(1)).isEqualTo(2L);
+        assertThat(migrated.isNullAt(2)).isTrue();
+    }
+
+    @Test
+    void positionalAppendedNotNullFieldIsIncompatible() {
+        RowDataSerializerSnapshot oldSnap = nameLessSnapshot(new IntType(), new BigIntType());
+        RowDataSerializerSnapshot newSnap =
+                newSnapshot(
+                        row(
+                                new String[] {"a", "b", "c"},
+                                new IntType(),
+                                new BigIntType(),
+                                new IntType(false)));
+
+        assertThat(newSnap.resolveSchemaCompatibility(oldSnap).isIncompatible()).isTrue();
+    }
+
+    @Test
+    void positionalRetypedFieldIsIncompatible() {
+        RowDataSerializerSnapshot oldSnap = nameLessSnapshot(new IntType(), new BigIntType());
+        RowDataSerializerSnapshot newSnap =
+                newSnapshot(
+                        row(
+                                new String[] {"a", "b", "c"},
+                                new IntType(),
+                                new IntType(),
+                                new IntType()));
+
+        assertThat(newSnap.resolveSchemaCompatibility(oldSnap).isIncompatible()).isTrue();
+    }
+
+    @Test
+    void positionalDroppedFieldIsIncompatible() {
+        RowDataSerializerSnapshot oldSnap = nameLessSnapshot(new IntType(), new BigIntType());
+        RowDataSerializerSnapshot newSnap = newSnapshot(row(new String[] {"a"}, new IntType()));
+
+        assertThat(newSnap.resolveSchemaCompatibility(oldSnap).isIncompatible()).isTrue();
+    }
+
+    @Test
+    void nameLessNewSnapshotIsIncompatible() throws IOException {
+        // A STRUCTURED_TYPE resolves to a RowDataSerializer built from field types only, so it can
+        // be opted in and armed while still carrying no field names.
+        StructuredType structuredType =
+                StructuredType.newBuilder("org.apache.flink.table.NameLess")
+                        .attributes(
+                                Arrays.asList(
+                                        new StructuredType.StructuredAttribute("a", new IntType()),
+                                        new StructuredType.StructuredAttribute(
+                                                "b", new BigIntType())))
+                        .build();
+        RowDataSerializer nameLess =
+                (RowDataSerializer)
+                        InternalTypeInfo.<RowData>of(structuredType).createSerializer(config(true));
+        RowDataSerializer stateSerializer = (RowDataSerializer) nameLess.withStateSchemaEvolution();
+
+        assertThat(stateSerializer.getFieldNames()).isNull();
+        assertThat(stateSerializer.isStateSchemaEvolutionEnabled()).isTrue();
+
+        RowDataSerializerSnapshot newSnap =
+                (RowDataSerializerSnapshot) stateSerializer.snapshotConfiguration();
+
+        assertThat(
+                        newSnap.resolveSchemaCompatibility(
+                                        oldSnapshot(row(new String[] {"a"}, new IntType())))
+                                .isIncompatible())
+                .isTrue();
+    }
+
+    // ------------------------------------------------------------------------
+
+    private static RowType row(String[] names, LogicalType... types) {
+        return RowType.of(types, names);
+    }
+
+    private static SerializerConfig config(boolean schemaEvolutionEnabled) {
+        Configuration configuration = new Configuration();
+        configuration.set(STATE_SCHEMA_EVOLUTION_ENABLED, schemaEvolutionEnabled);
+        return new SerializerConfigImpl(configuration);
+    }
+
+    /** A serializer the job opted in, but that is not yet a state's own value serializer. */
+    private static RowDataSerializer optedIn(RowType rowType) {
+        return (RowDataSerializer) InternalTypeInfo.of(rowType).createSerializer(config(true));
+    }
+
+    private static RowDataSerializer armed(RowType rowType) {
+        return (RowDataSerializer) optedIn(rowType).withStateSchemaEvolution();
+    }
+
+    /**
+     * The new side of a resolution. Kept in memory rather than round-tripped, because the state bit
+     * is not part of the snapshot format and a round trip clears it.
+     */
+    private static RowDataSerializerSnapshot newSnapshot(RowType rowType) {
+        return (RowDataSerializerSnapshot) armed(rowType).snapshotConfiguration();
+    }
+
+    /** The old side of a resolution, read back from bytes the way a restore produces it. */
+    private static RowDataSerializerSnapshot oldSnapshot(RowType rowType) throws IOException {
+        return roundTrip(InternalSerializers.create(rowType).snapshotConfiguration());
+    }
+
+    /** A prior snapshot from before field names were persisted. */
+    private static RowDataSerializerSnapshot nameLessSnapshot(LogicalType... types) {
+        return (RowDataSerializerSnapshot) new RowDataSerializer(types).snapshotConfiguration();
+    }
+
+    private static RowDataSerializerSnapshot roundTrip(TypeSerializerSnapshot<RowData> snapshot)
+            throws IOException {
+        DataOutputSerializer out = new DataOutputSerializer(256);
+        TypeSerializerSnapshot.writeVersionedSnapshot(out, snapshot);
+        DataInputDeserializer in = new DataInputDeserializer(out.getCopyOfBuffer());
+        return (RowDataSerializerSnapshot)
+                TypeSerializerSnapshot.<RowData>readVersionedSnapshot(
+                        in, RowDataSerializerSchemaEvolutionTest.class.getClassLoader());
+    }
+}

--- a/flink-table/flink-table-type-utils/src/test/java/org/apache/flink/table/runtime/typeutils/RowDataStateSchemaEvolutionArmingTest.java
+++ b/flink-table/flink-table-type-utils/src/test/java/org/apache/flink/table/runtime/typeutils/RowDataStateSchemaEvolutionArmingTest.java
@@ -1,0 +1,160 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.typeutils;
+
+import org.apache.flink.api.common.functions.SerializerFactory;
+import org.apache.flink.api.common.serialization.SerializerConfig;
+import org.apache.flink.api.common.serialization.SerializerConfigImpl;
+import org.apache.flink.api.common.state.ListStateDescriptor;
+import org.apache.flink.api.common.state.MapStateDescriptor;
+import org.apache.flink.api.common.state.ValueStateDescriptor;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.api.common.typeutils.StateSchemaEvolvingSerializer;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.base.ListSerializer;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.api.java.typeutils.ListTypeInfo;
+import org.apache.flink.api.java.typeutils.TupleTypeInfo;
+import org.apache.flink.api.java.typeutils.runtime.TupleSerializer;
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.ConfigOptions;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.runtime.typeutils.RowDataSerializer.RowDataSerializerSnapshot;
+import org.apache.flink.table.types.logical.BigIntType;
+import org.apache.flink.table.types.logical.IntType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.RowType;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests which state shapes the arming {@link SerializerFactory} decorator reaches. It arms exactly
+ * one structural level, so a {@link RowDataSerializer} sitting below any composite serializer stays
+ * unarmed and its state fails closed at restore.
+ *
+ * <p>Every assertion is made on the serializer object actually reached through the state
+ * descriptor. {@link RowDataSerializerSchemaEvolutionTest} covers what an armed serializer then
+ * admits.
+ */
+class RowDataStateSchemaEvolutionArmingTest {
+
+    /**
+     * Mirrors {@code ExecutionConfigOptions.TABLE_EXEC_STATE_SCHEMA_EVOLUTION_ENABLED}, which lives
+     * in a module this one cannot depend on.
+     */
+    private static final ConfigOption<Boolean> STATE_SCHEMA_EVOLUTION_ENABLED =
+            ConfigOptions.key("table.exec.state.schema-evolution.enabled")
+                    .booleanType()
+                    .defaultValue(false);
+
+    private static final RowType ROW_TYPE =
+            RowType.of(
+                    new LogicalType[] {new IntType(), new BigIntType()}, new String[] {"a", "b"});
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void intervalJoinShapedMapStateIsNotArmed() {
+        // MapState<Long, List<Tuple2<RowData, Boolean>>>, the shape the interval join registers.
+        ListTypeInfo<Tuple2<RowData, Boolean>> valueTypeInfo =
+                new ListTypeInfo<>(
+                        new TupleTypeInfo<Tuple2<RowData, Boolean>>(
+                                InternalTypeInfo.of(ROW_TYPE), Types.BOOLEAN));
+        MapStateDescriptor<Long, List<Tuple2<RowData, Boolean>>> descriptor =
+                new MapStateDescriptor<>("cache", Types.LONG, valueTypeInfo);
+
+        descriptor.initializeSerializerUnlessSet(armingFactory(true));
+
+        ListSerializer<Tuple2<RowData, Boolean>> listSerializer =
+                (ListSerializer<Tuple2<RowData, Boolean>>) descriptor.getValueSerializer();
+        TupleSerializer<Tuple2<RowData, Boolean>> tupleSerializer =
+                (TupleSerializer<Tuple2<RowData, Boolean>>) listSerializer.getElementSerializer();
+        TypeSerializer<?> nestedField = tupleSerializer.getFieldSerializers()[0];
+        RowDataSerializer nested = (RowDataSerializer) nestedField;
+
+        // The job opted in, so the nested serializer carries the opt-in bit; what it must not carry
+        // is the state bit, because nothing will call migrate on a serializer two levels down.
+        assertThat(nested.isSchemaEvolutionAllowed()).isTrue();
+        assertThat(nested.isStateSchemaEvolutionEnabled()).isFalse();
+
+        RowType priorRowType = RowType.of(new LogicalType[] {new IntType()}, new String[] {"a"});
+        RowDataSerializerSnapshot nestedSnapshot =
+                (RowDataSerializerSnapshot) nested.snapshotConfiguration();
+        RowDataSerializerSnapshot priorSnapshot =
+                (RowDataSerializerSnapshot)
+                        InternalSerializers.create(priorRowType).snapshotConfiguration();
+
+        assertThat(nestedSnapshot.resolveSchemaCompatibility(priorSnapshot).isIncompatible())
+                .isTrue();
+    }
+
+    @Test
+    void valueStateIsArmed() {
+        ValueStateDescriptor<RowData> descriptor =
+                new ValueStateDescriptor<>("value", InternalTypeInfo.of(ROW_TYPE));
+
+        descriptor.initializeSerializerUnlessSet(armingFactory(true));
+
+        assertThat(((RowDataSerializer) descriptor.getSerializer()).isStateSchemaEvolutionEnabled())
+                .isTrue();
+    }
+
+    @Test
+    void valueStateIsNotArmedWhenTheOptionIsOff() {
+        ValueStateDescriptor<RowData> descriptor =
+                new ValueStateDescriptor<>("value", InternalTypeInfo.of(ROW_TYPE));
+
+        descriptor.initializeSerializerUnlessSet(armingFactory(false));
+
+        assertThat(((RowDataSerializer) descriptor.getSerializer()).isStateSchemaEvolutionEnabled())
+                .isFalse();
+    }
+
+    @Test
+    void listStateElementIsNotArmed() {
+        ListStateDescriptor<RowData> descriptor =
+                new ListStateDescriptor<>("list", InternalTypeInfo.of(ROW_TYPE));
+
+        descriptor.initializeSerializerUnlessSet(armingFactory(true));
+
+        assertThat(
+                        ((RowDataSerializer) descriptor.getElementSerializer())
+                                .isStateSchemaEvolutionEnabled())
+                .isFalse();
+    }
+
+    private static SerializerFactory armingFactory(boolean schemaEvolutionEnabled) {
+        Configuration configuration = new Configuration();
+        configuration.set(STATE_SCHEMA_EVOLUTION_ENABLED, schemaEvolutionEnabled);
+        SerializerConfig config = new SerializerConfigImpl(configuration);
+        return StateSchemaEvolvingSerializer.arming(
+                new SerializerFactory() {
+                    @Override
+                    public <T> TypeSerializer<T> createSerializer(
+                            TypeInformation<T> typeInformation) {
+                        return typeInformation.createSerializer(config);
+                    }
+                });
+    }
+}


### PR DESCRIPTION

This is the third PR of the [FLIP-527](https://cwiki.apache.org/confluence/spaces/FLINK/pages/353601981/FLIP-527+State+Schema+Evolution+for+RowData) implementation, split into a stack of small, independently reviewable PRs under the umbrella issue [FLINK-37732](https://issues.apache.org/jira/browse/FLINK-37732). Landing order:

| Step | Sub-task | Scope |
|---|---|---|
| PR-1 | [FLINK-40296](https://issues.apache.org/jira/browse/FLINK-40296) | Object-level `migrate` hook on `TypeSerializerSnapshot` |
| PR-2 | [FLINK-40297](https://issues.apache.org/jira/browse/FLINK-40297) | Route TTL-aware value migration through the hook |
| **PR-3 (this PR)** | [FLINK-40298](https://issues.apache.org/jira/browse/FLINK-40298) | Opt-in name-based schema evolution for `RowData` |
| PR-4 | [FLINK-40299](https://issues.apache.org/jira/browse/FLINK-40299) | End-to-end state migration coverage on RocksDB |

Each PR depends on the one before it. This is where the feature becomes observable: PR-1 and PR-2 were behavior-neutral, because the hook added in PR-1 defaults to returning its argument and this PR adds the first override.

Because this branch is stacked, the diff here also contains the PR-1 and PR-2 commits. For the isolated diff of this step alone, weiqingy/flink#12 has the same head branch based on PR-2 instead of `master`. It is a reference only and is not for merge.

## What is the purpose of the change

Lets a `RowData` state value survive a backward-compatible schema change instead of failing the restore, behind a new opt-in option that defaults to off.

Compatibility becomes name based. When the field layouts differ but the difference is a supported backward-compatible change, `RowDataSerializerSnapshot.resolveSchemaCompatibility` returns `compatibleAfterMigration()` rather than `incompatible()`. Fields are matched by the names persisted by FLINK-40120. Added fields must be nullable; removed fields and changed leaf types are rejected; nested `ROW` fields are validated by recursion. The `migrate` override then remaps the row into the new layout, placing fields by name, null filling added fields, preserving the row kind, and recursing into nested `ROW` values.

The opt-in is carried as an in-memory, non-persisted flag on the serializer rather than as anything written into the snapshot, so nothing about the option reaches the snapshot format.

A snapshot written before field names were persisted carries no names. Rather than being rejected, it falls back to positional mapping, bounded to the one edit under which position is a stable identity: the old layout must be a prefix of the new one and every appended field must be nullable. Without names, an insertion in the middle is indistinguishable from a retype plus an append, and the two demand opposite migrations, so nothing broader can be admitted safely.

### Why the flag is set where it is

The flag is set only on a serializer that is a state's own value serializer, and only when the keyed state backend actually performs object-level value migration. Both halves are load-bearing, and together they are what makes the feature fail closed.

The governing invariant is that a serializer may carry the flag only if some backend will actually invoke `migrate` on that exact serializer. Where compatibility reports `compatibleAfterMigration` and nothing calls `migrate`, the backend accepts the restore and later writes the old binary layout back through a serializer of the new arity, which corrupts the value silently rather than failing.

Two consequences follow. First, a `RowData` serializer nested below a composite serializer, as in interval and outer join buffers, is never a state's own value serializer, so it never carries the flag and its state is rejected on restore rather than migrated. Second, `KeyedStateBackend` gains an `@Internal` capability method defaulting to `false`, which only the RocksDB backend overrides. The heap backend accepts `compatibleAfterMigration` and relies on the next checkpoint rewriting already deserialized objects, which is sound for schema-free objects but not for `RowData`, whose restored value is a `BinaryRowData` view over the old bytes. Operator state, broadcast state and the batch backend never invoke the hook either. All of them therefore leave the flag off and reject the restore.

Extending coverage to `ListState<RowData>` and `MapState<K, RowData>`, and propagating migration through composite serializers, is follow-up work.

## Brief change log

  - Add `table.exec.state.schema-evolution.enabled`, default `false`, and expose it to the serializer layer through `SerializerConfig`
  - Add an `@Internal` marker interface so a keyed state path can hand a serializer the opt-in without flink-core knowing about `RowData`
  - Add an `@Internal` `KeyedStateBackend` capability, default `false`, overridden only by the RocksDB backend, and arm the serializer only on that path
  - Remove five redundant serializer pre-initializations in `StreamingRuntimeContext`, which duplicated what `DefaultKeyedStateStore` does immediately afterwards with an equivalent factory
  - Implement name-based compatibility, the bounded positional fallback, and the `migrate` override in `RowDataSerializerSnapshot`

## Verifying this change

This change added tests and can be verified as follows:

  - Compatibility and migration matrix: nullable field added, NOT NULL field added, field dropped, fields reordered, leaf type changed, nested `ROW` evolved, `ARRAY<ROW>` changed
  - Same-typed reorder and rename: a reorder of two fields of the same type has an identical `LogicalType` array, so it is covered explicitly to confirm it is matched by name rather than accepted positionally
  - Positional fallback: a name-less prior snapshot migrates an appended nullable field, and is rejected for an appended NOT NULL field, a dropped field, and a field retyped mid-layout. An unchanged layout still resolves as compatible as is, so enabling the option on an older savepoint does not force a rewrite of state whose schema did not change.
  - Opt-in semantics: option off preserves today's behavior, the flag is not persisted across a snapshot write and read, and `duplicate()` carries it
  - Fail-closed: a state descriptor shaped like an interval join buffer does not arm the nested `RowData` serializer and an evolved schema is rejected, and a backend that does not perform object-level migration leaves the serializer unarmed
  - The option survives construction, `copy()` and `configure()`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes. `SerializerConfig` is `@PublicEvolving` and gains an `@Internal` `default` method, and `KeyedStateBackend` gains an `@Internal` `default` method. Both are source and binary compatible and no existing implementor needs to change. A new table option is added.
  - The serializers: yes
  - The runtime per-record code paths (performance sensitive): no, the added work is on the restore path. With the option off, the only added cost is a boolean check during compatibility resolution.
  - Anything that affects deployment or recovery: yes, it changes which restores are accepted when the option is enabled. With the option off, restore behavior is unchanged.
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? The generated execution config option page, plus JavaDocs. The prose documentation the FLIP calls for, covering which schema changes are supported versus rejected, is tracked separately and will follow.

## Notes for reviewers comparing this against the FLIP

Four points where the implementation is narrower than, or additional to, the approved design. Flagging them here rather than leaving them to be found.

  - **A new `@Internal` capability on `KeyedStateBackend`.** The FLIP does not describe one. It became necessary because the flag alone does not establish that anything will act on it: `HeapKeyedStateBackend` accepts `compatibleAfterMigration` and relies on the next checkpoint rewriting already-deserialized objects, which is correct for schema-free objects but not for `RowData`, whose restored value is a `BinaryRowData` view over the old bytes. Operator state, broadcast state and the batch backend accept it and never invoke the hook either. Rather than enumerate the backends that do not migrate, the capability states which one does.
  - **The positional fallback is bounded.** The FLIP authorises a fallback to position-based mapping for a name-less prior snapshot without constraining it. This restricts it to an append-only change: the old layout must be a prefix of the new one and every appended field must be nullable. Without names, an insertion in the middle is indistinguishable from a retype followed by an append, and the two require opposite migrations.
  - **Key serializers are not armed.** The FLIP says the flag is applied uniformly without distinguishing key from value serializers. Here it reaches value serializers only. The effect is the same, since `RowData` as a state key is out of scope either way.
  - **The option is exposed through `SerializerConfig`.** The FLIP notes that persisting field names unconditionally keeps the opt-in a table-layer concern and avoids plumbing configuration into the serialization layer. Reading the option still requires it to reach the layer that arms the serializer, so `SerializerConfig` gains an `@Internal` accessor mirroring the table option by key. Suggestions for a cleaner route are welcome.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: Claude Code (Opus 5)

---

