### PR TITLE
[FLINK-40199][python] Add generic DataFrame I/O methods

### DIFF
--- a/flink-python/docs/reference/pyflink.dataframe/io.rst
+++ b/flink-python/docs/reference/pyflink.dataframe/io.rst
@@ -16,17 +16,30 @@
     limitations under the License.
    ################################################################################
 
-==================
-PyFlink DataFrame
-==================
+==============
+Input / Output
+==============
 
-This page gives an overview of all public PyFlink DataFrame APIs.
+DataFrame I/O functions read from and write to external systems through Flink connectors.
+Connector-specific methods provide convenient interfaces for common systems, while generic
+methods expose the raw connector identifiers and string options used by Table connector factories.
 
-.. toctree::
-    :maxdepth: 1
+Readers
+-------
 
-    dataframe
-    creation
-    io
-    datatype
-    environment
+.. currentmodule:: pyflink.dataframe
+
+.. autosummary::
+    :toctree: api/
+
+    read_generic
+
+Writers
+-------
+
+.. currentmodule:: pyflink.dataframe
+
+.. autosummary::
+    :toctree: api/
+
+    DataFrame.write_generic

--- a/flink-python/pyflink/dataframe/__init__.py
+++ b/flink-python/pyflink/dataframe/__init__.py
@@ -46,6 +46,7 @@ from pyflink.dataframe.context import (
 )
 from pyflink.dataframe.dataframe import DataFrame, GroupedDataFrame, col, lit
 from pyflink.dataframe.datatype import DataType
+from pyflink.dataframe.io import read_generic
 
 __all__ = [
     "DataFrame",
@@ -55,6 +56,7 @@ __all__ = [
     "lit",
     "from_dict",
     "from_records",
+    "read_generic",
     "set_table_environment",
     "get_table_environment",
     "get_or_create_table_environment",

--- a/flink-python/pyflink/dataframe/dataframe.py
+++ b/flink-python/pyflink/dataframe/dataframe.py
@@ -434,6 +434,47 @@ class DataFrame:
         with self._table.execute().collect() as rows:
             return list(rows)
 
+    # ======================== I/O ========================
+
+    @PublicEvolving()
+    def write_generic(self, connector: str, *, options: Dict[str, str]) -> None:
+        """
+        Write this DataFrame using a connector and its raw Table connector options.
+
+        The connector must be available through Flink's factory discovery mechanism. The write is
+        submitted immediately and waits for completion when using local or MiniCluster execution.
+        Sink columns are derived from this DataFrame's output schema.
+
+        :param connector: Factory identifier used as the ``connector`` Table option.
+        :param options: Connector options, excluding the reserved ``connector`` option.
+        :raises TypeError: If an argument has an invalid type.
+        :raises ValueError: If the connector or an option key is empty, or if ``options`` contains
+            the reserved ``connector`` key.
+
+        Example::
+
+            >>> import pyflink.dataframe as pf
+            >>> events = pf.from_records([(1, "login")], schema=["id", "event"])
+            >>> events.write_generic(
+            ...     "filesystem",
+            ...     options={
+            ...         "path": "file:///tmp/events",
+            ...         "format": "csv",
+            ...     },
+            ... )
+
+        .. versionadded:: 2.4.0
+        """
+        from pyflink.dataframe.io import _build_generic_descriptor
+
+        descriptor = _build_generic_descriptor(connector, options)
+        result = self._table.execute_insert(descriptor)
+        execution_target = self._table._t_env.get_config().get(
+            "execution.target", None
+        )
+        if execution_target in ("local", "minicluster"):
+            result.wait()
+
 
 @PublicEvolving()
 class GroupedDataFrame:

--- a/flink-python/pyflink/dataframe/io.py
+++ b/flink-python/pyflink/dataframe/io.py
@@ -1,0 +1,192 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+from typing import Dict, Optional, Tuple
+
+from pyflink.dataframe.context import get_or_create_table_environment
+from pyflink.dataframe.dataframe import DataFrame
+from pyflink.dataframe.datatype import DataType
+from pyflink.table import Schema, TableDescriptor
+from pyflink.util.api_stability_decorators import PublicEvolving
+
+__all__ = ["read_generic"]
+
+
+def _validate_connector(connector: str) -> None:
+    if not isinstance(connector, str):
+        raise TypeError("connector must be a string")
+    if not connector:
+        raise ValueError("connector must not be empty")
+
+
+def _validate_options(options: Dict[str, str]) -> None:
+    if not isinstance(options, dict):
+        raise TypeError("options must be a dict of string keys and values")
+    for key, value in options.items():
+        if not isinstance(key, str):
+            raise TypeError("option keys must be strings")
+        if not key:
+            raise ValueError("option keys must not be empty")
+        if key == "connector":
+            raise ValueError(
+                "connector must be specified with the connector argument, not in options"
+            )
+        if not isinstance(value, str):
+            raise TypeError(f"option {key!r} must have a string value")
+
+
+def _validate_computed_columns(
+    computed_columns: Optional[Dict[str, str]], physical_columns: Dict[str, DataType]
+) -> Dict[str, str]:
+    if computed_columns is None:
+        return {}
+    if not isinstance(computed_columns, dict):
+        raise TypeError("computed_columns must be a dict of string keys and values")
+
+    validated_columns: Dict[str, str] = {}
+    for name, expression in computed_columns.items():
+        if not isinstance(name, str):
+            raise TypeError("computed column names must be strings")
+        if not name:
+            raise ValueError("computed column names must not be empty")
+        if name in physical_columns:
+            raise ValueError(
+                f"computed column {name!r} conflicts with a physical column"
+            )
+        if not isinstance(expression, str):
+            raise TypeError(f"computed column {name!r} must use a string expression")
+        if not expression:
+            raise ValueError(
+                f"computed column {name!r} expression must not be empty"
+            )
+        validated_columns[name] = expression
+    return validated_columns
+
+
+def _validate_watermark(
+    watermark: Optional[Tuple[str, str]],
+) -> Optional[Tuple[str, str]]:
+    if watermark is None:
+        return None
+    if not isinstance(watermark, tuple) or len(watermark) != 2:
+        raise TypeError("watermark must be a tuple of (column, expression)")
+    if any(not isinstance(value, str) for value in watermark):
+        raise TypeError("watermark column and expression must be strings")
+    if any(not value for value in watermark):
+        raise ValueError("watermark column and expression must not be empty")
+    return watermark
+
+
+def _build_source_schema(
+    schema: Dict[str, DataType],
+    computed_columns: Optional[Dict[str, str]],
+    watermark: Optional[Tuple[str, str]],
+) -> Schema:
+    if not isinstance(schema, dict):
+        raise TypeError("schema must be a dict of column names and DataType values")
+    if not schema:
+        raise ValueError("schema must not be empty")
+
+    schema_builder = Schema.new_builder()
+    for name, data_type in schema.items():
+        if not isinstance(name, str):
+            raise TypeError("schema column names must be strings")
+        if not name:
+            raise ValueError("schema column names must not be empty")
+        if not isinstance(data_type, DataType):
+            raise TypeError(f"schema column {name!r} must use a DataType value")
+        schema_builder.column(name, data_type._to_table_data_type())
+
+    for name, expression in _validate_computed_columns(
+        computed_columns, schema
+    ).items():
+        schema_builder.column_by_expression(name, expression)
+
+    validated_watermark = _validate_watermark(watermark)
+    if validated_watermark is not None:
+        schema_builder.watermark(*validated_watermark)
+
+    return schema_builder.build()
+
+
+def _build_generic_descriptor(
+    connector: str,
+    options: Dict[str, str],
+    schema: Optional[Schema] = None,
+) -> TableDescriptor:
+    _validate_connector(connector)
+    _validate_options(options)
+
+    descriptor_builder = TableDescriptor.for_connector(connector)
+    if schema is not None:
+        descriptor_builder.schema(schema)
+    for key, value in options.items():
+        descriptor_builder.option(key, value)
+    return descriptor_builder.build()
+
+
+@PublicEvolving()
+def read_generic(
+    connector: str,
+    *,
+    schema: Dict[str, DataType],
+    options: Dict[str, str],
+    computed_columns: Optional[Dict[str, str]] = None,
+    watermark: Optional[Tuple[str, str]] = None,
+) -> DataFrame:
+    """
+    Read data from a connector using its raw Table connector options.
+
+    The connector must be available through Flink's factory discovery mechanism. Physical columns
+    are followed by computed columns in dictionary insertion order. A watermark can reference a
+    physical or computed timestamp column.
+
+    :param connector: Factory identifier used as the ``connector`` Table option.
+    :param schema: Non-empty mapping of physical column names to DataFrame data types.
+    :param options: Connector options, excluding the reserved ``connector`` option.
+    :param computed_columns: Optional SQL expressions keyed by computed column name.
+    :param watermark: Optional ``(column, expression)`` watermark declaration.
+    :return: A DataFrame backed by the configured source.
+    :raises TypeError: If an argument has an invalid type.
+    :raises ValueError: If a connector, schema, option key, computed column, or watermark value is
+        empty, or if a computed column conflicts with a physical column.
+
+    Example::
+
+        >>> import pyflink.dataframe as pf
+        >>> events = pf.read_generic(
+        ...     "filesystem",
+        ...     schema={
+        ...         "id": pf.DataType.int64(),
+        ...         "ts_millis": pf.DataType.int64(),
+        ...     },
+        ...     options={"path": "file:///tmp/events", "format": "csv"},
+        ...     computed_columns={
+        ...         "event_time": "TO_TIMESTAMP_LTZ(ts_millis, 3)"
+        ...     },
+        ...     watermark=(
+        ...         "event_time", "event_time - INTERVAL '5' SECOND"
+        ...     ),
+        ... )
+
+    .. versionadded:: 2.4.0
+    """
+    source_schema = _build_source_schema(schema, computed_columns, watermark)
+    descriptor = _build_generic_descriptor(connector, options, source_schema)
+    table_environment = get_or_create_table_environment()
+    return DataFrame(table_environment.from_descriptor(descriptor))

--- a/flink-python/pyflink/dataframe/tests/test_io.py
+++ b/flink-python/pyflink/dataframe/tests/test_io.py
@@ -1,0 +1,311 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+import os
+import unittest
+from unittest.mock import MagicMock, patch
+
+import pyflink.dataframe as pf
+from pyflink.dataframe import DataType
+from pyflink.testing.test_case_utils import (
+    PyFlinkDataFrameUTTestCase,
+    PyFlinkStreamDataFrameTestCase,
+)
+
+
+class GenericIOTests(PyFlinkDataFrameUTTestCase):
+    _SCHEMA = {"id": DataType.int64(), "name": DataType.string()}
+
+    def test_read_generic_builds_source_descriptor(self):
+        with patch.object(
+            self.t_env,
+            "from_descriptor",
+            wraps=self.t_env.from_descriptor,
+        ) as from_descriptor:
+            dataframe = pf.read_generic(
+                "datagen",
+                schema={
+                    "id": DataType.int64(),
+                    "ts_millis": DataType.int64(),
+                },
+                options={"number-of-rows": "1"},
+                computed_columns={
+                    "event_time": "TO_TIMESTAMP_LTZ(ts_millis, 3)"
+                },
+                watermark=(
+                    "event_time",
+                    "event_time - INTERVAL '5' SECOND",
+                ),
+            )
+
+        descriptor = from_descriptor.call_args.args[0]
+        self.assertEqual(descriptor.get_options().get("connector"), "datagen")
+        self.assertEqual(descriptor.get_options().get("number-of-rows"), "1")
+        self.assert_dataframe_schema(
+            dataframe,
+            ["id", "ts_millis", "event_time"],
+        )
+        watermark_specs = dataframe._table.get_resolved_schema().get_watermark_specs()
+        self.assertEqual(len(watermark_specs), 1)
+        self.assertEqual(
+            watermark_specs[0].get_rowtime_attribute(), "event_time"
+        )
+
+    def test_read_generic_rejects_invalid_arguments(self):
+        cases = [
+            (
+                "connector type",
+                {"connector": None},
+                TypeError,
+                "connector must be a string",
+            ),
+            (
+                "empty connector",
+                {"connector": ""},
+                ValueError,
+                "connector must not be empty",
+            ),
+            (
+                "schema type",
+                {"schema": []},
+                TypeError,
+                "schema must be a dict",
+            ),
+            (
+                "empty schema",
+                {"schema": {}},
+                ValueError,
+                "schema must not be empty",
+            ),
+            (
+                "schema name",
+                {"schema": {1: DataType.int64()}},
+                TypeError,
+                "schema column names must be strings",
+            ),
+            (
+                "empty schema name",
+                {"schema": {"": DataType.int64()}},
+                ValueError,
+                "schema column names must not be empty",
+            ),
+            (
+                "schema data type",
+                {"schema": {"id": object()}},
+                TypeError,
+                "must use a DataType value",
+            ),
+            (
+                "options type",
+                {"options": []},
+                TypeError,
+                "options must be a dict",
+            ),
+            (
+                "option name",
+                {"options": {"": "value"}},
+                ValueError,
+                "option keys must not be empty",
+            ),
+            (
+                "option key type",
+                {"options": {1: "value"}},
+                TypeError,
+                "option keys must be strings",
+            ),
+            (
+                "reserved connector option",
+                {"options": {"connector": "filesystem"}},
+                ValueError,
+                "connector argument",
+            ),
+            (
+                "option value",
+                {"options": {"rows": 1}},
+                TypeError,
+                "must have a string value",
+            ),
+            (
+                "computed columns type",
+                {"computed_columns": []},
+                TypeError,
+                "computed_columns must be a dict",
+            ),
+            (
+                "duplicate computed column",
+                {"computed_columns": {"id": "id + 1"}},
+                ValueError,
+                "conflicts with a physical column",
+            ),
+            (
+                "computed column name type",
+                {"computed_columns": {1: "id + 1"}},
+                TypeError,
+                "computed column names must be strings",
+            ),
+            (
+                "empty computed column name",
+                {"computed_columns": {"": "id + 1"}},
+                ValueError,
+                "computed column names must not be empty",
+            ),
+            (
+                "computed expression type",
+                {"computed_columns": {"computed": 1}},
+                TypeError,
+                "must use a string expression",
+            ),
+            (
+                "empty computed expression",
+                {"computed_columns": {"computed": ""}},
+                ValueError,
+                "expression must not be empty",
+            ),
+            (
+                "watermark shape",
+                {"watermark": ("id",)},
+                TypeError,
+                "watermark must be a tuple",
+            ),
+            (
+                "watermark type",
+                {"watermark": ("id", 1)},
+                TypeError,
+                "watermark column and expression must be strings",
+            ),
+            (
+                "watermark value",
+                {"watermark": ("", "id")},
+                ValueError,
+                "must not be empty",
+            ),
+        ]
+
+        for name, overrides, error_type, message in cases:
+            with self.subTest(name=name):
+                arguments = {
+                    "connector": "datagen",
+                    "schema": self._SCHEMA,
+                    "options": {},
+                }
+                arguments.update(overrides)
+                with self.assertRaisesRegex(error_type, message):
+                    pf.read_generic(**arguments)
+
+    def test_write_generic_builds_sink_descriptor(self):
+        dataframe = pf.from_records([(1, "a")], schema=["id", "name"])
+
+        with patch.object(dataframe._table, "execute_insert") as execute_insert:
+            execute_insert.return_value = MagicMock()
+            result = dataframe.write_generic(
+                "blackhole", options={"sink.parallelism": "1"}
+            )
+
+        descriptor = execute_insert.call_args.args[0]
+        self.assertIsNone(result)
+        self.assertIsNone(descriptor.get_schema())
+        self.assertEqual(descriptor.get_options().get("connector"), "blackhole")
+        self.assertEqual(descriptor.get_options().get("sink.parallelism"), "1")
+
+    def test_write_generic_waits_for_local_and_minicluster_execution(self):
+        dataframe = pf.from_records([(1,)], schema=["id"])
+
+        for execution_target, waits in [
+            ("local", True),
+            ("minicluster", True),
+            ("remote", False),
+        ]:
+            with self.subTest(execution_target=execution_target):
+                table_result = MagicMock()
+                table_config = MagicMock()
+                table_config.get.return_value = execution_target
+                with patch.object(
+                    dataframe._table,
+                    "execute_insert",
+                    return_value=table_result,
+                ), patch.object(
+                    dataframe._table._t_env,
+                    "get_config",
+                    return_value=table_config,
+                ):
+                    dataframe.write_generic("blackhole", options={})
+
+                if waits:
+                    table_result.wait.assert_called_once_with()
+                else:
+                    table_result.wait.assert_not_called()
+
+    def test_write_generic_uses_shared_validation(self):
+        dataframe = pf.from_records([(1,)], schema=["id"])
+        cases = [
+            (None, {}, TypeError, "connector must be a string"),
+            ("", {}, ValueError, "connector must not be empty"),
+            ("blackhole", [], TypeError, "options must be a dict"),
+            (
+                "blackhole",
+                {"connector": "filesystem"},
+                ValueError,
+                "connector argument",
+            ),
+            (
+                "blackhole",
+                {"sink.parallelism": 1},
+                TypeError,
+                "must have a string value",
+            ),
+        ]
+
+        for connector, options, error_type, message in cases:
+            with self.subTest(connector=connector, options=options):
+                with self.assertRaisesRegex(error_type, message):
+                    dataframe.write_generic(connector, options=options)
+
+
+class GenericIOITTests(PyFlinkStreamDataFrameTestCase):
+    def test_filesystem_csv_round_trip(self):
+        input_path = os.path.join(self.tempdir, "input.csv")
+        with open(input_path, "w", encoding="utf-8") as input_file:
+            input_file.write("1,a\n2,b\n3,c\n")
+
+        source = pf.read_generic(
+            "filesystem",
+            schema={
+                "id": DataType.int64(),
+                "name": DataType.string(),
+            },
+            options={"path": input_path, "format": "csv"},
+        )
+
+        output_path = os.path.join(self.tempdir, "output")
+        source.write_generic(
+            "filesystem",
+            options={"path": output_path, "format": "csv"},
+        )
+
+        output_lines = []
+        for file_name in os.listdir(output_path):
+            file_path = os.path.join(output_path, file_name)
+            if os.path.isfile(file_path) and not file_name.startswith((".", "_")):
+                with open(file_path, encoding="utf-8") as output_file:
+                    output_lines.extend(line.rstrip("\n") for line in output_file)
+
+        self.assertEqual(sorted(output_lines), ["1,a", "2,b", "3,c"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What is the purpose of the change

This pull request implements the generic DataFrame connector I/O APIs proposed by [FLINK-40199](https://issues.apache.org/jira/browse/FLINK-40199). It allows PyFlink DataFrame users to read from and write to Table API connectors.

## Brief change log

  - Add the public evolving `pyflink.dataframe.read_generic` API with physical columns, computed columns, and watermark support.
  - Add the public evolving `DataFrame.write_generic` API, backed by eager `Table.execute_insert()` execution.
  - Share connector descriptor construction and validation between the read and write paths.
  - Add DataFrame I/O reference documentation and CSV filesystem examples.
  - Add compact unit coverage and one MiniCluster filesystem/CSV round-trip test.

## Verifying this change

This change added tests and can be verified as follows:

  - Ran `pyflink.dataframe.tests.test_io`, including descriptor/schema construction, shared argument validation, writer delegation and waiting behavior, and one filesystem/CSV MiniCluster round trip.
  - Ran the existing `pyflink.dataframe.tests.test_dataframe` suite.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? docs and API docstrings

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: Codex (GPT-5)
