### PR TITLE
[FLINK-40391][table] PTF with non default convertion-class of table arg might fail

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/TypeInferenceUtil.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/TypeInferenceUtil.java
@@ -505,7 +505,10 @@ public final class TypeInferenceUtil {
                                             final DataType actualType =
                                                     castCallContext.getArgumentDataTypes().get(pos);
                                             if (expectedType == null) {
-                                                return actualType;
+                                                return expectedArg
+                                                        .getConversionClass()
+                                                        .map(actualType::bridgedTo)
+                                                        .orElse(actualType);
                                             }
                                             if (!supportsImplicitCast(
                                                     actualType.getLogicalType(),

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/ProcessTableFunctionSemanticTests.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/ProcessTableFunctionSemanticTests.java
@@ -97,6 +97,7 @@ public class ProcessTableFunctionSemanticTests extends SemanticTestBase {
                 ProcessTableFunctionTestPrograms.PROCESS_ORDER_BY,
                 ProcessTableFunctionTestPrograms.PROCESS_MULTI_INPUT_ORDER_BY,
                 ProcessTableFunctionTestPrograms.PROCESS_ORDER_BY_TABLE_API,
-                ProcessTableFunctionTestPrograms.PROCESS_IMPLICIT_CASTS);
+                ProcessTableFunctionTestPrograms.PROCESS_IMPLICIT_CASTS,
+                ProcessTableFunctionTestPrograms.PROCESS_ROW_DATA_CONVERSION_TABLE);
     }
 }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/ProcessTableFunctionTestPrograms.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/ProcessTableFunctionTestPrograms.java
@@ -52,6 +52,7 @@ import org.apache.flink.table.planner.plan.nodes.exec.stream.ProcessTableFunctio
 import org.apache.flink.table.planner.plan.nodes.exec.stream.ProcessTableFunctionTestUtils.PojoStateTimeFunction;
 import org.apache.flink.table.planner.plan.nodes.exec.stream.ProcessTableFunctionTestUtils.PojoWithDefaultStateFunction;
 import org.apache.flink.table.planner.plan.nodes.exec.stream.ProcessTableFunctionTestUtils.RequiredTimeFunction;
+import org.apache.flink.table.planner.plan.nodes.exec.stream.ProcessTableFunctionTestUtils.RowDataRowSemanticTableFunction;
 import org.apache.flink.table.planner.plan.nodes.exec.stream.ProcessTableFunctionTestUtils.RowSemanticTableFunction;
 import org.apache.flink.table.planner.plan.nodes.exec.stream.ProcessTableFunctionTestUtils.RowSemanticTablePassThroughFunction;
 import org.apache.flink.table.planner.plan.nodes.exec.stream.ProcessTableFunctionTestUtils.ScalarArgsFunction;
@@ -2042,5 +2043,19 @@ public class ProcessTableFunctionTestPrograms {
                     .runSql(
                             "INSERT INTO sink SELECT * FROM f("
                                     + "r => TABLE v PARTITION BY (suite_name, test_name) ORDER BY (window_time ASC, c DESC), i => 1)")
+                    .build();
+
+    public static final TableTestProgram PROCESS_ROW_DATA_CONVERSION_TABLE =
+            TableTestProgram.of(
+                            "process-row-data-conversion",
+                            "table argument with a non-default RowData conversion class")
+                    .setupTemporarySystemFunction("f", RowDataRowSemanticTableFunction.class)
+                    .setupSql(BASIC_VALUES)
+                    .setupTableSink(
+                            SinkTestStep.newBuilder("sink")
+                                    .addSchema(BASE_SINK_SCHEMA)
+                                    .consumedValues("+I[{Hello Bob!}]", "+I[{Hello Alice!}]")
+                                    .build())
+                    .runSql("INSERT INTO sink SELECT * FROM f(input => TABLE t)")
                     .build();
 }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/ProcessTableFunctionTestUtils.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/ProcessTableFunctionTestUtils.java
@@ -1195,26 +1195,7 @@ public class ProcessTableFunctionTestUtils {
      * RowData} instead of {@link Row}.
      */
     public static class RowDataRowSemanticTableFunction extends AppendProcessTableFunctionBase {
-        public TypeInference getTypeInference(DataTypeFactory typeFactory) {
-            return TypeInference.newBuilder()
-                    .staticArguments(
-                            StaticArgument.table(
-                                    "input",
-                                    RowData.class,
-                                    false,
-                                    EnumSet.of(StaticArgumentTrait.ROW_SEMANTIC_TABLE)))
-                    .outputTypeStrategy(
-                            callContext ->
-                                    Optional.of(
-                                            DataTypes.ROW(
-                                                            DataTypes.FIELD(
-                                                                    "out",
-                                                                    DataTypes.STRING().notNull()))
-                                                    .notNull()))
-                    .build();
-        }
-
-        public void eval(RowData input) {
+        public void eval(@ArgumentHint(ROW_SEMANTIC_TABLE) RowData input) {
             collectObjects("Hello " + input.getString(0) + "!");
         }
     }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/ProcessTableFunctionTestUtils.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/ProcessTableFunctionTestUtils.java
@@ -29,6 +29,7 @@ import org.apache.flink.table.api.dataview.ListView;
 import org.apache.flink.table.api.dataview.MapView;
 import org.apache.flink.table.catalog.DataTypeFactory;
 import org.apache.flink.table.connector.ChangelogMode;
+import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.functions.ChangelogFunction;
 import org.apache.flink.table.functions.ProcessTableFunction;
 import org.apache.flink.table.functions.ScalarFunction;
@@ -1185,6 +1186,36 @@ public class ProcessTableFunctionTestUtils {
     public static class ImplicitCastingFunction extends AppendProcessTableFunctionBase {
         public void eval(@ArgumentHint(ROW_SEMANTIC_TABLE) CastingPojo p, long b) {
             collectObjects(p, b);
+        }
+    }
+
+    /**
+     * Testing function whose table argument declares a non-default conversion class ({@link
+     * RowData}). The conversion class must be preserved so that {@code eval()} receives {@link
+     * RowData} instead of {@link Row}.
+     */
+    public static class RowDataRowSemanticTableFunction extends AppendProcessTableFunctionBase {
+        public TypeInference getTypeInference(DataTypeFactory typeFactory) {
+            return TypeInference.newBuilder()
+                    .staticArguments(
+                            StaticArgument.table(
+                                    "input",
+                                    RowData.class,
+                                    false,
+                                    EnumSet.of(StaticArgumentTrait.ROW_SEMANTIC_TABLE)))
+                    .outputTypeStrategy(
+                            callContext ->
+                                    Optional.of(
+                                            DataTypes.ROW(
+                                                            DataTypes.FIELD(
+                                                                    "out",
+                                                                    DataTypes.STRING().notNull()))
+                                                    .notNull()))
+                    .build();
+        }
+
+        public void eval(RowData input) {
+            collectObjects("Hello " + input.getString(0) + "!");
         }
     }
 

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/ProcessTableFunctionTestUtils.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/ProcessTableFunctionTestUtils.java
@@ -1189,11 +1189,7 @@ public class ProcessTableFunctionTestUtils {
         }
     }
 
-    /**
-     * Testing function whose table argument declares a non-default conversion class ({@link
-     * RowData}). The conversion class must be preserved so that {@code eval()} receives {@link
-     * RowData} instead of {@link Row}.
-     */
+    /** Testing function with non default conversion class. */
     public static class RowDataRowSemanticTableFunction extends AppendProcessTableFunctionBase {
         public void eval(@ArgumentHint(ROW_SEMANTIC_TABLE) RowData input) {
             collectObjects("Hello " + input.getString(0) + "!");


### PR DESCRIPTION

## What is the purpose of the change

The PR is going to fix case of PTF with non default conversion class of table arg, like in jira (also in test)


## Verifying this change

test added

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no )

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change the checkbox below to `[X]` and replace the placeholder in the "Generated-by"
line with the tool name and version. Otherwise remove the "Generated-by" line.
See the ASF Generative Tooling Guidance for details:
https://www.apache.org/legal/generative-tooling.html

You are responsible for the quality and correctness of every change in this PR
regardless of the tooling used. Low-effort AI-generated PRs will be closed. See
AGENTS.md for the full guidance.
-->

- [ ] Yes (please specify the tool below)

Generated-by: [Tool Name and Version]
