### PR TITLE
[FLINK-40368][table-planner] Fix deduplication changelog inference

### DIFF
--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/optimize/program/FlinkChangelogModeInferenceProgram.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/optimize/program/FlinkChangelogModeInferenceProgram.scala
@@ -291,7 +291,9 @@ class FlinkChangelogModeInferenceProgram extends FlinkOptimizeProgram[StreamOpti
 
         val providedTrait = {
           if (
-            insertOnly && RankUtil.outputInsertOnlyInDeduplicate(
+            insertOnly && RankUtil.sortOnTimeAttributeOnly(
+              rank.orderKey,
+              rank.getInput.getRowType) && RankUtil.outputInsertOnlyInDeduplicate(
               tableConfig,
               RankUtil.keepLastDeduplicateRow(rank.orderKey))
           ) {


### PR DESCRIPTION
## What is the purpose of the change

Streaming deduplication represented by a Top-1 Rank can be incorrectly inferred as INSERT_ONLY when its ORDER BY uses a non-time attribute or multiple columns. This can cause downstream operators to miss required updates and retractions. This change restricts INSERT_ONLY inference to the existing single-time-attribute case.

## Brief change log

- Gate deduplication INSERT_ONLY changelog inference with RankUtil.sortOnTimeAttributeOnly.
- Preserve ALL_CHANGES for non-time-attribute and multi-column ORDER BY keys.

## Verifying this change

- Existing plan regressions cover RankTest#testDeduplicateOnNonTimeAttributeGeneratesUpdates and RankTest#testDeduplicateOnMultipleColumnsGeneratesUpdates.
- flink-table-planner Spotless check passes.
- Full reactor compilation was not completed locally because the configured Maven repository could not resolve flink-core:tests:2.4-SNAPSHOT before reaching Table Planner.

## Does this pull request potentially affect one of the following parts:

- Dependencies: no
- Public API: no
- Serializers: no
- Runtime per-record code paths: no
- Deployment or recovery: no
- S3 file system connector: no

## Documentation

- New feature: no
- Documentation: not applicable

---

##### Was generative AI tooling used to co-author this PR?

- [x] Yes (Codex GPT-5)

Generated-by: Codex GPT-5