### PR TITLE
[FLINK-40387][s3] Add option to disable S3 SDK retry circuit breaker

### DIFF
--- a/flink-filesystems/flink-s3-fs-native/src/main/java/org/apache/flink/fs/s3native/NativeS3FileSystemFactory.java
+++ b/flink-filesystems/flink-s3-fs-native/src/main/java/org/apache/flink/fs/s3native/NativeS3FileSystemFactory.java
@@ -294,8 +294,7 @@ public class NativeS3FileSystemFactory implements FileSystemFactory {
                                     + "throttling (e.g. large incremental checkpoints), this bucket can drain "
                                     + "within seconds, causing retries to be abandoned well before the "
                                     + "configured backoff and retry count are exhausted. Disabled by default "
-                                    + "so the retry/backoff settings above fully govern retry behavior, "
-                                    + "matching the S3A plugin's behavior.");
+                                    + "so the retry/backoff settings above fully govern retry behavior.");
 
     public static final ConfigOption<Duration> CONNECTION_TIMEOUT =
             ConfigOptions.key("s3.connection.timeout")

--- a/flink-filesystems/flink-s3-fs-native/src/main/java/org/apache/flink/fs/s3native/NativeS3FileSystemFactory.java
+++ b/flink-filesystems/flink-s3-fs-native/src/main/java/org/apache/flink/fs/s3native/NativeS3FileSystemFactory.java
@@ -282,6 +282,21 @@ public class NativeS3FileSystemFactory implements FileSystemFactory {
                             "Maximum delay cap for exponential backoff, applied to both "
                                     + "normal and throttle retry paths.");
 
+    public static final ConfigOption<Boolean> RETRY_CIRCUIT_BREAKER_ENABLED =
+            ConfigOptions.key("s3.retry.circuit-breaker.enabled")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription(
+                            "Whether the AWS SDK's retry circuit breaker (token bucket) is enabled. "
+                                    + "The SDK stops retrying once a shared per-client token bucket is "
+                                    + "drained by recent failures, regardless of the retry/backoff settings "
+                                    + "above. Under a high volume of concurrent requests hitting S3 "
+                                    + "throttling (e.g. large incremental checkpoints), this bucket can drain "
+                                    + "within seconds, causing retries to be abandoned well before the "
+                                    + "configured backoff and retry count are exhausted. Disabled by default "
+                                    + "so the retry/backoff settings above fully govern retry behavior, "
+                                    + "matching the S3A plugin's behavior.");
+
     public static final ConfigOption<Duration> CONNECTION_TIMEOUT =
             ConfigOptions.key("s3.connection.timeout")
                     .durationType()
@@ -615,6 +630,7 @@ public class NativeS3FileSystemFactory implements FileSystemFactory {
                         .retryBaseDelay(config.get(RETRY_BASE_DELAY))
                         .retryThrottleBaseDelay(config.get(RETRY_THROTTLE_BASE_DELAY))
                         .retryMaxBackoff(config.get(RETRY_MAX_BACKOFF))
+                        .retryCircuitBreakerEnabled(config.get(RETRY_CIRCUIT_BREAKER_ENABLED))
                         .credentialsProviderClasses(credentialsProviderClasses)
                         .encryptionConfig(encryptionConfig)
                         .useCrt(crtEnabled);

--- a/flink-filesystems/flink-s3-fs-native/src/main/java/org/apache/flink/fs/s3native/S3ClientProvider.java
+++ b/flink-filesystems/flink-s3-fs-native/src/main/java/org/apache/flink/fs/s3native/S3ClientProvider.java
@@ -97,6 +97,7 @@ class S3ClientProvider implements AutoCloseableAsync {
     private final Duration retryBaseDelay;
     private final Duration retryThrottleBaseDelay;
     private final Duration retryMaxBackoff;
+    private final boolean retryCircuitBreakerEnabled;
     @Nullable private final String region;
     @Nullable private final String endpoint;
     @Nullable private final String assumeRoleArn;
@@ -129,6 +130,7 @@ class S3ClientProvider implements AutoCloseableAsync {
             Duration retryBaseDelay,
             Duration retryThrottleBaseDelay,
             Duration retryMaxBackoff,
+            boolean retryCircuitBreakerEnabled,
             @Nullable String region,
             @Nullable String endpoint,
             @Nullable String assumeRoleArn,
@@ -172,6 +174,7 @@ class S3ClientProvider implements AutoCloseableAsync {
                         retryThrottleBaseDelay, "retryThrottleBaseDelay must not be null");
         this.retryMaxBackoff =
                 Preconditions.checkNotNull(retryMaxBackoff, "retryMaxBackoff must not be null");
+        this.retryCircuitBreakerEnabled = retryCircuitBreakerEnabled;
         this.region = region;
         this.endpoint = endpoint;
         this.assumeRoleArn = assumeRoleArn;
@@ -268,6 +271,11 @@ class S3ClientProvider implements AutoCloseableAsync {
     @VisibleForTesting
     Duration getRetryMaxBackoff() {
         return retryMaxBackoff;
+    }
+
+    @VisibleForTesting
+    boolean isRetryCircuitBreakerEnabled() {
+        return retryCircuitBreakerEnabled;
     }
 
     @VisibleForTesting
@@ -427,6 +435,8 @@ class S3ClientProvider implements AutoCloseableAsync {
                 NativeS3FileSystemFactory.RETRY_THROTTLE_BASE_DELAY.defaultValue();
         private Duration retryMaxBackoff =
                 NativeS3FileSystemFactory.RETRY_MAX_BACKOFF.defaultValue();
+        private boolean retryCircuitBreakerEnabled =
+                NativeS3FileSystemFactory.RETRY_CIRCUIT_BREAKER_ENABLED.defaultValue();
         private Duration clientCloseTimeout =
                 NativeS3FileSystemFactory.CLIENT_CLOSE_TIMEOUT.defaultValue();
 
@@ -547,6 +557,11 @@ class S3ClientProvider implements AutoCloseableAsync {
                     "retryMaxBackoff must be positive, but was %s",
                     retryMaxBackoff);
             this.retryMaxBackoff = retryMaxBackoff;
+            return this;
+        }
+
+        public Builder retryCircuitBreakerEnabled(boolean retryCircuitBreakerEnabled) {
+            this.retryCircuitBreakerEnabled = retryCircuitBreakerEnabled;
             return this;
         }
 
@@ -671,6 +686,7 @@ class S3ClientProvider implements AutoCloseableAsync {
                                                     BackoffStrategy.exponentialDelay(
                                                             retryThrottleBaseDelay,
                                                             retryMaxBackoff))
+                                            .circuitBreakerEnabled(retryCircuitBreakerEnabled)
                                             .build())
                             .build();
 
@@ -711,6 +727,7 @@ class S3ClientProvider implements AutoCloseableAsync {
                     retryBaseDelay,
                     retryThrottleBaseDelay,
                     retryMaxBackoff,
+                    retryCircuitBreakerEnabled,
                     region,
                     endpoint,
                     assumeRoleArn,

--- a/flink-filesystems/flink-s3-fs-native/src/test/java/org/apache/flink/fs/s3native/NativeS3FileSystemFactoryTest.java
+++ b/flink-filesystems/flink-s3-fs-native/src/test/java/org/apache/flink/fs/s3native/NativeS3FileSystemFactoryTest.java
@@ -359,6 +359,19 @@ class NativeS3FileSystemFactoryTest {
                 .isEqualTo(Duration.ofSeconds(30));
     }
 
+    @Test
+    void testRetryCircuitBreakerEnabledDefault() throws Exception {
+        assertThat(createFs(baseConfig()).getClientProvider().isRetryCircuitBreakerEnabled())
+                .isEqualTo(NativeS3FileSystemFactory.RETRY_CIRCUIT_BREAKER_ENABLED.defaultValue());
+    }
+
+    @Test
+    void testRetryCircuitBreakerEnabledExplicitlyConfigured() throws Exception {
+        Configuration config = baseConfig();
+        config.set(NativeS3FileSystemFactory.RETRY_CIRCUIT_BREAKER_ENABLED, true);
+        assertThat(createFs(config).getClientProvider().isRetryCircuitBreakerEnabled()).isTrue();
+    }
+
     // --- Timeouts ---
 
     @Test

--- a/flink-filesystems/flink-s3-fs-native/src/test/java/org/apache/flink/fs/s3native/S3ClientProviderTest.java
+++ b/flink-filesystems/flink-s3-fs-native/src/test/java/org/apache/flink/fs/s3native/S3ClientProviderTest.java
@@ -237,6 +237,20 @@ class S3ClientProviderTest {
                 .isEqualTo(NativeS3FileSystemFactory.RETRY_THROTTLE_BASE_DELAY.defaultValue());
         assertThat(provider.getRetryMaxBackoff())
                 .isEqualTo(NativeS3FileSystemFactory.RETRY_MAX_BACKOFF.defaultValue());
+        assertThat(provider.isRetryCircuitBreakerEnabled())
+                .isEqualTo(NativeS3FileSystemFactory.RETRY_CIRCUIT_BREAKER_ENABLED.defaultValue());
+    }
+
+    @Test
+    void testRetryCircuitBreakerEnabledOverride() {
+        S3ClientProvider provider =
+                S3ClientProvider.builder()
+                        .endpoint(DUMMY_ENDPOINT)
+                        .region(DUMMY_REGION)
+                        .retryCircuitBreakerEnabled(true)
+                        .build();
+
+        assertThat(provider.isRetryCircuitBreakerEnabled()).isTrue();
     }
 
     @Test


### PR DESCRIPTION
## What is the purpose of the change

The AWS SDK v2 `StandardRetryStrategy` used by `flink-s3-fs-native` enables a token-bucket circuit breaker by default. Under a high volume of concurrent S3 requests hitting throttling (e.g. `getFileStatus`/`headObject` calls during a large incremental checkpoint), this shared bucket can drain within seconds, causing the SDK to abandon retries entirely and fail fast — regardless of the configured `s3.retry.max-num-retries` and backoff settings. This differs from the `flink-s3-fs-hadoop` (S3A) plugin's behavior, which keeps retrying/backing off through throttling. This pull request adds a config option to disable the circuit breaker so the configured retry/backoff settings fully govern retry behavior, restoring S3A-like behavior by default.

## Brief change log

  - Added `s3.retry.circuit-breaker.enabled` config option to `NativeS3FileSystemFactory`, defaulting to `false`
  - Wired the option through `S3ClientProvider.Builder` into `StandardRetryStrategy.Builder#circuitBreakerEnabled(...)`
  - Added a `@VisibleForTesting` getter on `S3ClientProvider` for the new setting

## Verifying this change

This change added tests and can be verified as follows:

  - Added `testRetryCircuitBreakerEnabledOverride` and extended `testRetryBuilderDefaultsMatchConfigOptions` in `S3ClientProviderTest` to verify the builder default and explicit override
  - Added `testRetryCircuitBreakerEnabledDefault` and `testRetryCircuitBreakerEnabledExplicitlyConfigured` in `NativeS3FileSystemFactoryTest` to verify the config option is correctly read and wired through the filesystem factory

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: yes, improves checkpoint reliability against S3 throttling for `flink-s3-fs-native`
  - The S3 file system connector: yes

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? JavaDocs / config option description (`s3.retry.circuit-breaker.enabled`)

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)
Claude code