### PR TITLE
[FLINK-40410][table-planner] Exclude VARIANT from constant folding

### DIFF
--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/ExpressionReducer.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/ExpressionReducer.scala
@@ -274,7 +274,7 @@ class ExpressionReducer(
         // we don't support object literals yet, we skip those constant expressions
         case (SqlTypeName.ANY, _) | (SqlTypeName.OTHER, _) | (SqlTypeName.ROW, _) |
             (SqlTypeName.STRUCTURED, _) | (SqlTypeName.ARRAY, _) | (SqlTypeName.MAP, _) |
-            (SqlTypeName.MULTISET, _) =>
+            (SqlTypeName.MULTISET, _) | (SqlTypeName.VARIANT, _) =>
           None
 
         case (_, call: RexCall) => {

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/JsonFunctionsITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/JsonFunctionsITCase.java
@@ -1038,10 +1038,6 @@ class JsonFunctionsITCase extends BuiltInFunctionTestBase {
                                 "JSON_STRING(TRY_PARSE_JSON(f1))",
                                 null,
                                 STRING()),
-                // Regression test for FLINK-40410: PARSE_JSON(f0) (VARIANT) precedes
-                // JSON_STRING(PARSE_JSON(f0)) (STRING) in a constant-folded projection. VARIANT
-                // is excluded from folding in ExpressionReducer, like ROW/ARRAY/MAP, and
-                // evaluated normally at runtime.
                 TestSetSpec.forFunction(
                                 BuiltInFunctionDefinitions.PARSE_JSON,
                                 "VARIANT expression preceding another expression in a"

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/JsonFunctionsITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/JsonFunctionsITCase.java
@@ -31,6 +31,8 @@ import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
 import org.apache.flink.table.functions.ScalarFunction;
 import org.apache.flink.types.Row;
+import org.apache.flink.types.variant.BinaryVariantInternalBuilder;
+import org.apache.flink.types.variant.Variant;
 
 import org.apache.commons.io.IOUtils;
 
@@ -62,6 +64,7 @@ import static org.apache.flink.table.api.DataTypes.STRING;
 import static org.apache.flink.table.api.DataTypes.TIMESTAMP;
 import static org.apache.flink.table.api.DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE;
 import static org.apache.flink.table.api.DataTypes.VARBINARY;
+import static org.apache.flink.table.api.DataTypes.VARIANT;
 import static org.apache.flink.table.api.Expressions.$;
 import static org.apache.flink.table.api.Expressions.call;
 import static org.apache.flink.table.api.Expressions.json;
@@ -1034,7 +1037,35 @@ class JsonFunctionsITCase extends BuiltInFunctionTestBase {
                                 jsonString(call("TRY_PARSE_JSON", $("f1"))),
                                 "JSON_STRING(TRY_PARSE_JSON(f1))",
                                 null,
-                                STRING()));
+                                STRING()),
+                // Regression test for FLINK-40410: PARSE_JSON(f0) (VARIANT) precedes
+                // JSON_STRING(PARSE_JSON(f0)) (STRING) in a constant-folded projection. VARIANT
+                // is excluded from folding in ExpressionReducer, like ROW/ARRAY/MAP, and
+                // evaluated normally at runtime.
+                TestSetSpec.forFunction(
+                                BuiltInFunctionDefinitions.PARSE_JSON,
+                                "VARIANT expression preceding another expression in a"
+                                        + " constant-folded projection")
+                        .onFieldsWithData("{\"a\": 1}")
+                        .andDataTypes(STRING().notNull())
+                        .withConstantFoldingEnabled()
+                        .testResult(
+                                resultSpec(
+                                        call("PARSE_JSON", $("f0")),
+                                        "PARSE_JSON(f0)",
+                                        getVariantForJson("{\"a\": 1}"),
+                                        VARIANT().notNull(),
+                                        VARIANT().notNull()),
+                                resultSpec(
+                                        jsonString(call("PARSE_JSON", $("f0"))),
+                                        "JSON_STRING(PARSE_JSON(f0))",
+                                        "{\"a\":1}",
+                                        STRING().notNull(),
+                                        STRING().notNull()))
+                        .testSqlResult(
+                                "PARSE_JSON(f0), JSON_STRING(PARSE_JSON(f0))",
+                                List.of(getVariantForJson("{\"a\": 1}"), "{\"a\":1}"),
+                                List.of(VARIANT().notNull(), STRING().notNull())));
     }
 
     private static List<TestSetSpec> jsonSpec() {
@@ -2238,6 +2269,14 @@ class JsonFunctionsITCase extends BuiltInFunctionTestBase {
 
         try {
             return IOUtils.toString(jsonResource, Charset.defaultCharset());
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static Variant getVariantForJson(String json) {
+        try {
+            return BinaryVariantInternalBuilder.parseJson(json, false);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
## What is the purpose of the change

This pull request excludes the VARIANT data type from constant folding VARIANT expressions. This previously resulted in a `ClassCastException` when running a query such as the following, where a constant expression followed a VARIANT expression in the projection. 
```sql
SELECT PARSE_JSON('{}'), JSON_STRING(PARSE_JSON('{}'));
```

The `ExpressionReducer.scala` in `flink-table-planner` evaluates constant sub-expressions, so they get computed during compile-time and not during query run-time. It runs in two passes that must agree on which types get a slot in the intermediate (compile-time) result:

- **Phase 1** excludes unsupported "object literal" types (ROW/ARRAY/MAP/MULTISET/...) from compile-time evaluation. **VARIANT** was previously missing from this list and was therefore evaluated at compile-time and added to the intermediate result list.
- **Phase 2** has an specific case for VARIANT and treats VARIANT as excluded from compile-time evaluation. So a VARIANT constant gets evaluated and occupies a real slot in phase 1, but phase 2 doesn't know that and never advances its slot index. Then the next reduced expression reads the stale slot containing the VARIANT data and crashes on the bad cast.


## Brief change log

  - Adds **VARIANT** to the exclude list of data types that use constant folding

## Verifying this change

This change added tests and can be verified as follows:

  - Added test in `JsonFunctionsITCase.java` for VARIANT, where constant folding is enabled
 
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change the checkbox below to `[X]` and replace the placeholder in the "Generated-by"
line with the tool name and version. Otherwise remove the "Generated-by" line.
See the ASF Generative Tooling Guidance for details:
https://www.apache.org/legal/generative-tooling.html

You are responsible for the quality and correctness of every change in this PR
regardless of the tooling used. Low-effort AI-generated PRs will be closed. See
AGENTS.md for the full guidance.
-->

- [x] Yes (please specify the tool below)

Generated-by: Claude Sonnet 5
