### PR TITLE
[FLINK-40415][python] Fix Python 3.9 dependency conflict of grpcio-tools

### DIFF
--- a/flink-python/pyflink/fn_execution/tests/test_flink_fn_execution_pb2.py
+++ b/flink-python/pyflink/fn_execution/tests/test_flink_fn_execution_pb2.py
@@ -17,6 +17,8 @@
 ################################################################################
 import filecmp
 import os
+import sys
+import unittest
 
 from pyflink.gen_protos import generate_proto_files
 from pyflink.testing.test_case_utils import PyFlinkTestCase
@@ -41,6 +43,11 @@ class FlinkFnExecutionTests(PyFlinkTestCase):
                            self.gen_protos_script,
                            self.flink_fn_execution_proto_file_name))
 
+    @unittest.skipIf(
+        sys.version_info < (3, 10),
+        "grpcio-tools 1.80.0 is incompatible with Apache Beam's grpcio "
+        "constraint on Python 3.9",
+    )
     def test_flink_fn_execution_pb2_synced(self):
         generate_proto_files('True', self.tempdir)
         self.check_file_content(self.flink_fn_execution_pb2_file_name)

--- a/flink-python/pyproject.toml
+++ b/flink-python/pyproject.toml
@@ -44,7 +44,8 @@ dev = [
   "numpy>=1.22.4,<2.3.0",
   "fastavro>=1.1.0,!=1.8.0",
   "grpcio>=1.33.1,<2",
-  "grpcio-tools==1.80.0",
+  # Apache Beam 2.69 is the last version supporting Python 3.9 and requires grpcio<1.66.
+  "grpcio-tools==1.80.0; python_version >= '3.10'",
   "pemja>=0.5.7,<0.5.8; platform_system != 'Windows'",
   "httplib2>=0.19.0",
   "protobuf>=6.31.1,<7.0.0.dev0",


### PR DESCRIPTION
## What is the purpose of the change

*This pull request fixes the dependency conflicts after bumping the Apache Beam version*


## Brief change log

  - *Only install grpcio-tools on Python 3.10+*
  - *Skip proto generation verification on Python 3.9*


## Verifying this change

This change is already covered by existing tests


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no )
  - The runtime per-record code paths (performance sensitive): (no )
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: ( no )
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change the checkbox below to `[X]` and replace the placeholder in the "Generated-by"
line with the tool name and version. Otherwise remove the "Generated-by" line.
See the ASF Generative Tooling Guidance for details:
https://www.apache.org/legal/generative-tooling.html

You are responsible for the quality and correctness of every change in this PR
regardless of the tooling used. Low-effort AI-generated PRs will be closed. See
AGENTS.md for the full guidance.
-->

- [x] Yes (please specify the tool below)

Generated-by: [Codex GPT-5.6 Sol]
