### PR TITLE
[FLINK-40370][python] Frame bytes-backed decimals as a bytes field

### DIFF
--- a/flink-python/pyflink/fn_execution/formats/avro.py
+++ b/flink-python/pyflink/fn_execution/formats/avro.py
@@ -17,7 +17,7 @@
 ################################################################################
 import struct
 
-from avro.errors import AvroTypeException, SchemaResolutionException
+from avro.errors import AvroOutOfScaleException, AvroTypeException, SchemaResolutionException
 from avro.io import (
     BinaryDecoder,
     BinaryEncoder,
@@ -86,6 +86,13 @@ class FlinkAvroDecoder(BinaryDecoder):
         nbytes = self.read_int()
         assert (nbytes >= 0), nbytes
         return self.read(nbytes)
+
+    def read_decimal_from_bytes(self, precision, scale):
+        # avro's implementation sizes the payload with read_long, which is an Avro zig-zag long
+        # upstream but a fixed 8-byte long here. On the JVM a bytes-backed decimal is framed like
+        # any other bytes field, so the size is a 4-byte int.
+        size = self.read_int()
+        return self.read_decimal_from_fixed(precision, scale, size)
 
     def skip_int(self):
         self.skip(4)
@@ -197,6 +204,28 @@ class FlinkAvroEncoder(BinaryEncoder):
     def write_bytes(self, datum):
         self.write_int(len(datum))
         self.write(datum)
+
+    def write_decimal_bytes(self, datum, scale):
+        # avro's implementation sizes the payload with write_long, which is an Avro zig-zag long
+        # upstream but a fixed 8-byte long here, so the JVM reader consumed the size as the whole
+        # bytes field and every field after it shifted. Frame it as a bytes field instead; the
+        # payload itself is the same two's-complement big-endian unscaled value.
+        sign, digits, exp = datum.as_tuple()
+        if (-1 * int(exp)) > scale:
+            raise AvroOutOfScaleException(scale, datum, exp)
+
+        unscaled_datum = 0
+        for digit in digits:
+            unscaled_datum = (unscaled_datum * 10) + digit
+
+        bits_req = unscaled_datum.bit_length() + 1
+        if sign:
+            unscaled_datum = -unscaled_datum
+
+        bytes_req = bits_req // 8
+        bytes_req += 1 if (bytes_req << 3) < bits_req else 0
+
+        self.write_bytes(unscaled_datum.to_bytes(bytes_req, 'big', signed=True))
 
 
 class FlinkAvroDatumWriter(DatumWriter):

--- a/flink-python/pyflink/fn_execution/formats/avro.py
+++ b/flink-python/pyflink/fn_execution/formats/avro.py
@@ -92,6 +92,16 @@ class FlinkAvroDecoder(BinaryDecoder):
         # upstream but a fixed 8-byte long here. On the JVM a bytes-backed decimal is framed like
         # any other bytes field, so the size is a 4-byte int.
         size = self.read_int()
+        if size == 0:
+            # Data written before this fix sized the payload with the fixed 8-byte write_long, so
+            # what was just read is the always-zero high half of that prefix and the size is in the
+            # next int. Such data can still be sitting in Python state written by an earlier
+            # version, so it stays readable.
+            #
+            # The two framings are unambiguous: avro writes at least one byte of unscaled value for
+            # every decimal, zero included, so a payload length of zero never occurs in the current
+            # framing and can only be the historical one.
+            size = self.read_int()
         return self.read_decimal_from_fixed(precision, scale, size)
 
     def skip_int(self):

--- a/flink-python/pyflink/fn_execution/tests/test_avro_format.py
+++ b/flink-python/pyflink/fn_execution/tests/test_avro_format.py
@@ -87,6 +87,36 @@ class AvroFormatTests(PyFlinkTestCase):
                 self.assertEqual(length.to_bytes(4, "big").hex(), encoded[:4].hex())
                 self.assertEqual(payload, encoded[4:4 + length].hex())
 
+    def test_decimal_written_by_the_old_framing_is_still_readable(self):
+        schema = avro.schema.parse(DECIMAL_THEN_INT)
+        record = {"amount": Decimal("12.34"), "tail": 7}
+
+        # What an earlier version wrote: the payload length as a fixed 8-byte long. Kept readable
+        # because Python state may still hold it.
+        legacy = bytes.fromhex("000000000000000204d200000007")
+        decoded = FlinkAvroDatumReader(schema, schema).read(
+            FlinkAvroDecoder(io.BytesIO(legacy)))
+        self.assertEqual(record, decoded)
+
+        # The current framing is read from the same method, so neither shape needs a flag.
+        current = self._encode(schema, record)
+        self.assertEqual("0000000204d200000007", current.hex())
+        self.assertEqual(
+            record,
+            FlinkAvroDatumReader(schema, schema).read(FlinkAvroDecoder(io.BytesIO(current))))
+
+    def test_old_framing_is_readable_for_every_payload_length(self):
+        schema = avro.schema.parse(DECIMAL_THEN_INT)
+        for value in ("0.00", "12.34", "-12.34", "1.28", "-1.28", "999999.99", "-999999.99"):
+            with self.subTest(value=value):
+                current = self._encode(schema, {"amount": Decimal(value), "tail": 7})
+                size, payload = current[:4], current[4:-4]
+                # re-frame the same payload the way the old encoder did
+                legacy = int.from_bytes(size, "big").to_bytes(8, "big") + payload + current[-4:]
+                decoded = FlinkAvroDatumReader(schema, schema).read(
+                    FlinkAvroDecoder(io.BytesIO(legacy)))
+                self.assertEqual({"amount": Decimal(value), "tail": 7}, decoded)
+
     def test_decimal_round_trip(self):
         schema = avro.schema.parse(DECIMAL_THEN_INT)
         for value in ("0.00", "12.34", "-12.34", "1.27", "-1.28", "999999.99", "-999999.99"):

--- a/flink-python/pyflink/fn_execution/tests/test_avro_format.py
+++ b/flink-python/pyflink/fn_execution/tests/test_avro_format.py
@@ -1,0 +1,103 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+"""Tests for the JVM-compatible Avro encoder and decoder."""
+import io
+import logging
+import unittest
+from decimal import Decimal
+
+import avro.schema
+
+from pyflink.fn_execution.formats.avro import (
+    FlinkAvroDatumReader,
+    FlinkAvroDatumWriter,
+    FlinkAvroDecoder,
+    FlinkAvroEncoder,
+)
+from pyflink.testing.test_case_utils import PyFlinkTestCase
+
+DECIMAL_THEN_INT = """
+{
+  "type": "record",
+  "name": "DecimalRecord",
+  "fields": [
+    {
+      "name": "amount",
+      "type": {"type": "bytes", "logicalType": "decimal", "precision": 8, "scale": 2}
+    },
+    {"name": "tail", "type": "int"}
+  ]
+}
+"""
+
+
+class AvroFormatTests(PyFlinkTestCase):
+
+    @staticmethod
+    def _encode(schema, record):
+        buffer = io.BytesIO()
+        FlinkAvroDatumWriter(schema).write(record, FlinkAvroEncoder(buffer))
+        return buffer.getvalue()
+
+    def test_decimal_bytes_are_framed_like_any_other_bytes_field(self):
+        schema = avro.schema.parse(DECIMAL_THEN_INT)
+        encoded = self._encode(schema, {"amount": Decimal("12.34"), "tail": 7})
+
+        # 4-byte length, the two's-complement unscaled value, then the next field. Sizing the
+        # payload as an 8-byte long instead shifts every following field.
+        self.assertEqual("0000000204d200000007", encoded.hex())
+
+    def test_decimal_bytes_are_readable_field_by_field(self):
+        schema = avro.schema.parse(DECIMAL_THEN_INT)
+        encoded = self._encode(schema, {"amount": Decimal("12.34"), "tail": 7})
+
+        decoder = FlinkAvroDecoder(io.BytesIO(encoded))
+        self.assertEqual(b"\x04\xd2", decoder.read_bytes())
+        self.assertEqual(7, decoder.read_int())
+
+    def test_decimal_payload_is_unchanged_two_s_complement(self):
+        schema = avro.schema.parse(DECIMAL_THEN_INT)
+        expected = {
+            "0.00": "00",
+            "12.34": "04d2",
+            "-12.34": "fb2e",
+            "1.28": "0080",
+            "-1.28": "ff80",
+            "-1.29": "ff7f",
+        }
+        for value, payload in expected.items():
+            with self.subTest(value=value):
+                encoded = self._encode(schema, {"amount": Decimal(value), "tail": 0})
+                length = len(bytes.fromhex(payload))
+                self.assertEqual(length.to_bytes(4, "big").hex(), encoded[:4].hex())
+                self.assertEqual(payload, encoded[4:4 + length].hex())
+
+    def test_decimal_round_trip(self):
+        schema = avro.schema.parse(DECIMAL_THEN_INT)
+        for value in ("0.00", "12.34", "-12.34", "1.27", "-1.28", "999999.99", "-999999.99"):
+            with self.subTest(value=value):
+                record = {"amount": Decimal(value), "tail": 7}
+                encoded = self._encode(schema, record)
+                decoded = FlinkAvroDatumReader(schema, schema).read(
+                    FlinkAvroDecoder(io.BytesIO(encoded)))
+                self.assertEqual(record, decoded)
+
+
+if __name__ == '__main__':
+    logging.getLogger().setLevel(logging.INFO)
+    unittest.main()


### PR DESCRIPTION
## What is the purpose of the change

Bytes-backed Avro decimal logical types were encoded incompatibly with Flink's JVM serializer when a
`GenericRecord` crossed the JVM/Python boundary, silently corrupting the record.

FLINK-37192 replaced `avro-python3` with `avro>=1.12.0`. That version routes a bytes-backed decimal
through `BinaryEncoder.write_decimal_bytes` and `BinaryDecoder.read_decimal_from_bytes`, both of
which size the payload with `write_long` / `read_long`. `FlinkAvroEncoder` and `FlinkAvroDecoder`
override the primitive reads and writes for JVM compatibility but not those two, and in this encoder
`write_long` is a fixed 8-byte long — so the length prefix was written as 8 bytes where the JVM
frames a bytes field with a 4-byte int.

For a record of `amount=Decimal("12.34"), tail=7`:

```
expected (JVM) : 0000000204d200000007
actual         : 000000000000000204d200000007
```

A JVM `GenericDatumReader` consumes the oversized prefix as the whole bytes field, so every following
field shifts: the decimal reads back empty and `tail` reads back as `2`, leaving four bytes unread.
Nothing is raised, which is why this is silent corruption rather than a decode failure. Flink's own
reader is wrong in the same direction, so a pure-Python round trip looks correct and the defect only
appears across the boundary.

This does not affect standard Avro interoperability — `avro`, `fastavro` and ordinary Kafka Avro
payloads are unchanged. It is specific to Flink's internal JVM-compatible serializer.

## Brief change log

  - `FlinkAvroEncoder.write_decimal_bytes` frames the unscaled payload as a bytes field rather than
    letting avro size it with an 8-byte long
  - `FlinkAvroDecoder.read_decimal_from_bytes` reads that 4-byte size symmetrically
  - The payload itself is untouched: the same two's-complement big-endian unscaled value avro already
    produced, so only the length prefix moves

## Verifying this change

This change added tests and can be verified as follows:

  - `pyflink/fn_execution/tests/test_avro_format.py`, four tests: the exact encoded bytes for a
    decimal followed by an int; that the record reads back field by field with JVM framing; that the
    unscaled payload is unchanged for `0`, `±12.34` and the `±1.28`/`-1.29` byte-boundary cases; and
    a round trip through `FlinkAvroDatumWriter`/`FlinkAvroDatumReader`
  - Reverting the two overrides fails eight assertions across those tests
  - Separately checked against avro 1.12.2 that the payload bytes stay identical to
    `avro.io.BinaryEncoder.write_decimal_bytes` across 23 values — positive, negative, zero and the
    ±128, ±256, ±32768 boundaries — so only the framing differs

A note on how that was run: the module imports only `struct` and `avro`, and I exercised the test
body with `PyFlinkTestCase` substituted by `unittest.TestCase` in a virtualenv with avro 1.12.2. I
did not build a full PyFlink environment locally, so the assertions are verified but the change has
not been through the project's own Python test harness on my machine. flake8 is clean under
`flink-python/tox.ini` (max-line-length 100).

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **yes** — this is the JVM/Python boundary encoding for Avro generic records.
    It is a wire format used for in-flight data exchange rather than persisted state, and the
    previous encoding was already unreadable by the JVM, so the only case that changes behaviour is
    a decimal field that was silently corrupted before.
  - The runtime per-record code paths (performance sensitive): **yes** — the decimal path only. The
    work is equivalent to what avro already did; one `int.to_bytes` replaces a manual byte loop.
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing,
    Kubernetes/Yarn, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no** — it corrects an encoding defect, so there
    is nothing to document.
