### PR TITLE
[FLINK-40446][tests] Make CommonTestUtils.terminateJob wait for the CANCELED terminal state

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/CommonTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/CommonTestUtils.java
@@ -49,6 +49,7 @@ import java.lang.management.ManagementFactory;
 import java.lang.management.RuntimeMXBean;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -300,7 +301,11 @@ public class CommonTestUtils {
     }
 
     public static void terminateJob(JobClient client) throws Exception {
+        // cancel() only acknowledges that cancellation was initiated; wait for the terminal state
+        // so callers can rely on the job having fully stopped (e.g. before deleting checkpoint dirs
+        // or asserting on final state) rather than each caller re-adding the wait themselves.
         client.cancel().get();
+        waitForJobStatus(client, Collections.singletonList(JobStatus.CANCELED));
     }
 
     public static void waitForSubtasksToFinish(

--- a/flink-test-utils-parent/flink-connector-test-utils/src/main/java/org/apache/flink/connector/testframe/testsuites/SinkTestSuiteBase.java
+++ b/flink-test-utils-parent/flink-connector-test-utils/src/main/java/org/apache/flink/connector/testframe/testsuites/SinkTestSuiteBase.java
@@ -289,7 +289,7 @@ public abstract class SinkTestSuiteBase<T extends Comparable<T>> {
             waitForJobStatus(jobClient, Collections.singletonList(JobStatus.FINISHED));
         } catch (Exception e) {
             executorService.shutdown();
-            killJob(jobClient);
+            terminateJob(jobClient);
             throw e;
         }
 
@@ -328,7 +328,7 @@ public abstract class SinkTestSuiteBase<T extends Comparable<T>> {
                     externalContext.createSinkDataReader(sinkSettings), testRecords, semantic);
         } finally {
             executorService.shutdown();
-            killJob(restartJobClient);
+            terminateJob(restartJobClient);
             iterator.close();
         }
     }
@@ -406,7 +406,7 @@ public abstract class SinkTestSuiteBase<T extends Comparable<T>> {
         } finally {
             // Clean up
             executorService.shutdown();
-            killJob(jobClient);
+            terminateJob(jobClient);
         }
     }
 
@@ -561,11 +561,6 @@ public abstract class SinkTestSuiteBase<T extends Comparable<T>> {
 
     private TestingSinkSettings getTestingSinkSettings(CheckpointingMode checkpointingMode) {
         return TestingSinkSettings.builder().setCheckpointingMode(checkpointingMode).build();
-    }
-
-    private void killJob(JobClient jobClient) throws Exception {
-        terminateJob(jobClient);
-        waitForJobStatus(jobClient, Collections.singletonList(JobStatus.CANCELED));
     }
 
     private DataStreamSink<T> tryCreateSink(

--- a/flink-test-utils-parent/flink-connector-test-utils/src/main/java/org/apache/flink/connector/testframe/testsuites/SourceTestSuiteBase.java
+++ b/flink-test-utils-parent/flink-connector-test-utils/src/main/java/org/apache/flink/connector/testframe/testsuites/SourceTestSuiteBase.java
@@ -332,7 +332,7 @@ public abstract class SourceTestSuiteBase<T> {
                     semantic,
                     getTestDataSize(testRecordCollections));
         } catch (Exception e) {
-            killJob(jobClient);
+            terminateJob(jobClient);
             throw e;
         }
         String savepointPath =
@@ -393,7 +393,7 @@ public abstract class SourceTestSuiteBase<T> {
                     getTestDataSize(newTestRecordCollections));
         } finally {
             // Clean up
-            killJob(restartJobClient);
+            terminateJob(restartJobClient);
             iterator.close();
         }
     }
@@ -468,7 +468,7 @@ public abstract class SourceTestSuiteBase<T> {
         } finally {
             // Clean up
             executorService.shutdown();
-            killJob(jobClient);
+            terminateJob(jobClient);
         }
     }
 
@@ -621,7 +621,6 @@ public abstract class SourceTestSuiteBase<T> {
 
         // Step 8: Clean up
         terminateJob(jobClient);
-        waitForJobStatus(jobClient, singletonList(JobStatus.CANCELED));
         iterator.close();
     }
 
@@ -766,11 +765,6 @@ public abstract class SourceTestSuiteBase<T> {
                         MetricNames.IO_NUM_RECORDS_IN,
                         null);
         return Precision.equals(allRecordSize, sumNumRecordsIn);
-    }
-
-    private void killJob(JobClient jobClient) throws Exception {
-        terminateJob(jobClient);
-        waitForJobStatus(jobClient, singletonList(JobStatus.CANCELED));
     }
 
     /** Builder class for constructing {@link CollectResultIterator} of collect sink. */

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/UnalignedCheckpointRescaleSameUpstreamITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/UnalignedCheckpointRescaleSameUpstreamITCase.java
@@ -111,7 +111,7 @@ class UnalignedCheckpointRescaleSameUpstreamITCase {
                     CommonTestUtils.waitForCheckpointWithInflightBuffers(
                             initialJobGraph.getJobID(), miniCluster, CHECKPOINTS_TO_WAIT);
         } finally {
-            initialJobClient.cancel().get();
+            CommonTestUtils.terminateJob(initialJobClient);
         }
 
         final JobGraph restoredJobGraph =
@@ -177,7 +177,7 @@ class UnalignedCheckpointRescaleSameUpstreamITCase {
 
     private static void cancelIfRunning(JobClient jobClient) throws Exception {
         if (jobClient.getJobStatus().get() != JobStatus.FAILED) {
-            jobClient.cancel().get();
+            CommonTestUtils.terminateJob(jobClient);
         }
     }
 

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/UnalignedCheckpointRescaleWithMixedExchangesITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/UnalignedCheckpointRescaleWithMixedExchangesITCase.java
@@ -132,7 +132,7 @@ class UnalignedCheckpointRescaleWithMixedExchangesITCase {
         String checkpointPath1 =
                 CommonTestUtils.waitForCheckpointWithInflightBuffers(
                         jobClient1.getJobID(), miniCluster);
-        jobClient1.cancel().get();
+        CommonTestUtils.terminateJob(jobClient1);
         LOG.info("First checkpoint path: {}", checkpointPath1);
 
         // Step 2: Restore the job with a different parallelism
@@ -144,7 +144,7 @@ class UnalignedCheckpointRescaleWithMixedExchangesITCase {
         String checkpointPath2 =
                 CommonTestUtils.waitForCheckpointWithInflightBuffers(
                         jobClient2.getJobID(), miniCluster);
-        jobClient2.cancel().get();
+        CommonTestUtils.terminateJob(jobClient2);
         LOG.info("Second checkpoint path: {}", checkpointPath2);
 
         // Step 3: Restore from Step 2's checkpoint with random parallelism. This validates
@@ -156,7 +156,7 @@ class UnalignedCheckpointRescaleWithMixedExchangesITCase {
         CommonTestUtils.waitForAllTaskRunning(miniCluster, jobClient3.getJobID(), false);
         // Wait for at least one checkpoint to verify the recovery was successful
         CommonTestUtils.waitForCheckpointWithInflightBuffers(jobClient3.getJobID(), miniCluster);
-        jobClient3.cancel().get();
+        CommonTestUtils.terminateJob(jobClient3);
     }
 
     private StreamExecutionEnvironment getUnalignedCheckpointEnv(@Nullable String recoveryPath)


### PR DESCRIPTION
## What is the purpose of the change

`UnalignedCheckpointRescaleWithMixedExchangesITCase` is occasionally unstable: the
test body passes, but teardown fails while JUnit deletes the `@TempDir` that also
serves as the checkpoint directory:

```
java.io.IOException: Failed to delete temp directory /tmp/junit-...
  Suppressed: java.nio.file.DirectoryNotEmptyException: /tmp/junit-...
```

Root cause: the test ends each job with `jobClient.cancel().get()`. `cancel()` is
asynchronous — `.get()` only signals that cancellation was *initiated*, not that the
job reached a terminal state. The test then returns and JUnit deletes the `@TempDir`
while the source subtasks' async snapshot of the just-completed checkpoint is still
writing `SourceReaderState` into the file-merging `taskowned` directory, so the
post-order delete walk hits `DirectoryNotEmptyException`. It only reproduces with
file-merging enabled.

## Brief change log

  - `CommonTestUtils.terminateJob` now waits for the `CANCELED` terminal state after `cancel().get()`.
  - The UC rescale ITCases (`UnalignedCheckpointRescaleWithMixedExchangesITCase`, `UnalignedCheckpointRescaleSameUpstreamITCase`) cancel via `terminateJob` instead of bare `cancel().get()`.
  - `SourceTestSuiteBase` / `SinkTestSuiteBase` drop their local `killJob` helper (which duplicated `terminateJob` + wait-for-`CANCELED`) and call `terminateJob` directly.

## Verifying this change

This change is a test-stability fix without new production behavior; it is covered by
the existing ITCases and connector test suites. The teardown race no longer occurs
because callers wait for the job to reach `CANCELED` before the `@TempDir`/checkpoint
directory is deleted.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: Claude Code (Opus 4.8)
