### PR TITLE
[FLINK-40379][runtime] Wait for pre-restart parallelism to become available again after a rescale-triggered restart

### DIFF
--- a/docs/layouts/shortcodes/generated/all_jobmanager_section.html
+++ b/docs/layouts/shortcodes/generated/all_jobmanager_section.html
@@ -69,6 +69,12 @@
             <td>The maximum time the JobManager will wait with evaluating previously observed events for rescaling (default: 0ms if checkpointing is disabled and the checkpointing interval multiplied by the by-1-incremented parameter value of jobmanager.adaptive-scheduler.rescale-trigger.max-checkpoint-failures if checkpointing is enabled).</td>
         </tr>
         <tr>
+            <td><h5>jobmanager.adaptive-scheduler.rescale.resource-stabilization-timeout</h5></td>
+            <td style="word-wrap: break-word;">2 min</td>
+            <td>Duration</td>
+            <td>The maximum time the JobManager will wait, after a restart triggered to change the job's parallelism, for the parallelism that was determined as the target before triggering the rescale to be available again. Once reached, the JobManager proceeds immediately. Reaching the timeout would make the JobManager proceed with whatever sufficient resources are available.<br />This accounts for the fact that the slot used by the execution being restarted is not freed synchronously with its cancellation being observed: e.g., if the cancellation does not complete within <code class="highlighter-rouge">task.cancellation.timeout</code>, the TaskManager providing that slot is marked failed and has to be reprovisioned before the slot is returned to the pool. This value should be configured high enough to cover that delay across all restarted vertices, to avoid restarting with fewer resources than were available right before the restart.</td>
+        </tr>
+        <tr>
             <td><h5>jobmanager.adaptive-scheduler.submission.resource-stabilization-timeout</h5></td>
             <td style="word-wrap: break-word;">10 s</td>
             <td>Duration</td>

--- a/docs/layouts/shortcodes/generated/expert_scheduling_section.html
+++ b/docs/layouts/shortcodes/generated/expert_scheduling_section.html
@@ -123,6 +123,12 @@
             <td>The maximum time the JobManager will wait with evaluating previously observed events for rescaling (default: 0ms if checkpointing is disabled and the checkpointing interval multiplied by the by-1-incremented parameter value of jobmanager.adaptive-scheduler.rescale-trigger.max-checkpoint-failures if checkpointing is enabled).</td>
         </tr>
         <tr>
+            <td><h5>jobmanager.adaptive-scheduler.rescale.resource-stabilization-timeout</h5></td>
+            <td style="word-wrap: break-word;">2 min</td>
+            <td>Duration</td>
+            <td>The maximum time the JobManager will wait, after a restart triggered to change the job's parallelism, for the parallelism that was determined as the target before triggering the rescale to be available again. Once reached, the JobManager proceeds immediately. Reaching the timeout would make the JobManager proceed with whatever sufficient resources are available.<br />This accounts for the fact that the slot used by the execution being restarted is not freed synchronously with its cancellation being observed: e.g., if the cancellation does not complete within <code class="highlighter-rouge">task.cancellation.timeout</code>, the TaskManager providing that slot is marked failed and has to be reprovisioned before the slot is returned to the pool. This value should be configured high enough to cover that delay across all restarted vertices, to avoid restarting with fewer resources than were available right before the restart.</td>
+        </tr>
+        <tr>
             <td><h5>jobmanager.adaptive-scheduler.submission.resource-stabilization-timeout</h5></td>
             <td style="word-wrap: break-word;">10 s</td>
             <td>Duration</td>

--- a/docs/layouts/shortcodes/generated/job_manager_configuration.html
+++ b/docs/layouts/shortcodes/generated/job_manager_configuration.html
@@ -69,6 +69,12 @@
             <td>The maximum time the JobManager will wait with evaluating previously observed events for rescaling (default: 0ms if checkpointing is disabled and the checkpointing interval multiplied by the by-1-incremented parameter value of jobmanager.adaptive-scheduler.rescale-trigger.max-checkpoint-failures if checkpointing is enabled).</td>
         </tr>
         <tr>
+            <td><h5>jobmanager.adaptive-scheduler.rescale.resource-stabilization-timeout</h5></td>
+            <td style="word-wrap: break-word;">2 min</td>
+            <td>Duration</td>
+            <td>The maximum time the JobManager will wait, after a restart triggered to change the job's parallelism, for the parallelism that was determined as the target before triggering the rescale to be available again. Once reached, the JobManager proceeds immediately. Reaching the timeout would make the JobManager proceed with whatever sufficient resources are available.<br />This accounts for the fact that the slot used by the execution being restarted is not freed synchronously with its cancellation being observed: e.g., if the cancellation does not complete within <code class="highlighter-rouge">task.cancellation.timeout</code>, the TaskManager providing that slot is marked failed and has to be reprovisioned before the slot is returned to the pool. This value should be configured high enough to cover that delay across all restarted vertices, to avoid restarting with fewer resources than were available right before the restart.</td>
+        </tr>
+        <tr>
             <td><h5>jobmanager.adaptive-scheduler.submission.resource-stabilization-timeout</h5></td>
             <td style="word-wrap: break-word;">10 s</td>
             <td>Duration</td>

--- a/flink-core/src/main/java/org/apache/flink/configuration/JobManagerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/JobManagerOptions.java
@@ -717,6 +717,33 @@ public class JobManagerOptions {
         Documentation.Sections.EXPERT_SCHEDULING,
         Documentation.Sections.ALL_JOB_MANAGER
     })
+    public static final ConfigOption<Duration> SCHEDULER_RESCALE_RESOURCE_STABILIZATION_TIMEOUT =
+            key("jobmanager.adaptive-scheduler.rescale.resource-stabilization-timeout")
+                    .durationType()
+                    .defaultValue(Duration.ofMinutes(2))
+                    .withDescription(
+                            Description.builder()
+                                    .text(
+                                            "The maximum time the JobManager will wait, after a restart triggered to change the job's parallelism, "
+                                                    + "for the parallelism that was determined as the target before triggering the rescale to be "
+                                                    + "available again. Once reached, the JobManager proceeds immediately. "
+                                                    + "Reaching the timeout would make the JobManager proceed with whatever sufficient resources "
+                                                    + "are available.")
+                                    .linebreak()
+                                    .text(
+                                            "This accounts for the fact that the slot used by the execution being restarted is not freed "
+                                                    + "synchronously with its cancellation being observed: e.g., if the cancellation does not "
+                                                    + "complete within %s, the TaskManager providing that slot is marked failed and has to be "
+                                                    + "reprovisioned before the slot is returned to the pool. This value should be configured high "
+                                                    + "enough to cover that delay across all restarted vertices, to avoid restarting with fewer "
+                                                    + "resources than were available right before the restart.",
+                                            code(TaskManagerOptions.TASK_CANCELLATION_TIMEOUT.key()))
+                                    .build());
+
+    @Documentation.Section({
+        Documentation.Sections.EXPERT_SCHEDULING,
+        Documentation.Sections.ALL_JOB_MANAGER
+    })
     public static final ConfigOption<Integer> SCHEDULER_RESCALE_TRIGGER_MAX_CHECKPOINT_FAILURES =
             key("jobmanager.adaptive-scheduler.rescale-trigger.max-checkpoint-failures")
                     .intType()

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveScheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveScheduler.java
@@ -241,9 +241,13 @@ public class AdaptiveScheduler
             Duration submissionStabilizationTimeoutDefault =
                     JobManagerOptions.SCHEDULER_SUBMISSION_RESOURCE_STABILIZATION_TIMEOUT
                             .defaultValue();
+            Duration rescaleResourceStabilizationTimeoutDefault =
+                    JobManagerOptions.SCHEDULER_RESCALE_RESOURCE_STABILIZATION_TIMEOUT
+                            .defaultValue();
             if (executionMode == SchedulerExecutionMode.REACTIVE) {
                 submissionResourceWaitTimeoutDefault = Duration.ofMillis(-1);
                 submissionStabilizationTimeoutDefault = Duration.ZERO;
+                rescaleResourceStabilizationTimeoutDefault = Duration.ZERO;
             }
 
             final Duration executingCooldownTimeout =
@@ -306,6 +310,11 @@ public class AdaptiveScheduler
                                     JobManagerOptions
                                             .SCHEDULER_SUBMISSION_RESOURCE_STABILIZATION_TIMEOUT)
                             .orElse(submissionStabilizationTimeoutDefault),
+                    configuration
+                            .getOptional(
+                                    JobManagerOptions
+                                            .SCHEDULER_RESCALE_RESOURCE_STABILIZATION_TIMEOUT)
+                            .orElse(rescaleResourceStabilizationTimeoutDefault),
                     configuration.get(JobManagerOptions.SLOT_IDLE_TIMEOUT),
                     executingCooldownTimeout,
                     configuration.get(
@@ -322,6 +331,7 @@ public class AdaptiveScheduler
         private final SchedulerExecutionMode executionMode;
         private final Duration submissionResourceWaitTimeout;
         private final Duration submissionResourceStabilizationTimeout;
+        private final Duration rescaleResourceStabilizationTimeout;
         private final Duration slotIdleTimeout;
         private final Duration executingCooldownTimeout;
         private final Duration executingResourceStabilizationTimeout;
@@ -334,6 +344,7 @@ public class AdaptiveScheduler
                 SchedulerExecutionMode executionMode,
                 Duration submissionResourceWaitTimeout,
                 Duration submissionResourceStabilizationTimeout,
+                Duration rescaleResourceStabilizationTimeout,
                 Duration slotIdleTimeout,
                 Duration executingCooldownTimeout,
                 Duration executingResourceStabilizationTimeout,
@@ -344,6 +355,7 @@ public class AdaptiveScheduler
             this.executionMode = executionMode;
             this.submissionResourceWaitTimeout = submissionResourceWaitTimeout;
             this.submissionResourceStabilizationTimeout = submissionResourceStabilizationTimeout;
+            this.rescaleResourceStabilizationTimeout = rescaleResourceStabilizationTimeout;
             this.slotIdleTimeout = slotIdleTimeout;
             this.executingCooldownTimeout = executingCooldownTimeout;
             this.executingResourceStabilizationTimeout = executingResourceStabilizationTimeout;
@@ -363,6 +375,10 @@ public class AdaptiveScheduler
 
         public Duration getSubmissionResourceStabilizationTimeout() {
             return submissionResourceStabilizationTimeout;
+        }
+
+        public Duration getRescaleResourceStabilizationTimeout() {
+            return rescaleResourceStabilizationTimeout;
         }
 
         public Duration getSlotIdleTimeout() {
@@ -1269,7 +1285,9 @@ public class AdaptiveScheduler
     }
 
     @Override
-    public void goToWaitingForResources(@Nullable ExecutionGraph previousExecutionGraph) {
+    public void goToWaitingForResources(
+            @Nullable ExecutionGraph previousExecutionGraph,
+            @Nullable VertexParallelism restartWithParallelism) {
         declareDesiredResources();
 
         transitionToState(
@@ -1277,8 +1295,11 @@ public class AdaptiveScheduler
                         this,
                         LOG,
                         settings.getSubmissionResourceWaitTimeout(),
-                        this::createWaitingForResourceStateTransitionManager,
-                        previousExecutionGraph));
+                        restartWithParallelism != null
+                                ? this::createRestartWaitingForResourceStateTransitionManager
+                                : this::createWaitingForResourceStateTransitionManager,
+                        previousExecutionGraph,
+                        restartWithParallelism));
     }
 
     private StateTransitionManager createWaitingForResourceStateTransitionManager(
@@ -1288,6 +1309,16 @@ public class AdaptiveScheduler
                 clock,
                 Duration.ZERO, // skip cooldown phase
                 settings.getSubmissionResourceStabilizationTimeout(),
+                Duration.ZERO); // trigger immediately once the stabilization phase is over
+    }
+
+    private StateTransitionManager createRestartWaitingForResourceStateTransitionManager(
+            StateTransitionManager.Context ctx) {
+        return stateTransitionManagerFactory.create(
+                ctx,
+                clock,
+                Duration.ZERO, // skip cooldown phase
+                settings.getRescaleResourceStabilizationTimeout(),
                 Duration.ZERO); // trigger immediately once the stabilization phase is over
     }
 
@@ -1641,6 +1672,17 @@ public class AdaptiveScheduler
     public Optional<VertexParallelism> getAvailableVertexParallelism() {
         return slotAllocator.determineParallelism(
                 jobInformation, declarativeSlotPool.getAllSlotsInformation());
+    }
+
+    @Override
+    public Optional<VertexParallelism> getFreeSlotVertexParallelism() {
+        return slotAllocator.determineParallelism(
+                jobInformation, declarativeSlotPool.getFreeSlotTracker().getFreeSlotsInformation());
+    }
+
+    @Override
+    public int getUpperBoundParallelism(JobVertexID jobVertexId) {
+        return jobInformation.getVertexInformation(jobVertexId).getParallelism();
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveScheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveScheduler.java
@@ -1287,7 +1287,7 @@ public class AdaptiveScheduler
     @Override
     public void goToWaitingForResources(
             @Nullable ExecutionGraph previousExecutionGraph,
-            @Nullable VertexParallelism restartWithParallelism) {
+            @Nullable VertexParallelism targetVertexParallelism) {
         declareDesiredResources();
 
         transitionToState(
@@ -1295,11 +1295,11 @@ public class AdaptiveScheduler
                         this,
                         LOG,
                         settings.getSubmissionResourceWaitTimeout(),
-                        restartWithParallelism != null
+                        targetVertexParallelism != null
                                 ? this::createRestartWaitingForResourceStateTransitionManager
                                 : this::createWaitingForResourceStateTransitionManager,
                         previousExecutionGraph,
-                        restartWithParallelism));
+                        targetVertexParallelism));
     }
 
     private StateTransitionManager createWaitingForResourceStateTransitionManager(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/Created.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/Created.java
@@ -43,7 +43,7 @@ class Created extends StateWithoutExecutionGraph {
     /** Starts the scheduling by going into the {@link WaitingForResources} state. */
     void startScheduling() {
         recordRescaleForInitialScheduling();
-        context.goToWaitingForResources(null);
+        context.goToWaitingForResources(null, null);
     }
 
     private void recordRescaleForInitialScheduling() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/CreatingExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/CreatingExecutionGraph.java
@@ -158,7 +158,7 @@ public class CreatingExecutionGraph extends StateWithoutExecutionGraph {
                 getLogger()
                         .debug(
                                 "Failed to reserve and assign the required slots. Waiting for new resources.");
-                context.goToWaitingForResources(previousExecutionGraph);
+                context.goToWaitingForResources(previousExecutionGraph, null);
             }
         }
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/Restarting.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/Restarting.java
@@ -114,23 +114,26 @@ class Restarting extends StateWithExecutionGraph {
     }
 
     private void goToSubsequentState() {
-        if (availableParallelismNotChanged(restartWithParallelism)
-                || context.hasDesiredResources()) {
+        if (parallelismBasedOnFreeSlotsUnchanged() || context.hasDesiredResources()) {
             context.goToCreatingExecutionGraph(getExecutionGraph());
         } else {
-            context.goToWaitingForResources(getExecutionGraph());
+            context.goToWaitingForResources(getExecutionGraph(), restartWithParallelism);
         }
     }
 
-    private boolean availableParallelismNotChanged(VertexParallelism restartWithParallelism) {
-        if (this.restartWithParallelism == null) {
+    private boolean parallelismBasedOnFreeSlotsUnchanged() {
+        if (restartWithParallelism == null) {
             return false;
         }
 
-        return context.getAvailableVertexParallelism()
+        return context.getFreeSlotVertexParallelism()
                 .map(
                         vertexParallelism ->
-                                vertexParallelism.getVertices().stream()
+                                // Iterate over restartWithParallelism (the restart target), not
+                                // vertexParallelism (the free-slot-based result): a vertex present
+                                // in the target but missing from the free-slot-based result must
+                                // fail the check, not be silently skipped by allMatch.
+                                restartWithParallelism.getVertices().stream()
                                         .allMatch(
                                                 vertex ->
                                                         restartWithParallelism.getParallelism(
@@ -160,10 +163,10 @@ class Restarting extends StateWithExecutionGraph {
         ScheduledFuture<?> runIfState(State expectedState, Runnable action, Duration delay);
 
         /**
-         * Returns the {@link VertexParallelism} that can be provided by the currently available
-         * slots.
+         * Returns the {@link VertexParallelism} that can be achieved with the currently free slots
+         * (excluding slots still reserved by the execution that is being cancelled).
          */
-        Optional<VertexParallelism> getAvailableVertexParallelism();
+        Optional<VertexParallelism> getFreeSlotVertexParallelism();
 
         /**
          * Checks whether we have the desired resources.
@@ -181,7 +184,7 @@ class Restarting extends StateWithExecutionGraph {
         private final ExecutionGraphHandler executionGraphHandler;
         private final OperatorCoordinatorHandler operatorCoordinatorHandler;
         private final Duration backoffTime;
-        private final @Nullable VertexParallelism restartWithParallelism;
+        private final @Nullable VertexParallelism targetVertexParallelism;
         private final ClassLoader userCodeClassLoader;
         private final List<ExceptionHistoryEntry> failureCollection;
 
@@ -192,7 +195,7 @@ class Restarting extends StateWithExecutionGraph {
                 OperatorCoordinatorHandler operatorCoordinatorHandler,
                 Logger log,
                 Duration backoffTime,
-                @Nullable VertexParallelism restartWithParallelism,
+                @Nullable VertexParallelism targetVertexParallelism,
                 ClassLoader userCodeClassLoader,
                 List<ExceptionHistoryEntry> failureCollection) {
             this.context = context;
@@ -201,7 +204,7 @@ class Restarting extends StateWithExecutionGraph {
             this.executionGraphHandler = executionGraphHandler;
             this.operatorCoordinatorHandler = operatorCoordinatorHandler;
             this.backoffTime = backoffTime;
-            this.restartWithParallelism = restartWithParallelism;
+            this.targetVertexParallelism = targetVertexParallelism;
             this.userCodeClassLoader = userCodeClassLoader;
             this.failureCollection = failureCollection;
         }
@@ -218,7 +221,7 @@ class Restarting extends StateWithExecutionGraph {
                     operatorCoordinatorHandler,
                     log,
                     backoffTime,
-                    restartWithParallelism,
+                    targetVertexParallelism,
                     userCodeClassLoader,
                     failureCollection);
         }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/Restarting.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/Restarting.java
@@ -114,14 +114,19 @@ class Restarting extends StateWithExecutionGraph {
     }
 
     private void goToSubsequentState() {
-        if (parallelismBasedOnFreeSlotsUnchanged() || context.hasDesiredResources()) {
+        // hasDesiredResources() counts all slots allocated to the job, including ones still
+        // reserved by the execution that is only now being cancelled: it must not be used as a
+        // fallback here when a restart target is known, or it would immediately undo the very
+        // guard freeSlotVertexParallelismUnchanged() exists to provide.
+        if (freeSlotVertexParallelismUnchanged()
+                || (restartWithParallelism == null && context.hasDesiredResources())) {
             context.goToCreatingExecutionGraph(getExecutionGraph());
         } else {
             context.goToWaitingForResources(getExecutionGraph(), restartWithParallelism);
         }
     }
 
-    private boolean parallelismBasedOnFreeSlotsUnchanged() {
+    private boolean freeSlotVertexParallelismUnchanged() {
         if (restartWithParallelism == null) {
             return false;
         }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/StateTransitions.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/StateTransitions.java
@@ -173,6 +173,8 @@ public interface StateTransitions {
     interface ToWaitingForResources extends StateTransitions {
 
         /** Transitions into the {@link WaitingForResources} state. */
-        void goToWaitingForResources(@Nullable ExecutionGraph previousExecutionGraph);
+        void goToWaitingForResources(
+                @Nullable ExecutionGraph previousExecutionGraph,
+                @Nullable VertexParallelism restartWithParallelism);
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/StateTransitions.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/StateTransitions.java
@@ -175,6 +175,6 @@ public interface StateTransitions {
         /** Transitions into the {@link WaitingForResources} state. */
         void goToWaitingForResources(
                 @Nullable ExecutionGraph previousExecutionGraph,
-                @Nullable VertexParallelism restartWithParallelism);
+                @Nullable VertexParallelism targetVertexParallelism);
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/WaitingForResources.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/WaitingForResources.java
@@ -21,6 +21,8 @@ package org.apache.flink.runtime.scheduler.adaptive;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.runtime.executiongraph.ExecutionGraph;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.scheduler.adaptive.allocator.VertexParallelism;
 import org.apache.flink.runtime.scheduler.adaptive.timeline.RescaleTimeline;
 import org.apache.flink.util.Preconditions;
 
@@ -29,6 +31,7 @@ import org.slf4j.Logger;
 import javax.annotation.Nullable;
 
 import java.time.Duration;
+import java.util.Optional;
 import java.util.concurrent.ScheduledFuture;
 import java.util.function.Function;
 
@@ -45,6 +48,7 @@ class WaitingForResources extends StateWithoutExecutionGraph
     @Nullable private final ExecutionGraph previousExecutionGraph;
 
     private final StateTransitionManager stateTransitionManager;
+    @Nullable private final VertexParallelism targetVertexParallelism;
 
     @VisibleForTesting
     WaitingForResources(
@@ -53,7 +57,13 @@ class WaitingForResources extends StateWithoutExecutionGraph
             Duration submissionResourceWaitTimeout,
             Function<StateTransitionManager.Context, StateTransitionManager>
                     stateTransitionManagerFactory) {
-        this(context, log, submissionResourceWaitTimeout, null, stateTransitionManagerFactory);
+        this(
+                context,
+                log,
+                submissionResourceWaitTimeout,
+                null,
+                stateTransitionManagerFactory,
+                null);
     }
 
     WaitingForResources(
@@ -62,10 +72,12 @@ class WaitingForResources extends StateWithoutExecutionGraph
             Duration submissionResourceWaitTimeout,
             @Nullable ExecutionGraph previousExecutionGraph,
             Function<StateTransitionManager.Context, StateTransitionManager>
-                    stateTransitionManagerFactory) {
+                    stateTransitionManagerFactory,
+            @Nullable VertexParallelism targetVertexParallelism) {
         super(context, log);
         this.context = Preconditions.checkNotNull(context);
         Preconditions.checkNotNull(submissionResourceWaitTimeout);
+        this.targetVertexParallelism = targetVertexParallelism;
         this.stateTransitionManager = stateTransitionManagerFactory.apply(this);
 
         // since state transitions are not allowed in state constructors, schedule calls for later.
@@ -128,8 +140,15 @@ class WaitingForResources extends StateWithoutExecutionGraph
         return context.hasSufficientResources();
     }
 
+    // Only "desired" is gated on the target parallelism, not "sufficient": the stabilization phase
+    // machine (see StateTransitionManager) already waits for "desired" and falls back to
+    // "sufficient" once the stabilization timeout elapses, so gating "sufficient" on the target
+    // too would just make that fallback impossible to reach.
     @Override
     public boolean hasDesiredResources() {
+        if (targetVertexParallelism != null) {
+            return isParallelismBasedOnFreeSlotsAtLeast(targetVertexParallelism);
+        }
         return context.hasDesiredResources();
     }
 
@@ -141,6 +160,29 @@ class WaitingForResources extends StateWithoutExecutionGraph
     @Override
     public ScheduledFuture<?> scheduleOperation(Runnable callback, Duration delay) {
         return context.runIfState(this, callback, delay);
+    }
+
+    private boolean isParallelismBasedOnFreeSlotsAtLeast(VertexParallelism target) {
+        final Optional<VertexParallelism> maybeParallelismBasedOnFreeSlots =
+                context.getFreeSlotVertexParallelism();
+        if (maybeParallelismBasedOnFreeSlots.isEmpty()) {
+            return false;
+        }
+
+        final VertexParallelism parallelismBasedOnFreeSlots = maybeParallelismBasedOnFreeSlots.get();
+        return target.getVertices().stream()
+                .allMatch(
+                        vertex -> {
+                            // Concurrent resource requirements (e.g. a scale-down triggered while
+                            // still waiting to regain the pre-restart target) may have lowered
+                            // what's actually needed below the original target: cap the target so
+                            // this gate doesn't keep waiting for a level that's no longer relevant.
+                            final int cappedTarget =
+                                    Math.min(
+                                            target.getParallelism(vertex),
+                                            context.getUpperBoundParallelism(vertex));
+                            return cappedTarget <= parallelismBasedOnFreeSlots.getParallelism(vertex);
+                        });
     }
 
     /** Context of the {@link WaitingForResources} state. */
@@ -171,29 +213,44 @@ class WaitingForResources extends StateWithoutExecutionGraph
          * @return a ScheduledFuture representing pending completion of the task
          */
         ScheduledFuture<?> runIfState(State expectedState, Runnable action, Duration delay);
+
+        /**
+         * Returns the {@link VertexParallelism} that can be achieved with the currently free slots
+         * (excluding slots still reserved by the execution that is being cancelled).
+         */
+        Optional<VertexParallelism> getFreeSlotVertexParallelism();
+
+        /**
+         * Returns the parallelism upper bound currently allowed for the given vertex by the
+         * latest job resource requirements, independent of slot availability.
+         */
+        int getUpperBoundParallelism(JobVertexID jobVertexId);
     }
 
     static class Factory implements StateFactory<WaitingForResources> {
 
         private final Context context;
         private final Logger log;
-        private final Duration submissionResourceWaitTimeout;
+        private final Duration resourceWaitTimeout;
         @Nullable private final ExecutionGraph previousExecutionGraph;
         private final Function<StateTransitionManager.Context, StateTransitionManager>
                 stateTransitionManagerFactory;
+        @Nullable private final VertexParallelism targetVertexParallelism;
 
         public Factory(
                 Context context,
                 Logger log,
-                Duration submissionResourceWaitTimeout,
+                Duration resourceWaitTimeout,
                 Function<StateTransitionManager.Context, StateTransitionManager>
                         stateTransitionManagerFactory,
-                @Nullable ExecutionGraph previousExecutionGraph) {
+                @Nullable ExecutionGraph previousExecutionGraph,
+                @Nullable VertexParallelism targetVertexParallelism) {
             this.context = context;
             this.log = log;
-            this.submissionResourceWaitTimeout = submissionResourceWaitTimeout;
+            this.resourceWaitTimeout = resourceWaitTimeout;
             this.previousExecutionGraph = previousExecutionGraph;
             this.stateTransitionManagerFactory = stateTransitionManagerFactory;
+            this.targetVertexParallelism = targetVertexParallelism;
         }
 
         public Class<WaitingForResources> getStateClass() {
@@ -204,9 +261,10 @@ class WaitingForResources extends StateWithoutExecutionGraph
             return new WaitingForResources(
                     context,
                     log,
-                    submissionResourceWaitTimeout,
+                    resourceWaitTimeout,
                     previousExecutionGraph,
-                    stateTransitionManagerFactory);
+                    stateTransitionManagerFactory,
+                    targetVertexParallelism);
         }
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/WaitingForResources.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/WaitingForResources.java
@@ -147,7 +147,7 @@ class WaitingForResources extends StateWithoutExecutionGraph
     @Override
     public boolean hasDesiredResources() {
         if (targetVertexParallelism != null) {
-            return isParallelismBasedOnFreeSlotsAtLeast(targetVertexParallelism);
+            return isFreeSlotVertexParallelismAtLeast(targetVertexParallelism);
         }
         return context.hasDesiredResources();
     }
@@ -162,14 +162,14 @@ class WaitingForResources extends StateWithoutExecutionGraph
         return context.runIfState(this, callback, delay);
     }
 
-    private boolean isParallelismBasedOnFreeSlotsAtLeast(VertexParallelism target) {
-        final Optional<VertexParallelism> maybeParallelismBasedOnFreeSlots =
+    private boolean isFreeSlotVertexParallelismAtLeast(VertexParallelism target) {
+        final Optional<VertexParallelism> maybeFreeSlotVertexParallelism =
                 context.getFreeSlotVertexParallelism();
-        if (maybeParallelismBasedOnFreeSlots.isEmpty()) {
+        if (maybeFreeSlotVertexParallelism.isEmpty()) {
             return false;
         }
 
-        final VertexParallelism parallelismBasedOnFreeSlots = maybeParallelismBasedOnFreeSlots.get();
+        final VertexParallelism freeSlotVertexParallelism = maybeFreeSlotVertexParallelism.get();
         return target.getVertices().stream()
                 .allMatch(
                         vertex -> {
@@ -181,7 +181,7 @@ class WaitingForResources extends StateWithoutExecutionGraph
                                     Math.min(
                                             target.getParallelism(vertex),
                                             context.getUpperBoundParallelism(vertex));
-                            return cappedTarget <= parallelismBasedOnFreeSlots.getParallelism(vertex);
+                            return cappedTarget <= freeSlotVertexParallelism.getParallelism(vertex);
                         });
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveSchedulerFreeSlotVertexParallelismTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveSchedulerFreeSlotVertexParallelismTest.java
@@ -1,0 +1,146 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler.adaptive;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.JobManagerOptions;
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
+import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.jobmaster.slotpool.DefaultAllocatedSlotPool;
+import org.apache.flink.runtime.jobmaster.slotpool.DefaultDeclarativeSlotPool;
+import org.apache.flink.runtime.scheduler.adaptive.AdaptiveSchedulerTest.SubmissionBufferingTaskManagerGateway;
+import org.apache.flink.runtime.taskmanager.LocalTaskManagerLocation;
+import org.apache.flink.runtime.util.ResourceCounter;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+
+import static org.apache.flink.runtime.jobgraph.JobGraphTestUtils.streamingJobGraph;
+import static org.apache.flink.runtime.jobmaster.slotpool.SlotPoolTestUtils.createSlotOffersForResourceRequirements;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test proving that {@link AdaptiveScheduler#getAvailableVertexParallelism()} (which
+ * over-counts slots still reserved by a running task) and {@link
+ * AdaptiveScheduler#getFreeSlotVertexParallelism()} (which only counts genuinely free slots)
+ * diverge when a slot is reserved-but-not-yet-freed.
+ *
+ * <p>This is kept in its own file rather than {@link AdaptiveSchedulerTest} to avoid growing that
+ * file past the checkstyle {@code FileLength} limit, following the precedent set by extracting
+ * {@code LocalRecoveryTest} and other companion test files out of {@code AdaptiveSchedulerTest}.
+ */
+class AdaptiveSchedulerFreeSlotVertexParallelismTest extends AdaptiveSchedulerTestBase {
+
+    @Test
+    void testFreeSlotVertexParallelismExcludesReservedSlots() throws Exception {
+        final JobGraph jobGraph = createJobGraph();
+        final DefaultDeclarativeSlotPool declarativeSlotPool =
+                createDeclarativeSlotPool(jobGraph.getJobID(), singleThreadMainThreadExecutor);
+
+        scheduler = prepareSchedulerWithNoTimeouts(jobGraph, declarativeSlotPool).build();
+
+        final SubmissionBufferingTaskManagerGateway taskManagerGateway =
+                new SubmissionBufferingTaskManagerGateway(1);
+
+        startTestInstanceInMainThread();
+
+        // one slot is offered and immediately claimed by the running (parallelism-1) job.
+        runInMainThread(
+                () ->
+                        declarativeSlotPool.offerSlots(
+                                createSlotOffersForResourceRequirements(
+                                        ResourceCounter.withResource(ResourceProfile.UNKNOWN, 1)),
+                                new LocalTaskManagerLocation(),
+                                taskManagerGateway,
+                                System.currentTimeMillis()));
+        taskManagerGateway.waitForSubmissions(1);
+
+        // a second slot joins, but stays genuinely free: nothing has requested it yet.
+        runInMainThread(
+                () ->
+                        declarativeSlotPool.offerSlots(
+                                createSlotOffersForResourceRequirements(
+                                        ResourceCounter.withResource(ResourceProfile.UNKNOWN, 1)),
+                                new LocalTaskManagerLocation(),
+                                taskManagerGateway,
+                                System.currentTimeMillis()));
+
+        runInMainThread(
+                () -> {
+                    // over-counted view: 1 reserved (in use by the running task) + 1 free = 2.
+                    // This is correct for Executing's use (predicting a restart's target).
+                    assertThat(scheduler.getAvailableVertexParallelism())
+                            .hasValueSatisfying(
+                                    parallelism ->
+                                            assertThat(
+                                                            parallelism.getParallelism(
+                                                                    JOB_VERTEX.getID()))
+                                                    .isEqualTo(2));
+
+                    // free-slots-based view: only the genuinely free slot counts = 1.
+                    // This is what a restart can *actually* reserve right now.
+                    assertThat(scheduler.getFreeSlotVertexParallelism())
+                            .hasValueSatisfying(
+                                    parallelism ->
+                                            assertThat(
+                                                            parallelism.getParallelism(
+                                                                    JOB_VERTEX.getID()))
+                                                    .isEqualTo(1));
+                });
+    }
+
+    private static JobGraph createJobGraph() {
+        return streamingJobGraph(JOB_VERTEX);
+    }
+
+    private static DefaultDeclarativeSlotPool createDeclarativeSlotPool(
+            JobID jobId, ComponentMainThreadExecutor mainThreadExecutor) {
+        return new DefaultDeclarativeSlotPool(
+                jobId,
+                new DefaultAllocatedSlotPool(),
+                ignored -> {},
+                DEFAULT_TIMEOUT,
+                DEFAULT_TIMEOUT,
+                Duration.ZERO,
+                mainThreadExecutor);
+    }
+
+    private AdaptiveSchedulerBuilder prepareSchedulerWithNoTimeouts(
+            JobGraph jobGraph, DefaultDeclarativeSlotPool declarativeSlotPool) {
+        return new AdaptiveSchedulerBuilder(
+                        jobGraph, singleThreadMainThreadExecutor, EXECUTOR_RESOURCE.getExecutor())
+                .setDeclarativeSlotPool(declarativeSlotPool)
+                .setJobMasterConfiguration(createConfigurationWithNoTimeouts());
+    }
+
+    private static Configuration createConfigurationWithNoTimeouts() {
+        return new Configuration()
+                .set(
+                        JobManagerOptions.SCHEDULER_SUBMISSION_RESOURCE_WAIT_TIMEOUT,
+                        Duration.ofMillis(-1L))
+                .set(
+                        JobManagerOptions.SCHEDULER_RESCALE_RESOURCE_STABILIZATION_TIMEOUT,
+                        Duration.ZERO)
+                .set(
+                        JobManagerOptions.SCHEDULER_SUBMISSION_RESOURCE_STABILIZATION_TIMEOUT,
+                        Duration.ofMillis(1L));
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveSchedulerRescaleRestartTimingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveSchedulerRescaleRestartTimingTest.java
@@ -1,0 +1,193 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler.adaptive;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.JobManagerOptions;
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
+import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.jobmaster.slotpool.DefaultAllocatedSlotPool;
+import org.apache.flink.runtime.jobmaster.slotpool.DefaultDeclarativeSlotPool;
+import org.apache.flink.runtime.scheduler.adaptive.AdaptiveSchedulerTest.SubmissionBufferingTaskManagerGateway;
+import org.apache.flink.runtime.scheduler.adaptive.allocator.VertexParallelism;
+import org.apache.flink.runtime.taskmanager.LocalTaskManagerLocation;
+import org.apache.flink.runtime.testutils.CommonTestUtils;
+import org.apache.flink.runtime.util.ResourceCounter;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.Collections;
+
+import static org.apache.flink.runtime.jobgraph.JobGraphTestUtils.streamingJobGraph;
+import static org.apache.flink.runtime.jobmaster.slotpool.SlotPoolTestUtils.createSlotOffersForResourceRequirements;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration test proving that {@link WaitingForResources}, driven by the real {@link
+ * DefaultStateTransitionManager} (not a no-op test double), correctly gates a rescale-triggered
+ * restart on genuinely free slots reaching the pre-restart target, and falls back once the
+ * rescale resource-stabilization timeout elapses.
+ *
+ * <p>Kept in its own file, following the precedent set by {@link
+ * AdaptiveSchedulerFreeSlotVertexParallelismTest} and other companion test files extracted out of
+ * {@link AdaptiveSchedulerTest}.
+ */
+class AdaptiveSchedulerRescaleRestartTimingTest extends AdaptiveSchedulerTestBase {
+
+    private static final int RETRY_INTERVAL_MILLIS = 20;
+    private static final int RETRY_ATTEMPTS = 250;
+
+    @Test
+    void testWaitingForResourcesDoesNotTransitionUntilFreeSlotsReachRescaleTarget()
+            throws Exception {
+        final JobGraph jobGraph = createJobGraph();
+        final DefaultDeclarativeSlotPool declarativeSlotPool =
+                createDeclarativeSlotPool(jobGraph.getJobID(), singleThreadMainThreadExecutor);
+
+        // long enough that the stabilization timeout cannot fire during this test.
+        scheduler =
+                prepareScheduler(jobGraph, declarativeSlotPool, Duration.ofSeconds(10)).build();
+
+        final SubmissionBufferingTaskManagerGateway taskManagerGateway =
+                new SubmissionBufferingTaskManagerGateway(2);
+
+        // go straight to the restart-triggered WaitingForResources from the initial Created
+        // state, the same way Restarting#goToSubsequentState does - never through the plain
+        // submission path (startScheduling()), which would race a second, unrelated
+        // WaitingForResources transition using the submission timeout config.
+        final VertexParallelism restartTarget = vertexParallelism(2);
+        runInMainThread(
+                () ->
+                        scheduler.goToWaitingForResources(
+                                new StateTrackingMockExecutionGraph(), restartTarget));
+
+        assertThat(scheduler.getState()).isInstanceOf(WaitingForResources.class);
+
+        offerSlots(declarativeSlotPool, taskManagerGateway, 1);
+
+        // only 1 of the 2 targeted slots is free: must not have shortcut to
+        // CreatingExecutionGraph yet, even though 1 slot is already "sufficient" to run the job
+        // at a lower parallelism.
+        Thread.sleep(300);
+        assertThat(scheduler.getState()).isInstanceOf(WaitingForResources.class);
+
+        offerSlots(declarativeSlotPool, taskManagerGateway, 1);
+
+        CommonTestUtils.waitUntilCondition(
+                () -> scheduler.getState() instanceof CreatingExecutionGraph,
+                RETRY_INTERVAL_MILLIS,
+                RETRY_ATTEMPTS);
+    }
+
+    @Test
+    void testWaitingForResourcesFallsBackAfterRescaleResourceStabilizationTimeoutElapses()
+            throws Exception {
+        final JobGraph jobGraph = createJobGraph();
+        final DefaultDeclarativeSlotPool declarativeSlotPool =
+                createDeclarativeSlotPool(jobGraph.getJobID(), singleThreadMainThreadExecutor);
+
+        scheduler =
+                prepareScheduler(jobGraph, declarativeSlotPool, Duration.ofMillis(300)).build();
+
+        final SubmissionBufferingTaskManagerGateway taskManagerGateway =
+                new SubmissionBufferingTaskManagerGateway(1);
+
+        // go straight to the restart-triggered WaitingForResources from the initial Created
+        // state, as in the test above - never through the plain submission path.
+        final VertexParallelism restartTarget = vertexParallelism(2);
+        runInMainThread(
+                () ->
+                        scheduler.goToWaitingForResources(
+                                new StateTrackingMockExecutionGraph(), restartTarget));
+
+        assertThat(scheduler.getState()).isInstanceOf(WaitingForResources.class);
+
+        // only 1 of the 2 targeted slots is ever offered.
+        offerSlots(declarativeSlotPool, taskManagerGateway, 1);
+
+        // the target is never reached, but the stabilization timeout must still force the
+        // transition once it elapses, rather than waiting forever.
+        CommonTestUtils.waitUntilCondition(
+                () -> scheduler.getState() instanceof CreatingExecutionGraph,
+                RETRY_INTERVAL_MILLIS,
+                RETRY_ATTEMPTS);
+    }
+
+    private VertexParallelism vertexParallelism(int parallelism) {
+        return new VertexParallelism(Collections.singletonMap(JOB_VERTEX.getID(), parallelism));
+    }
+
+    private void offerSlots(
+            DefaultDeclarativeSlotPool declarativeSlotPool,
+            SubmissionBufferingTaskManagerGateway taskManagerGateway,
+            int numSlots) {
+        runInMainThread(
+                () ->
+                        declarativeSlotPool.offerSlots(
+                                createSlotOffersForResourceRequirements(
+                                        ResourceCounter.withResource(
+                                                ResourceProfile.UNKNOWN, numSlots)),
+                                new LocalTaskManagerLocation(),
+                                taskManagerGateway,
+                                System.currentTimeMillis()));
+    }
+
+    private static JobGraph createJobGraph() {
+        return streamingJobGraph(JOB_VERTEX);
+    }
+
+    private static DefaultDeclarativeSlotPool createDeclarativeSlotPool(
+            JobID jobId, ComponentMainThreadExecutor mainThreadExecutor) {
+        return new DefaultDeclarativeSlotPool(
+                jobId,
+                new DefaultAllocatedSlotPool(),
+                ignored -> {},
+                DEFAULT_TIMEOUT,
+                DEFAULT_TIMEOUT,
+                Duration.ZERO,
+                mainThreadExecutor);
+    }
+
+    private AdaptiveSchedulerBuilder prepareScheduler(
+            JobGraph jobGraph,
+            DefaultDeclarativeSlotPool declarativeSlotPool,
+            Duration rescaleResourceStabilizationTimeout) {
+        return new AdaptiveSchedulerBuilder(
+                        jobGraph, singleThreadMainThreadExecutor, EXECUTOR_RESOURCE.getExecutor())
+                .setDeclarativeSlotPool(declarativeSlotPool)
+                .setJobMasterConfiguration(
+                        createConfiguration(rescaleResourceStabilizationTimeout));
+    }
+
+    private static Configuration createConfiguration(
+            Duration rescaleResourceStabilizationTimeout) {
+        return new Configuration()
+                .set(
+                        JobManagerOptions.SCHEDULER_SUBMISSION_RESOURCE_WAIT_TIMEOUT,
+                        Duration.ofMillis(-1L))
+                .set(
+                        JobManagerOptions.SCHEDULER_RESCALE_RESOURCE_STABILIZATION_TIMEOUT,
+                        rescaleResourceStabilizationTimeout)
+                .set(
+                        JobManagerOptions.SCHEDULER_SUBMISSION_RESOURCE_STABILIZATION_TIMEOUT,
+                        Duration.ofMillis(1L));
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveSchedulerRescaleRestartTimingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveSchedulerRescaleRestartTimingTest.java
@@ -84,9 +84,11 @@ class AdaptiveSchedulerRescaleRestartTimingTest extends AdaptiveSchedulerTestBas
         offerSlots(declarativeSlotPool, taskManagerGateway, 1);
 
         // only 1 of the 2 targeted slots is free: must not have shortcut to
-        // CreatingExecutionGraph yet, even though 1 slot is already "sufficient" to run the job
-        // at a lower parallelism.
-        Thread.sleep(300);
+        // CreatingExecutionGraph, even though 1 slot is already "sufficient" to run the job at a
+        // lower parallelism. No sleep is needed here: offerSlots() runs synchronously on the main
+        // thread executor, and no stabilization work gets scheduled while desired resources
+        // (gated on the restart target) aren't met, so the state is already final by the time it
+        // returns.
         assertThat(scheduler.getState()).isInstanceOf(WaitingForResources.class);
 
         offerSlots(declarativeSlotPool, taskManagerGateway, 1);
@@ -104,15 +106,20 @@ class AdaptiveSchedulerRescaleRestartTimingTest extends AdaptiveSchedulerTestBas
         final DefaultDeclarativeSlotPool declarativeSlotPool =
                 createDeclarativeSlotPool(jobGraph.getJobID(), singleThreadMainThreadExecutor);
 
+        // short enough to keep the test fast, but comfortably longer than the offerSlots() call
+        // below so the fallback can only be triggered by the timeout, not by a race with it.
+        final Duration rescaleResourceStabilizationTimeout = Duration.ofMillis(300);
         scheduler =
-                prepareScheduler(jobGraph, declarativeSlotPool, Duration.ofMillis(300)).build();
+                prepareScheduler(jobGraph, declarativeSlotPool, rescaleResourceStabilizationTimeout)
+                        .build();
 
+        final int requiredParallelism = 2;
         final SubmissionBufferingTaskManagerGateway taskManagerGateway =
-                new SubmissionBufferingTaskManagerGateway(1);
+                new SubmissionBufferingTaskManagerGateway(requiredParallelism - 1);
 
         // go straight to the restart-triggered WaitingForResources from the initial Created
         // state, as in the test above - never through the plain submission path.
-        final VertexParallelism restartTarget = vertexParallelism(2);
+        final VertexParallelism restartTarget = vertexParallelism(requiredParallelism);
         runInMainThread(
                 () ->
                         scheduler.goToWaitingForResources(
@@ -121,7 +128,7 @@ class AdaptiveSchedulerRescaleRestartTimingTest extends AdaptiveSchedulerTestBas
         assertThat(scheduler.getState()).isInstanceOf(WaitingForResources.class);
 
         // only 1 of the 2 targeted slots is ever offered.
-        offerSlots(declarativeSlotPool, taskManagerGateway, 1);
+        offerSlots(declarativeSlotPool, taskManagerGateway, requiredParallelism - 1);
 
         // the target is never reached, but the stabilization timeout must still force the
         // transition once it elapses, rather than waiting forever.

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveSchedulerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveSchedulerTest.java
@@ -58,6 +58,7 @@ import org.apache.flink.runtime.executiongraph.ArchivedExecutionGraphTest;
 import org.apache.flink.runtime.executiongraph.ArchivedExecutionJobVertex;
 import org.apache.flink.runtime.executiongraph.ArchivedExecutionVertex;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
+import org.apache.flink.runtime.executiongraph.ExecutionGraph;
 import org.apache.flink.runtime.executiongraph.TaskExecutionStateTransition;
 import org.apache.flink.runtime.executiongraph.failover.FixedDelayRestartBackoffTimeStrategy;
 import org.apache.flink.runtime.executiongraph.failover.NoRestartBackoffTimeStrategy;
@@ -70,6 +71,7 @@ import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobResourceRequirements;
 import org.apache.flink.runtime.jobgraph.JobVertex;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobgraph.JobVertexResourceRequirements;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.jobgraph.tasks.CheckpointCoordinatorConfiguration;
@@ -1447,6 +1449,9 @@ public class AdaptiveSchedulerTest extends AdaptiveSchedulerTestBase {
                         JobManagerOptions.SCHEDULER_SUBMISSION_RESOURCE_STABILIZATION_TIMEOUT,
                         Duration.ofMillis(1L))
                 .set(
+                        JobManagerOptions.SCHEDULER_RESCALE_RESOURCE_STABILIZATION_TIMEOUT,
+                        Duration.ofMillis(1L))
+                .set(
                         JobManagerOptions.SCHEDULER_EXECUTING_COOLDOWN_AFTER_RESCALING,
                         Duration.ofMillis(1L))
                 .set(
@@ -2298,6 +2303,90 @@ public class AdaptiveSchedulerTest extends AdaptiveSchedulerTestBase {
     }
 
     @Test
+    void testRescaleResourceStabilizationTimeoutConfigurationIsRespected()
+            throws ConfigurationException {
+        final Duration rescaleResourceStabilizationTimeout = Duration.ofMillis(4242);
+        final Configuration configuration = createConfigurationWithNoTimeouts();
+        configuration.set(
+                JobManagerOptions.SCHEDULER_RESCALE_RESOURCE_STABILIZATION_TIMEOUT,
+                rescaleResourceStabilizationTimeout);
+
+        final AdaptiveScheduler.Settings settings = AdaptiveScheduler.Settings.of(configuration);
+        assertThat(settings.getRescaleResourceStabilizationTimeout())
+                .isEqualTo(rescaleResourceStabilizationTimeout);
+    }
+
+    @Test
+    void testRescaleResourceStabilizationTimeoutDefault() throws ConfigurationException {
+        final AdaptiveScheduler.Settings settings =
+                AdaptiveScheduler.Settings.of(new Configuration());
+
+        assertThat(settings.getRescaleResourceStabilizationTimeout())
+                .isEqualTo(
+                        JobManagerOptions.SCHEDULER_RESCALE_RESOURCE_STABILIZATION_TIMEOUT
+                                .defaultValue());
+    }
+
+    @Test
+    void testRescaleResourceStabilizationTimeoutIsDisabledInReactiveMode()
+            throws ConfigurationException {
+        final AdaptiveScheduler.Settings settings =
+                AdaptiveScheduler.Settings.of(
+                        new Configuration()
+                                .set(
+                                        JobManagerOptions.SCHEDULER_MODE,
+                                        SchedulerExecutionMode.REACTIVE));
+
+        assertThat(settings.getRescaleResourceStabilizationTimeout()).isEqualTo(Duration.ZERO);
+    }
+
+    @Test
+    void testGoToWaitingForResourcesForRestartConfiguresStateTransitionManagerFactory()
+            throws Exception {
+        final TestingStateTransitionManagerFactory factory =
+                new TestingStateTransitionManagerFactory(
+                        ctx -> TestingStateTransitionManager.withNoOp());
+
+        final Duration rescaleResourceStabilizationTimeout = Duration.ofMillis(1234);
+        final Configuration configuration = createConfigurationWithNoTimeouts();
+        configuration.set(
+                JobManagerOptions.SCHEDULER_RESCALE_RESOURCE_STABILIZATION_TIMEOUT,
+                rescaleResourceStabilizationTimeout);
+
+        scheduler =
+                new AdaptiveSchedulerBuilder(
+                                createJobGraph(),
+                                singleThreadMainThreadExecutor,
+                                EXECUTOR_RESOURCE.getExecutor())
+                        .setStateTransitionManagerFactory(factory)
+                        .setJobMasterConfiguration(configuration)
+                        .build();
+
+        final JobVertexID jobVertexId = new JobVertexID();
+        final VertexParallelism restartWithParallelism =
+                new VertexParallelism(Collections.singletonMap(jobVertexId, 2));
+        final ExecutionGraph mockExecutionGraph = new StateTrackingMockExecutionGraph();
+
+        final OneShotLatch latch = new OneShotLatch();
+        singleThreadMainThreadExecutor.execute(
+                () -> {
+                    scheduler.goToWaitingForResources(mockExecutionGraph, restartWithParallelism);
+                    latch.trigger();
+                });
+        latch.await();
+
+        assertThat(scheduler.getState()).isInstanceOf(WaitingForResources.class);
+        assertThat(factory.getCooldownTimeout()).isEqualTo(Duration.ZERO);
+        assertThat(factory.getResourceStabilizationTimeout())
+                .isEqualTo(rescaleResourceStabilizationTimeout);
+        // Same shape as submission: the eager, zero-delay evaluation is a fast path for "target
+        // already reached", not the mechanism enforcing the wait. The wait itself is enforced by
+        // hasDesiredResources() (gated on the restart target) versus hasSufficientResources()
+        // (the plain, restart-agnostic check) inside the stabilization phase machine.
+        assertThat(factory.getMaximumDelayForTrigger()).isEqualTo(Duration.ZERO);
+    }
+
+    @Test
     void testOnCompletedCheckpointIsHandledInMainThread() throws Exception {
         testCheckpointStatsEventBeingExecutedInTheMainThread(
                 CheckpointStatsListener::onCompletedCheckpoint, 1, Integer.MAX_VALUE);
@@ -2481,6 +2570,18 @@ public class AdaptiveSchedulerTest extends AdaptiveSchedulerTestBase {
             this.maximumDelayForTrigger = maximumDelayForTrigger;
 
             return stateTransitionManagerCreator.apply(context);
+        }
+
+        public Duration getCooldownTimeout() {
+            return cooldownTimeout;
+        }
+
+        public Duration getResourceStabilizationTimeout() {
+            return resourceStabilizationTimeout;
+        }
+
+        public Duration getMaximumDelayForTrigger() {
+            return maximumDelayForTrigger;
         }
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/CreatedTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/CreatedTest.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.scheduler.adaptive;
 import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.runtime.executiongraph.ArchivedExecutionGraph;
 import org.apache.flink.runtime.executiongraph.ExecutionGraph;
+import org.apache.flink.runtime.scheduler.adaptive.allocator.VertexParallelism;
 import org.apache.flink.runtime.scheduler.adaptive.timeline.RescaleTimeline;
 
 import org.junit.jupiter.api.Test;
@@ -66,7 +67,9 @@ class CreatedTest {
         }
 
         @Override
-        public void goToWaitingForResources(@Nullable ExecutionGraph previousExecutionGraph) {
+        public void goToWaitingForResources(
+                @Nullable ExecutionGraph previousExecutionGraph,
+                @Nullable VertexParallelism restartWithParallelism) {
             waitingForResourcesStateValidator.validateInput(null);
         }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/CreatedTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/CreatedTest.java
@@ -69,7 +69,7 @@ class CreatedTest {
         @Override
         public void goToWaitingForResources(
                 @Nullable ExecutionGraph previousExecutionGraph,
-                @Nullable VertexParallelism restartWithParallelism) {
+                @Nullable VertexParallelism targetVertexParallelism) {
             waitingForResourcesStateValidator.validateInput(null);
         }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/CreatingExecutionGraphTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/CreatingExecutionGraphTest.java
@@ -28,6 +28,7 @@ import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
 import org.apache.flink.runtime.scheduler.ExecutionGraphHandler;
 import org.apache.flink.runtime.scheduler.GlobalFailureHandler;
 import org.apache.flink.runtime.scheduler.OperatorCoordinatorHandler;
+import org.apache.flink.runtime.scheduler.adaptive.allocator.VertexParallelism;
 import org.apache.flink.runtime.scheduler.adaptive.timeline.RescaleTimeline;
 import org.apache.flink.runtime.scheduler.exceptionhistory.ExceptionHistoryEntry;
 import org.apache.flink.util.FlinkException;
@@ -233,7 +234,9 @@ class CreatingExecutionGraphTest {
         }
 
         @Override
-        public void goToWaitingForResources(@Nullable ExecutionGraph previousExecutionGraph) {
+        public void goToWaitingForResources(
+                @Nullable ExecutionGraph previousExecutionGraph,
+                @Nullable VertexParallelism restartWithParallelism) {
             waitingForResourcesStateValidator.validateInput(null);
             registerStateTransition();
         }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/CreatingExecutionGraphTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/CreatingExecutionGraphTest.java
@@ -236,7 +236,7 @@ class CreatingExecutionGraphTest {
         @Override
         public void goToWaitingForResources(
                 @Nullable ExecutionGraph previousExecutionGraph,
-                @Nullable VertexParallelism restartWithParallelism) {
+                @Nullable VertexParallelism targetVertexParallelism) {
             waitingForResourcesStateValidator.validateInput(null);
             registerStateTransition();
         }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/MockRestartingContext.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/MockRestartingContext.java
@@ -44,13 +44,13 @@ class MockRestartingContext extends MockStateWithExecutionGraphContext
     private final StateValidator<ExecutingTest.CancellingArguments> cancellingStateValidator =
             new StateValidator<>("Cancelling");
 
-    private final StateValidator<ExecutionGraph> waitingForResourcesStateValidator =
+    private final StateValidator<WaitingForResourcesArguments> waitingForResourcesStateValidator =
             new StateValidator<>("WaitingForResources");
 
     private final StateValidator<ExecutionGraph> creatingExecutionGraphStateValidator =
             new StateValidator<>("CreatingExecutionGraph");
 
-    @Nullable private VertexParallelism availableVertexParallelism;
+    @Nullable private VertexParallelism achievableVertexParallelism;
 
     private boolean hasDesiredResources = false;
 
@@ -66,9 +66,9 @@ class MockRestartingContext extends MockStateWithExecutionGraphContext
         creatingExecutionGraphStateValidator.expectInput(assertNonNull());
     }
 
-    public void setAvailableVertexParallelism(
-            @Nullable VertexParallelism availableVertexParallelism) {
-        this.availableVertexParallelism = availableVertexParallelism;
+    public void setAchievableVertexParallelism(
+            @Nullable VertexParallelism achievableVertexParallelism) {
+        this.achievableVertexParallelism = achievableVertexParallelism;
     }
 
     public void setHasDesiredResources(boolean hasDesiredResources) {
@@ -101,8 +101,11 @@ class MockRestartingContext extends MockStateWithExecutionGraphContext
     }
 
     @Override
-    public void goToWaitingForResources(@Nullable ExecutionGraph previousExecutionGraph) {
-        waitingForResourcesStateValidator.validateInput(previousExecutionGraph);
+    public void goToWaitingForResources(
+            @Nullable ExecutionGraph previousExecutionGraph,
+            @Nullable VertexParallelism restartWithParallelism) {
+        waitingForResourcesStateValidator.validateInput(
+                new WaitingForResourcesArguments(previousExecutionGraph, restartWithParallelism));
         hadStateTransition = true;
     }
 
@@ -121,8 +124,8 @@ class MockRestartingContext extends MockStateWithExecutionGraphContext
     }
 
     @Override
-    public Optional<VertexParallelism> getAvailableVertexParallelism() {
-        return Optional.ofNullable(availableVertexParallelism);
+    public Optional<VertexParallelism> getFreeSlotVertexParallelism() {
+        return Optional.ofNullable(achievableVertexParallelism);
     }
 
     @Override
@@ -131,5 +134,28 @@ class MockRestartingContext extends MockStateWithExecutionGraphContext
         cancellingStateValidator.close();
         waitingForResourcesStateValidator.close();
         creatingExecutionGraphStateValidator.close();
+    }
+
+    /** Arguments passed to {@link #goToWaitingForResources}. */
+    static class WaitingForResourcesArguments {
+        @Nullable private final ExecutionGraph executionGraph;
+        @Nullable private final VertexParallelism restartWithParallelism;
+
+        WaitingForResourcesArguments(
+                @Nullable ExecutionGraph executionGraph,
+                @Nullable VertexParallelism restartWithParallelism) {
+            this.executionGraph = executionGraph;
+            this.restartWithParallelism = restartWithParallelism;
+        }
+
+        @Nullable
+        public ExecutionGraph getExecutionGraph() {
+            return executionGraph;
+        }
+
+        @Nullable
+        public VertexParallelism getRestartWithParallelism() {
+            return restartWithParallelism;
+        }
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/MockRestartingContext.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/MockRestartingContext.java
@@ -36,6 +36,7 @@ import java.util.concurrent.ScheduledFuture;
 import java.util.function.Consumer;
 
 import static org.apache.flink.runtime.scheduler.adaptive.WaitingForResourcesTest.assertNonNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Mock the {@link StateWithExecutionGraph.Context} for restarting state. */
 class MockRestartingContext extends MockStateWithExecutionGraphContext
@@ -50,7 +51,7 @@ class MockRestartingContext extends MockStateWithExecutionGraphContext
     private final StateValidator<ExecutionGraph> creatingExecutionGraphStateValidator =
             new StateValidator<>("CreatingExecutionGraph");
 
-    @Nullable private VertexParallelism achievableVertexParallelism;
+    @Nullable private VertexParallelism freeSlotVertexParallelism;
 
     private boolean hasDesiredResources = false;
 
@@ -58,17 +59,23 @@ class MockRestartingContext extends MockStateWithExecutionGraphContext
         cancellingStateValidator.expectInput(asserter);
     }
 
-    public void setExpectWaitingForResources() {
-        waitingForResourcesStateValidator.expectInput(assertNonNull());
+    public void setExpectWaitingForResources(
+            @Nullable VertexParallelism expectedTargetVertexParallelism) {
+        waitingForResourcesStateValidator.expectInput(
+                arguments -> {
+                    assertNonNull().accept(arguments);
+                    assertThat(arguments.getTargetVertexParallelism())
+                            .isEqualTo(expectedTargetVertexParallelism);
+                });
     }
 
     public void setExpectCreatingExecutionGraph() {
         creatingExecutionGraphStateValidator.expectInput(assertNonNull());
     }
 
-    public void setAchievableVertexParallelism(
-            @Nullable VertexParallelism achievableVertexParallelism) {
-        this.achievableVertexParallelism = achievableVertexParallelism;
+    public void setFreeSlotVertexParallelism(
+            @Nullable VertexParallelism freeSlotVertexParallelism) {
+        this.freeSlotVertexParallelism = freeSlotVertexParallelism;
     }
 
     public void setHasDesiredResources(boolean hasDesiredResources) {
@@ -103,9 +110,9 @@ class MockRestartingContext extends MockStateWithExecutionGraphContext
     @Override
     public void goToWaitingForResources(
             @Nullable ExecutionGraph previousExecutionGraph,
-            @Nullable VertexParallelism restartWithParallelism) {
+            @Nullable VertexParallelism targetVertexParallelism) {
         waitingForResourcesStateValidator.validateInput(
-                new WaitingForResourcesArguments(previousExecutionGraph, restartWithParallelism));
+                new WaitingForResourcesArguments(previousExecutionGraph, targetVertexParallelism));
         hadStateTransition = true;
     }
 
@@ -125,7 +132,7 @@ class MockRestartingContext extends MockStateWithExecutionGraphContext
 
     @Override
     public Optional<VertexParallelism> getFreeSlotVertexParallelism() {
-        return Optional.ofNullable(achievableVertexParallelism);
+        return Optional.ofNullable(freeSlotVertexParallelism);
     }
 
     @Override
@@ -139,13 +146,13 @@ class MockRestartingContext extends MockStateWithExecutionGraphContext
     /** Arguments passed to {@link #goToWaitingForResources}. */
     static class WaitingForResourcesArguments {
         @Nullable private final ExecutionGraph executionGraph;
-        @Nullable private final VertexParallelism restartWithParallelism;
+        @Nullable private final VertexParallelism targetVertexParallelism;
 
         WaitingForResourcesArguments(
                 @Nullable ExecutionGraph executionGraph,
-                @Nullable VertexParallelism restartWithParallelism) {
+                @Nullable VertexParallelism targetVertexParallelism) {
             this.executionGraph = executionGraph;
-            this.restartWithParallelism = restartWithParallelism;
+            this.targetVertexParallelism = targetVertexParallelism;
         }
 
         @Nullable
@@ -154,8 +161,8 @@ class MockRestartingContext extends MockStateWithExecutionGraphContext
         }
 
         @Nullable
-        public VertexParallelism getRestartWithParallelism() {
-            return restartWithParallelism;
+        public VertexParallelism getTargetVertexParallelism() {
+            return targetVertexParallelism;
         }
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/RestartingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/RestartingTest.java
@@ -65,7 +65,7 @@ class RestartingTest {
     public void testTransitionToSubsequentStateWhenCancellationComplete(
             Optional<VertexParallelism> restartWithParallelism) throws Exception {
         try (MockRestartingContext ctx = new MockRestartingContext()) {
-            restartWithParallelism.ifPresent(ctx::setAvailableVertexParallelism);
+            restartWithParallelism.ifPresent(ctx::setAchievableVertexParallelism);
             Restarting restarting = createRestartingState(ctx, restartWithParallelism.orElse(null));
 
             if (restartWithParallelism.isPresent()) {
@@ -83,12 +83,15 @@ class RestartingTest {
             throws Exception {
         try (MockRestartingContext ctx = new MockRestartingContext()) {
             JobVertexID jobVertexId = new JobVertexID();
-            VertexParallelism availableParallelism =
+            // Only 1 slot is genuinely free (e.g. the slot backing the just-cancelled execution
+            // has not been released yet), even though the restart target is 2: must not shortcut
+            // straight to CreatingExecutionGraph.
+            VertexParallelism parallelismBasedOnFreeSlots =
                     new VertexParallelism(singletonMap(jobVertexId, 1));
             VertexParallelism requiredParallelismForForcedRestart =
                     new VertexParallelism(singletonMap(jobVertexId, 2));
 
-            ctx.setAvailableVertexParallelism(availableParallelism);
+            ctx.setAchievableVertexParallelism(parallelismBasedOnFreeSlots);
             ctx.setHasDesiredResources(hasDesiredResources);
             Restarting restarting = createRestartingState(ctx, requiredParallelismForForcedRestart);
             if (hasDesiredResources) {
@@ -153,7 +156,7 @@ class RestartingTest {
     public void testStateDoesNotExposeGloballyTerminalExecutionGraph(
             Optional<VertexParallelism> restartWithParallelism) throws Exception {
         try (MockRestartingContext ctx = new MockRestartingContext()) {
-            restartWithParallelism.ifPresent(ctx::setAvailableVertexParallelism);
+            restartWithParallelism.ifPresent(ctx::setAchievableVertexParallelism);
             StateTrackingMockExecutionGraph mockExecutionGraph =
                     new StateTrackingMockExecutionGraph();
             Restarting restarting =

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/RestartingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/RestartingTest.java
@@ -65,13 +65,13 @@ class RestartingTest {
     public void testTransitionToSubsequentStateWhenCancellationComplete(
             Optional<VertexParallelism> restartWithParallelism) throws Exception {
         try (MockRestartingContext ctx = new MockRestartingContext()) {
-            restartWithParallelism.ifPresent(ctx::setAchievableVertexParallelism);
+            restartWithParallelism.ifPresent(ctx::setFreeSlotVertexParallelism);
             Restarting restarting = createRestartingState(ctx, restartWithParallelism.orElse(null));
 
             if (restartWithParallelism.isPresent()) {
                 ctx.setExpectCreatingExecutionGraph();
             } else {
-                ctx.setExpectWaitingForResources();
+                ctx.setExpectWaitingForResources(null);
             }
             restarting.onGloballyTerminalState(JobStatus.CANCELED);
         }
@@ -85,20 +85,19 @@ class RestartingTest {
             JobVertexID jobVertexId = new JobVertexID();
             // Only 1 slot is genuinely free (e.g. the slot backing the just-cancelled execution
             // has not been released yet), even though the restart target is 2: must not shortcut
-            // straight to CreatingExecutionGraph.
-            VertexParallelism parallelismBasedOnFreeSlots =
+            // straight to CreatingExecutionGraph, regardless of hasDesiredResources() - which
+            // counts all slots allocated to the job, including the ones not yet released by the
+            // execution being cancelled, and must not be allowed to bypass the free-slot-based
+            // target gate.
+            VertexParallelism freeSlotVertexParallelism =
                     new VertexParallelism(singletonMap(jobVertexId, 1));
             VertexParallelism requiredParallelismForForcedRestart =
                     new VertexParallelism(singletonMap(jobVertexId, 2));
 
-            ctx.setAchievableVertexParallelism(parallelismBasedOnFreeSlots);
+            ctx.setFreeSlotVertexParallelism(freeSlotVertexParallelism);
             ctx.setHasDesiredResources(hasDesiredResources);
             Restarting restarting = createRestartingState(ctx, requiredParallelismForForcedRestart);
-            if (hasDesiredResources) {
-                ctx.setExpectCreatingExecutionGraph();
-            } else {
-                ctx.setExpectWaitingForResources();
-            }
+            ctx.setExpectWaitingForResources(requiredParallelismForForcedRestart);
             restarting.onGloballyTerminalState(JobStatus.CANCELED);
         }
     }
@@ -156,7 +155,7 @@ class RestartingTest {
     public void testStateDoesNotExposeGloballyTerminalExecutionGraph(
             Optional<VertexParallelism> restartWithParallelism) throws Exception {
         try (MockRestartingContext ctx = new MockRestartingContext()) {
-            restartWithParallelism.ifPresent(ctx::setAchievableVertexParallelism);
+            restartWithParallelism.ifPresent(ctx::setFreeSlotVertexParallelism);
             StateTrackingMockExecutionGraph mockExecutionGraph =
                     new StateTrackingMockExecutionGraph();
             Restarting restarting =
@@ -167,7 +166,7 @@ class RestartingTest {
             if (restartWithParallelism.isPresent()) {
                 ctx.setExpectCreatingExecutionGraph();
             } else {
-                ctx.setExpectWaitingForResources();
+                ctx.setExpectWaitingForResources(null);
             }
 
             mockExecutionGraph.completeTerminationFuture(JobStatus.CANCELED);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/WaitingForResourcesTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/WaitingForResourcesTest.java
@@ -20,6 +20,8 @@ package org.apache.flink.runtime.scheduler.adaptive;
 
 import org.apache.flink.core.testutils.ScheduledTask;
 import org.apache.flink.runtime.executiongraph.ExecutionGraph;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.scheduler.adaptive.allocator.VertexParallelism;
 import org.apache.flink.runtime.scheduler.adaptive.timeline.RescaleTimeline;
 import org.apache.flink.util.clock.ManualClock;
 
@@ -32,7 +34,9 @@ import org.slf4j.LoggerFactory;
 import javax.annotation.Nullable;
 
 import java.time.Duration;
+import java.util.Collections;
 import java.util.Comparator;
+import java.util.Optional;
 import java.util.PriorityQueue;
 import java.util.Queue;
 import java.util.concurrent.ScheduledFuture;
@@ -203,6 +207,116 @@ class WaitingForResourcesTest {
     }
 
     @Test
+    void testDesiredResourcesRequireReachingRestartTargetRegardlessOfBaseCheck() {
+        final JobVertexID jobVertexId = new JobVertexID();
+        final VertexParallelism targetParallelism =
+                new VertexParallelism(
+                        Collections.singletonMap(jobVertexId, 2));
+        final VertexParallelism freeSlotParallelism =
+                new VertexParallelism(
+                        Collections.singletonMap(jobVertexId, 1));
+
+        // the (over-counted) base "sufficient" check is untouched by the restart target and can
+        // freely say "enough resources" ...
+        ctx.setHasSufficientResources(() -> true);
+        // ... and the base "desired" check is stubbed to the opposite of the expected outcome, so
+        // the assertion below can only pass if the restart-target gate actually overrides it,
+        // rather than happening to agree with an unexercised base check.
+        ctx.setHasDesiredResources(() -> true);
+        // only 1 out of the 2 slots we had before the restart is genuinely free, so
+        // "desired" (which is restart-target-aware) must not be satisfied yet.
+        ctx.setAchievableVertexParallelism(() -> Optional.of(freeSlotParallelism));
+
+        final WaitingForResources wfr =
+                new WaitingForResources(
+                        ctx,
+                        LOG,
+                        DISABLED_RESOURCE_WAIT_TIMEOUT,
+                        null,
+                        context -> TestingStateTransitionManager.withNoOp(),
+                        targetParallelism);
+
+        assertThat(wfr.hasDesiredResources()).isFalse();
+        // "sufficient" is intentionally left as the plain, restart-agnostic base check: it is the
+        // stabilization phase's give-up bar, not another restart-target gate.
+        assertThat(wfr.hasSufficientResources()).isTrue();
+    }
+
+    @Test
+    void testDesiredResourcesCapRestartTargetToLatestResourceRequirements() {
+        final JobVertexID jobVertexId = new JobVertexID();
+        final VertexParallelism targetParallelism =
+                new VertexParallelism(
+                        Collections.singletonMap(jobVertexId, 2));
+        final VertexParallelism freeSlotParallelism =
+                new VertexParallelism(
+                        Collections.singletonMap(jobVertexId, 1));
+
+        // a concurrent scale-down lowered what's actually needed for this vertex to 1, below the
+        // pre-restart target of 2: the gate must not keep waiting for the stale target.
+        ctx.setUpperBoundParallelism(vertex -> 1);
+        ctx.setAchievableVertexParallelism(() -> Optional.of(freeSlotParallelism));
+
+        final WaitingForResources wfr =
+                new WaitingForResources(
+                        ctx,
+                        LOG,
+                        DISABLED_RESOURCE_WAIT_TIMEOUT,
+                        null,
+                        context -> TestingStateTransitionManager.withNoOp(),
+                        targetParallelism);
+
+        assertThat(wfr.hasDesiredResources()).isTrue();
+    }
+
+    @Test
+    void testDesiredResourcesAreMetOnceFreeSlotParallelismReachesRestartTarget() {
+        final JobVertexID jobVertexId = new JobVertexID();
+        final VertexParallelism targetParallelism =
+                new VertexParallelism(
+                        Collections.singletonMap(jobVertexId, 2));
+
+        ctx.setHasSufficientResources(() -> false);
+        ctx.setAchievableVertexParallelism(() -> Optional.of(targetParallelism));
+
+        final WaitingForResources wfr =
+                new WaitingForResources(
+                        ctx,
+                        LOG,
+                        DISABLED_RESOURCE_WAIT_TIMEOUT,
+                        null,
+                        context -> TestingStateTransitionManager.withNoOp(),
+                        targetParallelism);
+
+        assertThat(wfr.hasDesiredResources()).isTrue();
+        // "sufficient" still just reflects the plain base check, unaffected by the restart target.
+        assertThat(wfr.hasSufficientResources()).isFalse();
+    }
+
+    @Test
+    void testResourceTimeoutOverridesRestartTargetGuard() {
+        final JobVertexID jobVertexId = new JobVertexID();
+        final VertexParallelism targetParallelism =
+                new VertexParallelism(
+                        Collections.singletonMap(jobVertexId, 2));
+
+        // free-slot-based parallelism never reaches the restart target ...
+        ctx.setAchievableVertexParallelism(Optional::empty);
+
+        new WaitingForResources(
+                ctx,
+                LOG,
+                Duration.ZERO,
+                null,
+                context -> TestingStateTransitionManager.withNoOp(),
+                targetParallelism);
+
+        // ... but the resource-wait timeout fires immediately and forces the transition anyway.
+        ctx.setExpectCreatingExecutionGraph();
+        ctx.runScheduledTasks();
+    }
+
+    @Test
     void testInternalRunScheduledTasks_correctExecutionOrder() {
         AtomicBoolean firstRun = new AtomicBoolean(false);
         AtomicBoolean secondRun = new AtomicBoolean(false);
@@ -293,6 +407,10 @@ class WaitingForResourcesTest {
 
         private Supplier<Boolean> hasDesiredResourcesSupplier = () -> false;
         private Supplier<Boolean> hasSufficientResourcesSupplier = () -> false;
+        private Supplier<Optional<VertexParallelism>> achievableVertexParallelismSupplier =
+                Optional::empty;
+        private Function<JobVertexID, Integer> upperBoundParallelismFunction =
+                jobVertexId -> Integer.MAX_VALUE;
 
         private final Queue<ScheduledTask<Void>> scheduledTasks =
                 new PriorityQueue<>(
@@ -306,6 +424,14 @@ class WaitingForResourcesTest {
 
         public void setHasSufficientResources(Supplier<Boolean> sup) {
             hasSufficientResourcesSupplier = sup;
+        }
+
+        public void setAchievableVertexParallelism(Supplier<Optional<VertexParallelism>> sup) {
+            achievableVertexParallelismSupplier = sup;
+        }
+
+        public void setUpperBoundParallelism(Function<JobVertexID, Integer> fn) {
+            upperBoundParallelismFunction = fn;
         }
 
         void setExpectCreatingExecutionGraph() {
@@ -348,6 +474,16 @@ class WaitingForResourcesTest {
         @Override
         public boolean hasSufficientResources() {
             return hasSufficientResourcesSupplier.get();
+        }
+
+        @Override
+        public Optional<VertexParallelism> getFreeSlotVertexParallelism() {
+            return achievableVertexParallelismSupplier.get();
+        }
+
+        @Override
+        public int getUpperBoundParallelism(JobVertexID jobVertexId) {
+            return upperBoundParallelismFunction.apply(jobVertexId);
         }
 
         @Override


### PR DESCRIPTION
## What is the purpose of the change

When the adaptive scheduler restarts a job to change its parallelism (a rescale), it previously fell back to "sufficient resources" as soon as a single slot became free — even if the slots backing the just-cancelled execution had not been released yet. This caused avoidable churn: the job would restart at a lower parallelism than what was actually about to become available, only to be rescaled again shortly after - in the worst case, when the slot is canceled by timeout(or failed during the cancellation), it can lead to an infinite restarting loop: (for 1 -> 2 scaling) JM sees 2 slots -> cancel the current execution -> one slot fail -> the job restart with 1 slot only -> JM sees 2 slots again -> ...

This pull request makes the JobManager wait, after a rescale-triggered restart, for the pre-restart target parallelism to become available again from genuinely free slots, bounded by a new configurable timeout, before proceeding with whatever is sufficient.

## Brief change log

  - Added `jobmanager.adaptive-scheduler.rescale.resource-stabilization-timeout`, bounding how long the JobManager waits after a rescale-triggered restart for the pre-restart target parallelism to become available again.
  - `AdaptiveScheduler#goToWaitingForResources` now accepts the target `VertexParallelism` of a restart and configures the `WaitingForResources` state's stabilization phase with the new rescale timeout instead of the submission one when restarting.
  - `WaitingForResources` gates `hasDesiredResources()` on the restart target parallelism (computed from genuinely free slots, excluding slots still reserved by the execution being cancelled) instead of the plain "sufficient resources" check, only for restarts with a known target.
  - `Restarting` now determines and passes through the target parallelism to restart with, via `getFreeSlotVertexParallelism()` / `getUpperBoundParallelism(...)`.
  - Regenerated the configuration reference documentation for the new option.

## Verifying this change

This change added tests and can be verified as follows:

  - `AdaptiveSchedulerRescaleRestartTimingTest#testWaitingForResourcesDoesNotTransitionUntilFreeSlotsReachRescaleTarget` verifies the scheduler keeps waiting until the restart target parallelism is reachable from free slots.
  - `AdaptiveSchedulerRescaleRestartTimingTest#testWaitingForResourcesFallsBackAfterRescaleResourceStabilizationTimeoutElapses` verifies the scheduler proceeds with whatever is sufficient once the new stabilization timeout elapses, rather than waiting forever.
  - `AdaptiveSchedulerFreeSlotVertexParallelismTest#testFreeSlotVertexParallelismExcludesReservedSlots` verifies free-slot-based parallelism calculation excludes slots still reserved by the execution being cancelled.
  - `AdaptiveSchedulerTest#testGoToWaitingForResourcesForRestartConfiguresStateTransitionManagerFactory` verifies the restart path configures the state transition manager with the rescale resource-stabilization timeout and skips the cooldown phase.
  - New/extended cases in `WaitingForResourcesTest` (e.g. `testDesiredResourcesRequireReachingRestartTargetRegardlessOfBaseCheck`, `testDesiredResourcesCapRestartTargetToLatestResourceRequirements`, `testDesiredResourcesAreMetOnceFreeSlotParallelismReachesRestartTarget`, `testResourceTimeoutOverridesRestartTargetGuard`) cover the new restart-target gating logic in isolation.
  - Existing `CreatedTest`, `CreatingExecutionGraphTest`, and `RestartingTest` were extended to cover passing the restart target parallelism through the relevant state transitions.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes (a new `ConfigOption` was added to `JobManagerOptions`, which is `@PublicEvolving`; purely additive, no existing options changed behavior)
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: yes (changes the adaptive scheduler's restart/rescaling behavior in the JobManager)
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? docs (generated configuration reference)

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: Claude Code (Sonnet 5)
