### PR TITLE
[FLINK-40456][datastream] `AsyncWaitOperator` can permanently drop an element's result when timeout races with a retry

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/async/AsyncWaitOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/async/AsyncWaitOperator.java
@@ -484,6 +484,9 @@ public class AsyncWaitOperator<IN, OUT>
          */
         private final AtomicBoolean retryAwaiting = new AtomicBoolean(false);
 
+        // set once the timeout fired; makes the result terminal and bypass the retry path
+        private final AtomicBoolean timedOut = new AtomicBoolean(false);
+
         public RetryableResultHandlerDelegator(
                 StreamRecord<IN> inputRecord,
                 ResultFuture<OUT> resultFuture,
@@ -511,6 +514,9 @@ public class AsyncWaitOperator<IN, OUT>
                 // cancel delayed retry timer first
                 cancelRetryTimer();
 
+                // timeout result is terminal: route it straight to the handler, not the retry path
+                timedOut.set(true);
+
                 // force reset retryAwaiting to prevent the handler to trigger retry unnecessarily
                 retryAwaiting.set(false);
 
@@ -522,7 +528,9 @@ public class AsyncWaitOperator<IN, OUT>
         public void complete(Collection<OUT> results) {
             Preconditions.checkNotNull(
                     results, "Results must not be null, use empty collection to emit nothing");
-            if (!retryDisabledOnFinish.get() && resultHandler.inputRecord.isRecord()) {
+            if (!timedOut.get()
+                    && !retryDisabledOnFinish.get()
+                    && resultHandler.inputRecord.isRecord()) {
                 processRetryInMailBox(results, null);
             } else {
                 cancelRetryTimer();
@@ -533,7 +541,9 @@ public class AsyncWaitOperator<IN, OUT>
 
         @Override
         public void completeExceptionally(Throwable error) {
-            if (!retryDisabledOnFinish.get() && resultHandler.inputRecord.isRecord()) {
+            if (!timedOut.get()
+                    && !retryDisabledOnFinish.get()
+                    && resultHandler.inputRecord.isRecord()) {
                 processRetryInMailBox(null, error);
             } else {
                 cancelRetryTimer();
@@ -546,7 +556,9 @@ public class AsyncWaitOperator<IN, OUT>
         public void complete(CollectionSupplier<OUT> supplier) {
             Preconditions.checkNotNull(
                     supplier, "Runnable must not be null, return empty collection to emit nothing");
-            if (!retryDisabledOnFinish.get() && resultHandler.inputRecord.isRecord()) {
+            if (!timedOut.get()
+                    && !retryDisabledOnFinish.get()
+                    && resultHandler.inputRecord.isRecord()) {
                 mailboxExecutor.submit(
                         () -> {
                             try {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/async/AsyncWaitOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/async/AsyncWaitOperator.java
@@ -528,9 +528,7 @@ public class AsyncWaitOperator<IN, OUT>
         public void complete(Collection<OUT> results) {
             Preconditions.checkNotNull(
                     results, "Results must not be null, use empty collection to emit nothing");
-            if (!timedOut.get()
-                    && !retryDisabledOnFinish.get()
-                    && resultHandler.inputRecord.isRecord()) {
+            if (shouldProcessResultForRetry()) {
                 processRetryInMailBox(results, null);
             } else {
                 cancelRetryTimer();
@@ -541,9 +539,7 @@ public class AsyncWaitOperator<IN, OUT>
 
         @Override
         public void completeExceptionally(Throwable error) {
-            if (!timedOut.get()
-                    && !retryDisabledOnFinish.get()
-                    && resultHandler.inputRecord.isRecord()) {
+            if (shouldProcessResultForRetry()) {
                 processRetryInMailBox(null, error);
             } else {
                 cancelRetryTimer();
@@ -556,9 +552,7 @@ public class AsyncWaitOperator<IN, OUT>
         public void complete(CollectionSupplier<OUT> supplier) {
             Preconditions.checkNotNull(
                     supplier, "Runnable must not be null, return empty collection to emit nothing");
-            if (!timedOut.get()
-                    && !retryDisabledOnFinish.get()
-                    && resultHandler.inputRecord.isRecord()) {
+            if (shouldProcessResultForRetry()) {
                 mailboxExecutor.submit(
                         () -> {
                             try {
@@ -573,6 +567,12 @@ public class AsyncWaitOperator<IN, OUT>
 
                 resultHandler.complete(supplier);
             }
+        }
+
+        private boolean shouldProcessResultForRetry() {
+            return !timedOut.get()
+                    && !retryDisabledOnFinish.get()
+                    && resultHandler.inputRecord.isRecord();
         }
 
         private void processRetryInMailBox(Collection<OUT> results, Throwable error) {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/async/AsyncWaitOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/async/AsyncWaitOperatorTest.java
@@ -1399,52 +1399,49 @@ public class AsyncWaitOperatorTest {
         testProcessingTimeAlwaysTimeoutFunctionWithRetry(AsyncDataStream.OutputMode.UNORDERED);
     }
 
-    // timeout+retry with serialized async completions must still emit every timeout result
+    /** A timeout firing while a retry is already queued must still emit its result. */
     @Test
-    void reproSerializedCompletionsWithRetry() throws Exception {
-        StreamTaskMailboxTestHarnessBuilder<Integer> builder =
-                new StreamTaskMailboxTestHarnessBuilder<>(
-                                OneInputStreamTask::new, BasicTypeInfo.INT_TYPE_INFO)
-                        .addInput(BasicTypeInfo.INT_TYPE_INFO);
+    void testTimeoutRaceWithRetry() throws Exception {
+        ControllableExceptionThenTimeoutFunction.releaseCompletion = new CountDownLatch(1);
+        ControllableExceptionThenTimeoutFunction.completionEnqueued = new CountDownLatch(1);
 
-        AsyncRetryStrategy exceptionRetryStrategy =
-                new AsyncRetryStrategies.FixedDelayRetryStrategyBuilder(5, 100L)
-                        .ifException(RetryPredicates.HAS_EXCEPTION_PREDICATE)
-                        .build();
+        try (OneInputStreamOperatorTestHarness<Integer, Integer> testHarness =
+                createTestHarnessWithRetry(
+                        new ControllableExceptionThenTimeoutFunction(),
+                        TIMEOUT,
+                        1,
+                        AsyncDataStream.OutputMode.UNORDERED,
+                        exceptionRetryStrategy)) {
 
-        try (StreamTaskMailboxTestHarness<Integer> testHarness =
-                builder.setupOutputForSingletonOperatorChain(
-                                new AsyncWaitOperatorFactory<>(
-                                        new AlwaysTimeoutSingleThreadAsyncFunction(),
-                                        TIMEOUT,
-                                        10,
-                                        AsyncDataStream.OutputMode.UNORDERED,
-                                        exceptionRetryStrategy))
-                        .build()) {
+            testHarness.open();
+            testHarness.setProcessingTime(0L);
 
-            testHarness.processElement(new StreamRecord<>(1, 1L));
-            testHarness.processElement(new StreamRecord<>(2, 2L));
-
-            long deadlineNanos = System.nanoTime() + TimeUnit.SECONDS.toNanos(5);
-            while (testHarness.getOutput().size() < 2) {
-                testHarness.processAll();
-                if (System.nanoTime() > deadlineNanos) {
-                    throw new AssertionError(
-                            "REPRO CONFIRMED: operator produced only "
-                                    + testHarness.getOutput().size()
-                                    + "/2 outputs within 5s when async completions are serialized "
-                                    + "(single-thread executor). Timeout default value was dropped.");
-                }
-                //noinspection BusyWait
-                Thread.sleep(50);
+            // start the async call; its timeout timer is now registered at TIMEOUT
+            synchronized (testHarness.getCheckpointLock()) {
+                testHarness.processElement(new StreamRecord<>(1, 1L));
             }
+
+            // let the async call complete exceptionally, then wait until the resulting retry mail
+            // is actually enqueued in the mailbox
+            ControllableExceptionThenTimeoutFunction.releaseCompletion.countDown();
+            ControllableExceptionThenTimeoutFunction.completionEnqueued.await();
+
+            // fire the timeout while the retry mail is still queued, then run both mails in order
+            testHarness.setProcessingTime(TIMEOUT + 1L);
+            drainMailbox(testHarness);
+
+            assertThat(testHarness.getOutput()).containsExactly(new StreamRecord<>(-1, 1L));
         }
     }
 
-    private static class AlwaysTimeoutSingleThreadAsyncFunction
+    private static class ControllableExceptionThenTimeoutFunction
             extends AlwaysTimeoutWithDefaultValueAsyncFunction {
         private static final long serialVersionUID = 2L;
-        private static final ExecutorService POOL = Executors.newSingleThreadExecutor();
+
+        // released by the test to let the async call complete exceptionally
+        static CountDownLatch releaseCompletion;
+        // counted down once the exceptional completion has been enqueued into the mailbox
+        static CountDownLatch completionEnqueued;
 
         @Override
         public void asyncInvoke(Integer input, ResultFuture<Integer> resultFuture) {
@@ -1452,13 +1449,13 @@ public class AsyncWaitOperatorTest {
             CompletableFuture.runAsync(
                     () -> {
                         try {
-                            Thread.sleep(501L);
+                            releaseCompletion.await();
                         } catch (InterruptedException e) {
                             throw new RuntimeException(e);
                         }
                         resultFuture.completeExceptionally(new Exception("Dummy error"));
-                    },
-                    POOL);
+                        completionEnqueued.countDown();
+                    });
         }
     }
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/async/AsyncWaitOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/async/AsyncWaitOperatorTest.java
@@ -1399,6 +1399,69 @@ public class AsyncWaitOperatorTest {
         testProcessingTimeAlwaysTimeoutFunctionWithRetry(AsyncDataStream.OutputMode.UNORDERED);
     }
 
+    // timeout+retry with serialized async completions must still emit every timeout result
+    @Test
+    void reproSerializedCompletionsWithRetry() throws Exception {
+        StreamTaskMailboxTestHarnessBuilder<Integer> builder =
+                new StreamTaskMailboxTestHarnessBuilder<>(
+                                OneInputStreamTask::new, BasicTypeInfo.INT_TYPE_INFO)
+                        .addInput(BasicTypeInfo.INT_TYPE_INFO);
+
+        AsyncRetryStrategy exceptionRetryStrategy =
+                new AsyncRetryStrategies.FixedDelayRetryStrategyBuilder(5, 100L)
+                        .ifException(RetryPredicates.HAS_EXCEPTION_PREDICATE)
+                        .build();
+
+        try (StreamTaskMailboxTestHarness<Integer> testHarness =
+                builder.setupOutputForSingletonOperatorChain(
+                                new AsyncWaitOperatorFactory<>(
+                                        new AlwaysTimeoutSingleThreadAsyncFunction(),
+                                        TIMEOUT,
+                                        10,
+                                        AsyncDataStream.OutputMode.UNORDERED,
+                                        exceptionRetryStrategy))
+                        .build()) {
+
+            testHarness.processElement(new StreamRecord<>(1, 1L));
+            testHarness.processElement(new StreamRecord<>(2, 2L));
+
+            long deadlineNanos = System.nanoTime() + TimeUnit.SECONDS.toNanos(5);
+            while (testHarness.getOutput().size() < 2) {
+                testHarness.processAll();
+                if (System.nanoTime() > deadlineNanos) {
+                    throw new AssertionError(
+                            "REPRO CONFIRMED: operator produced only "
+                                    + testHarness.getOutput().size()
+                                    + "/2 outputs within 5s when async completions are serialized "
+                                    + "(single-thread executor). Timeout default value was dropped.");
+                }
+                //noinspection BusyWait
+                Thread.sleep(50);
+            }
+        }
+    }
+
+    private static class AlwaysTimeoutSingleThreadAsyncFunction
+            extends AlwaysTimeoutWithDefaultValueAsyncFunction {
+        private static final long serialVersionUID = 2L;
+        private static final ExecutorService POOL = Executors.newSingleThreadExecutor();
+
+        @Override
+        public void asyncInvoke(Integer input, ResultFuture<Integer> resultFuture) {
+            tryCounts.merge(input, 1, Integer::sum);
+            CompletableFuture.runAsync(
+                    () -> {
+                        try {
+                            Thread.sleep(501L);
+                        } catch (InterruptedException e) {
+                            throw new RuntimeException(e);
+                        }
+                        resultFuture.completeExceptionally(new Exception("Dummy error"));
+                    },
+                    POOL);
+        }
+    }
+
     /**
      * Test the AsyncWaitOperator with an always-timeout async function under ordered mode and
      * processing time.


### PR DESCRIPTION

## What is the purpose of the change

The PR to fix `AsyncWaitOperator` race between retry and timeout
Also it is a step towards jdk25
## Brief change log
AsyncWaitOperator



## Verifying this change

test is added

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: ( no)
  - The runtime per-record code paths (performance sensitive): (no )
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no )
  - The S3 file system connector: ( no)

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable )

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change the checkbox below to `[X]` and replace the placeholder in the "Generated-by"
line with the tool name and version. Otherwise remove the "Generated-by" line.
See the ASF Generative Tooling Guidance for details:
https://www.apache.org/legal/generative-tooling.html

You are responsible for the quality and correctness of every change in this PR
regardless of the tooling used. Low-effort AI-generated PRs will be closed. See
AGENTS.md for the full guidance.
-->

- [ ] Yes (please specify the tool below)

Generated-by: [Tool Name and Version]
