### PR TITLE
[FLINK-34246][runtime] Add option to only archive failed jobs to history server

### DIFF
--- a/docs/layouts/shortcodes/generated/all_jobmanager_section.html
+++ b/docs/layouts/shortcodes/generated/all_jobmanager_section.html
@@ -87,6 +87,12 @@
             <td>Directory for JobManager to store the archives of completed jobs.</td>
         </tr>
         <tr>
+            <td><h5>jobmanager.archive.only-failed-jobs</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>Whether to only archive jobs that reached the <code class="highlighter-rouge">FAILED</code> terminal state to <code class="highlighter-rouge">jobmanager.archive.fs.dir</code>.When enabled, jobs that finished, were canceled, or were suspended are not archived to the history server, reducing the number of files written for large clusters running many short-lived batch jobs. This option has no effect unless <code class="highlighter-rouge">jobmanager.archive.fs.dir</code> is configured.</td>
+        </tr>
+        <tr>
             <td><h5>jobmanager.bind-host</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>String</td>

--- a/docs/layouts/shortcodes/generated/all_jobmanager_section.html
+++ b/docs/layouts/shortcodes/generated/all_jobmanager_section.html
@@ -90,7 +90,7 @@
             <td><h5>jobmanager.archive.only-failed-jobs</h5></td>
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>
-            <td>Whether to only archive jobs that reached the <code class="highlighter-rouge">FAILED</code> terminal state to <code class="highlighter-rouge">jobmanager.archive.fs.dir</code>.When enabled, jobs that finished, were canceled, or were suspended are not archived to the history server, reducing the number of files written for large clusters running many short-lived batch jobs. This option has no effect unless <code class="highlighter-rouge">jobmanager.archive.fs.dir</code> is configured.</td>
+            <td>Whether to only archive jobs that reached the <code class="highlighter-rouge">FAILED</code> terminal state to <code class="highlighter-rouge">jobmanager.archive.fs.dir</code>. When enabled, jobs that finished or were canceled are not archived to the history server, reducing the number of files written for large clusters running many short-lived batch jobs. This option has no effect unless <code class="highlighter-rouge">jobmanager.archive.fs.dir</code> is configured.</td>
         </tr>
         <tr>
             <td><h5>jobmanager.bind-host</h5></td>

--- a/docs/layouts/shortcodes/generated/job_manager_configuration.html
+++ b/docs/layouts/shortcodes/generated/job_manager_configuration.html
@@ -87,6 +87,12 @@
             <td>Directory for JobManager to store the archives of completed jobs.</td>
         </tr>
         <tr>
+            <td><h5>jobmanager.archive.only-failed-jobs</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>Whether to only archive jobs that reached the <code class="highlighter-rouge">FAILED</code> terminal state to <code class="highlighter-rouge">jobmanager.archive.fs.dir</code>.When enabled, jobs that finished, were canceled, or were suspended are not archived to the history server, reducing the number of files written for large clusters running many short-lived batch jobs. This option has no effect unless <code class="highlighter-rouge">jobmanager.archive.fs.dir</code> is configured.</td>
+        </tr>
+        <tr>
             <td><h5>jobmanager.bind-host</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>String</td>

--- a/docs/layouts/shortcodes/generated/job_manager_configuration.html
+++ b/docs/layouts/shortcodes/generated/job_manager_configuration.html
@@ -90,7 +90,7 @@
             <td><h5>jobmanager.archive.only-failed-jobs</h5></td>
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>
-            <td>Whether to only archive jobs that reached the <code class="highlighter-rouge">FAILED</code> terminal state to <code class="highlighter-rouge">jobmanager.archive.fs.dir</code>.When enabled, jobs that finished, were canceled, or were suspended are not archived to the history server, reducing the number of files written for large clusters running many short-lived batch jobs. This option has no effect unless <code class="highlighter-rouge">jobmanager.archive.fs.dir</code> is configured.</td>
+            <td>Whether to only archive jobs that reached the <code class="highlighter-rouge">FAILED</code> terminal state to <code class="highlighter-rouge">jobmanager.archive.fs.dir</code>. When enabled, jobs that finished or were canceled are not archived to the history server, reducing the number of files written for large clusters running many short-lived batch jobs. This option has no effect unless <code class="highlighter-rouge">jobmanager.archive.fs.dir</code> is configured.</td>
         </tr>
         <tr>
             <td><h5>jobmanager.bind-host</h5></td>

--- a/flink-core/src/main/java/org/apache/flink/configuration/JobManagerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/JobManagerOptions.java
@@ -309,6 +309,29 @@ public class JobManagerOptions {
                             "Directory for JobManager to store the archives of completed jobs.");
 
     /**
+     * Whether only jobs that reached the {@code FAILED} terminal state should be archived to {@link
+     * #ARCHIVE_DIR}.
+     */
+    @Documentation.Section(Documentation.Sections.ALL_JOB_MANAGER)
+    public static final ConfigOption<Boolean> ARCHIVE_ON_FAILED_JOBS_ONLY =
+            key("jobmanager.archive.only-failed-jobs")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription(
+                            Description.builder()
+                                    .text(
+                                            "Whether to only archive jobs that reached the %s terminal state to %s.",
+                                            code("FAILED"), code(ARCHIVE_DIR.key()))
+                                    .text(
+                                            "When enabled, jobs that finished, were canceled, or were suspended are not "
+                                                    + "archived to the history server, reducing the number of files written "
+                                                    + "for large clusters running many short-lived batch jobs. ")
+                                    .text(
+                                            "This option has no effect unless %s is configured.",
+                                            code(ARCHIVE_DIR.key()))
+                                    .build());
+
+    /**
      * @deprecated Use {@link JobManagerOptions#COMPLETED_APPLICATION_STORE_CACHE_SIZE}
      */
     @Deprecated

--- a/flink-core/src/main/java/org/apache/flink/configuration/JobManagerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/JobManagerOptions.java
@@ -320,10 +320,10 @@ public class JobManagerOptions {
                     .withDescription(
                             Description.builder()
                                     .text(
-                                            "Whether to only archive jobs that reached the %s terminal state to %s.",
+                                            "Whether to only archive jobs that reached the %s terminal state to %s. ",
                                             code("FAILED"), code(ARCHIVE_DIR.key()))
                                     .text(
-                                            "When enabled, jobs that finished, were canceled, or were suspended are not "
+                                            "When enabled, jobs that finished or were canceled are not "
                                                     + "archived to the history server, reducing the number of files written "
                                                     + "for large clusters running many short-lived batch jobs. ")
                                     .text(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
@@ -33,6 +33,7 @@ import org.apache.flink.configuration.ConfigOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.DeploymentOptions;
 import org.apache.flink.configuration.HighAvailabilityOptions;
+import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.configuration.PipelineOptions;
 import org.apache.flink.configuration.ThreadDumpMode;
 import org.apache.flink.configuration.WebOptions;
@@ -2315,7 +2316,9 @@ public abstract class Dispatcher extends FencedRpcEndpoint<DispatcherId>
         // do not create an archive for suspended jobs, as this would eventually lead to
         // multiple archive attempts which we currently do not support
         CompletableFuture<Acknowledge> archiveFuture =
-                archiveExecutionGraphToHistoryServer(executionGraphInfo);
+                shouldArchiveToHistoryServer(terminalJobStatus)
+                        ? archiveExecutionGraphToHistoryServer(executionGraphInfo)
+                        : CompletableFuture.completedFuture(Acknowledge.get());
 
         return archiveFuture.thenCompose(
                 ignored -> registerGloballyTerminatedJobInJobResultStore(executionGraphInfo));
@@ -2411,6 +2414,15 @@ public abstract class Dispatcher extends FencedRpcEndpoint<DispatcherId>
      */
     private void writeToExecutionGraphInfoStore(ExecutionGraphInfo executionGraphInfo) {
         partialExecutionGraphInfoStore.put(executionGraphInfo.getJobId(), executionGraphInfo);
+    }
+
+    /**
+     * Checks whether a job that reached the given globally terminal state should be archived to the
+     * history server, honoring {@link JobManagerOptions#ARCHIVE_ON_FAILED_JOBS_ONLY}.
+     */
+    private boolean shouldArchiveToHistoryServer(JobStatus terminalJobStatus) {
+        return terminalJobStatus == JobStatus.FAILED
+                || !configuration.get(JobManagerOptions.ARCHIVE_ON_FAILED_JOBS_ONLY);
     }
 
     private CompletableFuture<Acknowledge> archiveExecutionGraphToHistoryServer(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherResourceCleanupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherResourceCleanupTest.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.common.ApplicationID;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.core.failure.FailureEnricher;
 import org.apache.flink.core.testutils.OneShotLatch;
 import org.apache.flink.runtime.application.SingleJobApplication;
@@ -731,6 +732,39 @@ public class DispatcherResourceCleanupTest extends TestLogger {
         suspendJob(jobManagerRunnerFactory.takeCreatedJobManagerRunner());
 
         assertLocalCleanupTriggered(jobId);
+        dispatcher.getJobTerminationFuture(jobId, Duration.ofHours(1)).join();
+
+        assertFalse(isArchived.get());
+    }
+
+    @Test
+    public void testNotArchivingFinishedJobToHistoryServerWhenOnlyFailedJobsConfigured()
+            throws Exception {
+
+        final AtomicBoolean isArchived = new AtomicBoolean(false);
+
+        final Configuration configuration = new Configuration();
+        configuration.set(JobManagerOptions.ARCHIVE_ON_FAILED_JOBS_ONLY, true);
+
+        final TestingDispatcher.Builder testingDispatcherBuilder =
+                createTestingDispatcherBuilder()
+                        .setConfiguration(configuration)
+                        .setHistoryServerArchivist(
+                                TestingHistoryServerArchivist.builder()
+                                        .setArchiveExecutionGraphFunction(
+                                                (executionGraphInfo, applicationId) -> {
+                                                    isArchived.set(true);
+                                                    return CompletableFuture.completedFuture(
+                                                            Acknowledge.get());
+                                                })
+                                        .build());
+
+        final TestingJobManagerRunnerFactory jobManagerRunnerFactory =
+                startDispatcherAndSubmitApplication(testingDispatcherBuilder, 0);
+
+        finishJobAndApplication(jobManagerRunnerFactory.takeCreatedJobManagerRunner());
+
+        assertGlobalCleanupTriggered(jobId);
         dispatcher.getJobTerminationFuture(jobId, Duration.ofHours(1)).join();
 
         assertFalse(isArchived.get());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherResourceCleanupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherResourceCleanupTest.java
@@ -33,6 +33,7 @@ import org.apache.flink.runtime.client.DuplicateJobSubmissionException;
 import org.apache.flink.runtime.client.JobSubmissionException;
 import org.apache.flink.runtime.dispatcher.cleanup.TestingResourceCleanerFactory;
 import org.apache.flink.runtime.executiongraph.ArchivedExecutionGraph;
+import org.apache.flink.runtime.executiongraph.ErrorInfo;
 import org.apache.flink.runtime.executiongraph.JobStatusListener;
 import org.apache.flink.runtime.heartbeat.HeartbeatServices;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
@@ -510,12 +511,17 @@ public class DispatcherResourceCleanupTest extends TestLogger {
 
     private void terminateJobWithState(
             TestingJobManagerRunner takeCreatedJobManagerRunner, JobStatus state) {
+        final ArchivedExecutionGraphBuilder archivedExecutionGraphBuilder =
+                new ArchivedExecutionGraphBuilder().setJobID(jobId).setState(state);
+
+        if (state == JobStatus.FAILED) {
+            archivedExecutionGraphBuilder.setFailureCause(
+                    new ErrorInfo(
+                            new FlinkException("Test job failure"), System.currentTimeMillis()));
+        }
+
         takeCreatedJobManagerRunner.completeResultFuture(
-                new ExecutionGraphInfo(
-                        new ArchivedExecutionGraphBuilder()
-                                .setJobID(jobId)
-                                .setState(state)
-                                .build()));
+                new ExecutionGraphInfo(archivedExecutionGraphBuilder.build()));
     }
 
     private void assertThatNoCleanupWasTriggered() {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherResourceCleanupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherResourceCleanupTest.java
@@ -496,6 +496,14 @@ public class DispatcherResourceCleanupTest extends TestLogger {
         terminateJobWithState(takeCreatedJobManagerRunner, JobStatus.SUSPENDED);
     }
 
+    private void failJobAndApplication(TestingJobManagerRunner takeCreatedJobManagerRunner) {
+        terminateJobWithState(takeCreatedJobManagerRunner, JobStatus.FAILED);
+        application.jobStatusChanges(
+                takeCreatedJobManagerRunner.getJobID(),
+                JobStatus.FAILED,
+                System.currentTimeMillis());
+    }
+
     private void cancelJob(TestingJobManagerRunner takeCreatedJobManagerRunner) {
         terminateJobWithState(takeCreatedJobManagerRunner, JobStatus.CANCELED);
     }
@@ -796,8 +804,7 @@ public class DispatcherResourceCleanupTest extends TestLogger {
         final TestingJobManagerRunnerFactory jobManagerRunnerFactory =
                 startDispatcherAndSubmitApplication(testingDispatcherBuilder, 0);
 
-        terminateJobWithState(
-                jobManagerRunnerFactory.takeCreatedJobManagerRunner(), JobStatus.FAILED);
+        failJobAndApplication(jobManagerRunnerFactory.takeCreatedJobManagerRunner());
 
         assertGlobalCleanupTriggered(jobId);
         dispatcher.getJobTerminationFuture(jobId, Duration.ofHours(1)).join();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherResourceCleanupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherResourceCleanupTest.java
@@ -94,6 +94,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 /** Tests the resource cleanup by the {@link Dispatcher}. */
@@ -768,6 +769,40 @@ public class DispatcherResourceCleanupTest extends TestLogger {
         dispatcher.getJobTerminationFuture(jobId, Duration.ofHours(1)).join();
 
         assertFalse(isArchived.get());
+    }
+
+    @Test
+    public void testArchivingFailedJobToHistoryServerWhenOnlyFailedJobsConfigured()
+            throws Exception {
+
+        final AtomicBoolean isArchived = new AtomicBoolean(false);
+
+        final Configuration configuration = new Configuration();
+        configuration.set(JobManagerOptions.ARCHIVE_ON_FAILED_JOBS_ONLY, true);
+
+        final TestingDispatcher.Builder testingDispatcherBuilder =
+                createTestingDispatcherBuilder()
+                        .setConfiguration(configuration)
+                        .setHistoryServerArchivist(
+                                TestingHistoryServerArchivist.builder()
+                                        .setArchiveExecutionGraphFunction(
+                                                (executionGraphInfo, applicationId) -> {
+                                                    isArchived.set(true);
+                                                    return CompletableFuture.completedFuture(
+                                                            Acknowledge.get());
+                                                })
+                                        .build());
+
+        final TestingJobManagerRunnerFactory jobManagerRunnerFactory =
+                startDispatcherAndSubmitApplication(testingDispatcherBuilder, 0);
+
+        terminateJobWithState(
+                jobManagerRunnerFactory.takeCreatedJobManagerRunner(), JobStatus.FAILED);
+
+        assertGlobalCleanupTriggered(jobId);
+        dispatcher.getJobTerminationFuture(jobId, Duration.ofHours(1)).join();
+
+        assertTrue(isArchived.get());
     }
 
     private static final class BlockingJobManagerRunnerFactory


### PR DESCRIPTION
## What is the purpose of the change

History server archival currently writes an archive to `jobmanager.archive.fs.dir` for every job that reaches a globally terminal state (FINISHED, CANCELED, FAILED). For clusters running many short-lived batch jobs, this creates a large number of archive files even though most users primarily care about investigating failed jobs.

This PR adds an opt-in option to only archive jobs that reached the `FAILED` state, reducing the number of files written to the archive directory.

## Brief change log

- Added `jobmanager.archive.only-failed-jobs` (default `false`, backward compatible) to `JobManagerOptions`.
- `Dispatcher#jobReachedTerminalState` now skips calling the `HistoryServerArchivist` for non-`FAILED` terminal jobs when the option is enabled. The `submitFailedJob` path is unaffected since it always represents a `FAILED` job.
- Regenerated `docs/layouts/shortcodes/generated/job_manager_configuration.html`.

## Verification

- Added `DispatcherResourceCleanupTest#testNotArchivingFinishedJobToHistoryServerWhenOnlyFailedJobsConfigured`, asserting a FINISHED job is not archived when the option is enabled, while cleanup/termination still proceed normally.
- Ran `DispatcherResourceCleanupTest` (18/18 passed) and `DispatcherTest` (48/48 passed).

## Does this pull request potentially affect one of the following parts

- Dependencies (does it add or upgrade a dependency): no
- The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no (new `ConfigOption`, backward compatible, default preserves existing behavior)
- The serializers: no
- The runtime per-record code paths (performance sensitive): no
- Anything that affects deployment or recovery: no
- The S3 file system connector: no

## Documentation

- Does this pull request introduce a new feature? Yes
- If yes, how is the feature documented? Documented via the generated configuration docs (`ConfigOption` javadoc + regenerated HTML).
