### PR TITLE
[FLINK-40450][table-planner] Add missing flink-table-code-splitter test dependency

### DIFF
--- a/flink-table/flink-table-planner/pom.xml
+++ b/flink-table/flink-table-planner/pom.xml
@@ -177,6 +177,13 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-table-code-splitter</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-test-utils</artifactId>
 			<version>${project.version}</version>
 			<scope>test</scope>


### PR DESCRIPTION
## What is the purpose of the change

Fixes [FLINK-40450](https://issues.apache.org/jira/browse/FLINK-40450).

`JsonParseReuseTest.java:32` imports `org.apache.flink.table.codesplit.JavaCodeSplitter`, but `flink-table/flink-table-planner/pom.xml` declares no dependency on `flink-table-code-splitter`. Planner test compilation fails with `package org.apache.flink.table.codesplit does not exist`, so a focused run such as `-Dtest=CreateConnectionITCase` fails before the requested test executes.

## Brief change log

- Add a test-scoped dependency on `flink-table-code-splitter` to `flink-table/flink-table-planner/pom.xml`

## Verifying this change

This change is a build fix without new test coverage. It was verified by reproducing the compilation failure on an unpatched tree and confirming planner test compilation succeeds with the dependency added.

## Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): yes, a test-scoped dependency on `flink-table-code-splitter`, an existing module of this repo at `${project.version}`
- The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
- The serializers: no
- The runtime per-record code paths (performance sensitive): no
- Anything that affects deployment or recovery: no
- The S3 file system connector: no

## Documentation

- Does this pull request introduce a new feature?: no
