### PR TITLE
[FLINK-40478][runtime-web] Log effective HistoryServer configuration at startup

### DIFF
--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/history/HistoryServer.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/history/HistoryServer.java
@@ -261,6 +261,19 @@ public class HistoryServer {
         archiveLoadMode = config.get(HistoryServerOptions.HISTORY_SERVER_ARCHIVE_LOAD_MODE);
         HistoryServerOptions.HistoryServerArchiveStorageType archiveStorageType =
                 config.get(HistoryServerOptions.HISTORY_SERVER_ARCHIVE_STORAGE_TYPE);
+        LOG.info(
+                "HistoryServer effective configuration: storage-type={}, load-mode={}, "
+                        + "retained-jobs={}, retained-applications={}, retained-ttl={}, "
+                        + "clean-expired-jobs={}, clean-expired-applications={}.",
+                archiveStorageType,
+                archiveLoadMode,
+                config.get(HistoryServerOptions.HISTORY_SERVER_RETAINED_JOBS),
+                config.get(HistoryServerOptions.HISTORY_SERVER_RETAINED_APPLICATIONS),
+                config.getOptional(HistoryServerOptions.HISTORY_SERVER_RETAINED_TTL)
+                        .map(Object::toString)
+                        .orElse("unset"),
+                cleanupExpiredJobs,
+                cleanupExpiredApplications);
         AbstractHistoryServerHandler.HistoryServerHandlerFactory historyServerHandlerFactory;
         switch (archiveStorageType) {
             case FILE:

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/history/HistoryServer.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/history/HistoryServer.java
@@ -262,7 +262,7 @@ public class HistoryServer {
         HistoryServerOptions.HistoryServerArchiveStorageType archiveStorageType =
                 config.get(HistoryServerOptions.HISTORY_SERVER_ARCHIVE_STORAGE_TYPE);
         LOG.info(
-                "HistoryServer effective configuration: storage-type={}, load-mode={}, "
+                "HistoryServer effective configuration: storage.type={}, load.mode={}, "
                         + "retained-jobs={}, retained-applications={}, retained-ttl={}, "
                         + "clean-expired-jobs={}, clean-expired-applications={}.",
                 archiveStorageType,


### PR DESCRIPTION
## What is the purpose of the change

Several HistoryServer configuration options change its runtime behavior in meaningful ways: which archive storage backend it uses (FILE vs ROCKSDB), the archive load mode (EAGER vs LAZY), and the retention policy (retained job/application counts, TTL, cleanup flags). None of these are logged today, they are just read into local variables and used silently.

This makes it hard to confirm from the logs what configuration actually took effect on a given HistoryServer instance. A misconfigured or overridden option can go unnoticed until something looks wrong in the UI, at which point the only way to check is to read the config file directly on the host or dig through source code.

## Brief change log

  - Added a single log line in the HistoryServer constructor that reports the effective archive storage type, load mode, retained-jobs, retained-applications, retained-ttl, and clean-expired-jobs/applications settings.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

This change is already covered by existing tests, such as HistoryServerTest and HistoryServerArchiveFetcherTest, which continue to pass unmodified since no runtime behavior changes.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable

---

##### Was generative AI tooling used to co-author this PR?

- [ ] Yes (please specify the tool below)