### PR TITLE
[FLINK-40475][runtime] Fix watermark loss and stall in StatusWatermarkValve when subpartitions realign after idleness

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/watermarkstatus/StatusWatermarkValve.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/watermarkstatus/StatusWatermarkValve.java
@@ -69,7 +69,20 @@ public class StatusWatermarkValve {
     /** The last watermark status emitted from the valve. */
     private WatermarkStatus lastOutputWatermarkStatus;
 
-    /** A heap-based priority queue to help find the minimum watermark. */
+    /**
+     * A heap-based priority queue to help find the minimum watermark. It contains exactly the
+     * watermark-aligned subpartitions, for which the following invariants hold:
+     *
+     * <ul>
+     *   <li>only active subpartitions can be aligned
+     *   <li>the watermark of an aligned subpartition is never smaller than {@link
+     *       #lastOutputWatermark}
+     *   <li>whenever the queue is non-empty, its minimum watermark equals {@link
+     *       #lastOutputWatermark}; this is maintained by re-deriving the min watermark via {@link
+     *       #findAndOutputNewMinWatermarkAcrossAlignedSubpartitions} after every change to the
+     *       aligned set or to an aligned subpartition's watermark
+     * </ul>
+     */
     private final HeapPriorityQueue<SubpartitionStatus> alignedSubpartitionStatuses;
 
     /** Whether there are multiple subpartitions transmitted through the same input channel. */
@@ -231,10 +244,10 @@ public class StatusWatermarkValve {
 
                 lastOutputWatermarkStatus = WatermarkStatus.IDLE;
                 output.emitWatermarkStatus(lastOutputWatermarkStatus);
-            } else if (subpartitionStatus.watermark == lastOutputWatermark) {
-                // if the watermark of the subpartition that just became idle equals the last output
-                // watermark (the previous overall min watermark), we may be able to find a new
-                // min watermark from the remaining aligned subpartitions
+            } else {
+                // the min watermark across the remaining aligned subpartitions may be larger than
+                // the last output watermark, now that the subpartition that just became idle is no
+                // longer part of the aligned set
                 findAndOutputNewMinWatermarkAcrossAlignedSubpartitions(output);
             }
         } else if (watermarkStatus.isActive() && subpartitionStatus.watermarkStatus.isIdle()) {
@@ -242,21 +255,26 @@ public class StatusWatermarkValve {
             subpartitionStatus.watermarkStatus = WatermarkStatus.ACTIVE;
 
             // if the last watermark of the subpartition, before it was marked idle, is still
-            // larger than
-            // the overall last output watermark of the valve, then we can set the subpartition to
-            // be
-            // aligned already.
+            // larger than the overall last output watermark of the valve, then we can set the
+            // subpartition to be aligned already.
             if (subpartitionStatus.watermark >= lastOutputWatermark) {
                 markWatermarkAligned(subpartitionStatus);
             }
 
             // if the valve was previously marked to be idle, mark it as active and output an active
-            // stream
-            // status because at least one of the subpartitions is now active
+            // stream status because at least one of the subpartitions is now active
             if (lastOutputWatermarkStatus.isIdle()) {
                 lastOutputWatermarkStatus = WatermarkStatus.ACTIVE;
                 output.emitWatermarkStatus(lastOutputWatermarkStatus);
             }
+
+            // the subpartition that just realigned may hold the new min watermark of the aligned
+            // set (e.g. if it is the only aligned subpartition), in which case its watermark must
+            // be emitted now; otherwise it would be stalled until an even larger watermark arrives
+            // on the subpartition. This must happen after the ACTIVE status was emitted, so that
+            // downstream inputs do not drop the watermark while they still consider this input
+            // idle.
+            findAndOutputNewMinWatermarkAcrossAlignedSubpartitions(output);
         }
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/watermarkstatus/StatusWatermarkValve.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/watermarkstatus/StatusWatermarkValve.java
@@ -221,23 +221,13 @@ public class StatusWatermarkValve {
             // if all subpartitions of the valve are now idle, we need to output an idle stream
             // status from the valve (this also marks the valve as idle)
             if (!SubpartitionStatus.hasActiveSubpartitions(subpartitionStatuses)) {
-
-                // now that all subpartitions are idle and no subpartitions will continue to advance
-                // its
-                // watermark,
-                // we should "flush" all watermarks across all subpartitions; effectively, this
-                // means
-                // emitting
-                // the max watermark across all subpartitions as the new watermark. Also, since we
-                // already try to advance
-                // the min watermark as subpartitions individually become IDLE, here we only need to
-                // perform the flush
-                // if the watermark of the last active subpartition that just became idle is the
-                // current
-                // min watermark.
-                if (subpartitionStatus.watermark == lastOutputWatermark) {
-                    findAndOutputMaxWatermarkAcrossAllSubpartitions(output);
-                }
+                // now that all subpartitions are idle and no subpartition will continue to advance
+                // its watermark, we should "flush" all watermarks across all subpartitions;
+                // effectively, this means emitting the max watermark across all subpartitions as
+                // the new watermark, so that the eventual watermark is independent of the order in
+                // which the subpartitions became idle. This also keeps the valve consistent with
+                // the unconditional flush in CombinedWatermarkStatus.
+                findAndOutputMaxWatermarkAcrossAllSubpartitions(output);
 
                 lastOutputWatermarkStatus = WatermarkStatus.IDLE;
                 output.emitWatermarkStatus(lastOutputWatermarkStatus);

--- a/flink-runtime/src/test/java/org/apache/flink/streaming/runtime/watermarkstatus/StatusWatermarkValveTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/streaming/runtime/watermarkstatus/StatusWatermarkValveTest.java
@@ -337,6 +337,53 @@ class StatusWatermarkValveTest {
     }
 
     /**
+     * Tests that the max watermark across all channels is flushed once all inputs become idle, even
+     * when the last channel to become idle is unaligned, i.e. it went idle, resumed being active,
+     * and only partially caught up to the last output watermark. The eventual watermark advancement
+     * result must be independent of the order in which the inputs become idle (FLINK-7728).
+     */
+    @Test
+    void testMultipleInputFlushMaxWatermarkOnceAllInputsBecomeIdleWithUnalignedLastChannel()
+            throws Exception {
+        StatusWatermarkOutput valveOutput = new StatusWatermarkOutput();
+        StatusWatermarkValve valve = new StatusWatermarkValve(3);
+
+        valve.inputWatermark(new Watermark(100), 0, valveOutput);
+        valve.inputWatermark(new Watermark(50), 1, valveOutput);
+        valve.inputWatermark(new Watermark(70), 2, valveOutput);
+        assertThat(valveOutput.popLastSeenOutput()).isEqualTo(new Watermark(50));
+        assertThat(valveOutput.popLastSeenOutput()).isNull();
+
+        // channel 1 becomes idle; the new min watermark is computed from channels 0 and 2
+        valve.inputWatermarkStatus(WatermarkStatus.IDLE, 1, valveOutput);
+        assertThat(valveOutput.popLastSeenOutput()).isEqualTo(new Watermark(70));
+        assertThat(valveOutput.popLastSeenOutput()).isNull();
+
+        // channel 1 resumes being active, but stays unaligned since its watermark (50) has not
+        // caught up to the last output watermark (70)
+        valve.inputWatermarkStatus(WatermarkStatus.ACTIVE, 1, valveOutput);
+        assertThat(valve.getSubpartitionStatus(1).isWatermarkAligned).isFalse();
+        assertThat(valveOutput.popLastSeenOutput()).isNull();
+
+        // channel 1 partially catches up; its watermark is recorded but it remains unaligned
+        valve.inputWatermark(new Watermark(60), 1, valveOutput);
+        assertThat(valve.getSubpartitionStatus(1).watermark).isEqualTo(60);
+        assertThat(valve.getSubpartitionStatus(1).isWatermarkAligned).isFalse();
+        assertThat(valveOutput.popLastSeenOutput()).isNull();
+
+        valve.inputWatermarkStatus(WatermarkStatus.IDLE, 0, valveOutput);
+        valve.inputWatermarkStatus(WatermarkStatus.IDLE, 2, valveOutput);
+        assertThat(valveOutput.popLastSeenOutput()).isNull();
+
+        // the unaligned channel 1 is the last channel to become idle; the max watermark across
+        // all channels must still be flushed
+        valve.inputWatermarkStatus(WatermarkStatus.IDLE, 1, valveOutput);
+        assertThat(valveOutput.popLastSeenOutput()).isEqualTo(new Watermark(100));
+        assertThat(valveOutput.popLastSeenOutput()).isEqualTo(WatermarkStatus.IDLE);
+        assertThat(valveOutput.popLastSeenOutput()).isNull();
+    }
+
+    /**
      * Tests that when idle channels become active again, they need to "catch up" with the latest
      * watermark before they are considered for min watermark computation again.
      */

--- a/flink-runtime/src/test/java/org/apache/flink/streaming/runtime/watermarkstatus/StatusWatermarkValveTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/streaming/runtime/watermarkstatus/StatusWatermarkValveTest.java
@@ -478,6 +478,96 @@ class StatusWatermarkValveTest {
         assertThat(valveOutput.popLastSeenOutput()).isNull();
     }
 
+    /**
+     * Tests that when a channel reactivates and realigns while no other aligned channels remain
+     * (all remaining channels are idle or unaligned), the min watermark across aligned channels is
+     * re-derived and emitted; otherwise the realigned channel's watermark would be stalled until an
+     * even higher watermark arrives on it.
+     */
+    @Test
+    void testWatermarkAdvancesWhenReactivatedChannelBecomesOnlyAlignedChannel() throws Exception {
+        StatusWatermarkOutput valveOutput = new StatusWatermarkOutput();
+        StatusWatermarkValve valve = new StatusWatermarkValve(3);
+
+        valve.inputWatermark(new Watermark(10), 0, valveOutput);
+        valve.inputWatermark(new Watermark(7), 1, valveOutput);
+
+        // channel 2 becomes idle; the new min watermark is computed from channels 0 and 1
+        valve.inputWatermarkStatus(WatermarkStatus.IDLE, 2, valveOutput);
+        assertThat(valveOutput.popLastSeenOutput()).isEqualTo(new Watermark(7));
+        assertThat(valveOutput.popLastSeenOutput()).isNull();
+
+        // channel 2 resumes being active but is unaligned (its watermark has never advanced)
+        valve.inputWatermarkStatus(WatermarkStatus.ACTIVE, 2, valveOutput);
+        assertThat(valveOutput.popLastSeenOutput()).isNull();
+
+        // channels 0 and 1 become idle; channel 2 is the only active channel but it is unaligned,
+        // so no watermark can be emitted
+        valve.inputWatermarkStatus(WatermarkStatus.IDLE, 0, valveOutput);
+        valve.inputWatermarkStatus(WatermarkStatus.IDLE, 1, valveOutput);
+        assertThat(valveOutput.popLastSeenOutput()).isNull();
+
+        // channel 0 resumes being active; its watermark (10) has already caught up to the last
+        // output watermark (7), so it realigns and the min watermark must advance to 10
+        valve.inputWatermarkStatus(WatermarkStatus.ACTIVE, 0, valveOutput);
+        assertThat(valve.getSubpartitionStatus(0).isWatermarkAligned).isTrue();
+        assertThat(valveOutput.popLastSeenOutput()).isEqualTo(new Watermark(10));
+        assertThat(valveOutput.popLastSeenOutput()).isNull();
+
+        // the unaligned channel 2 becoming idle again must not change anything
+        valve.inputWatermarkStatus(WatermarkStatus.IDLE, 2, valveOutput);
+        assertThat(valveOutput.popLastSeenOutput()).isNull();
+    }
+
+    /**
+     * Tests that when a channel reactivates and realigns with a watermark larger than the last
+     * output watermark, the min watermark across aligned channels is re-derived and emitted, and
+     * that the flush once all inputs become idle afterwards does not emit a duplicate watermark.
+     */
+    @Test
+    void testRealignmentAfterResumeActiveEmitsNewMinWatermark() throws Exception {
+        StatusWatermarkOutput valveOutput = new StatusWatermarkOutput();
+        StatusWatermarkValve valve = new StatusWatermarkValve(3);
+
+        valve.inputWatermark(new Watermark(10), 0, valveOutput);
+        valve.inputWatermark(new Watermark(20), 1, valveOutput);
+        valve.inputWatermark(new Watermark(30), 2, valveOutput);
+        assertThat(valveOutput.popLastSeenOutput()).isEqualTo(new Watermark(10));
+        assertThat(valveOutput.popLastSeenOutput()).isNull();
+
+        // channel 2 becomes idle; its watermark (30) is above the min, so nothing changes
+        valve.inputWatermarkStatus(WatermarkStatus.IDLE, 2, valveOutput);
+        assertThat(valveOutput.popLastSeenOutput()).isNull();
+
+        // channel 0 becomes idle; the new min watermark is computed from channel 1
+        valve.inputWatermarkStatus(WatermarkStatus.IDLE, 0, valveOutput);
+        assertThat(valveOutput.popLastSeenOutput()).isEqualTo(new Watermark(20));
+        assertThat(valveOutput.popLastSeenOutput()).isNull();
+
+        // channel 0 resumes being active, but stays unaligned (10 < 20)
+        valve.inputWatermarkStatus(WatermarkStatus.ACTIVE, 0, valveOutput);
+        assertThat(valve.getSubpartitionStatus(0).isWatermarkAligned).isFalse();
+        assertThat(valveOutput.popLastSeenOutput()).isNull();
+
+        // channel 1 becomes idle; no aligned channels remain, so nothing can be emitted
+        valve.inputWatermarkStatus(WatermarkStatus.IDLE, 1, valveOutput);
+        assertThat(valveOutput.popLastSeenOutput()).isNull();
+
+        // channel 2 resumes being active; its watermark (30) is above the last output watermark
+        // (20), so it realigns and the min watermark must advance to 30
+        valve.inputWatermarkStatus(WatermarkStatus.ACTIVE, 2, valveOutput);
+        assertThat(valve.getSubpartitionStatus(2).isWatermarkAligned).isTrue();
+        assertThat(valveOutput.popLastSeenOutput()).isEqualTo(new Watermark(30));
+        assertThat(valveOutput.popLastSeenOutput()).isNull();
+
+        // all channels become idle; the flush must not emit another watermark, since the max
+        // watermark across all channels (30) has already been emitted
+        valve.inputWatermarkStatus(WatermarkStatus.IDLE, 0, valveOutput);
+        valve.inputWatermarkStatus(WatermarkStatus.IDLE, 2, valveOutput);
+        assertThat(valveOutput.popLastSeenOutput()).isEqualTo(WatermarkStatus.IDLE);
+        assertThat(valveOutput.popLastSeenOutput()).isNull();
+    }
+
     private static class StatusWatermarkOutput implements PushingAsyncDataInput.DataOutput {
 
         private BlockingQueue<StreamElement> allOutputs = new LinkedBlockingQueue<>();


### PR DESCRIPTION
## What is the purpose of the change

When a subpartition of `StatusWatermarkValve` reactivates after idleness and rejoins the aligned set, the min watermark across aligned subpartitions is not re-derived. This breaks the invariant that the aligned min equals the last output watermark, which two guards (`subpartitionStatus.watermark == lastOutputWatermark`) silently rely on, with two symptoms:

1. The all-idle flush-to-max from FLINK-7728 is skipped when the last subpartition to become idle is unaligned (went idle, resumed, only partially caught up), making the final watermark dependent on the order in which inputs became idle — the exact defect FLINK-7728 was created to fix. This also diverges from `CombinedWatermarkStatus`, which flushes unconditionally since FLINK-38454.
2. A subpartition that reactivates as the only aligned subpartition has its watermark stalled indefinitely, until an even larger watermark arrives on that subpartition — no all-idle transition involved.

## Brief change log

- Re-derive (and possibly emit) the min watermark at the end of the idle→active branch, after the ACTIVE status is emitted so downstream inputs do not drop the watermark while they still consider the input idle
- Flush the max watermark unconditionally when all subpartitions become idle (the flush helper already only emits when the max advances past the last output watermark, so monotonicity is unaffected)
- Drop the equivalent guard on the partial-idle min re-derivation for the same reason
- Document the invariants of the aligned-subpartition set on `alignedSubpartitionStatuses`

## Verifying this change

This change added tests and can be verified as follows:

- Added `testMultipleInputFlushMaxWatermarkOnceAllInputsBecomeIdleWithUnalignedLastChannel`, reproducing the order-dependent all-idle flush (fails on master: emits only `WatermarkStatus(IDLE)` instead of `Watermark(100)`)
- Added `testWatermarkAdvancesWhenReactivatedChannelBecomesOnlyAlignedChannel` and `testRealignmentAfterResumeActiveEmitsNewMinWatermark`, reproducing the stalled watermark on realignment (fail on master: no watermark emitted)
- All pre-existing tests in `StatusWatermarkValveTest` are unaffected; also verified green: `OneInputStreamTaskTest`, `TwoInputStreamTaskTest`, `WatermarkOutputMultiplexerTest`, `SourceOperatorSplitWatermarkAlignmentTest`
- Each commit passes the valve test suite individually (red-green verified per commit)

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no (only watermark-status transition paths; the added re-derivation is O(1), the unconditional flush is O(#subpartitions) once per all-idle transition, next to an existing O(#subpartitions) scan on the same path)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable

Note on behavior: jobs that previously ended with a lower watermark depending on idle-arrival order will now deterministically receive the flushed max watermark (timers/windows in that range fire); a release note is proposed on the JIRA ticket.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: Claude Code (claude-fable-5)