### PR TITLE
[FLINK-40476][docs] Clarify Changelog state backend requires CLAIM restore mode

### DIFF
--- a/docs/content.zh/docs/ops/state/state_backends.md
+++ b/docs/content.zh/docs/ops/state/state_backends.md
@@ -485,7 +485,7 @@ env.enable_changelog_statebackend(true)
 - 给定一个没有开启 Changelog 的作业
 - 创建一个 [savepoint]({{< ref "docs/ops/state/savepoints#resuming-from-savepoints" >}}) 或一个 [checkpoint]({{< ref "docs/ops/state/checkpoints#resuming-from-a-retained-checkpoint" >}})
 - 更改配置（开启 Changelog）
-- 从创建的 snapshot 恢复
+- 使用 [`CLAIM`]({{< ref "docs/deployment/config#execution-savepoint-restore-mode" >}}) 恢复模式从创建的 snapshot 恢复（参见[限制](#limitations)）
 
 **关闭 Changelog**
 
@@ -493,14 +493,18 @@ env.enable_changelog_statebackend(true)
 - 给定一个开启 Changelog 的作业
 - 创建一个 [savepoint]({{< ref "docs/ops/state/savepoints#resuming-from-savepoints" >}}) 或一个 [checkpoint]({{< ref "docs/ops/state/checkpoints#resuming-from-a-retained-checkpoint" >}})
 - 更改配置（关闭 Changelog）
-- 从创建的 snapshot 恢复
+- 使用 [`CLAIM`]({{< ref "docs/deployment/config#execution-savepoint-restore-mode" >}}) 恢复模式从创建的 snapshot 恢复（参见[限制](#limitations)）
+
+{{< hint warning >}}
+Changelog state backend 不支持 `NO_CLAIM` [恢复模式]({{< ref "docs/deployment/config#execution-savepoint-restore-mode" >}})，而这是**默认**模式。恢复涉及 Changelog 状态的作业时，必须使用 `CLAIM`（或已废弃的 `LEGACY`）恢复模式。在 `NO_CLAIM` 模式下，作业能够成功恢复，但会在第一次 checkpoint 时失败，抛出 `java.lang.IllegalStateException: Configured state backend (...ChangelogStateBackend...) does not support enforcing a full snapshot`。
+{{< /hint >}}
 
 <a name="limitations"></a>
 
 ### 限制
 - 最多同时创建一个 checkpoint
 - 到 Flink 1.15 为止, 只有 `filesystem` changelog 实现可用
-- 尚不支持 [NO_CLAIM]({{< ref "docs/deployment/config#execution-savepoint-restore-mode" >}}) 模式
+- 尚不支持 [`NO_CLAIM`]({{< ref "docs/deployment/config#execution-savepoint-restore-mode" >}}) 恢复模式；请改用 `CLAIM`（或已废弃的 `LEGACY`）恢复模式（参见上面的说明）
 
 {{< top >}}
 

--- a/docs/content/docs/ops/state/state_backends.md
+++ b/docs/content/docs/ops/state/state_backends.md
@@ -493,7 +493,7 @@ Resuming from both savepoints and checkpoints is supported:
 - given an existing non-changelog job
 - take either a [savepoint]({{< ref "docs/ops/state/savepoints#resuming-from-savepoints" >}}) or a [checkpoint]({{< ref "docs/ops/state/checkpoints#resuming-from-a-retained-checkpoint" >}})
 - alter configuration (enable Changelog)
-- resume from the taken snapshot
+- resume from the taken snapshot using [`CLAIM`]({{< ref "docs/deployment/config#execution-savepoint-restore-mode" >}}) restore mode (see [Limitations](#limitations))
 
 **Disabling Changelog**
 
@@ -501,12 +501,16 @@ Resuming from both savepoints and checkpoints is supported:
 - given an existing changelog job
 - take either a [savepoint]({{< ref "docs/ops/state/savepoints#resuming-from-savepoints" >}}) or a [checkpoint]({{< ref "docs/ops/state/checkpoints#resuming-from-a-retained-checkpoint" >}})
 - alter configuration (disable Changelog)
-- resume from the taken snapshot
+- resume from the taken snapshot using [`CLAIM`]({{< ref "docs/deployment/config#execution-savepoint-restore-mode" >}}) restore mode (see [Limitations](#limitations))
+
+{{< hint warning >}}
+The Changelog state backend does not support the `NO_CLAIM` [restore mode]({{< ref "docs/deployment/config#execution-savepoint-restore-mode" >}}), which is the **default**. When resuming a job that involves Changelog state, use `CLAIM` (or the deprecated `LEGACY`) restore mode. In `NO_CLAIM` mode the job restores successfully but then fails on its first checkpoint with `java.lang.IllegalStateException: Configured state backend (...ChangelogStateBackend...) does not support enforcing a full snapshot`.
+{{< /hint >}}
 
 ### Limitations
  - At most one concurrent checkpoint
  - As of Flink 1.15, only `filesystem` changelog implementation is available
-- [NO_CLAIM]({{< ref "docs/deployment/config#execution-savepoint-restore-mode" >}}) mode not supported
+- [`NO_CLAIM`]({{< ref "docs/deployment/config#execution-savepoint-restore-mode" >}}) restore mode is not supported; resume with `CLAIM` (or the deprecated `LEGACY`) restore mode instead (see the note above)
 
 ## Migrating from Legacy Backends
 


### PR DESCRIPTION
## What is the purpose of the change

Clarify the Changelog state backend documentation: `NO_CLAIM` restore mode (the default) is not supported. A changelog-enabled job resumed in `NO_CLAIM` mode restores successfully but then fails on its first checkpoint with:

```
java.lang.IllegalStateException: Configured state backend
(org.apache.flink.state.changelog.ChangelogStateBackend@...) does not support
enforcing a full snapshot. If you are restoring in NO_CLAIM mode, please consider
choosing CLAIM restore mode.
```

The docs previously stated "Resuming from both savepoints and checkpoints is supported" without noting the required restore mode, and the `NO_CLAIM` limitation was an easily-missed bullet that contradicted that statement. This mismatch contributed to [FLINK-38307](https://issues.apache.org/jira/browse/FLINK-38307) being reported as a bug.

## Brief change log

- Note that resuming a job involving Changelog state must use `CLAIM` (or the deprecated `LEGACY`) restore mode, in both the "Enabling Changelog" and "Disabling Changelog" sections.
- Add a warning note describing the exact failure that occurs in `NO_CLAIM` mode.
- Expand the `NO_CLAIM` limitation bullet to point users to `CLAIM`/`LEGACY`.
- Mirror all changes in the Chinese documentation (`docs/content.zh`).

## Verifying this change

This change is a documentation-only change. The described behavior was verified empirically on Flink 1.19 (RocksDB + Changelog via the Kubernetes operator): resuming a changelog-enabled job in `NO_CLAIM` mode restores successfully but fails on the first checkpoint with the exception above, while the same job resumed in `CLAIM` mode resumes and checkpoints normally.

## Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): no
- The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
- The serializers: no
- The runtime per-record code paths (performance sensitive): no
- Anything that affects deployment or recovery: no
- The S3 file system connector: no

## Documentation

- Does this pull request introduce a new feature? no
- If yes, how is the feature documented? docs (this PR updates documentation only)
