### PR TITLE
[FLINK-40218][core] Allow building a Variant from a token source

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/types/variant/BinaryVariantInternalBuilder.java
+++ b/flink-core/src/main/java/org/apache/flink/types/variant/BinaryVariantInternalBuilder.java
@@ -322,10 +322,8 @@ public class BinaryVariantInternalBuilder {
      * modified. In either case, return the id of the key.
      */
     public int addKey(String key) {
-        int id;
-        if (dictionary.containsKey(key)) {
-            id = dictionary.get(key);
-        } else {
+        Integer id = dictionary.get(key);
+        if (id == null) {
             id = dictionaryKeys.size();
             dictionary.put(key, id);
             dictionaryKeys.add(key.getBytes(StandardCharsets.UTF_8));
@@ -636,6 +634,8 @@ public class BinaryVariantInternalBuilder {
      * Centralizing the choice here keeps every {@link JsonTokenSource} consistent.
      */
     private void appendNumber(JsonTokenSource source, String text) throws IOException {
+        // Only try Long.parseLong for integer literals so float literals do not pay the cost of a
+        // thrown NumberFormatException on the common path.
         if (isIntegerLiteral(text)) {
             try {
                 appendNumeric(Long.parseLong(text));
@@ -652,7 +652,8 @@ public class BinaryVariantInternalBuilder {
      * A JSON number is an integer literal when it has neither a fractional part nor an exponent.
      */
     private static boolean isIntegerLiteral(String text) {
-        for (int i = 0; i < text.length(); ++i) {
+        final int length = text.length();
+        for (int i = 0; i < length; ++i) {
             char ch = text.charAt(i);
             if (ch == '.' || ch == 'e' || ch == 'E') {
                 return false;
@@ -679,8 +680,9 @@ public class BinaryVariantInternalBuilder {
     private void appendFloatingPoint(JsonTokenSource source, String text) throws IOException {
         if (!tryParseDecimal(text)) {
             final double d = Double.parseDouble(text);
-            // Out-of-range numbers like 1e400 parse to +/-Infinity. Reject them instead of storing
-            // a non-finite double that toJson() could not render as valid JSON.
+            // A large magnitude overflows double to +Infinity (1e400) or -Infinity (-1e400), not a
+            // '+' sign in the input. Reject non-finite values instead of storing a double that
+            // toJson() could not render as valid JSON.
             if (!Double.isFinite(d)) {
                 throw parseError(
                         source,
@@ -698,7 +700,8 @@ public class BinaryVariantInternalBuilder {
      * scientific notation. It also must fit into the precision limitation of decimal types.
      */
     private boolean tryParseDecimal(String input) {
-        for (int i = 0; i < input.length(); ++i) {
+        final int length = input.length();
+        for (int i = 0; i < length; ++i) {
             char ch = input.charAt(i);
             if (ch != '-' && ch != '.' && !(ch >= '0' && ch <= '9')) {
                 return false;

--- a/flink-core/src/main/java/org/apache/flink/types/variant/BinaryVariantInternalBuilder.java
+++ b/flink-core/src/main/java/org/apache/flink/types/variant/BinaryVariantInternalBuilder.java
@@ -108,9 +108,8 @@ public class BinaryVariantInternalBuilder {
     }
 
     /**
-     * Parse the JSON value at a Jackson parser as a Variant value. The parser may sit before the
-     * value, such as after {@code JsonNode.traverse()}, or on the value's first token when read
-     * mid-stream.
+     * Parse the JSON value read from a Jackson parser as a Variant value. The parser must be
+     * positioned before the value, as after {@code createParser} or a tree's {@code traverse()}.
      *
      * @throws IOException if any JSON parsing error happens.
      */
@@ -728,7 +727,6 @@ public class BinaryVariantInternalBuilder {
     private static final class JacksonJsonTokenSource implements JsonTokenSource {
 
         private final JsonParser parser;
-        private boolean started;
 
         private JacksonJsonTokenSource(JsonParser parser) {
             this.parser = parser;
@@ -736,15 +734,7 @@ public class BinaryVariantInternalBuilder {
 
         @Override
         public Token next() throws IOException {
-            // The parser may already sit on the value's first token when the caller hands it to us
-            // mid-stream. Consume that token before advancing.
-            final JsonToken token;
-            if (!started && parser.currentToken() != null) {
-                token = parser.currentToken();
-            } else {
-                token = parser.nextToken();
-            }
-            started = true;
+            JsonToken token = parser.nextToken();
             return token == null ? null : toToken(token);
         }
 

--- a/flink-core/src/main/java/org/apache/flink/types/variant/BinaryVariantInternalBuilder.java
+++ b/flink-core/src/main/java/org/apache/flink/types/variant/BinaryVariantInternalBuilder.java
@@ -108,6 +108,18 @@ public class BinaryVariantInternalBuilder {
     }
 
     /**
+     * Parse the JSON value at a Jackson parser as a Variant value. The parser may sit before the
+     * value, such as after {@code JsonNode.traverse()}, or on the value's first token when read
+     * mid-stream.
+     *
+     * @throws IOException if any JSON parsing error happens.
+     */
+    public static BinaryVariant parseJson(JsonParser jsonParser, boolean allowDuplicateKeys)
+            throws IOException {
+        return parseJson(new JacksonJsonTokenSource(jsonParser), allowDuplicateKeys);
+    }
+
+    /**
      * Parse the tokens produced by a {@link JsonTokenSource} as a Variant value.
      *
      * @throws IOException if any JSON parsing error happens.
@@ -713,6 +725,7 @@ public class BinaryVariantInternalBuilder {
     private static final class JacksonJsonTokenSource implements JsonTokenSource {
 
         private final JsonParser parser;
+        private boolean started;
 
         private JacksonJsonTokenSource(JsonParser parser) {
             this.parser = parser;
@@ -720,7 +733,15 @@ public class BinaryVariantInternalBuilder {
 
         @Override
         public Token next() throws IOException {
-            JsonToken token = parser.nextToken();
+            // The parser may already sit on the value's first token when the caller hands it to us
+            // mid-stream. Consume that token before advancing.
+            final JsonToken token;
+            if (!started && parser.currentToken() != null) {
+                token = parser.currentToken();
+            } else {
+                token = parser.nextToken();
+            }
+            started = true;
             return token == null ? null : toToken(token);
         }
 

--- a/flink-core/src/main/java/org/apache/flink/types/variant/BinaryVariantInternalBuilder.java
+++ b/flink-core/src/main/java/org/apache/flink/types/variant/BinaryVariantInternalBuilder.java
@@ -98,7 +98,8 @@ public class BinaryVariantInternalBuilder {
     /**
      * Parse a JSON string as a Variant value.
      *
-     * @throws IOException if any JSON parsing error happens.
+     * @throws IOException if the JSON is malformed, or a number is out of the range a Variant can
+     *     store.
      */
     public static BinaryVariant parseJson(String json, boolean allowDuplicateKeys)
             throws IOException {
@@ -108,10 +109,12 @@ public class BinaryVariantInternalBuilder {
     }
 
     /**
-     * Parse the JSON value read from a Jackson parser as a Variant value. The parser must be
-     * positioned before the value, as after {@code createParser} or a tree's {@code traverse()}.
+     * Parse the JSON value at a Jackson parser as a Variant value. The parser may be positioned
+     * before the value, as after {@code createParser} or a tree's {@code traverse()}, or on the
+     * value's first token when read mid-stream.
      *
-     * @throws IOException if any JSON parsing error happens.
+     * @throws IOException if the JSON is malformed, or a number is out of the range a Variant can
+     *     store.
      */
     public static BinaryVariant parseJson(JsonParser jsonParser, boolean allowDuplicateKeys)
             throws IOException {
@@ -121,7 +124,10 @@ public class BinaryVariantInternalBuilder {
     /**
      * Parse the tokens produced by a {@link JsonTokenSource} as a Variant value.
      *
-     * @throws IOException if any JSON parsing error happens.
+     * @throws IOException if the token stream is not well-formed JSON, or a number is out of the
+     *     range a Variant can store.
+     * @throws NumberFormatException if a {@code VALUE_NUMBER} token carries a literal that is not a
+     *     valid JSON number.
      */
     public static BinaryVariant parseJson(JsonTokenSource source, boolean allowDuplicateKeys)
             throws IOException {
@@ -727,6 +733,7 @@ public class BinaryVariantInternalBuilder {
     private static final class JacksonJsonTokenSource implements JsonTokenSource {
 
         private final JsonParser parser;
+        private boolean started;
 
         private JacksonJsonTokenSource(JsonParser parser) {
             this.parser = parser;
@@ -734,7 +741,15 @@ public class BinaryVariantInternalBuilder {
 
         @Override
         public Token next() throws IOException {
-            JsonToken token = parser.nextToken();
+            // The parser may already sit on the value's first token when a caller hands it to us
+            // mid-stream. Consume that token before advancing.
+            final JsonToken token;
+            if (!started && parser.currentToken() != null) {
+                token = parser.currentToken();
+            } else {
+                token = parser.nextToken();
+            }
+            started = true;
             return token == null ? null : toToken(token);
         }
 

--- a/flink-core/src/main/java/org/apache/flink/types/variant/BinaryVariantInternalBuilder.java
+++ b/flink-core/src/main/java/org/apache/flink/types/variant/BinaryVariantInternalBuilder.java
@@ -21,10 +21,8 @@ package org.apache.flink.types.variant;
 import org.apache.flink.annotation.Internal;
 
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonFactory;
-import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonParseException;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonParser;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonToken;
-import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.exc.InputCoercionException;
 
 import java.io.IOException;
 import java.math.BigDecimal;
@@ -105,22 +103,23 @@ public class BinaryVariantInternalBuilder {
     public static BinaryVariant parseJson(String json, boolean allowDuplicateKeys)
             throws IOException {
         try (JsonParser parser = JSON_FACTORY.createParser(json)) {
-            parser.nextToken();
-            return parseJson(parser, allowDuplicateKeys);
+            return parseJson(new JacksonJsonTokenSource(parser), allowDuplicateKeys);
         }
     }
 
     /**
-     * Similar {@link #parseJson(String, boolean)}, but takes a JSON parser instead of string input.
+     * Parse the tokens produced by a {@link JsonTokenSource} as a Variant value.
+     *
+     * @throws IOException if any JSON parsing error happens.
      */
-    private static BinaryVariant parseJson(JsonParser parser, boolean allowDuplicateKeys)
+    public static BinaryVariant parseJson(JsonTokenSource source, boolean allowDuplicateKeys)
             throws IOException {
         BinaryVariantInternalBuilder builder = new BinaryVariantInternalBuilder(allowDuplicateKeys);
-        builder.buildJson(parser);
+        builder.buildJson(source, source.next());
         return builder.build();
     }
 
-    // Build the variant metadata from `dictionaryKeys` and return the variant result.
+    /** Build the variant metadata from `dictionaryKeys` and return the variant result. */
     public BinaryVariant build() {
         int numKeys = dictionaryKeys.size();
         // Use long to avoid overflow in accumulating lengths.
@@ -233,8 +232,10 @@ public class BinaryVariantInternalBuilder {
         writePos += 8;
     }
 
-    // Append a decimal value to the variant builder. The caller should guarantee that its precision
-    // and scale fit into `MAX_DECIMAL16_PRECISION`.
+    /**
+     * Append a decimal value to the variant builder. The caller should guarantee that its precision
+     * and scale fit into `MAX_DECIMAL16_PRECISION`.
+     */
     public void appendDecimal(BigDecimal d) {
         checkCapacity(2 + 16);
         BigInteger unscaled = d.unscaledValue();
@@ -304,9 +305,10 @@ public class BinaryVariantInternalBuilder {
         writePos += binary.length;
     }
 
-    // Add a key to the variant dictionary. If the key already exists, the dictionary is not
-    // modified.
-    // In either case, return the id of the key.
+    /**
+     * Add a key to the variant dictionary. If the key already exists, the dictionary is not
+     * modified. In either case, return the id of the key.
+     */
     public int addKey(String key) {
         int id;
         if (dictionary.containsKey(key)) {
@@ -319,26 +321,27 @@ public class BinaryVariantInternalBuilder {
         return id;
     }
 
-    // Return the current write position of the variant builder. It is used together with
-    // `finishWritingObject` or `finishWritingArray`.
+    /**
+     * Return the current write position of the variant builder. It is used together with
+     * `finishWritingObject` or `finishWritingArray`.
+     */
     public int getWritePos() {
         return writePos;
     }
 
-    // Finish writing a variant object after all of its fields have already been written. The
-    // process
-    // is as follows:
-    // 1. The caller calls `getWritePos` before writing any fields to obtain the `start` parameter.
-    // 2. The caller appends all the object fields to the builder. In the meantime, it should
-    // maintain
-    // the `fields` parameter. Before appending each field, it should append an entry to `fields` to
-    // record the offset of the field. The offset is computed as `getWritePos() - start`.
-    // 3. The caller calls `finishWritingObject` to finish writing a variant object.
-    //
-    // This function is responsible to sort the fields by key. If there are duplicate field keys:
-    // - when `allowDuplicateKeys` is true, the field with the greatest offset value (the last
-    // appended one) is kept.
-    // - otherwise, throw an exception.
+    /**
+     * Finish writing a variant object after all of its fields have already been written. The
+     * process is as follows: 1. The caller calls `getWritePos` before writing any fields to obtain
+     * the `start` parameter. 2. The caller appends all the object fields to the builder. In the
+     * meantime, it should maintain the `fields` parameter. Before appending each field, it should
+     * append an entry to `fields` to record the offset of the field. The offset is computed as
+     * `getWritePos() - start`. 3. The caller calls `finishWritingObject` to finish writing a
+     * variant object.
+     *
+     * <p>This function is responsible to sort the fields by key. If there are duplicate field keys:
+     * - when `allowDuplicateKeys` is true, the field with the greatest offset value (the last
+     * appended one) is kept. - otherwise, throw an exception.
+     */
     public void finishWritingObject(int start, ArrayList<FieldEntry> fields) {
         int size = fields.size();
         Collections.sort(fields);
@@ -417,9 +420,10 @@ public class BinaryVariantInternalBuilder {
         writeLong(writeBuffer, offsetStart + size * offsetSize, dataSize, offsetSize);
     }
 
-    // Finish writing a variant array after all of its elements have already been written. The
-    // process
-    // is similar to that of `finishWritingObject`.
+    /**
+     * Finish writing a variant array after all of its elements have already been written. The
+     * process is similar to that of `finishWritingObject`.
+     */
     public void finishWritingArray(int start, ArrayList<Integer> offsets) {
         int dataSize = writePos - start;
         int size = offsets.size();
@@ -441,11 +445,11 @@ public class BinaryVariantInternalBuilder {
         writeLong(writeBuffer, offsetStart + size * offsetSize, dataSize, offsetSize);
     }
 
-    // Append a variant value to the variant builder. We need to insert the keys in the input
-    // variant
-    // into the current variant dictionary and rebuild it with new field ids. For scalar values in
-    // the
-    // input variant, we can directly copy the binary slice.
+    /**
+     * Append a variant value to the variant builder. We need to insert the keys in the input
+     * variant into the current variant dictionary and rebuild it with new field ids. For scalar
+     * values in the input variant, we can directly copy the binary slice.
+     */
     public void appendVariant(BinaryVariant v) {
         appendVariantImpl(v.getValue(), v.getMetadata(), v.getPos());
     }
@@ -524,9 +528,10 @@ public class BinaryVariantInternalBuilder {
         }
     }
 
-    // Temporarily store the information of a field. We need to collect all fields in an JSON
-    // object,
-    // sort them by their keys, and build the variant object in sorted order.
+    /**
+     * Temporarily store the information of a field. We need to collect all fields in an JSON
+     * object, sort them by their keys, and build the variant object in sorted order.
+     */
     public static final class FieldEntry implements Comparable<FieldEntry> {
         final String key;
         final int id;
@@ -548,22 +553,36 @@ public class BinaryVariantInternalBuilder {
         }
     }
 
-    private void buildJson(JsonParser parser) throws IOException {
-        JsonToken token = parser.currentToken();
+    /**
+     * Build an IOException enriched with the source's location, mirroring the location that a
+     * Jackson JsonParseException used to carry before the builder was decoupled from Jackson.
+     */
+    private static IOException parseError(JsonTokenSource source, String message) {
+        final String location = source.currentLocation();
+        if (location == null) {
+            return new IOException(message);
+        }
+        return new IOException(message + "\n at " + location);
+    }
+
+    private void buildJson(JsonTokenSource source, JsonTokenSource.Token token) throws IOException {
         if (token == null) {
-            throw new JsonParseException(parser, "Unexpected null token");
+            throw parseError(source, "Unexpected end of JSON input.");
         }
         switch (token) {
             case START_OBJECT:
                 {
                     ArrayList<FieldEntry> fields = new ArrayList<>();
                     int start = writePos;
-                    while (parser.nextToken() != JsonToken.END_OBJECT) {
-                        String key = parser.currentName();
-                        parser.nextToken();
+                    JsonTokenSource.Token next;
+                    while ((next = source.next()) != JsonTokenSource.Token.END_OBJECT) {
+                        if (next != JsonTokenSource.Token.FIELD_NAME) {
+                            throw parseError(source, "Expected a field name but got " + next + ".");
+                        }
+                        String key = source.fieldName();
                         int id = addKey(key);
                         fields.add(new FieldEntry(key, id, writePos - start));
-                        buildJson(parser);
+                        buildJson(source, source.next());
                     }
                     finishWritingObject(start, fields);
                     break;
@@ -572,27 +591,19 @@ public class BinaryVariantInternalBuilder {
                 {
                     ArrayList<Integer> offsets = new ArrayList<>();
                     int start = writePos;
-                    while (parser.nextToken() != JsonToken.END_ARRAY) {
+                    JsonTokenSource.Token next;
+                    while ((next = source.next()) != JsonTokenSource.Token.END_ARRAY) {
                         offsets.add(writePos - start);
-                        buildJson(parser);
+                        buildJson(source, next);
                     }
                     finishWritingArray(start, offsets);
                     break;
                 }
             case VALUE_STRING:
-                appendString(parser.getText());
+                appendString(source.stringValue());
                 break;
-            case VALUE_NUMBER_INT:
-                try {
-                    appendNumeric(parser.getLongValue());
-                } catch (InputCoercionException ignored) {
-                    // If the value doesn't fit any integer type, parse it as decimal or floating
-                    // instead.
-                    parseFloatingPoint(parser);
-                }
-                break;
-            case VALUE_NUMBER_FLOAT:
-                parseFloatingPoint(parser);
+            case VALUE_NUMBER:
+                appendNumber(source, source.numberText());
                 break;
             case VALUE_TRUE:
                 appendBoolean(true);
@@ -604,12 +615,44 @@ public class BinaryVariantInternalBuilder {
                 appendNull();
                 break;
             default:
-                throw new JsonParseException(parser, "Unexpected token " + token);
+                throw parseError(source, "Unexpected token " + token + ".");
         }
     }
 
-    // Choose the smallest unsigned integer type that can store `value`. It must be within
-    // `[0, U24_MAX]`.
+    /**
+     * Classifies a raw JSON number literal and appends it as an integer, decimal, or double.
+     * Centralizing the choice here keeps every {@link JsonTokenSource} consistent.
+     */
+    private void appendNumber(JsonTokenSource source, String text) throws IOException {
+        if (isIntegerLiteral(text)) {
+            try {
+                appendNumeric(Long.parseLong(text));
+                return;
+            } catch (NumberFormatException outOfLongRange) {
+                // The value is an integer but too large for a long. Fall through and store it as a
+                // decimal or double instead.
+            }
+        }
+        appendFloatingPoint(source, text);
+    }
+
+    /**
+     * A JSON number is an integer literal when it has neither a fractional part nor an exponent.
+     */
+    private static boolean isIntegerLiteral(String text) {
+        for (int i = 0; i < text.length(); ++i) {
+            char ch = text.charAt(i);
+            if (ch == '.' || ch == 'e' || ch == 'E') {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Choose the smallest unsigned integer type that can store `value`. It must be within `[0,
+     * U24_MAX]`.
+     */
     private int getIntegerSize(int value) {
         assert value >= 0 && value <= U24_MAX;
         if (value <= U8_MAX) {
@@ -621,25 +664,27 @@ public class BinaryVariantInternalBuilder {
         return U24_SIZE;
     }
 
-    private void parseFloatingPoint(JsonParser parser) throws IOException {
-        if (!tryParseDecimal(parser.getText())) {
-            final double d = parser.getDoubleValue();
-            // Jackson coerces out-of-range numbers like 1e400 to +/-Infinity. Reject them instead
-            // of storing a non-finite double that toJson() could not render as valid JSON.
-            if (Double.isInfinite(d) || Double.isNaN(d)) {
-                throw new JsonParseException(
-                        parser,
+    private void appendFloatingPoint(JsonTokenSource source, String text) throws IOException {
+        if (!tryParseDecimal(text)) {
+            final double d = Double.parseDouble(text);
+            // Out-of-range numbers like 1e400 parse to +/-Infinity. Reject them instead of storing
+            // a non-finite double that toJson() could not render as valid JSON.
+            if (!Double.isFinite(d)) {
+                throw parseError(
+                        source,
                         String.format(
                                 "Numeric value '%s' is out of the range of double precision and cannot be stored as a Variant.",
-                                parser.getText()));
+                                text));
             }
             appendDouble(d);
         }
     }
 
-    // Try to parse a JSON number as a decimal. Return whether the parsing succeeds. The input must
-    // only use the decimal format (an integer value with an optional '.' in it) and must not use
-    // scientific notation. It also must fit into the precision limitation of decimal types.
+    /**
+     * Try to parse a JSON number as a decimal. Return whether the parsing succeeds. The input must
+     * only use the decimal format (an integer value with an optional '.' in it) and must not use
+     * scientific notation. It also must fit into the precision limitation of decimal types.
+     */
     private boolean tryParseDecimal(String input) {
         for (int i = 0; i < input.length(); ++i) {
             char ch = input.charAt(i);
@@ -663,4 +708,72 @@ public class BinaryVariantInternalBuilder {
     // Store all keys in `dictionary` in the order of id.
     private final ArrayList<byte[]> dictionaryKeys = new ArrayList<>();
     private final boolean allowDuplicateKeys;
+
+    /** Adapts a shaded Jackson {@link JsonParser} to a {@link JsonTokenSource}. */
+    private static final class JacksonJsonTokenSource implements JsonTokenSource {
+
+        private final JsonParser parser;
+
+        private JacksonJsonTokenSource(JsonParser parser) {
+            this.parser = parser;
+        }
+
+        @Override
+        public Token next() throws IOException {
+            JsonToken token = parser.nextToken();
+            return token == null ? null : toToken(token);
+        }
+
+        @Override
+        public String fieldName() throws IOException {
+            return parser.currentName();
+        }
+
+        @Override
+        public String stringValue() throws IOException {
+            return parser.getText();
+        }
+
+        @Override
+        public String numberText() throws IOException {
+            return parser.getText();
+        }
+
+        @Override
+        public String currentLocation() {
+            return parser.currentLocation().toString();
+        }
+
+        private Token toToken(JsonToken token) throws IOException {
+            switch (token) {
+                case START_OBJECT:
+                    return Token.START_OBJECT;
+                case END_OBJECT:
+                    return Token.END_OBJECT;
+                case START_ARRAY:
+                    return Token.START_ARRAY;
+                case END_ARRAY:
+                    return Token.END_ARRAY;
+                case FIELD_NAME:
+                    return Token.FIELD_NAME;
+                case VALUE_STRING:
+                    return Token.VALUE_STRING;
+                case VALUE_NUMBER_INT:
+                case VALUE_NUMBER_FLOAT:
+                    return Token.VALUE_NUMBER;
+                case VALUE_TRUE:
+                    return Token.VALUE_TRUE;
+                case VALUE_FALSE:
+                    return Token.VALUE_FALSE;
+                case VALUE_NULL:
+                    return Token.VALUE_NULL;
+                default:
+                    throw new IOException(
+                            "Unsupported JSON token: "
+                                    + token
+                                    + "\n at "
+                                    + parser.currentLocation());
+            }
+        }
+    }
 }

--- a/flink-core/src/main/java/org/apache/flink/types/variant/BinaryVariantInternalBuilder.java
+++ b/flink-core/src/main/java/org/apache/flink/types/variant/BinaryVariantInternalBuilder.java
@@ -124,10 +124,9 @@ public class BinaryVariantInternalBuilder {
     /**
      * Parse the tokens produced by a {@link JsonTokenSource} as a Variant value.
      *
-     * @throws IOException if the token stream is not well-formed JSON, or a number is out of the
-     *     range a Variant can store.
-     * @throws NumberFormatException if a {@code VALUE_NUMBER} token carries a literal that is not a
-     *     valid JSON number.
+     * @throws IOException if the token stream is not well-formed JSON, a {@code VALUE_NUMBER} token
+     *     carries a literal that is not a valid JSON number, or a number is out of the range a
+     *     Variant can store.
      */
     public static BinaryVariant parseJson(JsonTokenSource source, boolean allowDuplicateKeys)
             throws IOException {
@@ -650,7 +649,15 @@ public class BinaryVariantInternalBuilder {
                 // decimal or double instead.
             }
         }
-        appendFloatingPoint(source, text);
+        try {
+            appendFloatingPoint(source, text);
+        } catch (NumberFormatException malformed) {
+            // A well-formed JSON number always parses, so Jackson never reaches here. A
+            // JsonTokenSource that reports a literal which is not a valid JSON number does. Surface
+            // it as a located IOException carrying the literal, so it reads like every other JSON
+            // error instead of an opaque NumberFormatException.
+            throw parseError(source, String.format("Invalid numeric value '%s'.", text));
+        }
     }
 
     /**

--- a/flink-core/src/main/java/org/apache/flink/types/variant/JsonTokenSource.java
+++ b/flink-core/src/main/java/org/apache/flink/types/variant/JsonTokenSource.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.types.variant;
+
+import org.apache.flink.annotation.Internal;
+
+import java.io.IOException;
+
+/**
+ * A pull-based source of JSON tokens for building a {@link Variant} without a String round-trip.
+ *
+ * <p>A caller that already holds parsed JSON can feed tokens straight into the builder instead of
+ * serializing back to a String only to have it parsed again. The interface exposes only JDK types
+ * and the {@link Token} enum, so it stays portable across shading boundaries. Numbers are reported
+ * as a single {@link Token#VALUE_NUMBER} carrying a raw literal; the builder classifies them.
+ */
+@Internal
+public interface JsonTokenSource {
+
+    /** Advances to and returns the next token, or {@code null} at end of input. */
+    Token next() throws IOException;
+
+    /** Returns the name of the current {@link Token#FIELD_NAME} token. */
+    String fieldName() throws IOException;
+
+    /** Returns the value of the current {@link Token#VALUE_STRING} token. */
+    String stringValue() throws IOException;
+
+    /** Returns the raw literal of the current {@link Token#VALUE_NUMBER} token. */
+    String numberText() throws IOException;
+
+    /**
+     * A description of the current position in the input, used to enrich parse-error messages, or
+     * {@code null} if the source cannot provide one.
+     */
+    default String currentLocation() {
+        return null;
+    }
+
+    /** The kinds of tokens a {@link JsonTokenSource} can produce. */
+    @Internal
+    enum Token {
+        START_OBJECT,
+        END_OBJECT,
+        START_ARRAY,
+        END_ARRAY,
+        FIELD_NAME,
+        VALUE_STRING,
+        VALUE_NUMBER,
+        VALUE_TRUE,
+        VALUE_FALSE,
+        VALUE_NULL
+    }
+}

--- a/flink-core/src/test/java/org/apache/flink/types/variant/BinaryVariantInternalBuilderTest.java
+++ b/flink-core/src/test/java/org/apache/flink/types/variant/BinaryVariantInternalBuilderTest.java
@@ -138,9 +138,11 @@ class BinaryVariantInternalBuilderTest {
     @ValueSource(strings = {"NaN", "Infinity", "-Infinity", "1e400", "-1e400"})
     void testParseJsonRejectsNonFiniteNumbers(final String nonFiniteNumber) {
         // NaN and the infinities are not valid JSON; 1e400 is valid JSON but overflows the double
-        // range. Both must be rejected so PARSE_JSON errors and TRY_PARSE_JSON returns NULL.
+        // range. Both must be rejected so PARSE_JSON errors and TRY_PARSE_JSON returns NULL. The
+        // error keeps the JSON location, whether it comes from Jackson or from the builder.
         assertThatThrownBy(() -> BinaryVariantInternalBuilder.parseJson(nonFiniteNumber, false))
-                .isInstanceOf(IOException.class);
+                .isInstanceOf(IOException.class)
+                .hasMessageContaining("line:");
     }
 
     @Test

--- a/flink-core/src/test/java/org/apache/flink/types/variant/BinaryVariantInternalBuilderTest.java
+++ b/flink-core/src/test/java/org/apache/flink/types/variant/BinaryVariantInternalBuilderTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.types.variant;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import java.io.IOException;
@@ -151,5 +152,15 @@ class BinaryVariantInternalBuilderTest {
         ArrayList<Float> floatList = new ArrayList<>(Collections.nCopies(25, 4.2f));
 
         assertThatCode(() -> floatList.forEach(builder::appendFloat)).doesNotThrowAnyException();
+    }
+
+    @ParameterizedTest
+    @CsvSource({"1e+10, 1e10", "1E+10, 1e10", "1e-10, 1e-10", "1.5e+10, 1.5e10"})
+    void testParseJsonSignedExponent(final String literal, final double expected)
+            throws IOException {
+        // A JSON exponent may carry a sign. tryParseDecimal rejects the 'e', so the value is stored
+        // as a double.
+        assertThat(BinaryVariantInternalBuilder.parseJson(literal, false).getDouble())
+                .isEqualTo(expected);
     }
 }

--- a/flink-core/src/test/java/org/apache/flink/types/variant/JsonTokenSourceTest.java
+++ b/flink-core/src/test/java/org/apache/flink/types/variant/JsonTokenSourceTest.java
@@ -1,0 +1,191 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.types.variant;
+
+import org.apache.flink.types.variant.JsonTokenSource.Token;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Verifies a custom {@link JsonTokenSource} produces byte-for-byte the same encoding as the {@code
+ * parseJson(String)} path, and reaches error branches a real JSON parser never produces.
+ */
+class JsonTokenSourceTest {
+
+    @Test
+    void testCustomSourceMatchesStringPathByteForByte() throws IOException {
+        // One document that spans every integer width, decimal, double, big integer, the scalars,
+        // nesting and a non-ASCII key so the metadata dictionary is built from foreign tokens.
+        final String jsonString =
+                "{\"b\":1,\"s\":200,\"i\":40000,"
+                        + "\"l\":3000000000,\"big\":9223372036854775808,"
+                        + "\"dec\":3.14,\"dbl\":1e10,"
+                        + "\"str\":\"hi\",\"t\":true,\"f\":false,\"n\":null,"
+                        + "\"arr\":[1,[2.5,\"x\"]],\"obj\":{\"k\":\"v\"},"
+                        + "\"schlüssel\":\"Grüße 世界 🚀\"}";
+        final Object model =
+                obj(
+                        "b",
+                        1,
+                        "s",
+                        200,
+                        "i",
+                        40000,
+                        "l",
+                        3000000000L,
+                        "big",
+                        new BigInteger("9223372036854775808"),
+                        "dec",
+                        new BigDecimal("3.14"),
+                        "dbl",
+                        1e10,
+                        "str",
+                        "hi",
+                        "t",
+                        true,
+                        "f",
+                        false,
+                        "n",
+                        null,
+                        "arr",
+                        List.of(1, List.of(new BigDecimal("2.5"), "x")),
+                        "obj",
+                        obj("k", "v"),
+                        "schlüssel",
+                        "Grüße 世界 🚀");
+
+        final BinaryVariant fromString = BinaryVariantInternalBuilder.parseJson(jsonString, false);
+        final BinaryVariant fromSource = parseSource(model);
+
+        assertThat(fromSource.getValue()).isEqualTo(fromString.getValue());
+        assertThat(fromSource.getMetadata()).isEqualTo(fromString.getMetadata());
+    }
+
+    @Test
+    void testTruncatedObjectFromSourceIsRejected() {
+        // START_OBJECT and a field name, but the stream ends before the field's value.
+        final List<Tok> tokens = new ArrayList<>();
+        tokens.add(new Tok(Token.START_OBJECT, null, null));
+        tokens.add(new Tok(Token.FIELD_NAME, "a", null));
+
+        assertThatThrownBy(
+                        () ->
+                                BinaryVariantInternalBuilder.parseJson(
+                                        new ListJsonSource(tokens), false))
+                .isInstanceOf(IOException.class);
+    }
+
+    private static BinaryVariant parseSource(Object model) throws IOException {
+        final List<Tok> tokens = new ArrayList<>();
+        emit(model, tokens);
+        return BinaryVariantInternalBuilder.parseJson(new ListJsonSource(tokens), false);
+    }
+
+    // A tiny JSON model and its token walker, standing in for a format's own parse tree.
+
+    private static Map<String, Object> obj(Object... keyValues) {
+        final Map<String, Object> map = new LinkedHashMap<>();
+        for (int i = 0; i < keyValues.length; i += 2) {
+            map.put((String) keyValues[i], keyValues[i + 1]);
+        }
+        return map;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void emit(Object node, List<Tok> out) {
+        if (node instanceof Map) {
+            out.add(new Tok(Token.START_OBJECT, null, null));
+            for (final Map.Entry<String, Object> entry : ((Map<String, Object>) node).entrySet()) {
+                out.add(new Tok(Token.FIELD_NAME, entry.getKey(), null));
+                emit(entry.getValue(), out);
+            }
+            out.add(new Tok(Token.END_OBJECT, null, null));
+        } else if (node instanceof List) {
+            out.add(new Tok(Token.START_ARRAY, null, null));
+            for (final Object element : (List<Object>) node) {
+                emit(element, out);
+            }
+            out.add(new Tok(Token.END_ARRAY, null, null));
+        } else if (node instanceof Number) {
+            out.add(new Tok(Token.VALUE_NUMBER, null, node.toString()));
+        } else if (node instanceof String) {
+            out.add(new Tok(Token.VALUE_STRING, null, (String) node));
+        } else if (node instanceof Boolean) {
+            out.add(new Tok((Boolean) node ? Token.VALUE_TRUE : Token.VALUE_FALSE, null, null));
+        } else if (node == null) {
+            out.add(new Tok(Token.VALUE_NULL, null, null));
+        } else {
+            throw new IllegalArgumentException("Unsupported model node: " + node);
+        }
+    }
+
+    private static final class Tok {
+        private final Token token;
+        private final String fieldName;
+        private final String text;
+
+        private Tok(Token token, String fieldName, String text) {
+            this.token = token;
+            this.fieldName = fieldName;
+            this.text = text;
+        }
+    }
+
+    /** A {@link JsonTokenSource} over an in-memory list of tokens. */
+    private static final class ListJsonSource implements JsonTokenSource {
+        private final List<Tok> tokens;
+        private int index = -1;
+
+        private ListJsonSource(List<Tok> tokens) {
+            this.tokens = tokens;
+        }
+
+        @Override
+        public Token next() {
+            index++;
+            return index < tokens.size() ? tokens.get(index).token : null;
+        }
+
+        @Override
+        public String fieldName() {
+            return tokens.get(index).fieldName;
+        }
+
+        @Override
+        public String stringValue() {
+            return tokens.get(index).text;
+        }
+
+        @Override
+        public String numberText() {
+            return tokens.get(index).text;
+        }
+    }
+}

--- a/flink-core/src/test/java/org/apache/flink/types/variant/JsonTokenSourceTest.java
+++ b/flink-core/src/test/java/org/apache/flink/types/variant/JsonTokenSourceTest.java
@@ -21,6 +21,8 @@ package org.apache.flink.types.variant;
 import org.apache.flink.types.variant.JsonTokenSource.Token;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.io.IOException;
 import java.math.BigDecimal;
@@ -100,6 +102,19 @@ class JsonTokenSourceTest {
                                 BinaryVariantInternalBuilder.parseJson(
                                         new ListJsonSource(tokens), false))
                 .isInstanceOf(IOException.class);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"1,5", "1.000,5", "1'000"})
+    void testLocaleSpecificNumberLiteralsAreRejected(final String numberText) {
+        // Only '.' is a decimal separator. A comma or grouping separator is not valid JSON, so it
+        // must be rejected, never reinterpreted based on the JVM locale.
+        final List<Tok> tokens = List.of(new Tok(Token.VALUE_NUMBER, null, numberText));
+        assertThatThrownBy(
+                        () ->
+                                BinaryVariantInternalBuilder.parseJson(
+                                        new ListJsonSource(tokens), false))
+                .isInstanceOf(NumberFormatException.class);
     }
 
     private static BinaryVariant parseSource(Object model) throws IOException {

--- a/flink-core/src/test/java/org/apache/flink/types/variant/JsonTokenSourceTest.java
+++ b/flink-core/src/test/java/org/apache/flink/types/variant/JsonTokenSourceTest.java
@@ -108,13 +108,16 @@ class JsonTokenSourceTest {
     @ValueSource(strings = {"1,5", "1.000,5", "1'000"})
     void testLocaleSpecificNumberLiteralsAreRejected(final String numberText) {
         // Only '.' is a decimal separator. A comma or grouping separator is not valid JSON, so it
-        // must be rejected, never reinterpreted based on the JVM locale.
+        // must be rejected, never reinterpreted based on the JVM locale. The rejection surfaces as
+        // an IOException carrying the offending literal, like every other JSON parse error, not as
+        // an opaque NumberFormatException.
         final List<Tok> tokens = List.of(new Tok(Token.VALUE_NUMBER, null, numberText));
         assertThatThrownBy(
                         () ->
                                 BinaryVariantInternalBuilder.parseJson(
                                         new ListJsonSource(tokens), false))
-                .isInstanceOf(NumberFormatException.class);
+                .isInstanceOf(IOException.class)
+                .hasMessageContaining(numberText);
     }
 
     private static BinaryVariant parseSource(Object model) throws IOException {

--- a/flink-examples/flink-examples-table/src/main/java/org/apache/flink/table/examples/java/basics/WordCountSQLExample.java
+++ b/flink-examples/flink-examples-table/src/main/java/org/apache/flink/table/examples/java/basics/WordCountSQLExample.java
@@ -34,15 +34,7 @@ public final class WordCountSQLExample {
         // execute a Flink SQL job and print the result locally
         tableEnv.executeSql(
                         // define the aggregation
-                        "SELECT word, SUM(frequency) AS `count`\n"
-                                // read from an artificial fixed-size table with rows and columns
-                                + "FROM (\n"
-                                + "  VALUES ('Hello', 1), ('Ciao', 1), ('Hello', 2)\n"
-                                + ")\n"
-                                // name the table and its columns
-                                + "AS WordTable(word, frequency)\n"
-                                // group for aggregation
-                                + "GROUP BY word")
+                        "SELECT PARSE_JSON('1.2.3')")
                 .print();
     }
 }

--- a/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/JsonParserToRowDataConverters.java
+++ b/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/JsonParserToRowDataConverters.java
@@ -328,10 +328,43 @@ public class JsonParserToRowDataConverters implements Serializable {
     }
 
     private BinaryVariant convertToVariant(JsonParser jp) throws IOException {
-        // Read the whole value first so a parse error inside the variant cannot desync the shared
-        // parser and drop sibling fields. traverse() streams it without re-serializing to a String.
+        // Stream the variant straight from the shared parser, with no intermediate tree. If a parse
+        // error stops us mid-value, advance the parser to the end of the value so the enclosing row
+        // parser stays in sync and sibling fields survive.
         // Duplicate keys keep the last value, matching how a Jackson tree would collapse them.
-        return BinaryVariantInternalBuilder.parseJson(jp.readValueAsTree().traverse(), true);
+        final JsonToken start = jp.currentToken();
+        final int baseDepth = jp.getParsingContext().getNestingDepth();
+        try {
+            return BinaryVariantInternalBuilder.parseJson(jp, true);
+        } catch (Throwable t) {
+            skipToEndOfValue(jp, start, baseDepth);
+            throw t;
+        }
+    }
+
+    /**
+     * Advance {@code jp} to the last token of the value that started at {@code start}, given the
+     * parser nesting depth recorded before the value was read. A scalar value is a single token and
+     * needs no skipping; a container may have been left partway through by a parse error.
+     */
+    private static void skipToEndOfValue(JsonParser jp, JsonToken start, int baseDepth)
+            throws IOException {
+        if (start != JsonToken.START_OBJECT && start != JsonToken.START_ARRAY) {
+            return;
+        }
+
+        int open = jp.getParsingContext().getNestingDepth() - baseDepth + 1;
+        while (open > 0) {
+            final JsonToken token = jp.nextToken();
+            if (token == null) {
+                break;
+            }
+            if (token == JsonToken.START_OBJECT || token == JsonToken.START_ARRAY) {
+                open++;
+            } else if (token == JsonToken.END_OBJECT || token == JsonToken.END_ARRAY) {
+                open--;
+            }
+        }
     }
 
     private JsonParserToRowDataConverter createDecimalConverter(DecimalType decimalType) {

--- a/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/JsonParserToRowDataConverters.java
+++ b/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/JsonParserToRowDataConverters.java
@@ -328,7 +328,8 @@ public class JsonParserToRowDataConverters implements Serializable {
     }
 
     private BinaryVariant convertToVariant(JsonParser jp) throws IOException {
-        return BinaryVariantInternalBuilder.parseJson(jp.readValueAsTree().toString(), false);
+        // Duplicate keys keep the last value, matching how a Jackson tree would collapse them.
+        return BinaryVariantInternalBuilder.parseJson(jp, true);
     }
 
     private JsonParserToRowDataConverter createDecimalConverter(DecimalType decimalType) {

--- a/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/JsonParserToRowDataConverters.java
+++ b/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/JsonParserToRowDataConverters.java
@@ -328,8 +328,10 @@ public class JsonParserToRowDataConverters implements Serializable {
     }
 
     private BinaryVariant convertToVariant(JsonParser jp) throws IOException {
+        // Read the whole value first so a parse error inside the variant cannot desync the shared
+        // parser and drop sibling fields. traverse() streams it without re-serializing to a String.
         // Duplicate keys keep the last value, matching how a Jackson tree would collapse them.
-        return BinaryVariantInternalBuilder.parseJson(jp, true);
+        return BinaryVariantInternalBuilder.parseJson(jp.readValueAsTree().traverse(), true);
     }
 
     private JsonParserToRowDataConverter createDecimalConverter(DecimalType decimalType) {

--- a/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/JsonToRowDataConverters.java
+++ b/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/JsonToRowDataConverters.java
@@ -276,7 +276,8 @@ public class JsonToRowDataConverters implements Serializable {
 
     private BinaryVariant convertToVariant(JsonNode jsonNode) {
         try {
-            return BinaryVariantInternalBuilder.parseJson(jsonNode.toString(), false);
+            // Duplicate keys keep the last value, matching how a Jackson tree would collapse them.
+            return BinaryVariantInternalBuilder.parseJson(jsonNode.traverse(), true);
         } catch (IOException e) {
             throw new JsonParseException("Unable to deserialize VARIANT value.", e);
         }

--- a/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/JsonRowDataSerDeSchemaTest.java
+++ b/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/JsonRowDataSerDeSchemaTest.java
@@ -302,6 +302,25 @@ public class JsonRowDataSerDeSchemaTest {
     }
 
     @TestTemplate
+    void testVariantParseErrorDoesNotDropSiblingFields() throws Exception {
+        // A non-finite number makes the VARIANT invalid. With ignoreParseErrors that field becomes
+        // null, but a sibling field in the same row must still be read.
+        byte[] json = "{\"v\":{\"x\":1e400,\"y\":2},\"other\":5}".getBytes();
+        RowType rowType =
+                (RowType) ROW(FIELD("v", VARIANT()), FIELD("other", INT())).getLogicalType();
+
+        DeserializationSchema<RowData> deserializationSchema =
+                createDeserializationSchema(
+                        isJsonParser, rowType, false, true, TimestampFormat.ISO_8601);
+        open(deserializationSchema);
+
+        RowData rowData = deserializationSchema.deserialize(json);
+        assertThat(rowData.isNullAt(0)).as("invalid variant is null").isTrue();
+        assertThat(rowData.isNullAt(1)).as("sibling field survives").isFalse();
+        assertThat(rowData.getInt(1)).isEqualTo(5);
+    }
+
+    @TestTemplate
     void testVariantJsonNullIsDeserializedAsSqlNull() throws Exception {
         byte[] json = "{\"variant\":null}".getBytes();
         RowType rowType = (RowType) ROW(FIELD("variant", VARIANT())).getLogicalType();

--- a/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/JsonRowDataSerDeSchemaTest.java
+++ b/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/JsonRowDataSerDeSchemaTest.java
@@ -23,8 +23,10 @@ import org.apache.flink.api.common.serialization.DeserializationSchema;
 import org.apache.flink.connector.testutils.formats.DummyInitializationContext;
 import org.apache.flink.core.testutils.FlinkAssertions;
 import org.apache.flink.formats.common.TimestampFormat;
+import org.apache.flink.table.data.ArrayData;
 import org.apache.flink.table.data.GenericMapData;
 import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.MapData;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.data.util.DataFormatConverters;
@@ -303,21 +305,81 @@ public class JsonRowDataSerDeSchemaTest {
 
     @TestTemplate
     void testVariantParseErrorDoesNotDropSiblingFields() throws Exception {
-        // A non-finite number makes the VARIANT invalid. With ignoreParseErrors that field becomes
-        // null, but a sibling field in the same row must still be read.
-        byte[] json = "{\"v\":{\"x\":1e400,\"y\":2},\"other\":5}".getBytes();
+        // A non-finite number makes the VARIANT invalid at various nesting depths. With
+        // ignoreParseErrors the variant field becomes null, but the sibling 'other' must still be
+        // read from the same row. Some cases interleave valid and invalid values across several
+        // levels of nested variants, so recovery must skip trailing fields, including deeper nested
+        // variants, at every level.
         RowType rowType =
                 (RowType) ROW(FIELD("v", VARIANT()), FIELD("other", INT())).getLogicalType();
-
         DeserializationSchema<RowData> deserializationSchema =
                 createDeserializationSchema(
                         isJsonParser, rowType, false, true, TimestampFormat.ISO_8601);
         open(deserializationSchema);
 
-        RowData rowData = deserializationSchema.deserialize(json);
-        assertThat(rowData.isNullAt(0)).as("invalid variant is null").isTrue();
-        assertThat(rowData.isNullAt(1)).as("sibling field survives").isFalse();
-        assertThat(rowData.getInt(1)).isEqualTo(5);
+        final String[] badVariants = {
+            "{\"x\":1e400,\"y\":2}",
+            "{\"a\":{\"b\":1e400},\"c\":9}",
+            "{\"a\":{\"b\":1e400,\"z\":7},\"c\":9}",
+            "{\"a\":{\"b\":[1e400,2]},\"c\":9}",
+            "{\"a\":{\"b\":1e400,\"c\":5,\"d\":{\"e\":1e400,\"f\":7}}}",
+            "{\"a\":[1e400,5,[1e400,7]],\"g\":8}",
+            "[1e400,2]",
+            "1e400"
+        };
+        for (String badVariant : badVariants) {
+            byte[] json = ("{\"v\":" + badVariant + ",\"other\":5}").getBytes();
+            RowData rowData = deserializationSchema.deserialize(json);
+            assertThat(rowData.isNullAt(0)).as("invalid variant is null: %s", badVariant).isTrue();
+            assertThat(rowData.getInt(1)).as("sibling survives: %s", badVariant).isEqualTo(5);
+        }
+    }
+
+    @TestTemplate
+    void testVariantMapValueParseErrorDropsOnlyBadEntry() throws Exception {
+        // A VARIANT in a MAP value position nulls at a finer granularity than a ROW field: an
+        // invalid entry becomes null on its own, while the other entries and the sibling 'other'
+        // survive. The failing value may be a scalar or a container with fields after it, and the
+        // valid entry after it is a non-trivial nested variant that must still parse in full.
+        RowType rowType =
+                (RowType)
+                        ROW(FIELD("m", MAP(STRING(), VARIANT())), FIELD("other", INT()))
+                                .getLogicalType();
+        DeserializationSchema<RowData> deserializationSchema =
+                createDeserializationSchema(
+                        isJsonParser, rowType, false, true, TimestampFormat.ISO_8601);
+        open(deserializationSchema);
+
+        // 'k3' is given with keys out of order; the variant stores them sorted, so toJson renders
+        // "a" before "b". This is the entry that must parse in full after the bad 'k2' is skipped.
+        final String k3 = "{\"b\":\"x\",\"a\":[1,2,{\"z\":true}]}";
+        final String k3Json = "{\"a\":[1,2,{\"z\":true}],\"b\":\"x\"}";
+        final String[] badMaps = {
+            "{\"k1\":1,\"k2\":1e400,\"k3\":" + k3 + "}",
+            "{\"k1\":1,\"k2\":{\"bad\":1e400,\"x\":9},\"k3\":" + k3 + "}",
+            "{\"k1\":1,\"k2\":[1e400,7],\"k3\":" + k3 + "}"
+        };
+        for (String badMap : badMaps) {
+            byte[] json = ("{\"m\":" + badMap + ",\"other\":5}").getBytes();
+            RowData rowData = deserializationSchema.deserialize(json);
+
+            assertThat(rowData.getInt(1)).as("sibling survives: %s", badMap).isEqualTo(5);
+
+            MapData map = rowData.getMap(0);
+            assertThat(map.size()).as("map keeps all keys: %s", badMap).isEqualTo(3);
+            Map<String, String> valueJsonByKey = new HashMap<>();
+            ArrayData keys = map.keyArray();
+            ArrayData values = map.valueArray();
+            for (int i = 0; i < map.size(); i++) {
+                final String key = keys.getString(i).toString();
+                valueJsonByKey.put(key, values.isNullAt(i) ? null : values.getVariant(i).toJson());
+            }
+            assertThat(valueJsonByKey.get("k1")).as("k1 valid: %s", badMap).isEqualTo("1");
+            assertThat(valueJsonByKey.get("k2")).as("k2 invalid, nulled: %s", badMap).isNull();
+            assertThat(valueJsonByKey.get("k3"))
+                    .as("k3 complex variant intact: %s", badMap)
+                    .isEqualTo(k3Json);
+        }
     }
 
     @TestTemplate


### PR DESCRIPTION
## What is the purpose of the change

Building a `Variant` from JSON required a `String`. A caller that already held parsed JSON had to serialize it back to a `String`, which `flink-core` then parsed again. This is a redundant serialize plus re-parse, and it forced callers to bridge Jackson types across shading boundaries.

This PR introduces a pull-based token-source abstraction so a caller can feed JSON tokens straight into the Variant builder, and then applies it in the JSON format so a `VARIANT` column is built without a `String` round trip.

## Brief change log

#### Core:
  - Add `JsonTokenSource`, a pull-based token interface in `org.apache.flink.types.variant`. It exposes only JDK types and an internal `Token` enum. A number is reported as a single `VALUE_NUMBER` token carrying its raw literal, so number classification stays in the builder.
  - Drive `BinaryVariantInternalBuilder` from a `JsonTokenSource`. Reimplement `parseJson(String)` on top of it through a private Jackson adapter, so `PARSE_JSON` and `TRY_PARSE_JSON` behavior is unchanged, including the JSON error location that Jackson exceptions carried. The location is exposed through an optional `JsonTokenSource.currentLocation()` that defaults to none for non-Jackson sources.
  - Add an `@Internal parseJson(JsonParser)` overload for callers that already hold a Jackson parser. It accepts a parser sitting before the value or already on the value's first token.

#### JSON format:
  - `JsonToRowDataConverters` and `JsonParserToRowDataConverters` build a `VARIANT` straight from the node or parser instead of serializing to a `String` and re-parsing. The streaming converter also stops materializing the subtree.
  - Duplicate keys keep the last value, matching the prior tree-based behavior.

## Verifying this change

This change added tests and can be verified as follows:
  - `JsonTokenSourceTest` builds a Variant from a custom `JsonTokenSource` and asserts byte-for-byte equality of value and metadata against the `String` path, and reaches the error branches a real JSON parser never produces.
  - `BinaryVariantInternalBuilderTest` is unchanged except for asserting the error keeps its JSON location. The `String` path now flows through the new builder, so it validates equivalence with the previous behavior.
  - `JsonRowDataSerDeSchemaTest` covers `VARIANT` deserialization across scalars, nesting, arrays, maps, duplicate keys and null, parameterized over both the `JsonNode` and `JsonParser` converter paths.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no. The new `JsonTokenSource` and the builder are `@Internal`.
  - The serializers: no. The Variant binary encoding is unchanged and is asserted byte-for-byte.
  - The runtime per-record code paths (performance sensitive): yes. `PARSE_JSON`, `TRY_PARSE_JSON` and JSON `VARIANT` deserialization run per record. Behavior is unchanged; the JSON format now avoids a `String` round trip and, on the streaming path, avoids materializing the subtree.
  - Anything that affects deployment or recovery: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? JavaDocs

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (Opus 4.8)