### PR TITLE
[FLINK-40232][table-runtime] Handle null rowtime in OutputConversionOperator

### DIFF
--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/sink/OutputConversionOperator.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/sink/OutputConversionOperator.java
@@ -24,6 +24,7 @@ import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.table.connector.RuntimeConverter.Context;
 import org.apache.flink.table.connector.sink.DynamicTableSink.DataStructureConverter;
 import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.TimestampData;
 import org.apache.flink.table.runtime.operators.TableStreamOperator;
 import org.apache.flink.util.FlinkRuntimeException;
 
@@ -69,14 +70,16 @@ public class OutputConversionOperator extends TableStreamOperator<Object>
     public void processElement(StreamRecord<RowData> element) throws Exception {
         final RowData rowData = element.getValue();
 
+        final int rowtimePos;
         if (consumeRowtimeMetadata) {
             // timestamp is TIMESTAMP_LTZ
-            final long rowtime = rowData.getTimestamp(rowData.getArity() - 1, 3).getMillisecond();
-            outRecord.setTimestamp(rowtime);
-        } else if (rowtimeIndex != -1) {
+            rowtimePos = rowData.getArity() - 1;
+        } else {
             // timestamp might be TIMESTAMP or TIMESTAMP_LTZ
-            final long rowtime = rowData.getTimestamp(rowtimeIndex, 3).getMillisecond();
-            outRecord.setTimestamp(rowtime);
+            rowtimePos = rowtimeIndex;
+        }
+        if (rowtimePos != -1) {
+            updateRowtime(rowData, rowtimePos);
         }
 
         final Object internalRecord;
@@ -103,5 +106,16 @@ public class OutputConversionOperator extends TableStreamOperator<Object>
         outRecord.replace(externalRecord);
 
         output.collect(outRecord);
+    }
+
+    private void updateRowtime(RowData rowData, int pos) {
+        final TimestampData rowtime = rowData.isNullAt(pos) ? null : rowData.getTimestamp(pos, 3);
+        if (rowtime != null) {
+            outRecord.setTimestamp(rowtime.getMillisecond());
+        } else {
+            // outRecord is reused across elements and replace(Object) keeps the timestamp,
+            // so the previous rowtime has to be erased explicitly
+            outRecord.eraseTimestamp();
+        }
     }
 }

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/sink/OutputConversionOperatorTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/sink/OutputConversionOperatorTest.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.operators.sink;
+
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
+import org.apache.flink.table.connector.RuntimeConverter;
+import org.apache.flink.table.connector.sink.DynamicTableSink.DataStructureConverter;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.data.TimestampData;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link OutputConversionOperator}. */
+class OutputConversionOperatorTest {
+
+    private static final int ROWTIME_INDEX = 1;
+
+    @Test
+    void testNullRowtimeMetadataIsEmittedWithoutTimestamp() throws Exception {
+        try (OneInputStreamOperatorTestHarness<RowData, Object> harness = createHarness(-1, true)) {
+            harness.open();
+
+            harness.processElement(new StreamRecord<>(row(null)));
+
+            final List<StreamRecord<? extends Object>> output =
+                    harness.extractOutputStreamRecords();
+            assertThat(output).hasSize(1);
+            assertThat(output.get(0).hasTimestamp()).isFalse();
+        }
+    }
+
+    @Test
+    void testNullRowtimeFieldIsEmittedWithoutTimestamp() throws Exception {
+        try (OneInputStreamOperatorTestHarness<RowData, Object> harness =
+                createHarness(ROWTIME_INDEX, false)) {
+            harness.open();
+
+            harness.processElement(new StreamRecord<>(row(null)));
+
+            final List<StreamRecord<? extends Object>> output =
+                    harness.extractOutputStreamRecords();
+            assertThat(output).hasSize(1);
+            assertThat(output.get(0).hasTimestamp()).isFalse();
+        }
+    }
+
+    @Test
+    void testNullRowtimeMetadataDoesNotInheritPreviousTimestamp() throws Exception {
+        assertNullRowtimeDoesNotInheritPreviousTimestamp(createHarness(-1, true));
+    }
+
+    @Test
+    void testNullRowtimeFieldDoesNotInheritPreviousTimestamp() throws Exception {
+        assertNullRowtimeDoesNotInheritPreviousTimestamp(createHarness(ROWTIME_INDEX, false));
+    }
+
+    private static void assertNullRowtimeDoesNotInheritPreviousTimestamp(
+            OneInputStreamOperatorTestHarness<RowData, Object> harness) throws Exception {
+        try (harness) {
+            harness.open();
+
+            harness.processElement(new StreamRecord<>(row(1000L)));
+            harness.processElement(new StreamRecord<>(row(null)));
+
+            final List<StreamRecord<? extends Object>> output =
+                    harness.extractOutputStreamRecords();
+            assertThat(output).hasSize(2);
+            assertThat(output.get(0).getTimestamp()).isEqualTo(1000L);
+            assertThat(output.get(1).hasTimestamp()).isFalse();
+        }
+    }
+
+    private static OneInputStreamOperatorTestHarness<RowData, Object> createHarness(
+            int rowtimeIndex, boolean consumeRowtimeMetadata) throws Exception {
+        return new OneInputStreamOperatorTestHarness<>(
+                new OutputConversionOperator(
+                        null, new ToStringConverter(), rowtimeIndex, consumeRowtimeMetadata));
+    }
+
+    private static RowData row(Long rowtime) {
+        return GenericRowData.of(
+                StringData.fromString("payload"),
+                rowtime == null ? null : TimestampData.fromEpochMillis(rowtime));
+    }
+
+    private static class ToStringConverter implements DataStructureConverter {
+
+        private static final long serialVersionUID = 1L;
+
+        @Override
+        public void open(RuntimeConverter.Context context) {}
+
+        @Override
+        public Object toExternal(Object internalStructure) {
+            return String.valueOf(internalStructure);
+        }
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

`OutputConversionOperator.processElement` dereferences the result of `RowData#getTimestamp(...)` without a null check, so converting a table with a `null` rowtime attribute into a `DataStream` fails the job with a `NullPointerException`. Both rowtime paths are affected: the rowtime metadata path and the rowtime column path.

Adding null checks alone is not enough. `outRecord` is a single `StreamRecord` allocated once in `open()` and reused for every element, and `StreamRecord#replace(Object)` leaves the timestamp untouched. Merely skipping `setTimestamp()` would leave the *previous* record's timestamp on the record carrying the null rowtime, i.e. it would trade the `NullPointerException` for a silently wrong timestamp. The null case therefore erases the timestamp explicitly.

## Brief change log

  - Both rowtime lookups in `OutputConversionOperator` go through a new private `updateRowtime(RowData, int)` helper
  - The helper sets the output timestamp when the rowtime is present, and calls `StreamRecord#eraseTimestamp()` when it is null, so a record with a null rowtime cannot inherit the preceding record's timestamp

## Verifying this change

This change added tests and can be verified as follows:

  - Added `OutputConversionOperatorTest` with four cases — a null rowtime is emitted without a timestamp, and a null rowtime does not inherit the timestamp of the preceding record — each covering the rowtime metadata path and the rowtime column path
  - All four tests were watched failing before the fix: first with the reported `NullPointerException`, and the two "does not inherit" cases again against a null-check-only variant of the fix, which is what motivated the explicit `eraseTimestamp()`
  - `flink-table-runtime` module test suite passes (1824 tests)
  - `DataStreamJavaITCase` passes (38 tests); it covers the non-null rowtime path end to end via `toDataStream` with event-time windows and a downstream assertion on `ctx.timestamp()`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **yes** — one additional `isNullAt` check per record, in an operator that already read the rowtime field
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: Claude Code (Claude Opus 5)
