### PR TITLE
[hotfix][docs] Fix OPTIONS hint key in time attributes docs

### DIFF
--- a/docs/content/docs/concepts/sql-table-concepts/time_attributes.md
+++ b/docs/content/docs/concepts/sql-table-concepts/time_attributes.md
@@ -60,7 +60,7 @@ Event time attributes can be defined in `CREATE` table DDL or during DataStream-
 The event time attribute is defined using a `WATERMARK` statement in `CREATE` table DDL. A watermark statement defines a watermark generation expression on an existing event time field, which marks the event time field as the event time attribute. Please see [CREATE TABLE DDL]({{< ref "docs/sql/reference/ddl/create" >}}#create-table) for more information about watermark statement and watermark strategies.
 
 Flink supports defining event time attribute on TIMESTAMP column and TIMESTAMP_LTZ column. 
-If the timestamp data in the source is represented as year-month-day-hour-minute-second, usually a string value without time-zone information, e.g. `2020-04-15 20:13:40.564`, it's recommended to define the event time attribute as a `TIMESTAMP` column::
+If the timestamp data in the source is represented as year-month-day-hour-minute-second, usually a string value without time-zone information, e.g. `2020-04-15 20:13:40.564`, it's recommended to define the event time attribute as a `TIMESTAMP` column:
 ```sql
 
 CREATE TABLE user_actions (
@@ -184,7 +184,7 @@ Of course, you can also still use the `OPTIONS` hint.
 
 ```sql
 -- use 'OPTIONS' hint
-select ... from source_table /*+ OPTIONS('scan.watermark.alignment.group'='alignment-group-1', 'scan.watermark.alignment.max-drift'='1min', 'scan. watermark.alignment.update-interval'='1s') */
+select ... from source_table /*+ OPTIONS('scan.watermark.alignment.group'='alignment-group-1', 'scan.watermark.alignment.max-drift'='1min', 'scan.watermark.alignment.update-interval'='1s') */
 ```
 
 There are three parameters :


### PR DESCRIPTION
## What is the purpose of the change

The watermark alignment `OPTIONS` example in the time attributes docs has a stray space in the option key (`scan. watermark.alignment.update-interval`). Copying that snippet does not set `scan.watermark.alignment.update-interval`.

Same page also had a double colon after `TIMESTAMP` column.

## Brief change log

- Remove the extra space in the `OPTIONS` hint example
- Drop the extra colon in the `TIMESTAMP` column sentence

## Verifying this change

This change is a trivial docs fix without any test coverage. The `OPTIONS` key now matches the `WITH` example on the same page.

## Does this pull request potentially affect one of the following parts:

 - Dependencies (does it add or upgrade a dependency): no
 - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
 - The serializers: no
 - The runtime per-record code paths (performance sensitive): no
 - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
 - The S3 file system connector: no

## Documentation

 - Does this pull request introduce a new feature? no
 - If yes, how is the feature documented? not applicable