### PR TITLE
[FLINK-40482][runtime] Abort checkpoint when a task is FAILED or CANCELED

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/DefaultCheckpointPlanCalculator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/DefaultCheckpointPlanCalculator.java
@@ -42,6 +42,7 @@ import java.util.concurrent.CompletionException;
 import java.util.stream.Collectors;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
+import static org.apache.flink.util.Preconditions.checkState;
 
 /**
  * Default implementation for {@link CheckpointPlanCalculator}. If all tasks are running, it
@@ -95,7 +96,7 @@ public class DefaultCheckpointPlanCalculator implements CheckpointPlanCalculator
                                     CheckpointFailureReason.NOT_ALL_REQUIRED_TASKS_RUNNING);
                         }
 
-                        checkAllTasksInitiated();
+                        checkAllTasksRunningOrFinished();
 
                         CheckpointPlan result =
                                 context.hasFinishedTasks()
@@ -113,18 +114,30 @@ public class DefaultCheckpointPlanCalculator implements CheckpointPlanCalculator
     }
 
     /**
-     * Checks if all tasks are attached with the current Execution already. This method should be
-     * called from JobMaster main thread executor.
+     * Checks that every task is attached with the current Execution and that this Execution is
+     * either RUNNING or FINISHED, the only states a checkpoint can be based on. This method should
+     * be called from JobMaster main thread executor.
      *
-     * @throws CheckpointException if some tasks do not have attached Execution.
+     * @throws CheckpointException if some task has no attached Execution or is neither RUNNING nor
+     *     FINISHED.
      */
-    private void checkAllTasksInitiated() throws CheckpointException {
+    private void checkAllTasksRunningOrFinished() throws CheckpointException {
         for (ExecutionVertex task : allTasks) {
-            if (task.getCurrentExecutionAttempt() == null) {
+            Execution attempt = task.getCurrentExecutionAttempt();
+            if (attempt == null) {
                 throw new CheckpointException(
                         String.format(
                                 "task %s of job %s is not being executed at the moment. Aborting checkpoint.",
                                 task.getTaskNameWithSubtaskIndex(), jobId),
+                        CheckpointFailureReason.NOT_ALL_REQUIRED_TASKS_RUNNING);
+            }
+
+            ExecutionState state = attempt.getState();
+            if (state != ExecutionState.RUNNING && state != ExecutionState.FINISHED) {
+                throw new CheckpointException(
+                        String.format(
+                                "task %s of job %s is in %s state instead of RUNNING or FINISHED. Aborting checkpoint.",
+                                task.getTaskNameWithSubtaskIndex(), jobId, state),
                         CheckpointFailureReason.NOT_ALL_REQUIRED_TASKS_RUNNING);
             }
         }
@@ -318,8 +331,18 @@ public class DefaultCheckpointPlanCalculator implements CheckpointPlanCalculator
             BitSet runningTasks = new BitSet(vertex.getTaskVertices().length);
 
             for (int i = 0; i < vertex.getTaskVertices().length; ++i) {
-                if (!vertex.getTaskVertices()[i].getCurrentExecutionAttempt().isFinished()) {
+                Execution attempt = vertex.getTaskVertices()[i].getCurrentExecutionAttempt();
+                ExecutionState state = attempt.getState();
+                if (state == ExecutionState.RUNNING) {
                     runningTasks.set(i);
+                } else {
+                    // A non-RUNNING task must be FINISHED; every other state is already rejected
+                    // by checkAllTasksRunningOrFinished().
+                    checkState(
+                            state == ExecutionState.FINISHED,
+                            "Task %s is %s, not FINISHED",
+                            attempt.getAttemptId(),
+                            state);
                 }
             }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
@@ -376,10 +376,6 @@ public class Execution
         return this.stateEndTimestamps[state.ordinal()];
     }
 
-    public boolean isFinished() {
-        return state.isTerminal();
-    }
-
     @Nullable
     public JobManagerTaskRestore getTaskRestore() {
         return taskRestore;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/DefaultCheckpointPlanCalculatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/DefaultCheckpointPlanCalculatorTest.java
@@ -37,6 +37,8 @@ import org.apache.flink.testutils.executor.TestExecutorExtension;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -164,6 +166,37 @@ class DefaultCheckpointPlanCalculatorTest {
         runWithNotRunningTask(false, true);
 
         // then: The plan failed because one task didn't have RUNNING state.
+    }
+
+    @ParameterizedTest
+    @EnumSource(
+            value = ExecutionState.class,
+            names = {"FAILED", "CANCELED", "CANCELING"})
+    void testPlanAbortedWhenTaskIsFailingOverWhileOthersFinished(ExecutionState failoverState)
+            throws Exception {
+        ExecutionGraph graph =
+                createExecutionGraph(
+                        Arrays.asList(
+                                new VertexDeclaration(1, of(0)), new VertexDeclaration(1, of())),
+                        Collections.emptyList());
+
+        chooseJobVertex(graph, 1)
+                .getTaskVertices()[0]
+                .getCurrentExecutionAttempt()
+                .transitionState(failoverState);
+
+        DefaultCheckpointPlanCalculator planCalculator = createCheckpointPlanCalculator(graph);
+
+        assertThatFuture(planCalculator.calculateCheckpointPlan())
+                .eventuallyFailsWith(ExecutionException.class)
+                .havingCause()
+                .isInstanceOfSatisfying(
+                        CheckpointException.class,
+                        e ->
+                                assertThat(e.getCheckpointFailureReason())
+                                        .isEqualTo(
+                                                CheckpointFailureReason
+                                                        .NOT_ALL_REQUIRED_TASKS_RUNNING));
     }
 
     private void runWithNotRunningTask(


### PR DESCRIPTION
## What is the purpose of the change

`DefaultCheckpointPlanCalculator` uses `Execution.isFinished()`, which returns `state.isTerminal()`, to decide whether a task is finished. This treats *any* terminal task — `FINISHED`, `FAILED` or `CANCELED` — as finished.

During a failover some tasks may be `FAILED`/`CANCELED`. The calculator then classifies them as finished and excludes them from `tasksToWaitFor`, producing a checkpoint plan that expects fewer acks than it should (in the extreme, an empty plan).

`"terminal"` is not the same as `"finished"`. `PendingCheckpoint` currently rejects an empty `tasksToWaitFor`, so the worst case is masked today, but the classification is wrong at its source and relying on that downstream guard leaves the issue latent.

## Brief change log

- `collectTaskRunningStatus`: classify explicitly — a non-terminal task is running; a terminal task must be genuinely `FINISHED` (`checkState`).
- `calculateCheckpointPlan`: add `checkNoTasksFailedOrCanceled()` — abort the checkpoint with a graceful `CheckpointException` when a task is `FAILED`/`CANCELED` (a failover is in progress) instead of building a plan from a transient state.
- Remove the misleading `Execution.isFinished()` (its only caller).

The check is condition-based, not mode-based, so it is correct for both streaming and batch. `calculateCheckpointPlan` and all task state transitions run on the JobManager main thread, so the pre-check and plan computation are atomic — a failover lands either before it (caught) or after (queued), never in between.

## Verifying this change

Added `DefaultCheckpointPlanCalculatorTest#testPlanAbortedWhenTaskFailedWhileOthersFinished`: builds a graph with one `FINISHED` and one `FAILED` task and asserts the plan is aborted with `NOT_ALL_REQUIRED_TASKS_RUNNING`.

## Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): **no**
- The public API: **no**
- The serializers: **no**
- The runtime per-record code paths (performance sensitive): **no**
- Anything that affects deployment or recovery: **yes** (checkpoint plan calculation)
- The S3 file system connector: **no**

## Documentation

- Does this pull request introduce a new feature: **no**
