### PR TITLE
[FLINK-40484][tests] Run UnalignedCheckpointTestBase with the DefaultScheduler instead of skipping it under AdaptiveScheduler

### DIFF
--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/UnalignedCheckpointTestBase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/UnalignedCheckpointTestBase.java
@@ -45,6 +45,7 @@ import org.apache.flink.changelog.fs.FsStateChangelogStorageFactory;
 import org.apache.flink.configuration.CheckpointingOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.ExternalizedCheckpointRetention;
+import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.configuration.NettyShuffleEnvironmentOptions;
 import org.apache.flink.configuration.RpcOptions;
@@ -77,7 +78,6 @@ import org.apache.flink.shaded.guava33.com.google.common.collect.Iterables;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
@@ -116,10 +116,10 @@ import static org.junit.jupiter.api.Assertions.fail;
  * <p>This test base relies on restarting the subtasks within the scheduler to trigger a reset of
  * the operators. The operator reset is counted in the LongSource. The job will terminate if the
  * number of expected restarts is reached. The AdaptiveScheduler won't trigger the operator reset
- * resulting in the test running forever. This is why this test suite is disabled for the {@link
- * org.apache.flink.runtime.scheduler.adaptive.AdaptiveScheduler}.
+ * resulting in the test running forever. This is why this test suite always pins {@link
+ * JobManagerOptions#SCHEDULER} to {@link JobManagerOptions.SchedulerType#Default}, independent of
+ * the scheduler selected by the build profile.
  */
-@Tag("org.apache.flink.testutils.junit.FailsWithAdaptiveScheduler")
 @ExtendWith(TestLoggerExtension.class)
 abstract class UnalignedCheckpointTestBase {
     protected static final Logger LOG = LoggerFactory.getLogger(UnalignedCheckpointTestBase.class);
@@ -840,6 +840,7 @@ abstract class UnalignedCheckpointTestBase {
             conf.set(TaskManagerOptions.NETWORK_MEMORY_FRACTION, 0.9f);
             conf.set(TaskManagerOptions.MEMORY_SEGMENT_SIZE, MemorySize.parse("4kb"));
             conf.set(StateBackendOptions.STATE_BACKEND, "hashmap");
+            conf.set(JobManagerOptions.SCHEDULER, JobManagerOptions.SchedulerType.Default);
             conf.set(CheckpointingOptions.CHECKPOINTS_DIRECTORY, checkpointDir.toURI().toString());
             if (restoreCheckpoint != null) {
                 conf.set(StateRecoveryOptions.SAVEPOINT_PATH, restoreCheckpoint);


### PR DESCRIPTION
## What is the purpose of the change

`UnalignedCheckpointTestBase` is tagged with `FailsWithAdaptiveScheduler`, so surefire skips
the whole suite whenever the `enable-adaptive-scheduler` profile is active. Since the suite is
only expected to fail under the AdaptiveScheduler, we can pin the DefaultScheduler in the test
configuration and drop the tag, so it always runs regardless of the profile.

## Brief change log

  - Set `JobManagerOptions#SCHEDULER` to `Default` in `UnalignedSettings#getConfiguration`
  - Remove the `FailsWithAdaptiveScheduler` tag, the now-unused import, and update the JavaDoc

## Verifying this change

Covered by the existing suites: `UnalignedCheckpointITCase` now runs and passes (11 tests, 0 skipped) with the `enable-adaptive-scheduler` profile active, where it was fully skipped before.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
