### PR TITLE
[FLINK-40505][runtime] Prune failed subtasks from watermark alignment

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/source/coordinator/SourceCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/source/coordinator/SourceCoordinator.java
@@ -380,6 +380,13 @@ public class SourceCoordinator<SplitT extends SourceSplit, EnumChkT>
 
                     context.subtaskReset(subtaskId);
 
+                    // Remove the last watermark reported by the failed subtask so that a stale
+                    // value does not keep constraining the watermark alignment group. The
+                    // restarted attempt re-registers itself with its next ReportedWatermarkEvent.
+                    combinedWatermark
+                            .remove(subtaskId)
+                            .ifPresent(this::updateAggregatedWatermarkOfGroup);
+
                     final List<SplitT> splitsToAddBack =
                             context.getAndRemoveUncheckpointedAssignment(subtaskId, checkpointId);
                     LOG.debug(
@@ -726,17 +733,18 @@ public class SourceCoordinator<SplitT extends SourceSplit, EnumChkT>
 
         combinedWatermark
                 .aggregate(subtask, watermark)
-                .ifPresent(
-                        newCombinedWatermark ->
-                                coordinatorStore.computeIfPresent(
-                                        watermarkAlignmentParams.getWatermarkGroup(),
-                                        (key, oldValue) -> {
-                                            WatermarkAggregator<String> watermarkAggregator =
-                                                    (WatermarkAggregator<String>) oldValue;
-                                            watermarkAggregator.aggregate(
-                                                    operatorName, newCombinedWatermark);
-                                            return watermarkAggregator;
-                                        }));
+                .ifPresent(this::updateAggregatedWatermarkOfGroup);
+    }
+
+    private void updateAggregatedWatermarkOfGroup(Watermark newCombinedWatermark) {
+        coordinatorStore.computeIfPresent(
+                watermarkAlignmentParams.getWatermarkGroup(),
+                (key, oldValue) -> {
+                    WatermarkAggregator<String> watermarkAggregator =
+                            (WatermarkAggregator<String>) oldValue;
+                    watermarkAggregator.aggregate(operatorName, newCombinedWatermark);
+                    return watermarkAggregator;
+                });
     }
 
     private void ensureStarted() {
@@ -856,6 +864,27 @@ public class SourceCoordinator<SplitT extends SourceSplit, EnumChkT>
                 orderedWatermarks.remove(oldWatermarkElement);
             }
             orderedWatermarks.add(watermarkElement);
+
+            Watermark newAggregatedWatermark = getAggregatedWatermark();
+            if (newAggregatedWatermark.equals(oldAggregatedWatermark)) {
+                return Optional.empty();
+            }
+            return Optional.of(newAggregatedWatermark);
+        }
+
+        /**
+         * Removes the {@link Watermark} for the given {@code key}.
+         *
+         * @return the new updated combined {@link Watermark} if the value has changed. {@code
+         *     Optional.empty()} otherwise.
+         */
+        public Optional<Watermark> remove(T key) {
+            Watermark oldAggregatedWatermark = getAggregatedWatermark();
+
+            WatermarkElement removedWatermarkElement = watermarks.remove(key);
+            if (removedWatermarkElement != null) {
+                orderedWatermarks.remove(removedWatermarkElement);
+            }
 
             Watermark newAggregatedWatermark = getAggregatedWatermark();
             if (newAggregatedWatermark.equals(oldAggregatedWatermark)) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorAlignmentTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorAlignmentTest.java
@@ -117,6 +117,70 @@ class SourceCoordinatorAlignmentTest extends SourceCoordinatorTestBase {
     }
 
     @Test
+    void testWatermarkAlignmentStatePrunedAfterSubtaskFailureAndReset() throws Exception {
+        try (AutoCloseableRegistry closeableRegistry = new AutoCloseableRegistry()) {
+            SourceCoordinator<?, ?> sourceCoordinator1 =
+                    getAndStartNewSourceCoordinator(
+                            new WatermarkAlignmentParams(1000L, "group1", Long.MAX_VALUE),
+                            closeableRegistry);
+
+            int subtask0 = 0;
+            int subtask1 = 1;
+
+            // baseline sanity: the group is constrained by the lowest reported watermark
+            reportWatermarkEvent(sourceCoordinator1, subtask0, 100);
+            assertLatestWatermarkAlignmentEvent(subtask0, 1100);
+
+            reportWatermarkEvent(sourceCoordinator1, subtask1, 200);
+            assertLatestWatermarkAlignmentEvent(subtask0, 1100);
+            assertLatestWatermarkAlignmentEvent(subtask1, 1100);
+
+            // the subtask holding the group back fails and is reset
+            sourceCoordinator1.executionAttemptFailed(
+                    subtask0, 0, new RuntimeException("Artificial failure for subtask 0"));
+            sourceCoordinator1.subtaskReset(subtask0, 1L);
+            CoordinatorTestUtils.waitForCoordinatorToProcessActions(
+                    sourceCoordinator1.getContext());
+
+            sourceCoordinator1.announceCombinedWatermark();
+
+            // CORRECT expectation: with the failed subtask's state pruned, the group should now
+            // only be constrained by the surviving subtask (200 + 1000 drift). The failed subtask
+            // will re-report its watermark after restart anyway.
+            assertLatestWatermarkAlignmentEvent(subtask1, 1200);
+        }
+    }
+
+    @Test
+    void testSubtaskThatNeverReportedReceivesNoAlignmentEvents() throws Exception {
+        try (AutoCloseableRegistry closeableRegistry = new AutoCloseableRegistry()) {
+            SourceCoordinator<?, ?> sourceCoordinator1 =
+                    getAndStartNewSourceCoordinator(
+                            new WatermarkAlignmentParams(1000L, "group1", Long.MAX_VALUE),
+                            closeableRegistry);
+
+            int subtask0 = 0;
+            int subtask2 = 2;
+
+            // subtask0 reports; subtask2 is ready (gateway registered) but never reports a
+            // watermark (e.g. idle from birth)
+            reportWatermarkEvent(sourceCoordinator1, subtask0, 100);
+            assertLatestWatermarkAlignmentEvent(subtask0, 1100);
+
+            sourceCoordinator1.announceCombinedWatermark();
+            sourceCoordinator1.announceCombinedWatermark();
+
+            // characterization: announceCombinedWatermark only iterates over subtasks that have
+            // reported (combinedWatermark.keySet()), so a never-reporting subtask never receives
+            // any WatermarkAlignmentEvent
+            List<OperatorEvent> eventsForSilentSubtask =
+                    receivingTasks.getSentEventsForSubtask(subtask2);
+            assertThat(eventsForSilentSubtask)
+                    .noneMatch(event -> event instanceof WatermarkAlignmentEvent);
+        }
+    }
+
+    @Test
     void testWatermarkAlignmentWithTwoGroups() throws Exception {
         try (AutoCloseableRegistry closeableRegistry = new AutoCloseableRegistry()) {
             long maxDrift = 1000L;


### PR DESCRIPTION
## What is the purpose of the change

Fixes FLINK-40505: `SourceCoordinator` never removed a subtask's last reported watermark from the watermark-alignment aggregation. After a subtask failure and reset, the stale entry kept constraining `maxAllowedWatermark` for the entire alignment group until the restarted subtask happened to report again — and indefinitely if it never did (e.g. after downscale). The retained value is not a conservative bound either: a restarted attempt can resume from an earlier checkpoint position than its last report.

## Brief change log

- Added `WatermarkAggregator#remove(key)`, returning the new aggregated watermark iff the aggregate changed.
- `SourceCoordinator#subtaskReset` now removes the failed subtask's watermark and, when the per-source aggregate changed, propagates it to the group-level aggregator in the coordinator store via the same update path used for reported watermarks (extracted as `updateAggregatedWatermarkOfGroup`).
- Removal is done in `subtaskReset` (per-subtask, fires only when no execution attempt is alive) rather than per-attempt `executionAttemptFailed`: watermark alignment is mutually exclusive with concurrent execution attempts (enforced in the constructor and in `handleReportedWatermark`), and global failover recreates the coordinator. Subtasks pick up the updated `maxAllowedWatermark` via the existing periodic `announceCombinedWatermark`.

Known follow-up (out of scope here): the group-level aggregator in the coordinator store never removes an `operatorName` entry, so a permanently stopped source in a multi-source alignment group is still never pruned.

## Verifying this change

This change added tests and can be verified as follows:

- New test `SourceCoordinatorAlignmentTest#testWatermarkAlignmentStatePrunedAfterSubtaskFailureAndReset` fails without the fix (announced `maxAllowedWatermark` stayed 1100 from the stale entry; expected 1200 after the constraining subtask fails and resets) and passes with it.
- New characterization test `testSubtaskThatNeverReportedReceivesNoAlignmentEvents` documents that only subtasks that have reported receive alignment events.
- Regression: `SourceCoordinatorAlignmentTest`, `SourceCoordinatorTest`, and `SourceCoordinatorContextTest` all pass locally.

Both new tests are additive; no existing tests were modified.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no (coordinator-side, failover-time only)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: yes — changes JobManager-side `SourceCoordinator` behavior on subtask reset during partial failover
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: Claude Code (Fable 5)
