### PR TITLE
[FLINK-40486][table] Introduce the UUID logical type

### DIFF
--- a/docs/static/generated/rest_v1_sql_gateway.yml
+++ b/docs/static/generated/rest_v1_sql_gateway.yml
@@ -403,6 +403,7 @@ components:
       - DESCRIPTOR
       - VARIANT
       - BITMAP
+      - UUID
     OpenSessionRequestBody:
       type: object
       properties:

--- a/docs/static/generated/rest_v2_sql_gateway.yml
+++ b/docs/static/generated/rest_v2_sql_gateway.yml
@@ -477,6 +477,7 @@ components:
       - DESCRIPTOR
       - VARIANT
       - BITMAP
+      - UUID
     OpenSessionRequestBody:
       type: object
       properties:

--- a/docs/static/generated/rest_v3_sql_gateway.yml
+++ b/docs/static/generated/rest_v3_sql_gateway.yml
@@ -506,6 +506,7 @@ components:
       - DESCRIPTOR
       - VARIANT
       - BITMAP
+      - UUID
     OpenSessionRequestBody:
       type: object
       properties:

--- a/docs/static/generated/rest_v4_sql_gateway.yml
+++ b/docs/static/generated/rest_v4_sql_gateway.yml
@@ -516,6 +516,7 @@ components:
       - DESCRIPTOR
       - VARIANT
       - BITMAP
+      - UUID
     OpenSessionRequestBody:
       type: object
       properties:

--- a/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/rest/serde/LogicalTypeJsonDeserializer.java
+++ b/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/rest/serde/LogicalTypeJsonDeserializer.java
@@ -46,6 +46,7 @@ import org.apache.flink.table.types.logical.SmallIntType;
 import org.apache.flink.table.types.logical.TimeType;
 import org.apache.flink.table.types.logical.TimestampType;
 import org.apache.flink.table.types.logical.TinyIntType;
+import org.apache.flink.table.types.logical.UuidType;
 import org.apache.flink.table.types.logical.VarBinaryType;
 import org.apache.flink.table.types.logical.VarCharType;
 import org.apache.flink.table.types.logical.VariantType;
@@ -165,6 +166,8 @@ public final class LogicalTypeJsonDeserializer extends StdDeserializer<LogicalTy
                 return new VariantType(isNullable);
             case BITMAP:
                 return new BitmapType(isNullable);
+            case UUID:
+                return new UuidType(isNullable);
             default:
                 throw new UnsupportedOperationException(
                         String.format(

--- a/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/rest/serde/LogicalTypeJsonSerializer.java
+++ b/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/rest/serde/LogicalTypeJsonSerializer.java
@@ -130,6 +130,7 @@ public final class LogicalTypeJsonSerializer extends StdSerializer<LogicalType> 
             case DATE:
             case VARIANT:
             case BITMAP:
+            case UUID:
                 break;
             case CHAR:
                 jsonGenerator.writeNumberField(

--- a/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/rest/serde/LogicalTypeJsonSerDeTest.java
+++ b/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/rest/serde/LogicalTypeJsonSerDeTest.java
@@ -48,6 +48,7 @@ import org.apache.flink.table.types.logical.TimeType;
 import org.apache.flink.table.types.logical.TimestampKind;
 import org.apache.flink.table.types.logical.TimestampType;
 import org.apache.flink.table.types.logical.TinyIntType;
+import org.apache.flink.table.types.logical.UuidType;
 import org.apache.flink.table.types.logical.VarBinaryType;
 import org.apache.flink.table.types.logical.VarCharType;
 import org.apache.flink.table.types.logical.YearMonthIntervalType;
@@ -197,6 +198,7 @@ class LogicalTypeJsonSerDeTest {
                         new MultisetType(BinaryType.ofEmptyLiteral()),
                         new MultisetType(VarBinaryType.ofEmptyLiteral()),
                         new BitmapType(),
+                        new UuidType(),
                         RowType.of(new BigIntType(), new IntType(false), new VarCharType(200)),
                         RowType.of(
                                 new LogicalType[] {

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/api/DataTypes.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/api/DataTypes.java
@@ -59,6 +59,7 @@ import org.apache.flink.table.types.logical.StructuredType.StructuredAttribute;
 import org.apache.flink.table.types.logical.TimeType;
 import org.apache.flink.table.types.logical.TimestampType;
 import org.apache.flink.table.types.logical.TinyIntType;
+import org.apache.flink.table.types.logical.UuidType;
 import org.apache.flink.table.types.logical.VarBinaryType;
 import org.apache.flink.table.types.logical.VarCharType;
 import org.apache.flink.table.types.logical.VariantType;
@@ -1073,6 +1074,17 @@ public final class DataTypes {
      */
     public static DataType BITMAP() {
         return new AtomicDataType(new BitmapType());
+    }
+
+    /**
+     * Data type of a universally unique identifier (UUID).
+     *
+     * <p>The type represents a 128-bit value stored as a fixed 16-byte big-endian sequence.
+     *
+     * @see UuidType
+     */
+    public static DataType UUID() {
+        return new AtomicDataType(new UuidType());
     }
 
     // --------------------------------------------------------------------------------------------

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/LogicalTypeRoot.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/LogicalTypeRoot.java
@@ -145,7 +145,9 @@ public enum LogicalTypeRoot {
 
     VARIANT(LogicalTypeFamily.EXTENSION),
 
-    BITMAP(LogicalTypeFamily.EXTENSION);
+    BITMAP(LogicalTypeFamily.EXTENSION),
+
+    UUID(LogicalTypeFamily.EXTENSION);
 
     private final Set<LogicalTypeFamily> families;
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/LogicalTypeVisitor.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/LogicalTypeVisitor.java
@@ -101,5 +101,9 @@ public interface LogicalTypeVisitor<R> {
         return visit((LogicalType) bitmapType);
     }
 
+    default R visit(UuidType uuidType) {
+        return visit((LogicalType) uuidType);
+    }
+
     R visit(LogicalType other);
 }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/UuidType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/UuidType.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.types.logical;
+
+import org.apache.flink.annotation.PublicEvolving;
+
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
+/**
+ * Data type of a universally unique identifier (UUID).
+ *
+ * <p>The type stores any 128-bit UUID as the canonical 16-byte big-endian encoding defined by RFC
+ * 9562 (which obsoletes RFC 4122). It is version-agnostic: the version and variant bits are stored
+ * as-is and never validated or interpreted.
+ *
+ * <p>The serializable string representation of this type is {@code UUID}.
+ */
+@PublicEvolving
+public final class UuidType extends LogicalType {
+
+    private static final long serialVersionUID = 1L;
+
+    private static final Set<String> INPUT_OUTPUT_CONVERSION = conversionSet(UUID.class.getName());
+
+    public UuidType(boolean isNullable) {
+        super(isNullable, LogicalTypeRoot.UUID);
+    }
+
+    public UuidType() {
+        this(true);
+    }
+
+    @Override
+    public LogicalType copy(boolean isNullable) {
+        return new UuidType(isNullable);
+    }
+
+    @Override
+    public String asSerializableString() {
+        return withNullability("UUID");
+    }
+
+    @Override
+    public boolean supportsInputConversion(Class<?> clazz) {
+        return INPUT_OUTPUT_CONVERSION.contains(clazz.getName());
+    }
+
+    @Override
+    public boolean supportsOutputConversion(Class<?> clazz) {
+        return INPUT_OUTPUT_CONVERSION.contains(clazz.getName());
+    }
+
+    @Override
+    public Class<?> getDefaultConversion() {
+        return UUID.class;
+    }
+
+    @Override
+    public List<LogicalType> getChildren() {
+        return List.of();
+    }
+
+    @Override
+    public <R> R accept(LogicalTypeVisitor<R> visitor) {
+        return visitor.visit(this);
+    }
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/utils/LogicalTypeParser.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/utils/LogicalTypeParser.java
@@ -54,6 +54,7 @@ import org.apache.flink.table.types.logical.TimeType;
 import org.apache.flink.table.types.logical.TimestampType;
 import org.apache.flink.table.types.logical.TinyIntType;
 import org.apache.flink.table.types.logical.UnresolvedUserDefinedType;
+import org.apache.flink.table.types.logical.UuidType;
 import org.apache.flink.table.types.logical.VarBinaryType;
 import org.apache.flink.table.types.logical.VarCharType;
 import org.apache.flink.table.types.logical.VariantType;
@@ -336,7 +337,8 @@ public final class LogicalTypeParser {
         DESCRIPTOR,
         STRUCTURED,
         VARIANT,
-        BITMAP
+        BITMAP,
+        UUID
     }
 
     private static final Set<String> KEYWORDS =
@@ -586,6 +588,8 @@ public final class LogicalTypeParser {
                     return new VariantType();
                 case BITMAP:
                     return new BitmapType();
+                case UUID:
+                    return new UuidType();
                 default:
                     throw parsingError("Unsupported type: " + token().value);
             }

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/DataTypesTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/DataTypesTest.java
@@ -44,6 +44,7 @@ import org.apache.flink.table.types.logical.SmallIntType;
 import org.apache.flink.table.types.logical.TimeType;
 import org.apache.flink.table.types.logical.TimestampType;
 import org.apache.flink.table.types.logical.TinyIntType;
+import org.apache.flink.table.types.logical.UuidType;
 import org.apache.flink.table.types.logical.VarBinaryType;
 import org.apache.flink.table.types.logical.VarCharType;
 import org.apache.flink.table.types.logical.VariantType;
@@ -68,6 +69,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.UUID;
 import java.util.stream.Stream;
 
 import static org.apache.flink.table.api.DataTypes.ARRAY;
@@ -100,6 +102,7 @@ import static org.apache.flink.table.api.DataTypes.TIMESTAMP_LTZ;
 import static org.apache.flink.table.api.DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE;
 import static org.apache.flink.table.api.DataTypes.TIMESTAMP_WITH_TIME_ZONE;
 import static org.apache.flink.table.api.DataTypes.TINYINT;
+import static org.apache.flink.table.api.DataTypes.UUID;
 import static org.apache.flink.table.api.DataTypes.VARBINARY;
 import static org.apache.flink.table.api.DataTypes.VARCHAR;
 import static org.apache.flink.table.api.DataTypes.VARIANT;
@@ -231,6 +234,9 @@ class DataTypesTest {
                 TestSpec.forDataType(BITMAP())
                         .expectLogicalType(new BitmapType())
                         .expectConversionClass(Bitmap.class),
+                TestSpec.forDataType(UUID())
+                        .expectLogicalType(new UuidType())
+                        .expectConversionClass(UUID.class),
                 TestSpec.forUnresolvedDataType(RAW(Types.VOID))
                         .expectUnresolvedString("[RAW('java.lang.Void', '?')]")
                         .lookupReturns(dummyRaw(Void.class))

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LogicalTypeParserTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LogicalTypeParserTest.java
@@ -55,6 +55,7 @@ import org.apache.flink.table.types.logical.TimeType;
 import org.apache.flink.table.types.logical.TimestampType;
 import org.apache.flink.table.types.logical.TinyIntType;
 import org.apache.flink.table.types.logical.UnresolvedUserDefinedType;
+import org.apache.flink.table.types.logical.UuidType;
 import org.apache.flink.table.types.logical.VarBinaryType;
 import org.apache.flink.table.types.logical.VarCharType;
 import org.apache.flink.table.types.logical.VariantType;
@@ -309,6 +310,8 @@ public class LogicalTypeParserTest {
                 TestSpec.forString("VARIANT NOT NULL").expectType(new VariantType(false)),
                 TestSpec.forString("BITMAP").expectType(new BitmapType()),
                 TestSpec.forString("BITMAP NOT NULL").expectType(new BitmapType(false)),
+                TestSpec.forString("UUID").expectType(new UuidType()),
+                TestSpec.forString("UUID NOT NULL").expectType(new UuidType(false)),
 
                 // error message testing
 

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LogicalTypesTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LogicalTypesTest.java
@@ -57,6 +57,7 @@ import org.apache.flink.table.types.logical.TimestampKind;
 import org.apache.flink.table.types.logical.TimestampType;
 import org.apache.flink.table.types.logical.TinyIntType;
 import org.apache.flink.table.types.logical.UnresolvedUserDefinedType;
+import org.apache.flink.table.types.logical.UuidType;
 import org.apache.flink.table.types.logical.VarBinaryType;
 import org.apache.flink.table.types.logical.VarCharType;
 import org.apache.flink.table.types.logical.VariantType;
@@ -79,6 +80,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
+import java.util.UUID;
 
 import static org.apache.flink.table.test.TableAssertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -624,6 +626,20 @@ public class LogicalTypesTest {
                                 new Class[] {Bitmap.class, RoaringBitmapData.class},
                                 new LogicalType[] {},
                                 new BitmapType(false)));
+    }
+
+    @Test
+    void testUuidType() {
+        assertThat(new UuidType())
+                .isJavaSerializable()
+                .satisfies(
+                        baseAssertions(
+                                "UUID",
+                                "UUID",
+                                new Class[] {UUID.class},
+                                new Class[] {UUID.class},
+                                new LogicalType[] {},
+                                new UuidType(false)));
     }
 
     @Test

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/calcite/FlinkTypeFactory.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/calcite/FlinkTypeFactory.java
@@ -63,6 +63,7 @@ import org.apache.flink.table.types.logical.TimeType;
 import org.apache.flink.table.types.logical.TimestampKind;
 import org.apache.flink.table.types.logical.TimestampType;
 import org.apache.flink.table.types.logical.TinyIntType;
+import org.apache.flink.table.types.logical.UuidType;
 import org.apache.flink.table.types.logical.VarBinaryType;
 import org.apache.flink.table.types.logical.VarCharType;
 import org.apache.flink.table.types.logical.VariantType;
@@ -490,6 +491,9 @@ public class FlinkTypeFactory extends JavaTypeFactoryImpl implements ExtendedRel
             case VARIANT:
                 return createSqlType(SqlTypeName.VARIANT);
 
+            case UUID:
+                return createSqlType(SqlTypeName.UUID);
+
             case BITMAP:
                 return new BitmapRelDataType((BitmapType) logicalType);
 
@@ -860,6 +864,9 @@ public class FlinkTypeFactory extends JavaTypeFactoryImpl implements ExtendedRel
 
             case VARIANT:
                 return new VariantType();
+
+            case UUID:
+                return new UuidType();
 
             case OTHER:
                 if (relDataType instanceof RawRelDataType) {

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/LogicalTypeJsonSerializer.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/LogicalTypeJsonSerializer.java
@@ -239,6 +239,7 @@ final class LogicalTypeJsonSerializer extends StdSerializer<LogicalType> {
                 break;
             case SYMBOL:
             case VARIANT:
+            case UUID:
                 // type root is enough
                 break;
             case RAW:
@@ -546,6 +547,7 @@ final class LogicalTypeJsonSerializer extends StdSerializer<LogicalType> {
                 case DESCRIPTOR:
                 case BITMAP:
                 case VARIANT:
+                case UUID:
                     return true;
                 default:
                     // fall back to generic serialization

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/typeutils/LogicalRelDataTypeConverter.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/typeutils/LogicalRelDataTypeConverter.java
@@ -57,6 +57,7 @@ import org.apache.flink.table.types.logical.TimeType;
 import org.apache.flink.table.types.logical.TimestampKind;
 import org.apache.flink.table.types.logical.TimestampType;
 import org.apache.flink.table.types.logical.TinyIntType;
+import org.apache.flink.table.types.logical.UuidType;
 import org.apache.flink.table.types.logical.VarBinaryType;
 import org.apache.flink.table.types.logical.VarCharType;
 import org.apache.flink.table.types.logical.VariantType;
@@ -468,6 +469,11 @@ public final class LogicalRelDataTypeConverter {
         }
 
         @Override
+        public RelDataType visit(UuidType uuidType) {
+            return relDataTypeFactory.createSqlType(SqlTypeName.UUID);
+        }
+
+        @Override
         public RelDataType visit(BitmapType bitmapType) {
             return new BitmapRelDataType(bitmapType);
         }
@@ -596,6 +602,8 @@ public final class LogicalRelDataTypeConverter {
                 return new DescriptorType(false);
             case VARIANT:
                 return new VariantType(false);
+            case UUID:
+                return new UuidType(false);
             case STRUCTURED:
             case OTHER:
                 if (relDataType instanceof StructuredRelDataType) {

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/calcite/FlinkTypeFactoryTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/calcite/FlinkTypeFactoryTest.java
@@ -46,6 +46,7 @@ import org.apache.flink.table.types.logical.SmallIntType;
 import org.apache.flink.table.types.logical.TimeType;
 import org.apache.flink.table.types.logical.TimestampType;
 import org.apache.flink.table.types.logical.TinyIntType;
+import org.apache.flink.table.types.logical.UuidType;
 import org.apache.flink.table.types.logical.VarBinaryType;
 import org.apache.flink.table.types.logical.VarCharType;
 import org.apache.flink.table.types.logical.utils.LogicalTypeMerging;
@@ -89,6 +90,7 @@ class FlinkTypeFactoryTest {
                 new TimeType(),
                 new TimestampType(3),
                 new LocalZonedTimestampType(3),
+                new UuidType(),
                 new ArrayType(new DoubleType()),
                 new MapType(new DoubleType(), VarCharType.STRING_TYPE),
                 RowType.of(new DoubleType(), VarCharType.STRING_TYPE),

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/LogicalTypeJsonSerdeTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/LogicalTypeJsonSerdeTest.java
@@ -59,6 +59,7 @@ import org.apache.flink.table.types.logical.TimeType;
 import org.apache.flink.table.types.logical.TimestampKind;
 import org.apache.flink.table.types.logical.TimestampType;
 import org.apache.flink.table.types.logical.TinyIntType;
+import org.apache.flink.table.types.logical.UuidType;
 import org.apache.flink.table.types.logical.VarBinaryType;
 import org.apache.flink.table.types.logical.VarCharType;
 import org.apache.flink.table.types.logical.VariantType;
@@ -268,6 +269,7 @@ public class LogicalTypeJsonSerdeTest {
                         new MultisetType(BinaryType.ofEmptyLiteral()),
                         new MultisetType(VarBinaryType.ofEmptyLiteral()),
                         new BitmapType(),
+                        new UuidType(),
                         new VariantType(),
                         new ArrayType(new VariantType()),
                         new MultisetType(new VariantType()),

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/typeutils/LogicalRelDataTypeConverterTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/typeutils/LogicalRelDataTypeConverterTest.java
@@ -48,6 +48,7 @@ import org.apache.flink.table.types.logical.TimeType;
 import org.apache.flink.table.types.logical.TimestampKind;
 import org.apache.flink.table.types.logical.TimestampType;
 import org.apache.flink.table.types.logical.TinyIntType;
+import org.apache.flink.table.types.logical.UuidType;
 import org.apache.flink.table.types.logical.VarBinaryType;
 import org.apache.flink.table.types.logical.VarCharType;
 import org.apache.flink.table.types.logical.VariantType;
@@ -153,6 +154,7 @@ public class LogicalRelDataTypeConverterTest {
                 new MultisetType(BinaryType.ofEmptyLiteral()),
                 new MultisetType(VarBinaryType.ofEmptyLiteral()),
                 new BitmapType(),
+                new UuidType(),
                 new VariantType(),
                 new ArrayType(new VariantType()),
                 new MapType(new VarCharType(5), new VariantType()),

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/typeutils/TypeCheckUtils.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/typeutils/TypeCheckUtils.java
@@ -39,6 +39,7 @@ import static org.apache.flink.table.types.logical.LogicalTypeRoot.STRUCTURED_TY
 import static org.apache.flink.table.types.logical.LogicalTypeRoot.TIMESTAMP_WITHOUT_TIME_ZONE;
 import static org.apache.flink.table.types.logical.LogicalTypeRoot.TIMESTAMP_WITH_LOCAL_TIME_ZONE;
 import static org.apache.flink.table.types.logical.LogicalTypeRoot.TIME_WITHOUT_TIME_ZONE;
+import static org.apache.flink.table.types.logical.LogicalTypeRoot.UUID;
 import static org.apache.flink.table.types.logical.LogicalTypeRoot.VARIANT;
 import static org.apache.flink.table.types.logical.utils.LogicalTypeChecks.isRowtimeAttribute;
 
@@ -146,6 +147,10 @@ public class TypeCheckUtils {
         return type.getTypeRoot() == BITMAP;
     }
 
+    private static boolean isUuidType(LogicalType type) {
+        return type.getTypeRoot() == UUID;
+    }
+
     public static boolean isComparable(LogicalType type) {
         return !isRaw(type)
                 && !isMap(type)
@@ -154,7 +159,8 @@ public class TypeCheckUtils {
                 && !isArray(type)
                 && !isStructuredType(type)
                 && !isVariantType(type)
-                && !isBitmapType(type);
+                && !isBitmapType(type)
+                && !isUuidType(type);
     }
 
     public static boolean isMutable(LogicalType type) {


### PR DESCRIPTION
## What is the purpose of the change

This is the first sub-task of FLIP-604 (Complete VARIANT Primitive Coverage with UUID and Timestamps). It introduces `UUID` as a native logical type in the Table/SQL type system.

`UUID` represents a 128-bit value stored as a fixed 16-byte big-endian sequence, with `java.util.UUID` as its default conversion class. It maps to Calcite's native `SqlTypeName.UUID`, which is available in the Calcite 1.41 version Flink already uses, so no SQL parser or Calcite version change is required. The type mirrors `VARIANT`: a parameterless scalar in the `EXTENSION` family.

This change is scoped to the type system only. It makes the type exist, be constructible, parseable, and round-trip through the planner and plan serde. It does not make queries over `UUID` execute. Runtime serialization and codegen (FLINK-40490), casting (FLINK-40487), comparison and ordering (FLINK-40488), functions (FLINK-40489), VARIANT integration (FLINK-40491–40493), and documentation (FLINK-40494) follow in separate sub-tasks.

## Brief change log

- Add `UuidType` and `LogicalTypeRoot.UUID` (EXTENSION family); add the `default visit(UuidType)` method to `LogicalTypeVisitor`.
- Add the `DataTypes.UUID()` factory and the `UUID` keyword to `LogicalTypeParser`.
- Map `UuidType` to and from `SqlTypeName.UUID` in `FlinkTypeFactory` and `LogicalRelDataTypeConverter`.
- Support `UUID` in the planner and SQL gateway logical-type JSON serde.

## Verifying this change

This change added unit tests and can be verified as follows:

- `LogicalTypesType`, `DataTypesTest`, `LogicalTypeParserTest` cover the type, the `DataTypes.UUID()` factory, and keyword parsing (`UUID` / `UUID NOT NULL`).
- `FlinkTypeFactoryTest#testInternalToRelType` covers the `LogicalType`↔`RelDataType` round-trip including nullability.
- `LogicalRelDataTypeConverterTest`, and the planner and SQL gateway `LogicalTypeJson(Ser)DeTest` cover JSON serde round-trips.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **yes** (new `@PublicEvolving` `UuidType`, `LogicalTypeRoot.UUID`, `DataTypes.UUID()`)
  - The serializers: **yes** (logical-type JSON serde for compiled plans and the SQL gateway REST; no binary/state `TypeSerializer` is added)
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **yes**
  - If yes, how is the feature documented? **not documented** (documentation is tracked separately in FLINK-40494)

Two things to confirm before you submit:

1. The "serializers" answer. I marked it yes because the compiled-plan JSON serde is a compatibility surface and this extends it. If you consider that question to mean only binary TypeSerializers, flip it to no. I'd keep it as yes with the clarifying note.
2. The ASF generative-AI disclosure section (new in the template). AI tooling was used here, so I left it out of the message above rather than fill it falsely. Per ASF policy you should append one of:
##### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: Claude Code (Opus 4.8)