### PR TITLE
[FLINK-39977][runtime] Recovery of merged channel state handles

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/filemerging/SubtaskFileMergingManagerRestoreOperation.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/filemerging/SubtaskFileMergingManagerRestoreOperation.java
@@ -35,6 +35,8 @@ import org.apache.flink.util.Preconditions;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
+import static org.apache.flink.runtime.state.ChannelStateHelper.collectUniqueDisposableInChannelState;
+
 /**
  * Restore operation that restores file-merging information belonging to one subtask for {@link
  * FileMergingSnapshotManager}.
@@ -89,10 +91,15 @@ public class SubtaskFileMergingManagerRestoreOperation {
                                 subtaskState.getRawOperatorState().stream())
                         .flatMap(this::getChildrenStreamHandles);
 
-        // TODO support channel state restore for unaligned checkpoint.
+        Stream<StreamStateHandle> channelStateHandles =
+                collectUniqueDisposableInChannelState(
+                        Stream.of(
+                                subtaskState.getInputChannelState(),
+                                subtaskState.getUpstreamOutputBufferState(),
+                                subtaskState.getResultSubpartitionState()));
 
         Stream<SegmentFileStateHandle> segmentStateHandles =
-                Stream.of(keyedStateHandles, operatorStateHandles)
+                Stream.of(keyedStateHandles, operatorStateHandles, channelStateHandles)
                         .flatMap(Function.identity())
                         .filter(
                                 handle ->

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/filemerging/FileMergingSnapshotManagerTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/filemerging/FileMergingSnapshotManagerTestBase.java
@@ -27,7 +27,10 @@ import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.core.fs.local.LocalFileSystem;
 import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
+import org.apache.flink.runtime.checkpoint.StateObjectCollection;
 import org.apache.flink.runtime.checkpoint.TaskStateSnapshot;
+import org.apache.flink.runtime.checkpoint.channel.InputChannelInfo;
+import org.apache.flink.runtime.checkpoint.channel.ResultSubpartitionInfo;
 import org.apache.flink.runtime.checkpoint.filemerging.FileMergingSnapshotManager.SpaceStat;
 import org.apache.flink.runtime.checkpoint.filemerging.FileMergingSnapshotManager.SubtaskKey;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
@@ -37,10 +40,14 @@ import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
 import org.apache.flink.runtime.state.CheckpointedStateScope;
 import org.apache.flink.runtime.state.IncrementalKeyedStateHandle;
 import org.apache.flink.runtime.state.IncrementalRemoteKeyedStateHandle;
+import org.apache.flink.runtime.state.InputChannelStateHandle;
 import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.runtime.state.KeyGroupRangeOffsets;
 import org.apache.flink.runtime.state.KeyGroupsStateHandle;
+import org.apache.flink.runtime.state.MergedInputChannelStateHandle;
 import org.apache.flink.runtime.state.OperatorStateHandle;
+import org.apache.flink.runtime.state.OutputStateHandle;
+import org.apache.flink.runtime.state.ResultSubpartitionStateHandle;
 import org.apache.flink.runtime.state.filemerging.FileMergingOperatorStreamStateHandle;
 import org.apache.flink.runtime.state.filemerging.SegmentFileStateHandle;
 import org.apache.flink.runtime.state.filesystem.FileMergingCheckpointStateOutputStream;
@@ -51,6 +58,7 @@ import org.junit.jupiter.api.io.TempDir;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -539,8 +547,8 @@ public abstract class FileMergingSnapshotManagerTestBase {
             assertThat(stateFiles.size()).isEqualTo(1);
             Set<LogicalFile> restoreFileSet = stateFiles.get(checkpointId);
             assertThat(restoreFileSet).isNotNull();
-            // 2 operators * (2 keyed state + 2 operator state)
-            assertThat(restoreFileSet.size()).isEqualTo(8);
+            // 2 operators * (2 keyed state + 2 operator state + 3 channel state delegates)
+            assertThat(restoreFileSet.size()).isEqualTo(14);
             assertThat(fmsm.spaceStat).isEqualTo(oldSpaceStat);
             for (LogicalFile file : restoreFileSet) {
                 assertThat(fmsm.getLogicalFile(file.getFileId())).isEqualTo(file);
@@ -741,11 +749,66 @@ public abstract class FileMergingSnapshotManagerTestBase {
                                 CheckpointedStateScope.EXCLUSIVE,
                                 closeableRegistry));
 
+        SegmentFileStateHandle inputChannelStateHandle =
+                buildOneSegmentFileHandle(
+                        checkpointId, fmsm, CheckpointedStateScope.EXCLUSIVE, closeableRegistry);
+        InputChannelStateHandle inputChannel1 =
+                new InputChannelStateHandle(
+                        0,
+                        new InputChannelInfo(0, 0),
+                        inputChannelStateHandle,
+                        Collections.singletonList(0L),
+                        16L);
+        InputChannelStateHandle inputChannel2 =
+                new InputChannelStateHandle(
+                        0,
+                        new InputChannelInfo(0, 1),
+                        inputChannelStateHandle,
+                        Collections.singletonList(16L),
+                        16L);
+
+        SegmentFileStateHandle upstreamOutputBufferStateHandle =
+                buildOneSegmentFileHandle(
+                        checkpointId, fmsm, CheckpointedStateScope.EXCLUSIVE, closeableRegistry);
+        InputChannelStateHandle upstreamOutputBuffer =
+                new InputChannelStateHandle(
+                        0,
+                        new InputChannelInfo(1, 0),
+                        upstreamOutputBufferStateHandle,
+                        Collections.singletonList(0L),
+                        upstreamOutputBufferStateHandle.getStateSize());
+
+        SegmentFileStateHandle resultSubpartitionStateHandle =
+                buildOneSegmentFileHandle(
+                        checkpointId, fmsm, CheckpointedStateScope.EXCLUSIVE, closeableRegistry);
+        ResultSubpartitionStateHandle resultSubpartition1 =
+                new ResultSubpartitionStateHandle(
+                        0,
+                        new ResultSubpartitionInfo(0, 0),
+                        resultSubpartitionStateHandle,
+                        Collections.singletonList(0L),
+                        16L);
+        ResultSubpartitionStateHandle resultSubpartition2 =
+                new ResultSubpartitionStateHandle(
+                        0,
+                        new ResultSubpartitionInfo(0, 1),
+                        resultSubpartitionStateHandle,
+                        Collections.singletonList(16L),
+                        16L);
+
         return OperatorSubtaskState.builder()
                 .setManagedKeyedState(keyedStateHandle1)
                 .setRawKeyedState(keyedStateHandle2)
                 .setManagedOperatorState(operatorStateHandle1)
                 .setRawOperatorState(operatorStateHandle2)
+                .setInputChannelState(
+                        StateObjectCollection.singleton(
+                                MergedInputChannelStateHandle.fromChannelHandles(
+                                        Arrays.asList(inputChannel1, inputChannel2))))
+                .setUpstreamOutputBufferState(StateObjectCollection.singleton(upstreamOutputBuffer))
+                .setResultSubpartitionState(
+                        new StateObjectCollection<OutputStateHandle>(
+                                Arrays.asList(resultSubpartition1, resultSubpartition2)))
                 .build();
     }
 

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/FileMergingChannelStateITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/FileMergingChannelStateITCase.java
@@ -1,0 +1,291 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.test.checkpointing;
+
+import org.apache.flink.api.common.JobExecutionResult;
+import org.apache.flink.api.common.functions.RichMapFunction;
+import org.apache.flink.api.common.state.ListState;
+import org.apache.flink.api.common.state.ListStateDescriptor;
+import org.apache.flink.api.common.typeutils.base.array.LongPrimitiveArraySerializer;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.configuration.CheckpointingOptions;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.execution.CheckpointingMode;
+import org.apache.flink.core.execution.JobClient;
+import org.apache.flink.runtime.checkpoint.OperatorState;
+import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
+import org.apache.flink.runtime.checkpoint.metadata.CheckpointMetadata;
+import org.apache.flink.runtime.minicluster.MiniCluster;
+import org.apache.flink.runtime.state.FunctionInitializationContext;
+import org.apache.flink.runtime.state.FunctionSnapshotContext;
+import org.apache.flink.runtime.state.StreamStateHandle;
+import org.apache.flink.runtime.state.filemerging.SegmentFileStateHandle;
+import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
+import org.apache.flink.streaming.api.checkpoint.CheckpointedFunction;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.sink.legacy.SinkFunction;
+import org.apache.flink.streaming.util.CheckpointStorageUtils;
+import org.apache.flink.streaming.util.RestartStrategyUtils;
+import org.apache.flink.test.junit5.InjectMiniCluster;
+import org.apache.flink.test.junit5.MiniClusterExtension;
+import org.apache.flink.test.util.TestUtils;
+import org.apache.flink.testutils.junit.SharedObjectsExtension;
+import org.apache.flink.testutils.junit.SharedReference;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicLongArray;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.apache.flink.runtime.state.ChannelStateHelper.collectUniqueDisposableInChannelState;
+import static org.apache.flink.runtime.testutils.CommonTestUtils.waitUntilCondition;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests recovery of file-merged channel state after the TaskManager is replaced. */
+class FileMergingChannelStateITCase {
+
+    private static final int TASK_MANAGER_COUNT = 3;
+    private static final int WORD_COUNT = 16;
+    private static final long RECORD_COUNT = 16_000L;
+    private static final long EXPECTED_COUNT_PER_WORD = RECORD_COUNT / WORD_COUNT;
+    private static final String SLOW_MAPPER_UID = "slow-word-mapper";
+
+    private static final List<String> WORDS =
+            Arrays.asList(
+                    "apple",
+                    "banana",
+                    "cherry",
+                    "date",
+                    "elderberry",
+                    "fig",
+                    "grape",
+                    "honeydew",
+                    "kiwi",
+                    "lemon",
+                    "mango",
+                    "nectarine",
+                    "orange",
+                    "papaya",
+                    "quince",
+                    "raspberry");
+
+    @TempDir private java.nio.file.Path checkpointDirectory;
+
+    @RegisterExtension
+    private final SharedObjectsExtension sharedObjects = SharedObjectsExtension.create();
+
+    @RegisterExtension
+    private static final MiniClusterExtension MINI_CLUSTER_EXTENSION =
+            new MiniClusterExtension(
+                    new MiniClusterResourceConfiguration.Builder()
+                            .setConfiguration(clusterConfiguration())
+                            .setNumberTaskManagers(TASK_MANAGER_COUNT)
+                            .setNumberSlotsPerTaskManager(1)
+                            .build());
+
+    private static Configuration clusterConfiguration() {
+        return new Configuration()
+                .set(CheckpointingOptions.FILE_MERGING_ENABLED, true)
+                .set(CheckpointingOptions.FILE_MERGING_ACROSS_BOUNDARY, false)
+                .set(CheckpointingOptions.MAX_RETAINED_CHECKPOINTS, 1);
+    }
+
+    @Test
+    void testRestoreFileMergedChannelState(@InjectMiniCluster MiniCluster miniCluster)
+            throws Exception {
+        final SharedReference<AtomicLong> mappedRecords = sharedObjects.add(new AtomicLong());
+        final SharedReference<AtomicLongArray> result =
+                sharedObjects.add(new AtomicLongArray(WORD_COUNT));
+        final StreamExecutionEnvironment env = createEnvironment(mappedRecords, result);
+        final JobClient jobClient = env.executeAsync("file-merging-channel-state-word-count");
+
+        try {
+            waitUntilCondition(() -> mappedRecords.get().get() >= 100L, 100L, 300);
+
+            final String checkpointPath =
+                    miniCluster.triggerCheckpoint(jobClient.getJobID()).get(30, TimeUnit.SECONDS);
+            assertFileMergedChannelState(TestUtils.loadCheckpointMetadata(checkpointPath));
+
+            for (int i = 0; i < TASK_MANAGER_COUNT; i++) {
+                miniCluster.terminateTaskManager(0).get(30, TimeUnit.SECONDS);
+            }
+            for (int i = 0; i < TASK_MANAGER_COUNT; i++) {
+                miniCluster.startTaskManager();
+            }
+
+            final long mappedRecordsBeforeRecovery = mappedRecords.get().get();
+            waitUntilCondition(
+                    () -> mappedRecords.get().get() >= mappedRecordsBeforeRecovery + 1_000L,
+                    100L,
+                    300);
+            final String postRecoveryCheckpointPath =
+                    miniCluster.triggerCheckpoint(jobClient.getJobID()).get(30, TimeUnit.SECONDS);
+            assertFileMergedChannelState(
+                    TestUtils.loadCheckpointMetadata(postRecoveryCheckpointPath));
+
+            final JobExecutionResult executionResult =
+                    jobClient.getJobExecutionResult().get(2, TimeUnit.MINUTES);
+            assertThat(executionResult.getJobID()).isEqualTo(jobClient.getJobID());
+            for (int i = 0; i < WORD_COUNT; i++) {
+                assertThat(result.get().get(i))
+                        .as("final count for word %s", WORDS.get(i))
+                        .isEqualTo(EXPECTED_COUNT_PER_WORD);
+            }
+        } finally {
+            if (!jobClient.getJobExecutionResult().isDone()) {
+                jobClient.cancel().get(30, TimeUnit.SECONDS);
+            }
+        }
+    }
+
+    private StreamExecutionEnvironment createEnvironment(
+            SharedReference<AtomicLong> mappedRecords, SharedReference<AtomicLongArray> result) {
+        final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        env.setParallelism(1);
+        env.enableCheckpointing(TimeUnit.DAYS.toMillis(1), CheckpointingMode.EXACTLY_ONCE);
+        env.getCheckpointConfig().enableUnalignedCheckpoints();
+        env.getCheckpointConfig().setAlignedCheckpointTimeout(Duration.ZERO);
+        CheckpointStorageUtils.configureFileSystemCheckpointStorage(
+                env, checkpointDirectory.toUri());
+        RestartStrategyUtils.configureFixedDelayRestartStrategy(env, 3, 100L);
+
+        env.fromSequence(0L, RECORD_COUNT - 1L)
+                .setParallelism(1)
+                .slotSharingGroup("source")
+                .rebalance()
+                .map(new SlowWordMapper(mappedRecords))
+                .setParallelism(1)
+                .slotSharingGroup("channel")
+                .uid(SLOW_MAPPER_UID)
+                .keyBy(value -> value.f0)
+                .sum(1)
+                .setParallelism(1)
+                .slotSharingGroup("state")
+                .addSink(new ResultSink(result))
+                .setParallelism(1)
+                .slotSharingGroup("state");
+        return env;
+    }
+
+    private static void assertFileMergedChannelState(CheckpointMetadata metadata) {
+        final List<StreamStateHandle> channelStateDelegates = new ArrayList<>();
+        final List<StreamStateHandle> slowMapperChannelStateDelegates = new ArrayList<>();
+        for (OperatorState operatorState : metadata.getOperatorStates()) {
+            for (OperatorSubtaskState subtaskState : operatorState.getStates()) {
+                final List<StreamStateHandle> subtaskChannelStateDelegates =
+                        collectUniqueDisposableInChannelState(
+                                        Stream.of(
+                                                subtaskState.getInputChannelState(),
+                                                subtaskState.getUpstreamOutputBufferState(),
+                                                subtaskState.getResultSubpartitionState()))
+                                .collect(Collectors.toList());
+                channelStateDelegates.addAll(subtaskChannelStateDelegates);
+                if (operatorState.getOperatorUid().filter(SLOW_MAPPER_UID::equals).isPresent()) {
+                    collectUniqueDisposableInChannelState(
+                                    Stream.of(subtaskState.getInputChannelState()))
+                            .forEach(slowMapperChannelStateDelegates::add);
+                }
+            }
+        }
+
+        assertThat(channelStateDelegates)
+                .as("channel state delegates in the checkpoint")
+                .isNotEmpty()
+                .allSatisfy(
+                        handle -> assertThat(handle).isInstanceOf(SegmentFileStateHandle.class));
+        assertThat(channelStateDelegates.stream().mapToLong(StreamStateHandle::getStateSize).sum())
+                .isPositive();
+        assertThat(slowMapperChannelStateDelegates)
+                .as("channel state delegates belonging to the stateless slow mapper")
+                .isNotEmpty();
+    }
+
+    private static final class SlowWordMapper extends RichMapFunction<Long, Tuple2<String, Long>> {
+
+        private static final long serialVersionUID = 1L;
+
+        private final SharedReference<AtomicLong> mappedRecords;
+
+        private SlowWordMapper(SharedReference<AtomicLong> mappedRecords) {
+            this.mappedRecords = mappedRecords;
+        }
+
+        @Override
+        public Tuple2<String, Long> map(Long value) throws Exception {
+            Thread.sleep(1L);
+            mappedRecords.get().incrementAndGet();
+            return Tuple2.of(WORDS.get((int) (value % WORD_COUNT)), 1L);
+        }
+    }
+
+    private static final class ResultSink
+            implements SinkFunction<Tuple2<String, Long>>, CheckpointedFunction {
+
+        private static final long serialVersionUID = 1L;
+
+        private final SharedReference<AtomicLongArray> result;
+
+        private transient ListState<long[]> resultState;
+        private long[] counts = new long[WORD_COUNT];
+
+        private ResultSink(SharedReference<AtomicLongArray> result) {
+            this.result = result;
+        }
+
+        @Override
+        public void invoke(Tuple2<String, Long> value, Context context) {
+            final int wordIndex = WORDS.indexOf(value.f0);
+            counts[wordIndex] = value.f1;
+            result.get().set(wordIndex, value.f1);
+        }
+
+        @Override
+        public void snapshotState(FunctionSnapshotContext context) throws Exception {
+            resultState.update(Arrays.asList(counts.clone()));
+        }
+
+        @Override
+        public void initializeState(FunctionInitializationContext context) throws Exception {
+            resultState =
+                    context.getOperatorStateStore()
+                            .getListState(
+                                    new ListStateDescriptor<>(
+                                            "word-count-results",
+                                            LongPrimitiveArraySerializer.INSTANCE));
+            counts = new long[WORD_COUNT];
+            if (context.isRestored()) {
+                for (long[] restoredCounts : resultState.get()) {
+                    counts = restoredCounts.clone();
+                }
+            }
+            for (int i = 0; i < WORD_COUNT; i++) {
+                result.get().set(i, counts[i]);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

This pull request fixes recovery from checkpoints containing channel state written by the unified file-merging mechanism.

During recovery, the file-merging snapshot manager previously restored keyed and operator state handles but ignored channel state handles. Consequently, merged files referenced by input channel state, upstream output buffer state, or result subpartition state were not restored into the file-merging snapshot manager's tracking information.

## Brief change log

- Restore file-merged state handles referenced by input channel state, upstream output buffer state, and result subpartition state.
- Deduplicate shared channel state delegates before restoring their corresponding logical files.
- Extend file-merging snapshot manager tests to cover merged channel state handles and shared delegates.
- Add `FileMergingChannelStateITCase` to verify recovery after replacing all TaskManagers.

## Verifying this change

This change added and extended tests and can be verified as follows:

- Added `FileMergingChannelStateITCase`, which:
  - Enables unaligned checkpoints and unified file merging.
  - Processes 16,000 records through a WordCount pipeline.
  - Verifies that checkpointed channel state uses `SegmentFileStateHandle`.
  - Replaces all TaskManagers and restores the job from the checkpoint.
  - Takes another checkpoint after recovery and verifies obsolete merged file cleanup.
  - Verifies the final count for every word to ensure data correctness.
- Extended `FileMergingSnapshotManagerTestBase` to verify that input channel, upstream output buffer, and result subpartition state handles are restored and tracked without duplicating shared delegates.
- Verified `FileMergingChannelStateITCase` successfully; it completed in approximately 22 seconds locally.

## Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): no
- The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
- The serializers: no
- The runtime per-record code paths (performance sensitive): no
- Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: yes; checkpoint recovery is affected
- The S3 file system connector: no

## Documentation

- Does this pull request introduce a new feature? no
- If yes, how is the feature documented? not applicable

---

### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: OpenAI Codex (GPT-5.6 Sol)