### PR TITLE
[hotfix][docs] Fix AzureTableConfiguration class name casing in Azure Table Storage doc

### DIFF
--- a/docs/content.zh/docs/connectors/datastream/formats/azure_table_storage.md
+++ b/docs/content.zh/docs/connectors/datastream/formats/azure_table_storage.md
@@ -92,7 +92,7 @@ public class AzureTableExample {
     HadoopInputFormat<Text, WritableEntity> hdIf = new HadoopInputFormat<Text, WritableEntity>(new AzureTableInputFormat(), Text.class, WritableEntity.class, new Job());
 
     // 设置 Account URI，如 https://apacheflink.table.core.windows.net
-    hdIf.getConfiguration().set(azuretableconfiguration.Keys.ACCOUNT_URI.getKey(), "TODO");
+    hdIf.getConfiguration().set(AzureTableConfiguration.Keys.ACCOUNT_URI.getKey(), "TODO");
     // 设置存储密钥
     hdIf.getConfiguration().set(AzureTableConfiguration.Keys.STORAGE_KEY.getKey(), "TODO");
     // 在此处设置表名

--- a/docs/content/docs/connectors/datastream/formats/azure_table_storage.md
+++ b/docs/content/docs/connectors/datastream/formats/azure_table_storage.md
@@ -92,7 +92,7 @@ public class AzureTableExample {
     HadoopInputFormat<Text, WritableEntity> hdIf = new HadoopInputFormat<Text, WritableEntity>(new AzureTableInputFormat(), Text.class, WritableEntity.class, new Job());
 
     // set the Account URI, something like: https://apacheflink.table.core.windows.net
-    hdIf.getConfiguration().set(azuretableconfiguration.Keys.ACCOUNT_URI.getKey(), "TODO");
+    hdIf.getConfiguration().set(AzureTableConfiguration.Keys.ACCOUNT_URI.getKey(), "TODO");
     // set the secret storage key here
     hdIf.getConfiguration().set(AzureTableConfiguration.Keys.STORAGE_KEY.getKey(), "TODO");
     // set the table name here


### PR DESCRIPTION
## What is the purpose of the change
In the Azure Table Storage documentation example snippet (\docs/content/docs/connectors/datastream/formats/azure_table_storage.md\ and \docs/content.zh/docs/connectors/datastream/formats/azure_table_storage.md\), \zuretableconfiguration.Keys.ACCOUNT_URI.getKey()\ was written with lowercase casing instead of the PascalCase Java class name \AzureTableConfiguration.Keys.ACCOUNT_URI.getKey()\.

## Brief change log
- Fixed \zuretableconfiguration\ to \AzureTableConfiguration\ in both English and Chinese documentation files for Azure Table Storage format.

## Verifying this change
This change is a documentation fix for code snippets.

## Does this pull request potentially affect one of the following parts:
- Dependencies (does it add or upgrade a dependency): no
- The public API, i.e., is any changed class annotated with \@Public(Evolving)\: no
- The serializers: no
- The runtime per-record code paths: no
- Anything that affects deployment or recovery: no

## Documentation
- Does this pull request introduce a new feature? no