### PR TITLE
[hotfix][runtime] Fix getOrinalTypeSerializerSnapshot typo

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/ttl/TtlAwareSerializerSnapshot.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/ttl/TtlAwareSerializerSnapshot.java
@@ -110,22 +110,22 @@ public class TtlAwareSerializerSnapshot<T> implements TypeSerializerSnapshot<T> 
             // Check compatibility from disabling to enabling ttl
             TtlStateFactory.TtlSerializerSnapshot<T> newSerializerSnapshot =
                     (TtlStateFactory.TtlSerializerSnapshot<T>)
-                            this.getOrinalTypeSerializerSnapshot();
+                            this.getOriginalTypeSerializerSnapshot();
             TypeSerializerSchemaCompatibility<T> compatibility =
                     newSerializerSnapshot
                             .getValueSerializerSnapshot()
                             .resolveSchemaCompatibility(
                                     oldTtlAwareSerializerSnapshot
-                                            .getOrinalTypeSerializerSnapshot());
+                                            .getOriginalTypeSerializerSnapshot());
 
             return resolveCompatibilityForTtlMigration(compatibility);
         } else if (oldTtlAwareSerializerSnapshot.isTtlEnabled() && !this.isTtlEnabled()) {
             // Check compatibility from enabling to disabling ttl
             TtlStateFactory.TtlSerializerSnapshot<T> oldTtlSerializerSnapshot =
                     (TtlStateFactory.TtlSerializerSnapshot<T>)
-                            oldTtlAwareSerializerSnapshot.getOrinalTypeSerializerSnapshot();
+                            oldTtlAwareSerializerSnapshot.getOriginalTypeSerializerSnapshot();
             TypeSerializerSchemaCompatibility<T> compatibility =
-                    this.getOrinalTypeSerializerSnapshot()
+                    this.getOriginalTypeSerializerSnapshot()
                             .resolveSchemaCompatibility(
                                     oldTtlSerializerSnapshot.getValueSerializerSnapshot());
 
@@ -133,16 +133,16 @@ public class TtlAwareSerializerSnapshot<T> implements TypeSerializerSnapshot<T> 
         }
 
         // Check compatibility with the same ttl config
-        return this.getOrinalTypeSerializerSnapshot()
+        return this.getOriginalTypeSerializerSnapshot()
                 .resolveSchemaCompatibility(
-                        oldTtlAwareSerializerSnapshot.getOrinalTypeSerializerSnapshot());
+                        oldTtlAwareSerializerSnapshot.getOriginalTypeSerializerSnapshot());
     }
 
     public boolean isTtlEnabled() {
         return isTtlEnabled;
     }
 
-    public TypeSerializerSnapshot<T> getOrinalTypeSerializerSnapshot() {
+    public TypeSerializerSnapshot<T> getOriginalTypeSerializerSnapshot() {
         return typeSerializerSnapshot;
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/TtlAwareSerializerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/TtlAwareSerializerTest.java
@@ -130,7 +130,7 @@ class TtlAwareSerializerTest {
         assertThat(
                         ((TtlAwareSerializerSnapshot<?>)
                                         intTtlAwareSerializer.snapshotConfiguration())
-                                .getOrinalTypeSerializerSnapshot())
+                                .getOriginalTypeSerializerSnapshot())
                 .isInstanceOf(IntSerializer.IntSerializerSnapshot.class);
 
         assertThat(listTtlAwareSerializer.snapshotConfiguration())


### PR DESCRIPTION
Renames `TtlAwareSerializerSnapshot#getOrinalTypeSerializerSnapshot` to `getOriginalTypeSerializerSnapshot`, matching the correctly spelled `TtlAwareSerializer#getOriginalTypeSerializer` that it mirrors.

Eight call sites, all within `flink-runtime`. No behaviour change.

Noticed while reviewing feedback on #28881, which calls this method.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: Claude Code (Opus 5)
