### PR TITLE
[FLINK-40523][network] Compute tracePersist debug string only when trace logging is enabled

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/logger/NetworkActionsLogger.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/logger/NetworkActionsLogger.java
@@ -98,7 +98,9 @@ public class NetworkActionsLogger {
 
     public static void tracePersist(
             String action, Buffer buffer, Object channelInfo, long checkpointId) {
-        tracePersist(action, buffer.toDebugString(INCLUDE_HASH), channelInfo, checkpointId);
+        if (LOG.isTraceEnabled()) {
+            tracePersist(action, buffer.toDebugString(INCLUDE_HASH), channelInfo, checkpointId);
+        }
     }
 
     public static void tracePersist(


### PR DESCRIPTION
## What is the purpose of the change

`NetworkActionsLogger.tracePersist(String, Buffer, ...)` computed `buffer.toDebugString(INCLUDE_HASH)`
(a full buffer copy + hash + string allocation) before delegating to the trace-guarded overload, so
under backpressure this cost was paid for every persisted in-flight buffer even when TRACE was off.
This guards the computation behind `isTraceEnabled()`.

## Brief change log

  - [FLINK-40523] Guard the `toDebugString` call in `NetworkActionsLogger.tracePersist(...)` with `LOG.isTraceEnabled()`.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage. It is behavior-preserving:
the delegate overload already no-ops when TRACE is off; only the redundant debug-string computation is skipped.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): yes (removes redundant work on the checkpoint persist path when TRACE is off)
  - Anything that affects deployment or recovery: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable

---

##### Was generative AI tooling used to co-author this PR?

- [ ] Yes (please specify the tool below)
