### PR TITLE
[FLINK-40525][network] Remove residual receivedBuffers lock in finishReadRecoveredState to avoid ABBA deadlock

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RecoveredInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RecoveredInputChannel.java
@@ -161,10 +161,8 @@ public abstract class RecoveredInputChannel extends InputChannel implements Chan
     }
 
     public void finishReadRecoveredState() throws IOException {
-        synchronized (receivedBuffers) {
-            onRecoveredStateBuffer(
-                    EventSerializer.toBuffer(EndOfInputChannelStateEvent.INSTANCE, false));
-        }
+        onRecoveredStateBuffer(
+                EventSerializer.toBuffer(EndOfInputChannelStateEvent.INSTANCE, false));
         bufferManager.releaseFloatingBuffers();
         LOG.debug("{}/{} finished recovering input.", inputGate.getOwningTaskName(), channelInfo);
     }


### PR DESCRIPTION
## What is the purpose of the change

`RecoveredInputChannel.finishReadRecoveredState()` wrapped `onRecoveredStateBuffer()` in
`synchronized(receivedBuffers)`, but that method already locks `receivedBuffers` internally and, when the
queue was empty, calls `notifyChannelNonEmpty()`, which acquires `inputChannelsWithData` while
`receivedBuffers` is still held. This inverts the task thread's `inputChannelsWithData -> receivedBuffers`
lock order and can deadlock on the error path (ABBA). Removing the redundant outer lock restores the correct
order with no behavior change, since `onRecoveredStateBuffer` already provides the required mutual exclusion.

## Brief change log

  - [FLINK-40525] Drop the outer `synchronized(receivedBuffers)` in `RecoveredInputChannel.finishReadRecoveredState()`.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage. The ABBA cycle is an error-path
lock-ordering issue that cannot be reproduced deterministically in a unit test; `onRecoveredStateBuffer`
retains its internal locking, so behavior is otherwise unchanged.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: yes (input channel-state recovery)
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable

---

##### Was generative AI tooling used to co-author this PR?

- [ ] Yes (please specify the tool below)
