### PR TITLE
[FLINK-40522][network] Deduplicate RecoveryCheckpointBarrier sentinel helpers shared by LocalInputChannel and RemoteInputChannel

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannel.java
@@ -24,7 +24,6 @@ import org.apache.flink.runtime.checkpoint.CheckpointException;
 import org.apache.flink.runtime.checkpoint.CheckpointFailureReason;
 import org.apache.flink.runtime.checkpoint.channel.ChannelStateWriter;
 import org.apache.flink.runtime.checkpoint.channel.RecoveryCheckpointBarrier;
-import org.apache.flink.runtime.event.AbstractEvent;
 import org.apache.flink.runtime.event.TaskEvent;
 import org.apache.flink.runtime.execution.CancelTaskException;
 import org.apache.flink.runtime.io.network.TaskEventPublisher;
@@ -349,7 +348,8 @@ public class LocalInputChannel extends InputChannel
             Iterator<Buffer> it = recoveredBuffers.iterator();
             while (it.hasNext()) {
                 Buffer b = it.next();
-                RecoveryCheckpointBarrier barrier = asRecoveryCheckpointBarrier(b);
+                RecoveryCheckpointBarrier barrier =
+                        RecoveryCheckpointBarrierUtils.asRecoveryCheckpointBarrier(b);
                 if (barrier != null) {
                     long barrierId = barrier.getCheckpointId();
                     if (barrierId == checkpointId) {
@@ -383,35 +383,15 @@ public class LocalInputChannel extends InputChannel
                 }
             }
         } catch (IOException e) {
-            releaseRetainedBuffers(retained);
+            RecoveryCheckpointBarrierUtils.releaseRetainedBuffers(retained);
             throw e;
         }
-        releaseRetainedBuffers(retained);
+        RecoveryCheckpointBarrierUtils.releaseRetainedBuffers(retained);
         throw new IOException(
                 "Missing RecoveryCheckpointBarrier for checkpoint "
                         + checkpointId
                         + " in recoveredBuffers for channel "
                         + getChannelInfo());
-    }
-
-    private static void releaseRetainedBuffers(List<Buffer> retained) {
-        for (Buffer buffer : retained) {
-            buffer.recycleBuffer();
-        }
-    }
-
-    @Nullable
-    private static RecoveryCheckpointBarrier asRecoveryCheckpointBarrier(Buffer b)
-            throws IOException {
-        if (b.isBuffer()) {
-            return null;
-        }
-        AbstractEvent event =
-                EventSerializer.fromBuffer(b, RecoveryCheckpointBarrier.class.getClassLoader());
-        b.setReaderIndex(0);
-        return event instanceof RecoveryCheckpointBarrier
-                ? (RecoveryCheckpointBarrier) event
-                : null;
     }
 
     // ------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RecoveryCheckpointBarrierUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RecoveryCheckpointBarrierUtils.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition.consumer;
+
+import org.apache.flink.runtime.checkpoint.channel.RecoveryCheckpointBarrier;
+import org.apache.flink.runtime.event.AbstractEvent;
+import org.apache.flink.runtime.io.network.api.serialization.EventSerializer;
+import org.apache.flink.runtime.io.network.buffer.Buffer;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * Shared stateless helpers for the checkpointing-during-recovery sentinel protocol, used by both
+ * {@link LocalInputChannel} and {@link RemoteInputChannel}.
+ */
+final class RecoveryCheckpointBarrierUtils {
+
+    private RecoveryCheckpointBarrierUtils() {}
+
+    static void releaseRetainedBuffers(List<Buffer> retained) {
+        for (Buffer buffer : retained) {
+            buffer.recycleBuffer();
+        }
+    }
+
+    @Nullable
+    static RecoveryCheckpointBarrier asRecoveryCheckpointBarrier(Buffer b) throws IOException {
+        if (b.isBuffer()) {
+            return null;
+        }
+        AbstractEvent event =
+                EventSerializer.fromBuffer(b, RecoveryCheckpointBarrier.class.getClassLoader());
+        b.setReaderIndex(0);
+        return event instanceof RecoveryCheckpointBarrier
+                ? (RecoveryCheckpointBarrier) event
+                : null;
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannel.java
@@ -986,7 +986,8 @@ public class RemoteInputChannel extends InputChannel implements RecoverableInput
             Iterators.advance(it, receivedBuffers.getNumPriorityElements());
             while (it.hasNext()) {
                 SequenceBuffer sb = it.next();
-                RecoveryCheckpointBarrier barrier = asRecoveryCheckpointBarrier(sb.buffer);
+                RecoveryCheckpointBarrier barrier =
+                        RecoveryCheckpointBarrierUtils.asRecoveryCheckpointBarrier(sb.buffer);
                 if (barrier != null) {
                     long barrierId = barrier.getCheckpointId();
                     if (barrierId == checkpointId) {
@@ -1020,11 +1021,11 @@ public class RemoteInputChannel extends InputChannel implements RecoverableInput
                 }
             }
         } catch (IOException e) {
-            releaseRetainedBuffers(retained);
+            RecoveryCheckpointBarrierUtils.releaseRetainedBuffers(retained);
             throw e;
         }
         if (sentinel == null) {
-            releaseRetainedBuffers(retained);
+            RecoveryCheckpointBarrierUtils.releaseRetainedBuffers(retained);
             throw new IOException(
                     "Missing RecoveryCheckpointBarrier for checkpoint "
                             + checkpointId
@@ -1045,26 +1046,6 @@ public class RemoteInputChannel extends InputChannel implements RecoverableInput
         receivedBuffers.getAndRemove(sb -> sb == sentinel);
         totalQueueSizeInBytes -= sentinel.buffer.getSize();
         sentinel.buffer.recycleBuffer();
-    }
-
-    private static void releaseRetainedBuffers(List<Buffer> retained) {
-        for (Buffer buffer : retained) {
-            buffer.recycleBuffer();
-        }
-    }
-
-    @Nullable
-    private static RecoveryCheckpointBarrier asRecoveryCheckpointBarrier(Buffer b)
-            throws IOException {
-        if (b.isBuffer()) {
-            return null;
-        }
-        AbstractEvent event =
-                EventSerializer.fromBuffer(b, RecoveryCheckpointBarrier.class.getClassLoader());
-        b.setReaderIndex(0);
-        return event instanceof RecoveryCheckpointBarrier
-                ? (RecoveryCheckpointBarrier) event
-                : null;
     }
 
     public void checkpointStopped(long checkpointId) {


### PR DESCRIPTION
## What is the purpose of the change

`LocalInputChannel` and `RemoteInputChannel` each defined a byte-identical pair of stateless static helpers
for the checkpointing-during-recovery sentinel protocol (`releaseRetainedBuffers` and
`asRecoveryCheckpointBarrier`). Keeping two copies invites silent drift. This extracts them into one shared
package-private class; it is a pure move with no behavior change.

## Brief change log

  - [FLINK-40522] Move `releaseRetainedBuffers` and `asRecoveryCheckpointBarrier` into a new package-private `RecoveryCheckpointBarrierUtils`; both channels delegate. The per-channel `collectPreRecoveryBarrier` is intentionally left as-is (the two walk different queue types).

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage (a pure move, no behavior change).

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable

---

##### Was generative AI tooling used to co-author this PR?

- [ ] Yes (please specify the tool below)
