### PR TITLE
[FLINK-40518][checkpointing] Only enable checkpointing-during-recovery when unaligned checkpoints are enabled

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/configuration/CheckpointingOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/CheckpointingOptions.java
@@ -831,10 +831,9 @@ public class CheckpointingOptions {
     /**
      * Determines whether unaligned checkpoint support during recovery is enabled.
      *
-     * <p>This feature requires {@link #UNALIGNED_RECOVER_OUTPUT_ON_DOWNSTREAM} to be enabled. Note
-     * that it does not require unaligned checkpoints to be currently enabled, because a job may
-     * restore from an unaligned checkpoint while having unaligned checkpoints disabled for the new
-     * execution.
+     * <p>Requires both {@link #UNALIGNED_RECOVER_OUTPUT_ON_DOWNSTREAM} and unaligned checkpoints to
+     * be enabled, because checkpointing during recovery is only supported on the unaligned
+     * barrier-handler path.
      *
      * @param config the configuration to check
      * @return {@code true} if unaligned checkpointing during recovery is enabled, {@code false}
@@ -845,6 +844,7 @@ public class CheckpointingOptions {
         if (!config.get(UNALIGNED_RECOVER_OUTPUT_ON_DOWNSTREAM)) {
             return false;
         }
-        return config.get(CHECKPOINTING_DURING_RECOVERY_ENABLED);
+        return config.get(CHECKPOINTING_DURING_RECOVERY_ENABLED)
+                && isUnalignedCheckpointEnabled(config);
     }
 }

--- a/flink-core/src/test/java/org/apache/flink/configuration/CheckpointingOptionsTest.java
+++ b/flink-core/src/test/java/org/apache/flink/configuration/CheckpointingOptionsTest.java
@@ -358,14 +358,33 @@ class CheckpointingOptionsTest {
                 .as("During-recovery should be disabled when during-recovery option is not enabled")
                 .isFalse();
 
-        // Test when both options are enabled - should return true
-        Configuration bothEnabledConfig = new Configuration();
-        bothEnabledConfig.set(CheckpointingOptions.UNALIGNED_RECOVER_OUTPUT_ON_DOWNSTREAM, true);
-        bothEnabledConfig.set(CheckpointingOptions.CHECKPOINTING_DURING_RECOVERY_ENABLED, true);
-        assertThat(CheckpointingOptions.isCheckpointingDuringRecoveryEnabled(bothEnabledConfig))
+        // Test when all three prerequisites are enabled - should return true
+        Configuration allEnabledConfig = new Configuration();
+        allEnabledConfig.set(CheckpointingOptions.CHECKPOINTING_INTERVAL, Duration.ofSeconds(5));
+        allEnabledConfig.set(CheckpointingOptions.UNALIGNED_RECOVER_OUTPUT_ON_DOWNSTREAM, true);
+        allEnabledConfig.set(CheckpointingOptions.CHECKPOINTING_DURING_RECOVERY_ENABLED, true);
+        allEnabledConfig.set(CheckpointingOptions.ENABLE_UNALIGNED, true);
+        assertThat(CheckpointingOptions.isCheckpointingDuringRecoveryEnabled(allEnabledConfig))
                 .as(
-                        "During-recovery should be enabled when both recover-output-on-downstream and during-recovery are enabled")
+                        "During-recovery should be enabled when recover-output-on-downstream, during-recovery and unaligned checkpoints are all enabled")
                 .isTrue();
+
+        // Test when recover-output-on-downstream and during-recovery are enabled but unaligned
+        // checkpoints are disabled - should return false (checkpointing during recovery only works
+        // on the unaligned barrier-handler path).
+        Configuration unalignedDisabledConfig = new Configuration();
+        unalignedDisabledConfig.set(
+                CheckpointingOptions.CHECKPOINTING_INTERVAL, Duration.ofSeconds(5));
+        unalignedDisabledConfig.set(
+                CheckpointingOptions.UNALIGNED_RECOVER_OUTPUT_ON_DOWNSTREAM, true);
+        unalignedDisabledConfig.set(
+                CheckpointingOptions.CHECKPOINTING_DURING_RECOVERY_ENABLED, true);
+        unalignedDisabledConfig.set(CheckpointingOptions.ENABLE_UNALIGNED, false);
+        assertThat(
+                        CheckpointingOptions.isCheckpointingDuringRecoveryEnabled(
+                                unalignedDisabledConfig))
+                .as("During-recovery should be disabled when unaligned checkpoints are disabled")
+                .isFalse();
 
         // Test when recover-output-on-downstream is explicitly false and during-recovery is true
         Configuration explicitlyDisabledConfig = new Configuration();


### PR DESCRIPTION
## What is the purpose of the change

`CheckpointingOptions.isCheckpointingDuringRecoveryEnabled` gated only on
`UNALIGNED_RECOVER_OUTPUT_ON_DOWNSTREAM` and `CHECKPOINTING_DURING_RECOVERY_ENABLED`, not on whether
unaligned checkpoints are enabled. But checkpointing during recovery only works on the unaligned
(`alternating()`) barrier-handler path; with unaligned checkpoints disabled the aligned path gets a NO_OP
recovery trigger, so a checkpoint triggered mid-recovery can neither be taken nor declined and hangs until
it expires, leading to a failover loop. This adds the missing precondition so such jobs fall back to the
tested non-CDR recovery path.

## Brief change log

  - [FLINK-40518] Also require unaligned checkpoints to be enabled in `CheckpointingOptions#isCheckpointingDuringRecoveryEnabled` (the single central gate for all CDR call sites).

## Verifying this change

This change added a unit test:

  - Extended `CheckpointingOptionsTest` to assert CDR requires unaligned checkpoints enabled (and is disabled otherwise).

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: yes (checkpointing during recovery)
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable

---

##### Was generative AI tooling used to co-author this PR?

- [ ] Yes (please specify the tool below)
