### PR TITLE
[FLINK-40519][network] Deliver priority barrier to a credited remote reader while the subpartition is blocked during recovery

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartition.java
@@ -472,7 +472,7 @@ public class PipelinedSubpartition extends ResultSubpartition implements Channel
             // When blocked (e.g. by RECOVERY_COMPLETION event), only allow priority buffers
             // (e.g. unaligned checkpoint barriers) to be polled. Regular buffers remain blocked
             // until resumeConsumption() is called. See needNotifyPriorityEvent() for details.
-            if (isBlocked && buffers.getNumPriorityElements() == 0) {
+            if (isBlockedForDelivery()) {
                 return null;
             }
 
@@ -619,11 +619,20 @@ public class PipelinedSubpartition extends ResultSubpartition implements Channel
         }
     }
 
+    /**
+     * Blocked for delivery when blocked (e.g. by RECOVERY_COMPLETION) with no priority element
+     * queued; priority buffers (e.g. unaligned barriers) are still delivered while blocked.
+     */
+    @GuardedBy("buffers")
+    private boolean isBlockedForDelivery() {
+        return isBlocked && buffers.getNumPriorityElements() == 0;
+    }
+
     @GuardedBy("buffers")
     private boolean isDataAvailableUnsafe() {
         assert Thread.holdsLock(buffers);
 
-        return !isBlocked && (flushRequested || getNumberOfFinishedBuffers() > 0);
+        return !isBlockedForDelivery() && (flushRequested || getNumberOfFinishedBuffers() > 0);
     }
 
     private Buffer.DataType getNextBufferTypeUnsafe() {
@@ -751,7 +760,7 @@ public class PipelinedSubpartition extends ResultSubpartition implements Channel
     @SuppressWarnings("FieldAccessNotGuarded")
     @Override
     public int getBuffersInBacklogUnsafe() {
-        if (isBlocked || buffers.isEmpty()) {
+        if (isBlockedForDelivery() || buffers.isEmpty()) {
             return 0;
         }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartitionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartitionTest.java
@@ -30,6 +30,7 @@ import org.apache.flink.runtime.io.network.api.serialization.EventSerializer;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
 import org.apache.flink.runtime.io.network.buffer.BufferBuilderTestUtils;
 import org.apache.flink.runtime.io.network.buffer.BufferConsumer;
+import org.apache.flink.runtime.io.network.partition.consumer.EndOfOutputChannelStateEvent;
 import org.apache.flink.runtime.io.network.util.TestConsumerCallback;
 import org.apache.flink.runtime.io.network.util.TestProducerSource;
 import org.apache.flink.runtime.io.network.util.TestSubpartitionConsumer;
@@ -470,6 +471,39 @@ public class PipelinedSubpartitionTest extends SubpartitionTestBase {
         assertThatThrownBy(checkpointFuture10::get)
                 .hasCauseInstanceOf(IllegalStateException.class)
                 .isInstanceOf(ExecutionException.class);
+    }
+
+    @TestTemplate
+    void testPriorityBarrierAvailableToCreditedReaderWhileBlocked() throws Exception {
+        PipelinedSubpartition subpartition = createSubpartition();
+        subpartition.setChannelStateWriter(ChannelStateWriter.NO_OP);
+
+        // Block the subpartition, mirroring the RECOVERY_COMPLETION event emitted during recovery.
+        subpartition.add(
+                EventSerializer.toBufferConsumer(EndOfOutputChannelStateEvent.INSTANCE, false));
+        pollBufferAndCheckType(subpartition, Buffer.DataType.RECOVERY_COMPLETION);
+
+        // While blocked and without any priority element, a credited reader sees no data.
+        assertThat(subpartition.getAvailabilityAndBacklog(true).isAvailable()).isFalse();
+        assertThat(subpartition.pollBuffer()).isNull();
+
+        // Enqueue an unaligned checkpoint barrier as a priority element.
+        CheckpointOptions options =
+                CheckpointOptions.unaligned(
+                        CheckpointType.CHECKPOINT, CheckpointStorageLocationReference.getDefault());
+        subpartition.add(
+                EventSerializer.toBufferConsumer(
+                        new CheckpointBarrier(1L, System.currentTimeMillis(), options), true));
+
+        // The credited-reader availability check must now report available so the remote reader is
+        // enqueued and the priority barrier is delivered even though the subpartition
+        // stays blocked.
+        assertThat(subpartition.getAvailabilityAndBacklog(true).isAvailable()).isTrue();
+        pollBufferAndCheckType(subpartition, Buffer.DataType.PRIORITIZED_EVENT_BUFFER);
+
+        // After the priority element is consumed, the subpartition should immediately re-block.
+        assertThat(subpartition.getAvailabilityAndBacklog(true).isAvailable()).isFalse();
+        assertThat(subpartition.pollBuffer()).isNull();
     }
 
     private BufferConsumer getTimeoutableBarrierBuffer(long checkpointId) throws IOException {


### PR DESCRIPTION
## What is the purpose of the change

A blocked `PipelinedSubpartition` still hands out priority buffers (unaligned-checkpoint barriers) in
`pollBuffer()`, but `isDataAvailableUnsafe()` and `getBuffersInBacklogUnsafe()` still gate on `!isBlocked`.
A credited remote reader decides availability through those methods, so its one-shot priority notification
is evaluated as "not available", the reader is not enqueued, and the barrier is not delivered until recovery
ends (`resumeConsumption()`) — the checkpoint can time out. The local channel path is already handled via
`hasPendingPriorityEvent`; the remote path was not.

## Brief change log

  - [FLINK-40519] Extract `PipelinedSubpartition#isBlockedForDelivery()` and use it in `pollBuffer`, `isDataAvailableUnsafe` and `getBuffersInBacklogUnsafe` so a queued priority barrier is delivered to a credited reader while the subpartition is blocked.

## Verifying this change

This change added a unit test:

  - Added a `PipelinedSubpartitionTest` case asserting that, while blocked with a priority barrier queued, the credited-reader availability check reports available and the barrier is pollable.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: yes (unaligned-checkpoint barrier delivery during recovery)
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable

---

##### Was generative AI tooling used to co-author this PR?

- [ ] Yes (please specify the tool below)
