### PR TITLE
[FLINK-40521][network] Document potential lost priority-barrier wakeup in LocalInputChannel during checkpointing-during-recovery

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannel.java
@@ -666,7 +666,9 @@ public class LocalInputChannel extends InputChannel
 
         Buffer.DataType expectedNextDataType = next.getNextDataType();
         if (!expectedNextDataType.hasPriority()) {
-            // Reset hasPendingPriorityEvent to false if no more priority event.
+            // Latent lost-wakeup: this lock-free clear can clobber a concurrent set-true in
+            // notifyPriorityEvent(). Safe today only because Flink runs no concurrent unaligned
+            // checkpoints, so at most one priority barrier is ever pending.
             hasPendingPriorityEvent = false;
             // Correct nextDataType: if recoveredBuffers is not empty, the actual next element to
             // consume is from recoveredBuffers, not from subpartitionView.


### PR DESCRIPTION
## What is the purpose of the change

In `LocalInputChannel`, `hasPendingPriorityEvent` is set lock-free in `notifyPriorityEvent()` and cleared
lock-free in `pullPriorityFromSubpartitionView()` on a stale snapshot, which is a latent lost-wakeup race.
It is currently safe because Flink runs no concurrent unaligned checkpoints, so at most one priority barrier
is ever pending. This documents the race and why it is safe today, rather than changing the logic.

## Brief change log

  - [FLINK-40521] Add a comment in `LocalInputChannel#pullPriorityFromSubpartitionView` describing the latent lost-wakeup race and why it is currently safe.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage (comment only, no behavior change).

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable

---

##### Was generative AI tooling used to co-author this PR?

- [ ] Yes (please specify the tool below)
