### PR TITLE
[FLINK-40524][network] Skip the recoveredBuffers monitor on the getNextBuffer hot path for channels that never recover

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannel.java
@@ -559,31 +559,32 @@ public class LocalInputChannel extends InputChannel
     public Optional<BufferAndAvailability> getNextBuffer() throws IOException {
         checkError();
 
-        // Read inRecovery and poll the recovered buffer under a single lock acquisition to avoid
-        // grabbing the monitor twice on the hot path.
-        boolean inRecovery;
-        Buffer recoveredBuf = null;
-        synchronized (recoveredBuffers) {
-            inRecovery = this.inRecovery;
-            if (inRecovery && !hasPendingPriorityEvent && !recoveredBuffers.isEmpty()) {
-                recoveredBuf = recoveredBuffers.poll();
+        if (needsRecovery) {
+            // Read inRecovery and poll the recovered buffer under a single lock acquisition to
+            // avoid grabbing the monitor twice on the hot path.
+            boolean inRecovery;
+            Buffer recoveredBuf = null;
+            synchronized (recoveredBuffers) {
+                inRecovery = this.inRecovery;
+                if (inRecovery && !hasPendingPriorityEvent && !recoveredBuffers.isEmpty()) {
+                    recoveredBuf = recoveredBuffers.poll();
+                }
             }
-        }
 
-        if (inRecovery) {
-            // Always return an already-polled recovered buffer first: hasPendingPriorityEvent may
-            // be flipped to true by a concurrent notifyPriorityEvent() after the poll, and
-            // re-reading
-            // it here would otherwise drop this buffer. A pending priority event is served on the
-            // next getNextBuffer() call instead.
-            if (recoveredBuf != null) {
-                return wrapRecoveredBufferAsAvailability(recoveredBuf);
+            if (inRecovery) {
+                // Always return an already-polled recovered buffer first: hasPendingPriorityEvent
+                // may be flipped to true by a concurrent notifyPriorityEvent() after the poll, and
+                // re-reading it here would otherwise drop this buffer. A pending priority event is
+                // served on the next getNextBuffer() call instead.
+                if (recoveredBuf != null) {
+                    return wrapRecoveredBufferAsAvailability(recoveredBuf);
+                }
+                if (hasPendingPriorityEvent) {
+                    return pullPriorityFromSubpartitionView();
+                }
+                // Drain not finished yet; block normal upstream data until delivery completes.
+                return Optional.empty();
             }
-            if (hasPendingPriorityEvent) {
-                return pullPriorityFromSubpartitionView();
-            }
-            // Drain not finished yet; block normal upstream data until delivery completes.
-            return Optional.empty();
         }
 
         if (!toBeConsumedBuffers.isEmpty()) {


### PR DESCRIPTION
## What is the purpose of the change

`LocalInputChannel.getNextBuffer()` always entered `synchronized (recoveredBuffers)` to check recovery
state, even for channels that never needed recovery (where `inRecovery` is always false and
`recoveredBuffers` always empty, so the block is dead). `needsRecovery` is a final field, so gating the
recovery block on it lets steady-state non-recovery channels skip the monitor on the hot path.

## Brief change log

  - [FLINK-40524] Wrap the recovery block in `LocalInputChannel#getNextBuffer` in an `if (needsRecovery)` gate so channels that never recover skip the `recoveredBuffers` monitor.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage. Behavior is identical when
`needsRecovery` is true; the only change is the added gate (the wrapped block is reindented accordingly).

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): yes (removes a lock acquisition on the `getNextBuffer` hot path)
  - Anything that affects deployment or recovery: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable

---

##### Was generative AI tooling used to co-author this PR?

- [ ] Yes (please specify the tool below)
