### PR TITLE
[FLINK-40463][table] Widen JSON_VALUE and JSON_QUERY RETURNING type support

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/sql/SqlJsonQueryFunctionWrapper.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/sql/SqlJsonQueryFunctionWrapper.java
@@ -19,6 +19,8 @@
 package org.apache.flink.table.planner.functions.sql;
 
 import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.planner.calcite.FlinkTypeFactory;
+import org.apache.flink.table.runtime.functions.SqlJsonUtils;
 
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.sql.SqlCallBinding;
@@ -89,12 +91,15 @@ public class SqlJsonQueryFunctionWrapper extends SqlJsonQueryFunction {
 
     private static boolean checkOperandsForArrayReturnType(
             boolean throwOnFailure, RelDataType type, SqlCallBinding callBinding) {
-        if (!SqlTypeUtil.isCharacter(type.getComponentType())) {
+        RelDataType elementType = type.getComponentType();
+        if (!SqlTypeUtil.isCharacter(elementType)
+                && !SqlJsonUtils.isSupportedJsonReturningType(
+                        FlinkTypeFactory.toLogicalType(elementType).getTypeRoot())) {
             if (throwOnFailure) {
                 throw new ValidationException(
                         String.format(
                                 "Unsupported array element type '%s' for RETURNING ARRAY in JSON_QUERY().",
-                                type.getComponentType()));
+                                elementType));
             } else {
                 return false;
             }

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/calls/JsonQueryCallGen.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/calls/JsonQueryCallGen.scala
@@ -17,14 +17,14 @@
  */
 package org.apache.flink.table.planner.codegen.calls
 
-import org.apache.flink.table.api.{JsonQueryOnEmptyOrError, JsonQueryWrapper, JsonValueOnEmptyOrError}
+import org.apache.flink.table.api.{JsonQueryOnEmptyOrError, JsonQueryWrapper}
+import org.apache.flink.table.api.ValidationException
 import org.apache.flink.table.planner.codegen.{CodeGeneratorContext, CodeGenException, CodeGenUtils, GeneratedExpression}
 import org.apache.flink.table.planner.codegen.CodeGenUtils.{qualifyEnum, qualifyMethod, BINARY_STRING, GENERIC_ARRAY}
 import org.apache.flink.table.planner.codegen.GenerateUtils.generateCallWithStmtIfArgsNotNull
+import org.apache.flink.table.runtime.functions.SqlJsonUtils
 import org.apache.flink.table.runtime.functions.SqlJsonUtils.JsonQueryReturnType
-import org.apache.flink.table.types.logical.{ArrayType, LogicalType, LogicalTypeRoot}
-
-import org.apache.calcite.sql.SqlJsonEmptyOrError
+import org.apache.flink.table.types.logical.{ArrayType, DecimalType, LogicalType, LogicalTypeRoot}
 
 /**
  * [[CallGenerator]] for [[BuiltInMethods.JSON_QUERY]].
@@ -72,11 +72,24 @@ class JsonQueryCallGen extends CallGenerator {
           val emptyBehavior = operands(3).literalValue.get.asInstanceOf[JsonQueryOnEmptyOrError]
           val errorBehavior = operands(4).literalValue.get.asInstanceOf[JsonQueryOnEmptyOrError]
           val wrapperBehavior = operands(2).literalValue.get.asInstanceOf[JsonQueryWrapper]
-          val jsonQueryReturnType = if (returnType.getTypeRoot == LogicalTypeRoot.ARRAY) {
-            JsonQueryReturnType.ARRAY
-          } else {
-            JsonQueryReturnType.STRING
+
+          // Three return paths:
+          //   VARCHAR         -> STRING    -> serialize to StringData
+          //   ARRAY<VARCHAR>  -> ARRAY     -> GenericArrayData of StringData (existing)
+          //   ARRAY<typed T>  -> RAW_ARRAY -> Object[] post-converted via convertJsonArray
+          val (isTypedArray, elementType) = returnType.getTypeRoot match {
+            case LogicalTypeRoot.ARRAY =>
+              val et = returnType.asInstanceOf[ArrayType].getElementType
+              (et.getTypeRoot != LogicalTypeRoot.VARCHAR, et)
+            case _ => (false, null)
           }
+
+          val jsonQueryReturnType = returnType.getTypeRoot match {
+            case LogicalTypeRoot.ARRAY if isTypedArray => JsonQueryReturnType.RAW_ARRAY
+            case LogicalTypeRoot.ARRAY => JsonQueryReturnType.ARRAY
+            case _ => JsonQueryReturnType.STRING
+          }
+
           val terms = Seq(
             parsed.resultTerm,
             s"${argTerms(1)}.toString()",
@@ -87,29 +100,52 @@ class JsonQueryCallGen extends CallGenerator {
           )
 
           val rawResultTerm = CodeGenUtils.newName(ctx, "rawResult")
-          val call = s"""
-                        |Object $rawResultTerm =
-                        |    ${qualifyMethod(BuiltInMethods.JSON_QUERY_PARSED)}(${terms
-                         .mkString(", ")});
+          val baseCall = s"""
+                            |Object $rawResultTerm =
+                            |    ${qualifyMethod(BuiltInMethods.JSON_QUERY_PARSED)}(${terms
+                             .mkString(", ")});
            """.stripMargin
 
-          val convertedResult = returnType.getTypeRoot match {
+          val (additionalCall, convertedResult) = returnType.getTypeRoot match {
             case LogicalTypeRoot.VARCHAR =>
-              s"$BINARY_STRING.fromString(java.lang.String.valueOf($rawResultTerm))"
-            case LogicalTypeRoot.ARRAY =>
-              val elementType = returnType.asInstanceOf[ArrayType].getElementType
-              if (elementType.getTypeRoot == LogicalTypeRoot.VARCHAR) {
-                s"($GENERIC_ARRAY) $rawResultTerm"
-              } else {
-                throw new CodeGenException(
-                  s"Unsupported array element type '$elementType' for RETURNING ARRAY in JSON_QUERY().")
-              }
-            case _ =>
+              ("", s"$BINARY_STRING.fromString(java.lang.String.valueOf($rawResultTerm))")
+            case LogicalTypeRoot.ARRAY if !isTypedArray =>
+              ("", s"($GENERIC_ARRAY) $rawResultTerm")
+            case LogicalTypeRoot.ARRAY
+                if !SqlJsonUtils.isSupportedJsonReturningType(elementType.getTypeRoot) =>
               throw new CodeGenException(
+                s"Unsupported element type '${elementType.getTypeRoot}' "
+                  + "for RETURNING ARRAY in JSON_QUERY().")
+            case LogicalTypeRoot.ARRAY =>
+              val jsonUtils =
+                "org.apache.flink.table.runtime.functions.SqlJsonUtils"
+              val typeRootEnum =
+                s"org.apache.flink.table.types.logical.LogicalTypeRoot.${elementType.getTypeRoot.name()}"
+              val (precisionStr, scaleStr) = elementType.getTypeRoot match {
+                case LogicalTypeRoot.DECIMAL =>
+                  val dt = elementType.asInstanceOf[DecimalType]
+                  (dt.getPrecision.toString, dt.getScale.toString)
+                case _ => ("0", "0")
+              }
+              val errorBehaviorEnum = qualifyEnum(errorBehavior)
+
+              val convertedTerm = CodeGenUtils.newName(ctx, "convertedArr")
+              val conversionCode =
+                s"""
+                   |$GENERIC_ARRAY $convertedTerm = $jsonUtils.convertJsonArray(
+                   |    $rawResultTerm, $typeRootEnum,
+                   |    $precisionStr, $scaleStr,
+                   |    $errorBehaviorEnum);
+                 """.stripMargin
+
+              (conversionCode, s"$convertedTerm")
+            case _ =>
+              throw new ValidationException(
                 s"Unsupported type '$returnType' "
-                  + "for RETURNING in JSON_VALUE().")
+                  + "for RETURNING in JSON_QUERY().")
           }
 
+          val call = baseCall + additionalCall
           val result = s"($rawResultTerm == null) ? null : ($convertedResult)"
           (call, result)
         }

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/calls/JsonQueryCallGen.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/calls/JsonQueryCallGen.scala
@@ -129,12 +129,14 @@ class JsonQueryCallGen extends CallGenerator {
               }
               val errorBehaviorEnum = qualifyEnum(errorBehavior)
 
+              val elementNullableStr = elementType.isNullable.toString
               val convertedTerm = CodeGenUtils.newName(ctx, "convertedArr")
               val conversionCode =
                 s"""
                    |$GENERIC_ARRAY $convertedTerm = $jsonUtils.convertJsonArray(
                    |    $rawResultTerm, $typeRootEnum,
                    |    $precisionStr, $scaleStr,
+                   |    $elementNullableStr,
                    |    $errorBehaviorEnum);
                  """.stripMargin
 

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/calls/JsonValueCallGen.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/calls/JsonValueCallGen.scala
@@ -21,7 +21,8 @@ import org.apache.flink.table.api.JsonValueOnEmptyOrError
 import org.apache.flink.table.planner.codegen.{CodeGeneratorContext, CodeGenException, CodeGenUtils, GeneratedExpression}
 import org.apache.flink.table.planner.codegen.CodeGenUtils.{qualifyEnum, qualifyMethod, BINARY_STRING}
 import org.apache.flink.table.planner.codegen.GenerateUtils.generateCallWithStmtIfArgsNotNull
-import org.apache.flink.table.types.logical.{LogicalType, LogicalTypeRoot}
+import org.apache.flink.table.runtime.functions.SqlJsonUtils
+import org.apache.flink.table.types.logical.{DecimalType, LogicalType, LogicalTypeRoot}
 
 import org.apache.calcite.sql.SqlJsonEmptyOrError
 
@@ -82,26 +83,48 @@ class JsonValueCallGen extends CallGenerator {
           )
 
           val rawResultTerm = CodeGenUtils.newName(ctx, "rawResult")
-          val call = s"""
-                        |Object $rawResultTerm =
-                        |    ${qualifyMethod(BuiltInMethods.JSON_VALUE)}(${terms
-                         .mkString(", ")});
+          val baseCall = s"""
+                            |Object $rawResultTerm =
+                            |    ${qualifyMethod(BuiltInMethods.JSON_VALUE)}(${terms
+                             .mkString(", ")});
            """.stripMargin
 
-          val convertedResult = returnType.getTypeRoot match {
+          returnType.getTypeRoot match {
             case LogicalTypeRoot.VARCHAR =>
-              s"$BINARY_STRING.fromString(java.lang.String.valueOf($rawResultTerm))"
-            case LogicalTypeRoot.BOOLEAN => s"(java.lang.Boolean) $rawResultTerm"
-            case LogicalTypeRoot.INTEGER => s"(java.lang.Integer) $rawResultTerm"
-            case LogicalTypeRoot.DOUBLE => s"((java.math.BigDecimal) $rawResultTerm).doubleValue()"
-            case _ =>
+              val result =
+                s"($rawResultTerm == null) ? null : " +
+                  s"($BINARY_STRING.fromString(java.lang.String.valueOf($rawResultTerm)))"
+              (baseCall, result)
+            case typeRoot if !SqlJsonUtils.isSupportedJsonReturningType(typeRoot) =>
               throw new CodeGenException(
-                s"Unsupported type '$returnType' "
-                  + "for RETURNING in JSON_VALUE().")
-          }
+                s"Unsupported type '$returnType' for RETURNING in JSON_VALUE().")
+            case _ =>
+              val jsonUtils =
+                "org.apache.flink.table.runtime.functions.SqlJsonUtils"
+              val typeRootEnum =
+                s"org.apache.flink.table.types.logical.LogicalTypeRoot.${returnType.getTypeRoot.name()}"
+              val (precisionStr, scaleStr) = returnType.getTypeRoot match {
+                case LogicalTypeRoot.DECIMAL =>
+                  val dt = returnType.asInstanceOf[DecimalType]
+                  (dt.getPrecision.toString, dt.getScale.toString)
+                case _ => ("0", "0")
+              }
+              val errorBehaviorEnum =
+                qualifyEnum(errorBehavior._1.asInstanceOf[JsonValueOnEmptyOrError])
+              val defaultExpr =
+                if (errorBehavior._2 != null) errorBehavior._2 else "null"
 
-          val result = s"($rawResultTerm == null) ? null : ($convertedResult)"
-          (call, result)
+              val boxedType = CodeGenUtils.boxedTypeTermForType(returnType)
+              val convertedTerm = CodeGenUtils.newName(ctx, "converted")
+              val call = baseCall +
+                s"""
+                   |$boxedType $convertedTerm = ($boxedType) $jsonUtils.convertJsonScalar(
+                   |    $rawResultTerm, $typeRootEnum,
+                   |    $precisionStr, $scaleStr,
+                   |    $errorBehaviorEnum, $defaultExpr);
+                 """.stripMargin
+              (call, s"$convertedTerm")
+          }
         }
     }
   }

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/calls/ScalarOperatorGens.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/calls/ScalarOperatorGens.scala
@@ -624,7 +624,14 @@ object ScalarOperatorGens {
         isNumeric(left.resultType) && isNumeric(right.resultType)
         || isTime(left.resultType) &&
         isTime(right.resultType)
-      ) { (leftTerm, rightTerm) => s"$leftTerm $operator $rightTerm" }
+      ) {
+        (leftTerm, rightTerm) =>
+          {
+            val l = s"((${primitiveTypeTermForType(left.resultType)}) $leftTerm)"
+            val r = s"((${primitiveTypeTermForType(right.resultType)}) $rightTerm)"
+            s"$l $operator $r"
+          }
+      }
 
       // both sides are timestamp
       else if (isTimestamp(left.resultType) && isTimestamp(right.resultType)) {
@@ -648,7 +655,8 @@ object ScalarOperatorGens {
         isInteroperable(left.resultType, right.resultType)
       ) {
         operator match {
-          case "==" | "!=" => (leftTerm, rightTerm) => s"$leftTerm $operator $rightTerm"
+          case "==" | "!=" =>
+            (leftTerm, rightTerm) => s"((boolean) $leftTerm) $operator ((boolean) $rightTerm)"
           case ">" | "<" | "<=" | ">=" =>
             (leftTerm, rightTerm) => s"java.lang.Boolean.compare($leftTerm, $rightTerm) $operator 0"
           case _ => throw new CodeGenException(s"Unsupported boolean comparison '$operator'.")

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/calls/ScalarOperatorGens.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/calls/ScalarOperatorGens.scala
@@ -956,10 +956,20 @@ object ScalarOperatorGens {
       case codeGeneratorCastRule: CodeGeneratorCastRule[_, _] =>
         val inputType = operand.resultType.copy(true)
 
+        // Ensure primitive-backed inputs are unboxed before entering cast rules.
+        // Some code generators (e.g. JsonValueCallGen) produce boxed result terms
+        // for primitive-backed types, which breaks cast rules that emit primitive
+        // casts like ((long)(java.lang.Double)).
+        val inputTerm = if (isPrimitive(operand.resultType)) {
+          s"((${primitiveTypeTermForType(operand.resultType)})(${operand.resultTerm}))"
+        } else {
+          operand.resultTerm
+        }
+
         // Generate the code block
         val castCodeBlock = codeGeneratorCastRule.generateCodeBlock(
           toCodegenCastContext(ctx),
-          operand.resultTerm,
+          inputTerm,
           operand.nullTerm,
           inputType,
           targetType

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/JsonFunctionsITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/JsonFunctionsITCase.java
@@ -705,6 +705,22 @@ class JsonFunctionsITCase extends BuiltInFunctionTestBase {
                         null,
                         BOOLEAN())
 
+                // Outer CAST on JSON_VALUE result (boxed-to-primitive codegen)
+                .testSqlResult(
+                        "CAST(JSON_VALUE(f0, '$.balance' RETURNING DOUBLE) AS BIGINT)",
+                        13L,
+                        BIGINT())
+                .testSqlResult(
+                        "CAST(JSON_VALUE(f0, '$.age' RETURNING INTEGER) AS DOUBLE)", 42.0, DOUBLE())
+                .testSqlResult(
+                        "CAST(JSON_VALUE(f0, '$.age' RETURNING INTEGER) AS BIGINT)", 42L, BIGINT())
+                .testSqlResult(
+                        "CAST(JSON_VALUE(f0, '$.balance' RETURNING DOUBLE) AS INTEGER)", 13, INT())
+                .testSqlResult(
+                        "CAST(JSON_VALUE(f0, '$.longBalance' RETURNING DOUBLE) AS BIGINT)",
+                        123456789L,
+                        BIGINT())
+
                 // path contains blank characters.
                 .testResult(
                         $("f0").jsonValue(

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/JsonFunctionsITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/JsonFunctionsITCase.java
@@ -721,6 +721,14 @@ class JsonFunctionsITCase extends BuiltInFunctionTestBase {
                         "JSON_VALUE('{\"x\": 0}', '$.x' RETURNING BOOLEAN)",
                         false,
                         BOOLEAN())
+                .testSqlResult(
+                        "JSON_VALUE('{\"x\": 1.9}', '$.x' RETURNING BOOLEAN NULL ON ERROR)",
+                        null,
+                        BOOLEAN())
+                .testSqlResult(
+                        "JSON_VALUE('{\"x\": 2}', '$.x' RETURNING BOOLEAN NULL ON ERROR)",
+                        null,
+                        BOOLEAN())
 
                 // Outer CAST on JSON_VALUE result (boxed-to-primitive codegen)
                 .testSqlResult(

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/JsonFunctionsITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/JsonFunctionsITCase.java
@@ -51,18 +51,22 @@ import java.util.Map;
 import java.util.stream.Stream;
 
 import static org.apache.flink.table.api.DataTypes.ARRAY;
+import static org.apache.flink.table.api.DataTypes.BIGINT;
 import static org.apache.flink.table.api.DataTypes.BINARY;
 import static org.apache.flink.table.api.DataTypes.BOOLEAN;
 import static org.apache.flink.table.api.DataTypes.BYTES;
 import static org.apache.flink.table.api.DataTypes.DECIMAL;
 import static org.apache.flink.table.api.DataTypes.DOUBLE;
 import static org.apache.flink.table.api.DataTypes.FIELD;
+import static org.apache.flink.table.api.DataTypes.FLOAT;
 import static org.apache.flink.table.api.DataTypes.INT;
 import static org.apache.flink.table.api.DataTypes.MAP;
 import static org.apache.flink.table.api.DataTypes.ROW;
+import static org.apache.flink.table.api.DataTypes.SMALLINT;
 import static org.apache.flink.table.api.DataTypes.STRING;
 import static org.apache.flink.table.api.DataTypes.TIMESTAMP;
 import static org.apache.flink.table.api.DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE;
+import static org.apache.flink.table.api.DataTypes.TINYINT;
 import static org.apache.flink.table.api.DataTypes.VARBINARY;
 import static org.apache.flink.table.api.DataTypes.VARIANT;
 import static org.apache.flink.table.api.Expressions.$;
@@ -480,6 +484,41 @@ class JsonFunctionsITCase extends BuiltInFunctionTestBase {
                         "JSON_VALUE(f0, '$.longBalance' RETURNING DOUBLE)",
                         123456789.987654321,
                         DOUBLE())
+                .testResult(
+                        $("f0").jsonValue("$.age", TINYINT()),
+                        "JSON_VALUE(f0, '$.age' RETURNING TINYINT)",
+                        (byte) 42,
+                        TINYINT())
+                .testResult(
+                        $("f0").jsonValue("$.age", SMALLINT()),
+                        "JSON_VALUE(f0, '$.age' RETURNING SMALLINT)",
+                        (short) 42,
+                        SMALLINT())
+                .testResult(
+                        $("f0").jsonValue("$.age", BIGINT()),
+                        "JSON_VALUE(f0, '$.age' RETURNING BIGINT)",
+                        42L,
+                        BIGINT())
+                .testResult(
+                        $("f0").jsonValue("$.bigCount", BIGINT()),
+                        "JSON_VALUE(f0, '$.bigCount' RETURNING BIGINT)",
+                        9999999999L,
+                        BIGINT())
+                .testResult(
+                        $("f0").jsonValue("$.balance", FLOAT()),
+                        "JSON_VALUE(f0, '$.balance' RETURNING FLOAT)",
+                        13.37f,
+                        FLOAT())
+                .testResult(
+                        $("f0").jsonValue("$.balance", DECIMAL(10, 2)),
+                        "JSON_VALUE(f0, '$.balance' RETURNING DECIMAL(10, 2))",
+                        new java.math.BigDecimal("13.37"),
+                        DECIMAL(10, 2))
+                .testResult(
+                        $("f0").jsonValue("$.longBalance", DECIMAL(30, 10)),
+                        "JSON_VALUE(f0, '$.longBalance' RETURNING DECIMAL(30, 10))",
+                        new java.math.BigDecimal("123456789.9876543210"),
+                        DECIMAL(30, 10))
 
                 // ON EMPTY / ON ERROR
                 .testResult(
@@ -528,6 +567,143 @@ class JsonFunctionsITCase extends BuiltInFunctionTestBase {
                         "JSON_VALUE(f0, 'strict $.invalid' RETURNING INTEGER NULL ON EMPTY DEFAULT 42 ON ERROR)",
                         42,
                         INT())
+                .testResult(
+                        $("f0").jsonValue(
+                                        "lax $.invalid",
+                                        BIGINT(),
+                                        JsonValueOnEmptyOrError.DEFAULT,
+                                        99L,
+                                        JsonValueOnEmptyOrError.ERROR,
+                                        null),
+                        "JSON_VALUE(f0, 'lax $.invalid' RETURNING BIGINT DEFAULT 99 ON EMPTY ERROR ON ERROR)",
+                        99L,
+                        BIGINT())
+
+                // JSON null at a valid path triggers ON EMPTY (default: NULL)
+                .testResult(
+                        $("f0").jsonValue("$.nullField", INT()),
+                        "JSON_VALUE(f0, '$.nullField' RETURNING INTEGER)",
+                        null,
+                        INT())
+
+                // Type mismatch: string value cast to numeric triggers ON ERROR
+                .testResult(
+                        $("f0").jsonValue(
+                                        "$.type",
+                                        INT(),
+                                        JsonValueOnEmptyOrError.NULL,
+                                        null,
+                                        JsonValueOnEmptyOrError.DEFAULT,
+                                        42),
+                        "JSON_VALUE(f0, '$.type' RETURNING INTEGER DEFAULT 42 ON ERROR)",
+                        42,
+                        INT())
+                .testResult(
+                        $("f0").jsonValue(
+                                        "$.type",
+                                        INT(),
+                                        JsonValueOnEmptyOrError.NULL,
+                                        null,
+                                        JsonValueOnEmptyOrError.NULL,
+                                        null),
+                        "JSON_VALUE(f0, '$.type' RETURNING INTEGER NULL ON ERROR)",
+                        null,
+                        INT())
+                .testResult(
+                        $("f0").jsonValue(
+                                        "$.type",
+                                        BIGINT(),
+                                        JsonValueOnEmptyOrError.NULL,
+                                        null,
+                                        JsonValueOnEmptyOrError.DEFAULT,
+                                        0L),
+                        "JSON_VALUE(f0, '$.type' RETURNING BIGINT DEFAULT 0 ON ERROR)",
+                        0L,
+                        BIGINT())
+                .testSqlRuntimeError(
+                        "JSON_VALUE(f0, '$.type' RETURNING INTEGER ERROR ON ERROR)",
+                        TableRuntimeException.class,
+                        "Cannot cast")
+
+                // Numeric overflow triggers ON ERROR (not silent wrapping)
+                .testResult(
+                        $("f0").jsonValue("$.bigCount", INT()),
+                        "JSON_VALUE(f0, '$.bigCount' RETURNING INTEGER)",
+                        null,
+                        INT())
+                // Fractional truncation (13.37 -> 13): MySQL truncates, PostgreSQL errors.
+                // We match MySQL (CAST(JSON_UNQUOTE(JSON_EXTRACT(...)) AS type)).
+                .testResult(
+                        $("f0").jsonValue("$.balance", INT()),
+                        "JSON_VALUE(f0, '$.balance' RETURNING INTEGER)",
+                        13,
+                        INT())
+                .testResult(
+                        $("f0").jsonValue(
+                                        "$.bigCount",
+                                        INT(),
+                                        JsonValueOnEmptyOrError.NULL,
+                                        null,
+                                        JsonValueOnEmptyOrError.DEFAULT,
+                                        -1),
+                        "JSON_VALUE(f0, '$.bigCount' RETURNING INTEGER DEFAULT -1 ON ERROR)",
+                        -1,
+                        INT())
+                .testSqlRuntimeError(
+                        "JSON_VALUE(f0, '$.bigCount' RETURNING INTEGER ERROR ON ERROR)",
+                        TableRuntimeException.class,
+                        "Cannot cast")
+
+                // DECIMAL precision overflow triggers ON ERROR
+                .testResult(
+                        $("f0").jsonValue("$.longBalance", DECIMAL(5, 2)),
+                        "JSON_VALUE(f0, '$.longBalance' RETURNING DECIMAL(5, 2))",
+                        null,
+                        DECIMAL(5, 2))
+                .testSqlRuntimeError(
+                        "JSON_VALUE(f0, '$.longBalance' RETURNING DECIMAL(5, 2) ERROR ON ERROR)",
+                        TableRuntimeException.class,
+                        "Cannot cast")
+                .testResult(
+                        $("f0").jsonValue(
+                                        "$.longBalance",
+                                        DECIMAL(5, 2),
+                                        JsonValueOnEmptyOrError.NULL,
+                                        null,
+                                        JsonValueOnEmptyOrError.DEFAULT,
+                                        0),
+                        "JSON_VALUE(f0, '$.longBalance' RETURNING DECIMAL(5, 2) DEFAULT 0 ON ERROR)",
+                        new java.math.BigDecimal("0.00"),
+                        DECIMAL(5, 2))
+                // String-literal DEFAULT with numeric RETURNING type
+                .testSqlResult(
+                        "JSON_VALUE(f0, '$.longBalance' RETURNING DECIMAL(5, 2) DEFAULT '0.00' ON ERROR)",
+                        new java.math.BigDecimal("0.00"),
+                        DECIMAL(5, 2))
+
+                // Boolean <-> numeric cross-type mismatch
+                .testResult(
+                        $("f0").jsonValue(
+                                        "$.activated",
+                                        INT(),
+                                        JsonValueOnEmptyOrError.NULL,
+                                        null,
+                                        JsonValueOnEmptyOrError.NULL,
+                                        null),
+                        "JSON_VALUE(f0, '$.activated' RETURNING INTEGER NULL ON ERROR)",
+                        null,
+                        INT())
+                .testResult(
+                        $("f0").jsonValue(
+                                        "$.age",
+                                        BOOLEAN(),
+                                        JsonValueOnEmptyOrError.NULL,
+                                        null,
+                                        JsonValueOnEmptyOrError.NULL,
+                                        null),
+                        "JSON_VALUE(f0, '$.age' RETURNING BOOLEAN NULL ON ERROR)",
+                        null,
+                        BOOLEAN())
 
                 // path contains blank characters.
                 .testResult(
@@ -709,9 +885,14 @@ class JsonFunctionsITCase extends BuiltInFunctionTestBase {
                                 "JSON_QUERY(f0, '$.b' RETURNING ARRAY<STRING> WITH CONDITIONAL WRAPPER)",
                                 new String[] {"1", "2"},
                                 DataTypes.ARRAY(DataTypes.STRING()))
+                        .testResult(
+                                $("f0").jsonQuery("$.b", ARRAY(INT()), CONDITIONAL_ARRAY),
+                                "JSON_QUERY(f0, '$.b' RETURNING ARRAY<INTEGER> WITH CONDITIONAL WRAPPER)",
+                                new Integer[] {1, 2},
+                                ARRAY(INT()))
                         .testSqlValidationError(
-                                "JSON_QUERY(f0, '$.b' RETURNING ARRAY<INTEGER>  WITH CONDITIONAL WRAPPER ERROR ON ERROR)",
-                                " Unsupported array element type 'INTEGER' for RETURNING ARRAY in JSON_QUERY()")
+                                "JSON_QUERY(f0, '$.n1' RETURNING INTEGER)",
+                                "for RETURNING in JSON_QUERY().")
                         .testResult(
                                 $("f0").jsonQuery("$.a"),
                                 "JSON_QUERY(f0, '$.a')",
@@ -886,7 +1067,214 @@ class JsonFunctionsITCase extends BuiltInFunctionTestBase {
                         .testTableApiRuntimeError(
                                 $("f0").jsonQuery("strict $.err10", WITHOUT_ARRAY, NULL, ERROR),
                                 TableRuntimeException.class,
-                                "No results for path"));
+                                "No results for path"),
+
+                // Typed RETURNING ARRAY<T> support
+                TestSetSpec.forFunction(BuiltInFunctionDefinitions.JSON_QUERY)
+                        .onFieldsWithData(
+                                "{\"ints\": [1, 2, 3], \"doubles\": [1.5, 2.5], \"bools\": [true, false], \"withNull\": [1, null, 3], \"bigints\": [1, 9999999999]}")
+                        .andDataTypes(STRING())
+                        .testResult(
+                                $("f0").jsonQuery("$.ints", ARRAY(INT())),
+                                "JSON_QUERY(f0, '$.ints' RETURNING ARRAY<INT>)",
+                                new Integer[] {1, 2, 3},
+                                ARRAY(INT()))
+                        .testResult(
+                                $("f0").jsonQuery("$.ints", ARRAY(TINYINT())),
+                                "JSON_QUERY(f0, '$.ints' RETURNING ARRAY<TINYINT>)",
+                                new Byte[] {1, 2, 3},
+                                ARRAY(TINYINT()))
+                        .testResult(
+                                $("f0").jsonQuery("$.ints", ARRAY(SMALLINT())),
+                                "JSON_QUERY(f0, '$.ints' RETURNING ARRAY<SMALLINT>)",
+                                new Short[] {1, 2, 3},
+                                ARRAY(SMALLINT()))
+                        .testResult(
+                                $("f0").jsonQuery("$.ints", ARRAY(BIGINT())),
+                                "JSON_QUERY(f0, '$.ints' RETURNING ARRAY<BIGINT>)",
+                                new Long[] {1L, 2L, 3L},
+                                ARRAY(BIGINT()))
+                        .testResult(
+                                $("f0").jsonQuery("$.bigints", ARRAY(BIGINT())),
+                                "JSON_QUERY(f0, '$.bigints' RETURNING ARRAY<BIGINT>)",
+                                new Long[] {1L, 9999999999L},
+                                ARRAY(BIGINT()))
+                        .testResult(
+                                $("f0").jsonQuery("$.doubles", ARRAY(DOUBLE())),
+                                "JSON_QUERY(f0, '$.doubles' RETURNING ARRAY<DOUBLE>)",
+                                new Double[] {1.5, 2.5},
+                                ARRAY(DOUBLE()))
+                        .testResult(
+                                $("f0").jsonQuery("$.doubles", ARRAY(FLOAT())),
+                                "JSON_QUERY(f0, '$.doubles' RETURNING ARRAY<FLOAT>)",
+                                new Float[] {1.5f, 2.5f},
+                                ARRAY(FLOAT()))
+                        .testResult(
+                                $("f0").jsonQuery("$.bools", ARRAY(BOOLEAN())),
+                                "JSON_QUERY(f0, '$.bools' RETURNING ARRAY<BOOLEAN>)",
+                                new Boolean[] {true, false},
+                                ARRAY(BOOLEAN()))
+                        .testResult(
+                                $("f0").jsonQuery("$.withNull", ARRAY(INT())),
+                                "JSON_QUERY(f0, '$.withNull' RETURNING ARRAY<INT>)",
+                                new Integer[] {1, null, 3},
+                                ARRAY(INT()))
+                        .testResult(
+                                $("f0").jsonQuery("$.doubles", ARRAY(DECIMAL(10, 2))),
+                                "JSON_QUERY(f0, '$.doubles' RETURNING ARRAY<DECIMAL(10,2)>)",
+                                new java.math.BigDecimal[] {
+                                    new java.math.BigDecimal("1.50"),
+                                    new java.math.BigDecimal("2.50")
+                                },
+                                ARRAY(DECIMAL(10, 2)))
+                        .testSqlValidationError(
+                                "JSON_QUERY(f0, '$.ints' RETURNING ARRAY<TIMESTAMP>)",
+                                "Unsupported array element type"),
+
+                // Type mismatch with ON ERROR behavior
+                TestSetSpec.forFunction(BuiltInFunctionDefinitions.JSON_QUERY)
+                        .onFieldsWithData(
+                                "{\"strings\": [\"a\", \"b\"]}",
+                                "{\"mixed\": [1, \"notANumber\", 3]}",
+                                "{\"ints\": [1, 2, 3]}",
+                                "{\"empty\": []}")
+                        .andDataTypes(STRING(), STRING(), STRING(), STRING())
+                        .testResult(
+                                $("f0").jsonQuery(
+                                                "$.strings",
+                                                ARRAY(INT()),
+                                                WITHOUT_ARRAY,
+                                                NULL,
+                                                NULL),
+                                "JSON_QUERY(f0, '$.strings' RETURNING ARRAY<INT> NULL ON ERROR)",
+                                null,
+                                ARRAY(INT()))
+                        .testResult(
+                                $("f0").jsonQuery(
+                                                "$.strings",
+                                                ARRAY(INT()),
+                                                WITHOUT_ARRAY,
+                                                NULL,
+                                                EMPTY_ARRAY),
+                                "JSON_QUERY(f0, '$.strings' RETURNING ARRAY<INT> EMPTY ARRAY ON ERROR)",
+                                new Integer[] {},
+                                ARRAY(INT()))
+                        .testSqlRuntimeError(
+                                "JSON_QUERY(f0, '$.strings' RETURNING ARRAY<INT> ERROR ON ERROR)",
+                                TableRuntimeException.class,
+                                "Array element type mismatch in JSON_QUERY")
+
+                        // Mixed-type array: one unconvertible element fails the whole array
+                        .testResult(
+                                $("f1").jsonQuery(
+                                                "$.mixed", ARRAY(INT()), WITHOUT_ARRAY, NULL, NULL),
+                                "JSON_QUERY(f1, '$.mixed' RETURNING ARRAY<INT> NULL ON ERROR)",
+                                null,
+                                ARRAY(INT()))
+                        .testResult(
+                                $("f2").jsonQuery(
+                                                "$.ints",
+                                                ARRAY(BOOLEAN()),
+                                                WITHOUT_ARRAY,
+                                                NULL,
+                                                NULL),
+                                "JSON_QUERY(f2, '$.ints' RETURNING ARRAY<BOOLEAN> NULL ON ERROR)",
+                                null,
+                                ARRAY(BOOLEAN()))
+
+                        // Empty JSON array and missing path
+                        .testResult(
+                                $("f3").jsonQuery("$.empty", ARRAY(INT())),
+                                "JSON_QUERY(f3, '$.empty' RETURNING ARRAY<INT>)",
+                                new Integer[] {},
+                                ARRAY(INT()))
+                        .testResult(
+                                $("f0").jsonQuery(
+                                                "lax $.missing",
+                                                ARRAY(INT()),
+                                                WITHOUT_ARRAY,
+                                                NULL,
+                                                NULL),
+                                "JSON_QUERY(f0, 'lax $.missing' RETURNING ARRAY<INT> NULL ON EMPTY)",
+                                null,
+                                ARRAY(INT()))
+                        .testResult(
+                                $("f0").jsonQuery(
+                                                "lax $.missing",
+                                                ARRAY(INT()),
+                                                WITHOUT_ARRAY,
+                                                EMPTY_ARRAY,
+                                                NULL),
+                                "JSON_QUERY(f0, 'lax $.missing' RETURNING ARRAY<INT> EMPTY ARRAY ON EMPTY)",
+                                new Integer[] {},
+                                ARRAY(INT())),
+
+                // ARRAY<BIGINT> near Long.MAX_VALUE boundary
+                TestSetSpec.forFunction(BuiltInFunctionDefinitions.JSON_QUERY)
+                        .onFieldsWithData(
+                                "{\"big\": [9223372036854775807, -9223372036854775808]}",
+                                "{\"overflow\": [9223372036854775808]}")
+                        .andDataTypes(STRING(), STRING())
+                        .testResult(
+                                $("f0").jsonQuery("$.big", ARRAY(BIGINT())),
+                                "JSON_QUERY(f0, '$.big' RETURNING ARRAY<BIGINT>)",
+                                new Long[] {Long.MAX_VALUE, Long.MIN_VALUE},
+                                ARRAY(BIGINT()))
+                        .testResult(
+                                $("f1").jsonQuery(
+                                                "$.overflow",
+                                                ARRAY(BIGINT()),
+                                                WITHOUT_ARRAY,
+                                                NULL,
+                                                NULL),
+                                "JSON_QUERY(f1, '$.overflow' RETURNING ARRAY<BIGINT> NULL ON ERROR)",
+                                null,
+                                ARRAY(BIGINT())),
+
+                // Edge cases: quoted number strings, nested arrays
+                TestSetSpec.forFunction(BuiltInFunctionDefinitions.JSON_VALUE)
+                        .onFieldsWithData("{\"v\":\"42\"}", "{\"neg\":-100}")
+                        .andDataTypes(STRING(), STRING())
+                        // Jayway returns String "42" -- string is parsed as number (MySQL/PG
+                        // compatible)
+                        .testResult(
+                                $("f0").jsonValue(
+                                                "$.v",
+                                                INT(),
+                                                JsonValueOnEmptyOrError.NULL,
+                                                null,
+                                                JsonValueOnEmptyOrError.NULL,
+                                                null),
+                                "JSON_VALUE(f0, '$.v' RETURNING INTEGER NULL ON ERROR)",
+                                42,
+                                INT())
+                        .testResult(
+                                $("f0").jsonValue(
+                                                "$.v",
+                                                INT(),
+                                                JsonValueOnEmptyOrError.NULL,
+                                                null,
+                                                JsonValueOnEmptyOrError.DEFAULT,
+                                                -1),
+                                "JSON_VALUE(f0, '$.v' RETURNING INTEGER DEFAULT -1 ON ERROR)",
+                                42,
+                                INT())
+                        // Negative value within TINYINT range
+                        .testResult(
+                                $("f1").jsonValue("$.neg", TINYINT()),
+                                "JSON_VALUE(f1, '$.neg' RETURNING TINYINT)",
+                                (byte) -100,
+                                TINYINT()),
+
+                // Nested arrays: inner arrays are Lists, not Numbers
+                TestSetSpec.forFunction(BuiltInFunctionDefinitions.JSON_QUERY)
+                        .onFieldsWithData("{\"a\":[[1,2],[3,4]]}")
+                        .andDataTypes(STRING())
+                        .testResult(
+                                $("f0").jsonQuery("$.a", ARRAY(INT()), WITHOUT_ARRAY, NULL, NULL),
+                                "JSON_QUERY(f0, '$.a' RETURNING ARRAY<INT> NULL ON ERROR)",
+                                null,
+                                ARRAY(INT())));
     }
 
     private static List<TestSetSpec> jsonStringSpec() {

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/JsonFunctionsITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/JsonFunctionsITCase.java
@@ -515,6 +515,11 @@ class JsonFunctionsITCase extends BuiltInFunctionTestBase {
                         new java.math.BigDecimal("13.37"),
                         DECIMAL(10, 2))
                 .testResult(
+                        $("f0").jsonValue("$.balance", DECIMAL(9, 2)),
+                        "JSON_VALUE(f0, '$.balance' RETURNING DECIMAL(9, 2))",
+                        new java.math.BigDecimal("13.37"),
+                        DECIMAL(9, 2))
+                .testResult(
                         $("f0").jsonValue("$.longBalance", DECIMAL(30, 10)),
                         "JSON_VALUE(f0, '$.longBalance' RETURNING DECIMAL(30, 10))",
                         new java.math.BigDecimal("123456789.9876543210"),
@@ -631,8 +636,9 @@ class JsonFunctionsITCase extends BuiltInFunctionTestBase {
                         "JSON_VALUE(f0, '$.bigCount' RETURNING INTEGER)",
                         null,
                         INT())
-                // Fractional truncation (13.37 -> 13): MySQL truncates, PostgreSQL errors.
-                // We match MySQL (CAST(JSON_UNQUOTE(JSON_EXTRACT(...)) AS type)).
+                // Fractional truncation toward zero (13.37 -> 13, -13.37 -> -13):
+                // MySQL truncates, PostgreSQL errors. We match MySQL behavior
+                // (CAST(JSON_UNQUOTE(JSON_EXTRACT(...)) AS type)).
                 .testResult(
                         $("f0").jsonValue("$.balance", INT()),
                         "JSON_VALUE(f0, '$.balance' RETURNING INTEGER)",
@@ -720,6 +726,17 @@ class JsonFunctionsITCase extends BuiltInFunctionTestBase {
                         "CAST(JSON_VALUE(f0, '$.longBalance' RETURNING DOUBLE) AS BIGINT)",
                         123456789L,
                         BIGINT())
+
+                // Equality on typed RETURNING results from different paths
+                // (distinct objects, same value -- must use value comparison, not reference)
+                .testSqlResult(
+                        "JSON_VALUE('{\"a\": 99999, \"b\": 99999}', '$.a' RETURNING INT) = JSON_VALUE('{\"a\": 99999, \"b\": 99999}', '$.b' RETURNING INT)",
+                        true,
+                        BOOLEAN())
+                .testSqlResult(
+                        "JSON_VALUE('{\"a\": 13.37, \"b\": 13.37}', '$.a' RETURNING DOUBLE) = JSON_VALUE('{\"a\": 13.37, \"b\": 13.37}', '$.b' RETURNING DOUBLE)",
+                        true,
+                        BOOLEAN())
 
                 // path contains blank characters.
                 .testResult(
@@ -1143,6 +1160,11 @@ class JsonFunctionsITCase extends BuiltInFunctionTestBase {
                                     new java.math.BigDecimal("2.50")
                                 },
                                 ARRAY(DECIMAL(10, 2)))
+                        .testResult(
+                                $("f0").jsonQuery("$.ints", ARRAY(INT().notNull())),
+                                "JSON_QUERY(f0, '$.ints' RETURNING ARRAY<INT NOT NULL>)",
+                                new Integer[] {1, 2, 3},
+                                ARRAY(INT().notNull()))
                         .testSqlValidationError(
                                 "JSON_QUERY(f0, '$.ints' RETURNING ARRAY<TIMESTAMP>)",
                                 "Unsupported array element type"),
@@ -1153,8 +1175,9 @@ class JsonFunctionsITCase extends BuiltInFunctionTestBase {
                                 "{\"strings\": [\"a\", \"b\"]}",
                                 "{\"mixed\": [1, \"notANumber\", 3]}",
                                 "{\"ints\": [1, 2, 3]}",
-                                "{\"empty\": []}")
-                        .andDataTypes(STRING(), STRING(), STRING(), STRING())
+                                "{\"empty\": []}",
+                                "{\"zeroAndOne\": [0, 1], \"yesAndNo\": [\"yes\", \"no\"], \"yAndN\": [\"Y\", \"n\"]}")
+                        .andDataTypes(STRING(), STRING(), STRING(), STRING(), STRING())
                         .testResult(
                                 $("f0").jsonQuery(
                                                 "$.strings",
@@ -1195,6 +1218,37 @@ class JsonFunctionsITCase extends BuiltInFunctionTestBase {
                                                 NULL,
                                                 NULL),
                                 "JSON_QUERY(f2, '$.ints' RETURNING ARRAY<BOOLEAN> NULL ON ERROR)",
+                                null,
+                                ARRAY(BOOLEAN()))
+
+                        // Integer [0, 1] does not convert to boolean
+                        .testResult(
+                                $("f4").jsonQuery(
+                                                "$.zeroAndOne",
+                                                ARRAY(BOOLEAN()),
+                                                WITHOUT_ARRAY,
+                                                NULL,
+                                                NULL),
+                                "JSON_QUERY(f4, '$.zeroAndOne' RETURNING ARRAY<BOOLEAN> NULL ON ERROR)",
+                                null,
+                                ARRAY(BOOLEAN()))
+
+                        // String ["yes", "no"] converts to boolean via parseStringAsBoolean
+                        .testResult(
+                                $("f4").jsonQuery("$.yesAndNo", ARRAY(BOOLEAN())),
+                                "JSON_QUERY(f4, '$.yesAndNo' RETURNING ARRAY<BOOLEAN>)",
+                                new Boolean[] {true, false},
+                                ARRAY(BOOLEAN()))
+
+                        // String ["Y", "n"] does not convert (not in accepted set)
+                        .testResult(
+                                $("f4").jsonQuery(
+                                                "$.yAndN",
+                                                ARRAY(BOOLEAN()),
+                                                WITHOUT_ARRAY,
+                                                NULL,
+                                                NULL),
+                                "JSON_QUERY(f4, '$.yAndN' RETURNING ARRAY<BOOLEAN> NULL ON ERROR)",
                                 null,
                                 ARRAY(BOOLEAN()))
 

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/JsonFunctionsITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/JsonFunctionsITCase.java
@@ -748,7 +748,62 @@ class JsonFunctionsITCase extends BuiltInFunctionTestBase {
                         "JSON_VALUE('{\"a\": 13.37, \"b\": 13.37}', '$.a' RETURNING DOUBLE) = JSON_VALUE('{\"a\": 13.37, \"b\": 13.37}', '$.b' RETURNING DOUBLE)",
                         true,
                         BOOLEAN())
+                // 200 is outside Short cache (-128..127), so boxed == would fail
+                .testSqlResult(
+                        "JSON_VALUE('{\"a\": 200, \"b\": 200}', '$.a' RETURNING SMALLINT) = JSON_VALUE('{\"a\": 200, \"b\": 200}', '$.b' RETURNING SMALLINT)",
+                        true,
+                        BOOLEAN())
+                // 9999999999 is outside Long cache (-128..127)
+                .testSqlResult(
+                        "JSON_VALUE('{\"a\": 9999999999, \"b\": 9999999999}', '$.a' RETURNING BIGINT) = JSON_VALUE('{\"a\": 9999999999, \"b\": 9999999999}', '$.b' RETURNING BIGINT)",
+                        true,
+                        BOOLEAN())
+                // Float has no JVM cache; exercises boxed Float equality codegen
+                .testSqlResult(
+                        "JSON_VALUE('{\"a\": 13.37, \"b\": 13.37}', '$.a' RETURNING FLOAT) = JSON_VALUE('{\"a\": 13.37, \"b\": 13.37}', '$.b' RETURNING FLOAT)",
+                        true,
+                        BOOLEAN())
+                // DECIMAL boundary: max precision (38 digits) succeeds
+                .testSqlResult(
+                        "JSON_VALUE('{\"x\": 99999999999999999999999999999999999999}', '$.x' RETURNING DECIMAL(38,0))",
+                        new BigDecimal("99999999999999999999999999999999999999"),
+                        DECIMAL(38, 0))
+                // DECIMAL boundary: 39-digit value overflows DECIMAL(38,0)
+                .testSqlResult(
+                        "JSON_VALUE('{\"x\": 999999999999999999999999999999999999999}', '$.x' RETURNING DECIMAL(38,0) NULL ON ERROR)",
+                        null,
+                        DECIMAL(38, 0))
+                // DECIMAL rounding: 123.456 rounds to 123.46 via HALF_UP
+                .testSqlResult(
+                        "JSON_VALUE('{\"x\": 123.456}', '$.x' RETURNING DECIMAL(5,2))",
+                        new BigDecimal("123.46"),
+                        DECIMAL(5, 2))
+                // DECIMAL rounding overflow: 999.999 rounds to 1000.00, exceeds DECIMAL(5,2)
+                .testSqlResult(
+                        "JSON_VALUE('{\"x\": 999.999}', '$.x' RETURNING DECIMAL(5,2) NULL ON ERROR)",
+                        null,
+                        DECIMAL(5, 2))
+                // Float precision: 2^24+1 silently loses precision to 2^24
+                .testSqlResult(
+                        "JSON_VALUE('{\"x\": 16777217}', '$.x' RETURNING FLOAT)",
+                        16777216.0f,
+                        FLOAT())
+                // Double precision: 2^53+1 silently loses precision to 2^53
+                .testSqlResult(
+                        "JSON_VALUE('{\"x\": 9007199254740993}', '$.x' RETURNING DOUBLE)",
+                        9.007199254740992E15,
+                        DOUBLE())
 
+                // String with whitespace: trimmed before parsing (matches PostgreSQL CAST)
+                .testSqlResult(
+                        "JSON_VALUE('{\"x\": \" 42 \"}', '$.x' RETURNING INT)",
+                        42,
+                        INT())
+                // Boolean with whitespace: parseStringAsBoolean trims
+                .testSqlResult(
+                        "JSON_VALUE('{\"x\": \" true \"}', '$.x' RETURNING BOOLEAN)",
+                        true,
+                        BOOLEAN())
                 // path contains blank characters.
                 .testResult(
                         $("f0").jsonValue(
@@ -1350,7 +1405,46 @@ class JsonFunctionsITCase extends BuiltInFunctionTestBase {
                                 $("f0").jsonQuery("$.a", ARRAY(INT()), WITHOUT_ARRAY, NULL, NULL),
                                 "JSON_QUERY(f0, '$.a' RETURNING ARRAY<INT> NULL ON ERROR)",
                                 null,
-                                ARRAY(INT())));
+                                ARRAY(INT())),
+
+                // ARRAY<DECIMAL(5,2)> with rounding
+                TestSetSpec.forFunction(BuiltInFunctionDefinitions.JSON_QUERY)
+                        .onFieldsWithData(
+                                "{\"vals\": [1.5, 123.456]}",
+                                "{\"vals\": [1.5, 999.999]}")
+                        .andDataTypes(STRING(), STRING())
+                        .testResult(
+                                $("f0").jsonQuery("$.vals", ARRAY(DECIMAL(5, 2))),
+                                "JSON_QUERY(f0, '$.vals' RETURNING ARRAY<DECIMAL(5,2)>)",
+                                new BigDecimal[] {
+                                    new BigDecimal("1.50"),
+                                    new BigDecimal("123.46")
+                                },
+                                ARRAY(DECIMAL(5, 2)))
+                        // 999.999 rounds to 1000.00 which overflows DECIMAL(5,2) -- atomic failure
+                        .testResult(
+                                $("f1").jsonQuery(
+                                                "$.vals",
+                                                ARRAY(DECIMAL(5, 2)),
+                                                WITHOUT_ARRAY,
+                                                NULL,
+                                                NULL),
+                                "JSON_QUERY(f1, '$.vals' RETURNING ARRAY<DECIMAL(5,2)> NULL ON ERROR)",
+                                null,
+                                ARRAY(DECIMAL(5, 2))),
+
+                // Null element in NOT NULL array triggers ON ERROR behavior
+                TestSetSpec.forFunction(BuiltInFunctionDefinitions.JSON_QUERY)
+                        .onFieldsWithData("{\"vals\": [1, null, 3]}")
+                        .andDataTypes(STRING())
+                        // NULL ON ERROR: null element in NOT NULL array returns null
+                        .testSqlResult(
+                                "JSON_QUERY(f0, '$.vals' RETURNING ARRAY<INT NOT NULL> NULL ON ERROR)",
+                                null,
+                                ARRAY(INT().notNull()))
+                        .testSqlRuntimeError(
+                                "JSON_QUERY(f0, '$.vals' RETURNING ARRAY<INT NOT NULL> ERROR ON ERROR)",
+                                "Array element type mismatch in JSON_QUERY"));
     }
 
     private static List<TestSetSpec> jsonStringSpec() {

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/JsonFunctionsITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/JsonFunctionsITCase.java
@@ -38,6 +38,7 @@ import org.apache.commons.io.IOUtils;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.math.BigDecimal;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
@@ -512,17 +513,17 @@ class JsonFunctionsITCase extends BuiltInFunctionTestBase {
                 .testResult(
                         $("f0").jsonValue("$.balance", DECIMAL(10, 2)),
                         "JSON_VALUE(f0, '$.balance' RETURNING DECIMAL(10, 2))",
-                        new java.math.BigDecimal("13.37"),
+                        new BigDecimal("13.37"),
                         DECIMAL(10, 2))
                 .testResult(
                         $("f0").jsonValue("$.balance", DECIMAL(9, 2)),
                         "JSON_VALUE(f0, '$.balance' RETURNING DECIMAL(9, 2))",
-                        new java.math.BigDecimal("13.37"),
+                        new BigDecimal("13.37"),
                         DECIMAL(9, 2))
                 .testResult(
                         $("f0").jsonValue("$.longBalance", DECIMAL(30, 10)),
                         "JSON_VALUE(f0, '$.longBalance' RETURNING DECIMAL(30, 10))",
-                        new java.math.BigDecimal("123456789.9876543210"),
+                        new BigDecimal("123456789.9876543210"),
                         DECIMAL(30, 10))
 
                 // ON EMPTY / ON ERROR
@@ -636,7 +637,7 @@ class JsonFunctionsITCase extends BuiltInFunctionTestBase {
                         "JSON_VALUE(f0, '$.bigCount' RETURNING INTEGER)",
                         null,
                         INT())
-                // Fractional truncation toward zero (13.37 -> 13, -13.37 -> -13):
+                // Fractional truncation toward zero (13.89 -> 13, -13.89 -> -13):
                 // MySQL truncates, PostgreSQL errors. We match MySQL behavior
                 // (CAST(JSON_UNQUOTE(JSON_EXTRACT(...)) AS type)).
                 .testResult(
@@ -679,12 +680,12 @@ class JsonFunctionsITCase extends BuiltInFunctionTestBase {
                                         JsonValueOnEmptyOrError.DEFAULT,
                                         0),
                         "JSON_VALUE(f0, '$.longBalance' RETURNING DECIMAL(5, 2) DEFAULT 0 ON ERROR)",
-                        new java.math.BigDecimal("0.00"),
+                        new BigDecimal("0.00"),
                         DECIMAL(5, 2))
                 // String-literal DEFAULT with numeric RETURNING type
                 .testSqlResult(
                         "JSON_VALUE(f0, '$.longBalance' RETURNING DECIMAL(5, 2) DEFAULT '0.00' ON ERROR)",
-                        new java.math.BigDecimal("0.00"),
+                        new BigDecimal("0.00"),
                         DECIMAL(5, 2))
 
                 // Boolean <-> numeric cross-type mismatch
@@ -709,6 +710,16 @@ class JsonFunctionsITCase extends BuiltInFunctionTestBase {
                                         null),
                         "JSON_VALUE(f0, '$.age' RETURNING BOOLEAN NULL ON ERROR)",
                         null,
+                        BOOLEAN())
+
+                // Integer 0/1 to boolean conversion
+                .testSqlResult(
+                        "JSON_VALUE('{\"x\": 1}', '$.x' RETURNING BOOLEAN)",
+                        true,
+                        BOOLEAN())
+                .testSqlResult(
+                        "JSON_VALUE('{\"x\": 0}', '$.x' RETURNING BOOLEAN)",
+                        false,
                         BOOLEAN())
 
                 // Outer CAST on JSON_VALUE result (boxed-to-primitive codegen)
@@ -1155,9 +1166,9 @@ class JsonFunctionsITCase extends BuiltInFunctionTestBase {
                         .testResult(
                                 $("f0").jsonQuery("$.doubles", ARRAY(DECIMAL(10, 2))),
                                 "JSON_QUERY(f0, '$.doubles' RETURNING ARRAY<DECIMAL(10,2)>)",
-                                new java.math.BigDecimal[] {
-                                    new java.math.BigDecimal("1.50"),
-                                    new java.math.BigDecimal("2.50")
+                                new BigDecimal[] {
+                                    new BigDecimal("1.50"),
+                                    new BigDecimal("2.50")
                                 },
                                 ARRAY(DECIMAL(10, 2)))
                         .testResult(
@@ -1221,16 +1232,11 @@ class JsonFunctionsITCase extends BuiltInFunctionTestBase {
                                 null,
                                 ARRAY(BOOLEAN()))
 
-                        // Integer [0, 1] does not convert to boolean
+                        // Integer [0, 1] converts to boolean {false, true}
                         .testResult(
-                                $("f4").jsonQuery(
-                                                "$.zeroAndOne",
-                                                ARRAY(BOOLEAN()),
-                                                WITHOUT_ARRAY,
-                                                NULL,
-                                                NULL),
-                                "JSON_QUERY(f4, '$.zeroAndOne' RETURNING ARRAY<BOOLEAN> NULL ON ERROR)",
-                                null,
+                                $("f4").jsonQuery("$.zeroAndOne", ARRAY(BOOLEAN())),
+                                "JSON_QUERY(f4, '$.zeroAndOne' RETURNING ARRAY<BOOLEAN>)",
+                                new Boolean[] {false, true},
                                 ARRAY(BOOLEAN()))
 
                         // String ["yes", "no"] converts to boolean via parseStringAsBoolean

--- a/flink-table/flink-table-planner/src/test/resources/json/json-value.json
+++ b/flink-table/flink-table-planner/src/test/resources/json/json-value.json
@@ -8,5 +8,7 @@
   "roles": ["user", "viewer"],
   "balance": 13.37,
   "longBalance": 123456789.987654321,
+  "bigCount": 9999999999,
+  "nullField": null,
   "contains blank": "right"
 }

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/JsonConversionException.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/JsonConversionException.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.functions;
+
+/**
+ * Thrown when a JSON value cannot be converted to the requested SQL type. Separates intentional
+ * conversion failures (range overflow, type mismatch) from unexpected ClassCastExceptions so that
+ * ON ERROR handling does not accidentally swallow unrelated errors.
+ */
+class JsonConversionException extends RuntimeException {
+
+    JsonConversionException(String message) {
+        super(message);
+    }
+
+    JsonConversionException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/SqlJsonUtils.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/SqlJsonUtils.java
@@ -926,6 +926,13 @@ public class SqlJsonUtils {
         try {
             switch (typeRoot) {
                 case BOOLEAN:
+                    if (raw instanceof Number) {
+                        int v = ((Number) raw).intValue();
+                        if (v == 0) return false;
+                        if (v == 1) return true;
+                        throw new JsonConversionException(
+                                "Cannot convert " + raw + " to BOOLEAN");
+                    }
                     return (Boolean) raw;
                 case TINYINT:
                     return toCheckedByte((Number) raw);

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/SqlJsonUtils.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/SqlJsonUtils.java
@@ -880,6 +880,7 @@ public class SqlJsonUtils {
             LogicalTypeRoot elementTypeRoot,
             int precision,
             int scale,
+            boolean elementNullable,
             JsonQueryOnEmptyOrError errorBehavior) {
         if (rawResult == null) {
             return null;
@@ -890,6 +891,9 @@ public class SqlJsonUtils {
             for (int i = 0; i < rawArr.length; i++) {
                 if (rawArr[i] != null) {
                     converted[i] = convertToType(rawArr[i], elementTypeRoot, precision, scale);
+                } else if (!elementNullable) {
+                    throw new JsonConversionException(
+                            "Null element at index " + i + " in NOT NULL array");
                 }
             }
             return new GenericArrayData(converted);
@@ -917,7 +921,8 @@ public class SqlJsonUtils {
                 return parseStringAsBoolean((String) raw);
             }
             try {
-                return convertToType(new BigDecimal((String) raw), typeRoot, precision, scale);
+                String trimmed = ((String) raw).trim();
+                return convertToType(new BigDecimal(trimmed), typeRoot, precision, scale);
             } catch (NumberFormatException e) {
                 throw new JsonConversionException(
                         "Cannot parse string '" + raw + "' as " + typeRoot, e);

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/SqlJsonUtils.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/SqlJsonUtils.java
@@ -932,9 +932,12 @@ public class SqlJsonUtils {
             switch (typeRoot) {
                 case BOOLEAN:
                     if (raw instanceof Number) {
-                        int v = ((Number) raw).intValue();
-                        if (v == 0) return false;
-                        if (v == 1) return true;
+                        BigDecimal bd =
+                                raw instanceof BigDecimal
+                                        ? (BigDecimal) raw
+                                        : new BigDecimal(raw.toString());
+                        if (BigDecimal.ZERO.compareTo(bd) == 0) return false;
+                        if (BigDecimal.ONE.compareTo(bd) == 0) return true;
                         throw new JsonConversionException(
                                 "Cannot convert " + raw + " to BOOLEAN");
                     }

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/SqlJsonUtils.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/SqlJsonUtils.java
@@ -24,8 +24,11 @@ import org.apache.flink.table.api.JsonQueryOnEmptyOrError;
 import org.apache.flink.table.api.JsonQueryWrapper;
 import org.apache.flink.table.api.JsonValueOnEmptyOrError;
 import org.apache.flink.table.api.TableRuntimeException;
+import org.apache.flink.table.data.DecimalData;
+import org.apache.flink.table.data.DecimalDataUtils;
 import org.apache.flink.table.data.GenericArrayData;
 import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.types.logical.LogicalTypeRoot;
 
 import org.apache.flink.shaded.com.jayway.jsonpath.Configuration;
 import org.apache.flink.shaded.com.jayway.jsonpath.DocumentContext;
@@ -49,6 +52,8 @@ import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.node.Json
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.node.ObjectNode;
 
 import java.lang.reflect.Array;
+import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -241,7 +246,8 @@ public class SqlJsonUtils {
 
     public enum JsonQueryReturnType {
         STRING,
-        ARRAY
+        ARRAY,
+        RAW_ARRAY
     }
 
     public static Object jsonQuery(
@@ -333,6 +339,9 @@ public class SqlJsonUtils {
                             }
 
                             return new GenericArrayData(arr);
+                        case RAW_ARRAY:
+                            final List<Object> rawList = (List<Object>) value;
+                            return rawList.toArray();
                         default:
                             throw new TableRuntimeException("illegal return type");
                     }
@@ -355,6 +364,8 @@ public class SqlJsonUtils {
                 switch (returnType) {
                     case ARRAY:
                         return new GenericArrayData(new StringData[0]);
+                    case RAW_ARRAY:
+                        return new Object[0];
                     case STRING:
                         return "[]";
                     default:
@@ -381,6 +392,8 @@ public class SqlJsonUtils {
                 switch (returnType) {
                     case ARRAY:
                         return new GenericArrayData(new StringData[0]);
+                    case RAW_ARRAY:
+                        return new Object[0];
                     case STRING:
                         return "[]";
                     default:
@@ -813,6 +826,233 @@ public class SqlJsonUtils {
         public String toString() {
             return "JsonPathContext{" + "mode=" + mode + ", obj=" + obj + ", exc=" + exc + '}';
         }
+    }
+
+    // --- Type conversion for JSON_VALUE / JSON_QUERY RETURNING ---
+
+    private static final java.util.EnumSet<LogicalTypeRoot> SUPPORTED_JSON_RETURNING_TYPES =
+            java.util.EnumSet.of(
+                    LogicalTypeRoot.BOOLEAN,
+                    LogicalTypeRoot.TINYINT,
+                    LogicalTypeRoot.SMALLINT,
+                    LogicalTypeRoot.INTEGER,
+                    LogicalTypeRoot.BIGINT,
+                    LogicalTypeRoot.FLOAT,
+                    LogicalTypeRoot.DOUBLE,
+                    LogicalTypeRoot.DECIMAL);
+
+    public static boolean isSupportedJsonReturningType(LogicalTypeRoot typeRoot) {
+        return SUPPORTED_JSON_RETURNING_TYPES.contains(typeRoot);
+    }
+
+    public static Object convertJsonScalar(
+            Object raw,
+            LogicalTypeRoot typeRoot,
+            int precision,
+            int scale,
+            JsonValueOnEmptyOrError errorBehavior,
+            Object defaultValue) {
+        if (raw == null) {
+            return null;
+        }
+        try {
+            return convertToType(raw, typeRoot, precision, scale);
+        } catch (JsonConversionException e) {
+            switch (errorBehavior) {
+                case NULL:
+                    return null;
+                case DEFAULT:
+                    return convertDefault(defaultValue, typeRoot, precision, scale);
+                case ERROR:
+                    throw new TableRuntimeException(
+                            "Cannot cast " + raw.getClass().getName() + " to " + typeRoot, e);
+                default:
+                    throw new TableRuntimeException(
+                            "Unreachable: unknown error behavior " + errorBehavior);
+            }
+        }
+    }
+
+    public static GenericArrayData convertJsonArray(
+            Object rawResult,
+            LogicalTypeRoot elementTypeRoot,
+            int precision,
+            int scale,
+            JsonQueryOnEmptyOrError errorBehavior) {
+        if (rawResult == null) {
+            return null;
+        }
+        try {
+            Object[] rawArr = (Object[]) rawResult;
+            Object[] converted = new Object[rawArr.length];
+            for (int i = 0; i < rawArr.length; i++) {
+                if (rawArr[i] != null) {
+                    converted[i] = convertToType(rawArr[i], elementTypeRoot, precision, scale);
+                }
+            }
+            return new GenericArrayData(converted);
+        } catch (JsonConversionException e) {
+            switch (errorBehavior) {
+                case NULL:
+                    return null;
+                case EMPTY_ARRAY:
+                    return new GenericArrayData(new Object[0]);
+                case ERROR:
+                    throw new TableRuntimeException("Array element type mismatch in JSON_QUERY", e);
+                default:
+                    return null;
+            }
+        }
+    }
+
+    private static Object convertToType(
+            Object raw, LogicalTypeRoot typeRoot, int precision, int scale) {
+        if (raw instanceof StringData) {
+            return convertToType(raw.toString(), typeRoot, precision, scale);
+        }
+        if (raw instanceof String) {
+            if (typeRoot == LogicalTypeRoot.BOOLEAN) {
+                return parseStringAsBoolean((String) raw);
+            }
+            try {
+                return convertToType(new BigDecimal((String) raw), typeRoot, precision, scale);
+            } catch (NumberFormatException e) {
+                throw new JsonConversionException(
+                        "Cannot parse string '" + raw + "' as " + typeRoot, e);
+            }
+        }
+        try {
+            switch (typeRoot) {
+                case BOOLEAN:
+                    return (Boolean) raw;
+                case TINYINT:
+                    return toCheckedByte((Number) raw);
+                case SMALLINT:
+                    return toCheckedShort((Number) raw);
+                case INTEGER:
+                    return toCheckedInt((Number) raw);
+                case BIGINT:
+                    return toCheckedLong((Number) raw);
+                case FLOAT:
+                    return toCheckedFloat((Number) raw);
+                case DOUBLE:
+                    return toCheckedDouble((Number) raw);
+                case DECIMAL:
+                    return toCheckedDecimal(((Number) raw).toString(), precision, scale);
+                default:
+                    throw new JsonConversionException(
+                            "Unsupported type for JSON conversion: " + typeRoot);
+            }
+        } catch (ClassCastException e) {
+            throw new JsonConversionException(
+                    "Cannot convert " + raw.getClass().getName() + " to " + typeRoot, e);
+        }
+    }
+
+    private static Object convertDefault(
+            Object defaultValue, LogicalTypeRoot typeRoot, int precision, int scale) {
+        if (defaultValue == null) {
+            return null;
+        }
+        try {
+            return convertToType(defaultValue, typeRoot, precision, scale);
+        } catch (JsonConversionException e) {
+            throw new TableRuntimeException(
+                    "Default value " + defaultValue + " cannot be represented as " + typeRoot, e);
+        }
+    }
+
+    static byte toCheckedByte(Number n) {
+        long v = n.longValue();
+        if (v < Byte.MIN_VALUE || v > Byte.MAX_VALUE) {
+            throw new JsonConversionException("Value " + n + " is out of range for TINYINT");
+        }
+        return (byte) v;
+    }
+
+    static short toCheckedShort(Number n) {
+        long v = n.longValue();
+        if (v < Short.MIN_VALUE || v > Short.MAX_VALUE) {
+            throw new JsonConversionException("Value " + n + " is out of range for SMALLINT");
+        }
+        return (short) v;
+    }
+
+    static int toCheckedInt(Number n) {
+        long v = n.longValue();
+        if (v < Integer.MIN_VALUE || v > Integer.MAX_VALUE) {
+            throw new JsonConversionException("Value " + n + " is out of range for INTEGER");
+        }
+        return (int) v;
+    }
+
+    static boolean parseStringAsBoolean(String s) {
+        String v = s.trim().toLowerCase(Locale.ROOT);
+        switch (v) {
+            case "true":
+            case "t":
+            case "yes":
+            case "1":
+                return true;
+            case "false":
+            case "f":
+            case "no":
+            case "0":
+                return false;
+            default:
+                throw new JsonConversionException("Cannot parse string '" + s + "' as BOOLEAN");
+        }
+    }
+
+    static float toCheckedFloat(Number n) {
+        float f = n.floatValue();
+        if (Float.isInfinite(f) || Float.isNaN(f)) {
+            throw new JsonConversionException("Value " + n + " is out of range for FLOAT");
+        }
+        return f;
+    }
+
+    static double toCheckedDouble(Number n) {
+        double d = n.doubleValue();
+        if (Double.isInfinite(d) || Double.isNaN(d)) {
+            throw new JsonConversionException("Value " + n + " is out of range for DOUBLE");
+        }
+        return d;
+    }
+
+    // Only guards BigDecimal/BigInteger overflow. A plain Double exceeding Long range
+    // would silently saturate via JLS narrowing, but Jayway's USE_BIG_DECIMAL_FOR_FLOATS
+    // ensures JSON floats arrive as BigDecimal so this path is not reachable from JSON input.
+    static long toCheckedLong(Number n) {
+        if (n instanceof BigDecimal) {
+            BigDecimal bd = (BigDecimal) n;
+            if (bd.compareTo(BigDecimal.valueOf(Long.MAX_VALUE)) > 0
+                    || bd.compareTo(BigDecimal.valueOf(Long.MIN_VALUE)) < 0) {
+                throw new JsonConversionException("Value " + n + " is out of range for BIGINT");
+            }
+        } else if (n instanceof BigInteger) {
+            BigInteger bi = (BigInteger) n;
+            if (bi.compareTo(BigInteger.valueOf(Long.MAX_VALUE)) > 0
+                    || bi.compareTo(BigInteger.valueOf(Long.MIN_VALUE)) < 0) {
+                throw new JsonConversionException("Value " + n + " is out of range for BIGINT");
+            }
+        }
+        return n.longValue();
+    }
+
+    static DecimalData toCheckedDecimal(String value, int precision, int scale) {
+        DecimalData result = DecimalDataUtils.castFrom(value, precision, scale);
+        if (result == null) {
+            throw new JsonConversionException(
+                    "Value "
+                            + value
+                            + " cannot be represented as DECIMAL("
+                            + precision
+                            + ", "
+                            + scale
+                            + ")");
+        }
+        return result;
     }
 
     public static class JsonValueContext {

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/SqlJsonUtils.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/SqlJsonUtils.java
@@ -932,12 +932,9 @@ public class SqlJsonUtils {
             switch (typeRoot) {
                 case BOOLEAN:
                     if (raw instanceof Number) {
-                        BigDecimal bd =
-                                raw instanceof BigDecimal
-                                        ? (BigDecimal) raw
-                                        : new BigDecimal(raw.toString());
-                        if (BigDecimal.ZERO.compareTo(bd) == 0) return false;
-                        if (BigDecimal.ONE.compareTo(bd) == 0) return true;
+                        double d = ((Number) raw).doubleValue();
+                        if (d == 0.0) return false;
+                        if (d == 1.0) return true;
                         throw new JsonConversionException(
                                 "Cannot convert " + raw + " to BOOLEAN");
                     }

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/SqlJsonUtils.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/SqlJsonUtils.java
@@ -51,6 +51,8 @@ import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.node.Arra
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.node.ObjectNode;
 
+import javax.annotation.Nullable;
+
 import java.lang.reflect.Array;
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -938,7 +940,7 @@ public class SqlJsonUtils {
                 case DOUBLE:
                     return toCheckedDouble((Number) raw);
                 case DECIMAL:
-                    return toCheckedDecimal(((Number) raw).toString(), precision, scale);
+                    return toCheckedDecimal(raw.toString(), precision, scale);
                 default:
                     throw new JsonConversionException(
                             "Unsupported type for JSON conversion: " + typeRoot);
@@ -962,7 +964,25 @@ public class SqlJsonUtils {
         }
     }
 
+    private static @Nullable BigInteger toBigIntegerTruncated(Number n) {
+        if (n instanceof BigDecimal) {
+            return ((BigDecimal) n).toBigInteger();
+        }
+        if (n instanceof BigInteger) {
+            return (BigInteger) n;
+        }
+        return null;
+    }
+
     static byte toCheckedByte(Number n) {
+        BigInteger bi = toBigIntegerTruncated(n);
+        if (bi != null) {
+            if (bi.compareTo(BigInteger.valueOf(Byte.MAX_VALUE)) > 0
+                    || bi.compareTo(BigInteger.valueOf(Byte.MIN_VALUE)) < 0) {
+                throw new JsonConversionException("Value " + n + " is out of range for TINYINT");
+            }
+            return bi.byteValue();
+        }
         long v = n.longValue();
         if (v < Byte.MIN_VALUE || v > Byte.MAX_VALUE) {
             throw new JsonConversionException("Value " + n + " is out of range for TINYINT");
@@ -971,6 +991,14 @@ public class SqlJsonUtils {
     }
 
     static short toCheckedShort(Number n) {
+        BigInteger bi = toBigIntegerTruncated(n);
+        if (bi != null) {
+            if (bi.compareTo(BigInteger.valueOf(Short.MAX_VALUE)) > 0
+                    || bi.compareTo(BigInteger.valueOf(Short.MIN_VALUE)) < 0) {
+                throw new JsonConversionException("Value " + n + " is out of range for SMALLINT");
+            }
+            return bi.shortValue();
+        }
         long v = n.longValue();
         if (v < Short.MIN_VALUE || v > Short.MAX_VALUE) {
             throw new JsonConversionException("Value " + n + " is out of range for SMALLINT");
@@ -979,6 +1007,14 @@ public class SqlJsonUtils {
     }
 
     static int toCheckedInt(Number n) {
+        BigInteger bi = toBigIntegerTruncated(n);
+        if (bi != null) {
+            if (bi.compareTo(BigInteger.valueOf(Integer.MAX_VALUE)) > 0
+                    || bi.compareTo(BigInteger.valueOf(Integer.MIN_VALUE)) < 0) {
+                throw new JsonConversionException("Value " + n + " is out of range for INTEGER");
+            }
+            return bi.intValue();
+        }
         long v = n.longValue();
         if (v < Integer.MIN_VALUE || v > Integer.MAX_VALUE) {
             throw new JsonConversionException("Value " + n + " is out of range for INTEGER");
@@ -1020,22 +1056,14 @@ public class SqlJsonUtils {
         return d;
     }
 
-    // Only guards BigDecimal/BigInteger overflow. A plain Double exceeding Long range
-    // would silently saturate via JLS narrowing, but Jayway's USE_BIG_DECIMAL_FOR_FLOATS
-    // ensures JSON floats arrive as BigDecimal so this path is not reachable from JSON input.
     static long toCheckedLong(Number n) {
-        if (n instanceof BigDecimal) {
-            BigDecimal bd = (BigDecimal) n;
-            if (bd.compareTo(BigDecimal.valueOf(Long.MAX_VALUE)) > 0
-                    || bd.compareTo(BigDecimal.valueOf(Long.MIN_VALUE)) < 0) {
-                throw new JsonConversionException("Value " + n + " is out of range for BIGINT");
-            }
-        } else if (n instanceof BigInteger) {
-            BigInteger bi = (BigInteger) n;
+        BigInteger bi = toBigIntegerTruncated(n);
+        if (bi != null) {
             if (bi.compareTo(BigInteger.valueOf(Long.MAX_VALUE)) > 0
                     || bi.compareTo(BigInteger.valueOf(Long.MIN_VALUE)) < 0) {
                 throw new JsonConversionException("Value " + n + " is out of range for BIGINT");
             }
+            return bi.longValue();
         }
         return n.longValue();
     }

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/SqlJsonUtils.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/SqlJsonUtils.java
@@ -933,8 +933,12 @@ public class SqlJsonUtils {
                 case BOOLEAN:
                     if (raw instanceof Number) {
                         double d = ((Number) raw).doubleValue();
-                        if (d == 0.0) return false;
-                        if (d == 1.0) return true;
+                        if (d == 0.0) {
+                            return false;
+                        }
+                        if (d == 1.0) {
+                            return true;
+                        }
                         throw new JsonConversionException(
                                 "Cannot convert " + raw + " to BOOLEAN");
                     }

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/functions/SqlJsonUtilsConversionTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/functions/SqlJsonUtilsConversionTest.java
@@ -1,0 +1,396 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.functions;
+
+import org.apache.flink.table.api.JsonValueOnEmptyOrError;
+import org.apache.flink.table.api.TableRuntimeException;
+import org.apache.flink.table.data.DecimalData;
+import org.apache.flink.table.data.GenericArrayData;
+import org.apache.flink.table.types.logical.LogicalTypeRoot;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.stream.Stream;
+
+import static org.apache.flink.table.api.JsonQueryOnEmptyOrError.EMPTY_ARRAY;
+import static org.apache.flink.table.api.JsonQueryOnEmptyOrError.ERROR;
+import static org.apache.flink.table.api.JsonQueryOnEmptyOrError.NULL;
+import static org.apache.flink.table.types.logical.LogicalTypeRoot.BIGINT;
+import static org.apache.flink.table.types.logical.LogicalTypeRoot.BOOLEAN;
+import static org.apache.flink.table.types.logical.LogicalTypeRoot.DECIMAL;
+import static org.apache.flink.table.types.logical.LogicalTypeRoot.DOUBLE;
+import static org.apache.flink.table.types.logical.LogicalTypeRoot.FLOAT;
+import static org.apache.flink.table.types.logical.LogicalTypeRoot.INTEGER;
+import static org.apache.flink.table.types.logical.LogicalTypeRoot.SMALLINT;
+import static org.apache.flink.table.types.logical.LogicalTypeRoot.TINYINT;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class SqlJsonUtilsConversionTest {
+
+    private static Object scalar(Object raw, LogicalTypeRoot type) {
+        return SqlJsonUtils.convertJsonScalar(raw, type, 0, 0, JsonValueOnEmptyOrError.NULL, null);
+    }
+
+    private static Object scalar(
+            Object raw,
+            LogicalTypeRoot type,
+            JsonValueOnEmptyOrError onError,
+            Object defaultValue) {
+        return SqlJsonUtils.convertJsonScalar(raw, type, 0, 0, onError, defaultValue);
+    }
+
+    private static Object scalarDecimal(Object raw, int precision, int scale) {
+        return SqlJsonUtils.convertJsonScalar(
+                raw, DECIMAL, precision, scale, JsonValueOnEmptyOrError.NULL, null);
+    }
+
+    private static GenericArrayData array(Object[] raw, LogicalTypeRoot elementType) {
+        return SqlJsonUtils.convertJsonArray(raw, elementType, 0, 0, NULL);
+    }
+
+    private static GenericArrayData arrayDecimal(
+            Object[] raw,
+            int precision,
+            int scale,
+            org.apache.flink.table.api.JsonQueryOnEmptyOrError onError) {
+        return SqlJsonUtils.convertJsonArray(raw, DECIMAL, precision, scale, onError);
+    }
+
+    static Stream<Arguments> validConversions() {
+        return Stream.of(
+                Arguments.of(42, TINYINT, (byte) 42),
+                Arguments.of(127L, TINYINT, Byte.MAX_VALUE),
+                Arguments.of(-128L, TINYINT, Byte.MIN_VALUE),
+                Arguments.of(1000, SMALLINT, (short) 1000),
+                Arguments.of((long) Short.MAX_VALUE, SMALLINT, Short.MAX_VALUE),
+                Arguments.of(42L, INTEGER, 42),
+                Arguments.of((long) Integer.MAX_VALUE, INTEGER, Integer.MAX_VALUE),
+                Arguments.of(42, BIGINT, 42L),
+                Arguments.of(9_999_999_999L, BIGINT, 9_999_999_999L),
+                Arguments.of(13.37, FLOAT, 13.37f),
+                Arguments.of(13.37, DOUBLE, 13.37));
+    }
+
+    static Stream<Arguments> overflowCases() {
+        return Stream.of(
+                Arguments.of(128, TINYINT),
+                Arguments.of(-129, TINYINT),
+                Arguments.of(200L, TINYINT),
+                Arguments.of(-200L, TINYINT),
+                Arguments.of((long) Short.MAX_VALUE + 1, SMALLINT),
+                Arguments.of((long) Short.MIN_VALUE - 1, SMALLINT),
+                Arguments.of(40_000L, SMALLINT),
+                Arguments.of(-40_000L, SMALLINT),
+                Arguments.of(9_999_999_999L, INTEGER),
+                Arguments.of(-9_999_999_999L, INTEGER));
+    }
+
+    @Nested
+    class RangeCheckedConversions {
+
+        @ParameterizedTest(name = "{0} -> {1}")
+        @MethodSource(
+                "org.apache.flink.table.runtime.functions.SqlJsonUtilsConversionTest#validConversions")
+        void convertsWithinRange(Number input, LogicalTypeRoot type, Object expected) {
+            assertThat(scalar(input, type)).isEqualTo(expected);
+        }
+
+        @ParameterizedTest(name = "{0} -> {1}")
+        @MethodSource(
+                "org.apache.flink.table.runtime.functions.SqlJsonUtilsConversionTest#overflowCases")
+        void overflowReturnsNull(Number input, LogicalTypeRoot type) {
+            assertThat(scalar(input, type)).isNull();
+        }
+
+        @Test
+        void intTruncatesFraction() {
+            assertThat(scalar(13.37, INTEGER)).isEqualTo(13);
+            assertThat(scalar(-13.99, INTEGER)).isEqualTo(-13);
+        }
+
+        @Test
+        void bigIntegerOverflow() {
+            BigInteger tooLarge = BigInteger.valueOf(Long.MAX_VALUE).add(BigInteger.ONE);
+            assertThat(scalar(tooLarge, BIGINT)).isNull();
+        }
+
+        @Test
+        void negativeBigIntegerOverflow() {
+            BigInteger tooSmall = BigInteger.valueOf(Long.MIN_VALUE).subtract(BigInteger.ONE);
+            assertThat(scalar(tooSmall, BIGINT)).isNull();
+        }
+
+        @Test
+        void bigDecimalOverflow() {
+            BigDecimal tooLarge = new BigDecimal(Long.MAX_VALUE).add(BigDecimal.ONE);
+            assertThat(scalar(tooLarge, BIGINT)).isNull();
+        }
+
+        @Test
+        void bigDecimalToBigintTruncatesFraction() {
+            assertThat(scalar(new BigDecimal("9999999999.5"), BIGINT)).isEqualTo(9_999_999_999L);
+            assertThat(scalar(new BigDecimal("-42.9"), BIGINT)).isEqualTo(-42L);
+        }
+
+        @Test
+        void floatOverflowReturnsNull() {
+            assertThat(scalar(1e40, FLOAT)).isNull();
+            assertThat(scalar(-1e40, FLOAT)).isNull();
+        }
+
+        @Test
+        void doubleOverflowReturnsNull() {
+            assertThat(scalar(new BigDecimal("1E309"), DOUBLE)).isNull();
+            assertThat(scalar(new BigDecimal("-1E309"), DOUBLE)).isNull();
+        }
+    }
+
+    @Nested
+    class DecimalConversion {
+
+        @Test
+        void validPrecision() {
+            Object result = scalarDecimal(13.37, 10, 2);
+            assertThat(result).isInstanceOf(DecimalData.class);
+            assertThat(((DecimalData) result).toBigDecimal())
+                    .isEqualByComparingTo(new BigDecimal("13.37"));
+        }
+
+        @Test
+        void precisionOverflowReturnsNull() {
+            assertThat(scalarDecimal(123456789.99, 5, 2)).isNull();
+        }
+
+        @Test
+        void precisionOverflowWithStringDefault() {
+            Object result =
+                    SqlJsonUtils.convertJsonScalar(
+                            123456789.99, DECIMAL, 5, 2, JsonValueOnEmptyOrError.DEFAULT, "0.00");
+            assertThat(result).isInstanceOf(DecimalData.class);
+            assertThat(((DecimalData) result).toBigDecimal())
+                    .isEqualByComparingTo(new BigDecimal("0.00"));
+        }
+
+        @Test
+        void scientificNotation() {
+            DecimalData result = SqlJsonUtils.toCheckedDecimal("1.5E1", 10, 2);
+            assertThat(result.toBigDecimal()).isEqualByComparingTo(new BigDecimal("15.00"));
+        }
+    }
+
+    @Nested
+    class ScalarErrorHandling {
+
+        @Test
+        void nullInputPassesThrough() {
+            assertThat(scalar(null, INTEGER)).isNull();
+        }
+
+        @Test
+        void numericStringParsedAsInteger() {
+            assertThat(scalar("42", INTEGER)).isEqualTo(42);
+        }
+
+        @Test
+        void numericStringParsedAsFloat() {
+            assertThat(scalar("13.37", FLOAT)).isEqualTo(13.37f);
+        }
+
+        @Test
+        void numericStringParsedAsBigint() {
+            assertThat(scalar("9999999999", BIGINT)).isEqualTo(9_999_999_999L);
+        }
+
+        @Test
+        void numericStringOverflowReturnsNull() {
+            assertThat(scalar("9999999999", INTEGER)).isNull();
+        }
+
+        @Test
+        void nonNumericStringReturnsDefault() {
+            assertThat(scalar("notANumber", INTEGER, JsonValueOnEmptyOrError.DEFAULT, 42))
+                    .isEqualTo(42);
+        }
+
+        @Test
+        void emptyStringReturnsNull() {
+            assertThat(scalar("", INTEGER)).isNull();
+        }
+
+        @Test
+        void nanStringReturnsNull() {
+            assertThat(scalar("NaN", FLOAT)).isNull();
+            assertThat(scalar("NaN", DOUBLE)).isNull();
+            assertThat(scalar("NaN", INTEGER)).isNull();
+        }
+
+        @Test
+        void infinityStringReturnsNull() {
+            assertThat(scalar("Infinity", FLOAT)).isNull();
+            assertThat(scalar("-Infinity", DOUBLE)).isNull();
+        }
+
+        @Test
+        void booleanStringCoerced() {
+            assertThat(scalar("true", BOOLEAN)).isEqualTo(true);
+            assertThat(scalar("false", BOOLEAN)).isEqualTo(false);
+            assertThat(scalar("TRUE", BOOLEAN)).isEqualTo(true);
+            assertThat(scalar("t", BOOLEAN)).isEqualTo(true);
+            assertThat(scalar("f", BOOLEAN)).isEqualTo(false);
+            assertThat(scalar("yes", BOOLEAN)).isEqualTo(true);
+            assertThat(scalar("no", BOOLEAN)).isEqualTo(false);
+            assertThat(scalar("1", BOOLEAN)).isEqualTo(true);
+            assertThat(scalar("0", BOOLEAN)).isEqualTo(false);
+        }
+
+        @Test
+        void invalidBooleanStringReturnsNull() {
+            assertThat(scalar("maybe", BOOLEAN)).isNull();
+            assertThat(scalar("2", BOOLEAN)).isNull();
+        }
+
+        @Test
+        void typeMismatchThrows() {
+            assertThatThrownBy(
+                            () ->
+                                    scalar(
+                                            9_999_999_999L,
+                                            INTEGER,
+                                            JsonValueOnEmptyOrError.ERROR,
+                                            null))
+                    .isInstanceOf(TableRuntimeException.class)
+                    .hasMessageContaining("Cannot cast");
+        }
+
+        @Test
+        void booleanToIntReturnsNull() {
+            assertThat(scalar(Boolean.TRUE, INTEGER)).isNull();
+        }
+
+        @Test
+        void intToBooleanReturnsNull() {
+            assertThat(scalar(42, BOOLEAN)).isNull();
+        }
+    }
+
+    @Nested
+    class ArrayConversion {
+
+        @Test
+        void nullInputPassesThrough() {
+            assertThat(SqlJsonUtils.convertJsonArray(null, INTEGER, 0, 0, NULL)).isNull();
+        }
+
+        @Test
+        void convertsIntegerArray() {
+            assertThat(array(new Object[] {1, 2, 3}, INTEGER).toObjectArray())
+                    .containsExactly(1, 2, 3);
+        }
+
+        @Test
+        void preservesNullElements() {
+            assertThat(array(new Object[] {1, null, 3}, INTEGER).toObjectArray())
+                    .containsExactly(1, null, 3);
+        }
+
+        @Test
+        void convertsBooleanArray() {
+            assertThat(array(new Object[] {true, false}, BOOLEAN).toObjectArray())
+                    .containsExactly(true, false);
+        }
+
+        @Test
+        void numericStringArrayParsed() {
+            assertThat(array(new Object[] {"1", "2", "3"}, INTEGER).toObjectArray())
+                    .containsExactly(1, 2, 3);
+        }
+
+        @Test
+        void emptyArrayStaysEmpty() {
+            assertThat(array(new Object[0], INTEGER).size()).isZero();
+        }
+
+        @Test
+        void typeMismatchReturnsNull() {
+            assertThat(SqlJsonUtils.convertJsonArray(new Object[] {"a", "b"}, INTEGER, 0, 0, NULL))
+                    .isNull();
+        }
+
+        @Test
+        void typeMismatchReturnsEmptyArray() {
+            GenericArrayData result =
+                    SqlJsonUtils.convertJsonArray(
+                            new Object[] {"a", "b"}, INTEGER, 0, 0, EMPTY_ARRAY);
+            assertThat(result).isNotNull();
+            assertThat(result.size()).isZero();
+        }
+
+        @Test
+        void typeMismatchThrows() {
+            assertThatThrownBy(
+                            () ->
+                                    SqlJsonUtils.convertJsonArray(
+                                            new Object[] {"a", "b"}, INTEGER, 0, 0, ERROR))
+                    .isInstanceOf(TableRuntimeException.class)
+                    .hasMessageContaining("Array element type mismatch");
+        }
+
+        @Test
+        void partialMismatchFailsAtomically() {
+            assertThat(
+                            SqlJsonUtils.convertJsonArray(
+                                    new Object[] {1, "notANumber", 3}, INTEGER, 0, 0, NULL))
+                    .isNull();
+        }
+
+        @Test
+        void decimalOverflowTriggersOnError() {
+            assertThat(SqlJsonUtils.convertJsonArray(new Object[] {999999}, DECIMAL, 2, 1, NULL))
+                    .isNull();
+        }
+
+        @Test
+        void decimalOverflowTriggersEmptyArray() {
+            GenericArrayData result = arrayDecimal(new Object[] {999999}, 2, 1, EMPTY_ARRAY);
+            assertThat(result).isNotNull();
+            assertThat(result.size()).isZero();
+        }
+
+        @Test
+        void decimalOverflowTriggersError() {
+            assertThatThrownBy(() -> arrayDecimal(new Object[] {999999}, 2, 1, ERROR))
+                    .isInstanceOf(TableRuntimeException.class)
+                    .hasMessageContaining("Array element type mismatch");
+        }
+
+        @Test
+        void emptyArrayWithDecimalType() {
+            GenericArrayData result = arrayDecimal(new Object[0], 10, 2, NULL);
+            assertThat(result).isNotNull();
+            assertThat(result.size()).isZero();
+        }
+    }
+}

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/functions/SqlJsonUtilsConversionTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/functions/SqlJsonUtilsConversionTest.java
@@ -374,6 +374,19 @@ class SqlJsonUtilsConversionTest {
             assertThat(scalar(-1, BOOLEAN)).isNull();
             assertThat(scalar(2, BOOLEAN)).isNull();
         }
+
+        @Test
+        void fractionalNumberToBooleanReturnsNull() {
+            assertThat(scalar(1.9, BOOLEAN)).isNull();
+            assertThat(scalar(0.5, BOOLEAN)).isNull();
+            assertThat(scalar(-0.1, BOOLEAN)).isNull();
+        }
+
+        @Test
+        void exactDoubleZeroOneToBooleanConverts() {
+            assertThat(scalar(0.0, BOOLEAN)).isEqualTo(false);
+            assertThat(scalar(1.0, BOOLEAN)).isEqualTo(true);
+        }
     }
 
     @Nested

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/functions/SqlJsonUtilsConversionTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/functions/SqlJsonUtilsConversionTest.java
@@ -68,13 +68,13 @@ class SqlJsonUtilsConversionTest {
     }
 
     private static GenericArrayData array(Object[] raw, LogicalTypeRoot elementType) {
-        return SqlJsonUtils.convertJsonArray(raw, elementType, 0, 0, NULL);
+        return SqlJsonUtils.convertJsonArray(raw, elementType, 0, 0, true, NULL);
     }
 
     private static GenericArrayData arrayDecimal(
             Object[] raw, int precision, int scale,
             org.apache.flink.table.api.JsonQueryOnEmptyOrError onError) {
-        return SqlJsonUtils.convertJsonArray(raw, DECIMAL, precision, scale, onError);
+        return SqlJsonUtils.convertJsonArray(raw, DECIMAL, precision, scale, true, onError);
     }
 
     private static final BigInteger HUGE = new BigInteger("18446744073709551616");
@@ -182,6 +182,18 @@ class SqlJsonUtilsConversionTest {
             assertThat(scalar(new BigDecimal("1E309"), DOUBLE)).isNull();
             assertThat(scalar(new BigDecimal("-1E309"), DOUBLE)).isNull();
         }
+
+        @Test
+        void floatPrecisionLossSilent() {
+            // 2^24+1 cannot be represented exactly in float; rounds to 2^24
+            assertThat(scalar(16777217, FLOAT)).isEqualTo(16777216.0f);
+        }
+
+        @Test
+        void doublePrecisionLossSilent() {
+            // 2^53+1 cannot be represented exactly in double; rounds to 2^53
+            assertThat(scalar(9007199254740993L, DOUBLE)).isEqualTo(9.007199254740992E15);
+        }
     }
 
     @Nested
@@ -214,6 +226,34 @@ class SqlJsonUtilsConversionTest {
         void scientificNotation() {
             DecimalData result = SqlJsonUtils.toCheckedDecimal("1.5E1", 10, 2);
             assertThat(result.toBigDecimal()).isEqualByComparingTo(new BigDecimal("15.00"));
+        }
+
+        @Test
+        void maxPrecision38Digits() {
+            Object result = scalarDecimal("99999999999999999999999999999999999999", 38, 0);
+            assertThat(result).isInstanceOf(DecimalData.class);
+            assertThat(((DecimalData) result).toBigDecimal())
+                    .isEqualByComparingTo(
+                            new BigDecimal("99999999999999999999999999999999999999"));
+        }
+
+        @Test
+        void overflowAt39DigitsReturnsNull() {
+            assertThat(scalarDecimal("999999999999999999999999999999999999999", 38, 0)).isNull();
+        }
+
+        @Test
+        void roundingHalfUp() {
+            Object result = scalarDecimal("123.456", 5, 2);
+            assertThat(result).isInstanceOf(DecimalData.class);
+            assertThat(((DecimalData) result).toBigDecimal())
+                    .isEqualByComparingTo(new BigDecimal("123.46"));
+        }
+
+        @Test
+        void roundingOverflow() {
+            // 999.999 rounds to 1000.00 (precision 6) which overflows DECIMAL(5,2)
+            assertThat(scalarDecimal("999.999", 5, 2)).isNull();
         }
     }
 
@@ -289,6 +329,20 @@ class SqlJsonUtilsConversionTest {
         }
 
         @Test
+        void whitespaceInNumericStringIsTrimmed() {
+            // Matches PostgreSQL: CAST trims leading/trailing whitespace
+            assertThat(scalar(" 42 ", INTEGER)).isEqualTo(42);
+            assertThat(scalar(" 13.37 ", DOUBLE)).isEqualTo(13.37);
+        }
+
+        @Test
+        void whitespaceInBooleanStringSucceeds() {
+            // parseStringAsBoolean trims before matching
+            assertThat(scalar(" true ", BOOLEAN)).isEqualTo(true);
+            assertThat(scalar(" FALSE ", BOOLEAN)).isEqualTo(false);
+        }
+
+        @Test
         void typeMismatchThrows() {
             assertThatThrownBy(
                             () ->
@@ -327,7 +381,7 @@ class SqlJsonUtilsConversionTest {
 
         @Test
         void nullInputPassesThrough() {
-            assertThat(SqlJsonUtils.convertJsonArray(null, INTEGER, 0, 0, NULL)).isNull();
+            assertThat(SqlJsonUtils.convertJsonArray(null, INTEGER, 0, 0, true, NULL)).isNull();
         }
 
         @Test
@@ -337,9 +391,26 @@ class SqlJsonUtilsConversionTest {
         }
 
         @Test
-        void preservesNullElements() {
+        void preservesNullElementsInNullableArray() {
             assertThat(array(new Object[] {1, null, 3}, INTEGER).toObjectArray())
                     .containsExactly(1, null, 3);
+        }
+
+        @Test
+        void nullElementInNotNullArrayReturnsNull() {
+            assertThat(SqlJsonUtils.convertJsonArray(
+                    new Object[] {1, null, 3}, INTEGER, 0, 0, false, NULL))
+                    .isNull();
+        }
+
+        @Test
+        void nullElementInNotNullArrayThrows() {
+            assertThatThrownBy(
+                            () ->
+                                    SqlJsonUtils.convertJsonArray(
+                                            new Object[] {1, null, 3}, INTEGER, 0, 0, false, ERROR))
+                    .isInstanceOf(TableRuntimeException.class)
+                    .hasMessageContaining("Array element type mismatch");
         }
 
         @Test
@@ -367,7 +438,7 @@ class SqlJsonUtilsConversionTest {
 
         @Test
         void typeMismatchReturnsNull() {
-            assertThat(SqlJsonUtils.convertJsonArray(new Object[] {"a", "b"}, INTEGER, 0, 0, NULL))
+            assertThat(SqlJsonUtils.convertJsonArray(new Object[] {"a", "b"}, INTEGER, 0, 0, true, NULL))
                     .isNull();
         }
 
@@ -375,7 +446,7 @@ class SqlJsonUtilsConversionTest {
         void typeMismatchReturnsEmptyArray() {
             GenericArrayData result =
                     SqlJsonUtils.convertJsonArray(
-                            new Object[] {"a", "b"}, INTEGER, 0, 0, EMPTY_ARRAY);
+                            new Object[] {"a", "b"}, INTEGER, 0, 0, true, EMPTY_ARRAY);
             assertThat(result).isNotNull();
             assertThat(result.size()).isZero();
         }
@@ -385,7 +456,7 @@ class SqlJsonUtilsConversionTest {
             assertThatThrownBy(
                             () ->
                                     SqlJsonUtils.convertJsonArray(
-                                            new Object[] {"a", "b"}, INTEGER, 0, 0, ERROR))
+                                            new Object[] {"a", "b"}, INTEGER, 0, 0, true, ERROR))
                     .isInstanceOf(TableRuntimeException.class)
                     .hasMessageContaining("Array element type mismatch");
         }
@@ -394,13 +465,13 @@ class SqlJsonUtilsConversionTest {
         void partialMismatchFailsAtomically() {
             assertThat(
                             SqlJsonUtils.convertJsonArray(
-                                    new Object[] {1, "notANumber", 3}, INTEGER, 0, 0, NULL))
+                                    new Object[] {1, "notANumber", 3}, INTEGER, 0, 0, true, NULL))
                     .isNull();
         }
 
         @Test
         void decimalOverflowTriggersOnError() {
-            assertThat(SqlJsonUtils.convertJsonArray(new Object[] {999999}, DECIMAL, 2, 1, NULL))
+            assertThat(SqlJsonUtils.convertJsonArray(new Object[] {999999}, DECIMAL, 2, 1, true, NULL))
                     .isNull();
         }
 
@@ -423,6 +494,23 @@ class SqlJsonUtilsConversionTest {
             GenericArrayData result = arrayDecimal(new Object[0], 10, 2, NULL);
             assertThat(result).isNotNull();
             assertThat(result.size()).isZero();
+        }
+
+        @Test
+        void decimalArrayWithRounding() {
+            GenericArrayData result = arrayDecimal(new Object[] {1.5, 123.456}, 5, 2, NULL);
+            assertThat(result).isNotNull();
+            Object[] elements = result.toObjectArray();
+            assertThat(((DecimalData) elements[0]).toBigDecimal())
+                    .isEqualByComparingTo(new BigDecimal("1.50"));
+            assertThat(((DecimalData) elements[1]).toBigDecimal())
+                    .isEqualByComparingTo(new BigDecimal("123.46"));
+        }
+
+        @Test
+        void decimalArrayRoundingOverflowFailsAtomically() {
+            // 999.999 rounds to 1000.00 which overflows DECIMAL(5,2); whole array fails
+            assertThat(arrayDecimal(new Object[] {1.5, 999.999}, 5, 2, NULL)).isNull();
         }
     }
 }

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/functions/SqlJsonUtilsConversionTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/functions/SqlJsonUtilsConversionTest.java
@@ -72,12 +72,12 @@ class SqlJsonUtilsConversionTest {
     }
 
     private static GenericArrayData arrayDecimal(
-            Object[] raw,
-            int precision,
-            int scale,
+            Object[] raw, int precision, int scale,
             org.apache.flink.table.api.JsonQueryOnEmptyOrError onError) {
         return SqlJsonUtils.convertJsonArray(raw, DECIMAL, precision, scale, onError);
     }
+
+    private static final BigInteger HUGE = new BigInteger("18446744073709551616");
 
     static Stream<Arguments> validConversions() {
         return Stream.of(
@@ -90,6 +90,10 @@ class SqlJsonUtilsConversionTest {
                 Arguments.of((long) Integer.MAX_VALUE, INTEGER, Integer.MAX_VALUE),
                 Arguments.of(42, BIGINT, 42L),
                 Arguments.of(9_999_999_999L, BIGINT, 9_999_999_999L),
+                Arguments.of(
+                        new BigDecimal("9223372036854775807.5"),
+                        BIGINT,
+                        Long.MAX_VALUE),
                 Arguments.of(13.37, FLOAT, 13.37f),
                 Arguments.of(13.37, DOUBLE, 13.37));
     }
@@ -100,12 +104,24 @@ class SqlJsonUtilsConversionTest {
                 Arguments.of(-129, TINYINT),
                 Arguments.of(200L, TINYINT),
                 Arguments.of(-200L, TINYINT),
+                Arguments.of(HUGE, TINYINT),
+                Arguments.of(HUGE.negate(), TINYINT),
+                Arguments.of(new BigDecimal("18446744073709551616"), TINYINT),
                 Arguments.of((long) Short.MAX_VALUE + 1, SMALLINT),
                 Arguments.of((long) Short.MIN_VALUE - 1, SMALLINT),
                 Arguments.of(40_000L, SMALLINT),
                 Arguments.of(-40_000L, SMALLINT),
+                Arguments.of(HUGE, SMALLINT),
+                Arguments.of(HUGE.negate(), SMALLINT),
+                Arguments.of(new BigDecimal("18446744073709551616"), SMALLINT),
                 Arguments.of(9_999_999_999L, INTEGER),
-                Arguments.of(-9_999_999_999L, INTEGER));
+                Arguments.of(-9_999_999_999L, INTEGER),
+                Arguments.of(HUGE, INTEGER),
+                Arguments.of(HUGE.negate(), INTEGER),
+                Arguments.of(new BigDecimal("18446744073709551616"), INTEGER),
+                Arguments.of(HUGE, BIGINT),
+                Arguments.of(HUGE.negate(), BIGINT),
+                Arguments.of(new BigDecimal("18446744073709551616"), BIGINT));
     }
 
     @Nested

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/functions/SqlJsonUtilsConversionTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/functions/SqlJsonUtilsConversionTest.java
@@ -307,8 +307,18 @@ class SqlJsonUtilsConversionTest {
         }
 
         @Test
-        void intToBooleanReturnsNull() {
+        void intZeroOneToBooleanConverts() {
+            assertThat(scalar(0, BOOLEAN)).isEqualTo(false);
+            assertThat(scalar(1, BOOLEAN)).isEqualTo(true);
+            assertThat(scalar(0L, BOOLEAN)).isEqualTo(false);
+            assertThat(scalar(1L, BOOLEAN)).isEqualTo(true);
+        }
+
+        @Test
+        void otherIntToBooleanReturnsNull() {
             assertThat(scalar(42, BOOLEAN)).isNull();
+            assertThat(scalar(-1, BOOLEAN)).isNull();
+            assertThat(scalar(2, BOOLEAN)).isNull();
         }
     }
 
@@ -336,6 +346,12 @@ class SqlJsonUtilsConversionTest {
         void convertsBooleanArray() {
             assertThat(array(new Object[] {true, false}, BOOLEAN).toObjectArray())
                     .containsExactly(true, false);
+        }
+
+        @Test
+        void integerZeroOneToBooleanArray() {
+            assertThat(array(new Object[] {0, 1}, BOOLEAN).toObjectArray())
+                    .containsExactly(false, true);
         }
 
         @Test


### PR DESCRIPTION
## What is the purpose of the change

`JSON_VALUE` and `JSON_QUERY` both accept a `RETURNING` clause, but only a narrow set of types is supported. This PR widens both:

- `JSON_VALUE`: adds TINYINT, SMALLINT, BIGINT, FLOAT, and DECIMAL. Fixes the existing INTEGER and DOUBLE casts, which fail at runtime on certain JSON values (INTEGER throws on large numbers because Jayway returns Long instead of Integer; DOUBLE throws on integers because Jayway returns Integer instead of BigDecimal). All numeric casts now go through range-checked conversions that route to ON ERROR behavior on overflow. FLOAT and DOUBLE reject infinity/NaN as overflow. This matches MySQL, Oracle, and PostgreSQL, which all treat numeric overflow as a conversion error handled by ON ERROR.

- `JSON_QUERY`: adds ARRAY with numeric and boolean element types (INT, TINYINT, SMALLINT, BIGINT, FLOAT, DOUBLE, DECIMAL, BOOLEAN). Previously only ARRAY\<VARCHAR\> was accepted. Array element conversions use the same range-checked methods.

- **String coercion**: JSON string values (e.g. `"42"`) are parsed as numbers when the RETURNING clause requests a numeric type, matching MySQL and PostgreSQL semantics. Boolean string coercion follows PostgreSQL's bool input function (`true/t/yes/1`, `false/f/no/0`, case-insensitive). Non-parseable strings route to ON ERROR.

- **Whitespace handling**: String-to-numeric conversion now trims leading/trailing whitespace before parsing, matching PostgreSQL's CAST behavior. Previously `" 42 "` would fail while `" true "` (boolean) would succeed -- the inconsistency is fixed.

- **NOT NULL array elements**: `JSON_QUERY` with `RETURNING ARRAY<T NOT NULL>` now enforces the NOT NULL constraint on array elements. Null elements trigger ON ERROR behavior instead of silently passing through.

### Architectural approach

Type conversion and error handling live in testable Java methods in `SqlJsonUtils` (`convertJsonScalar`, `convertJsonArray`) rather than in Scala codegen string templates. The codegen files emit a single method call each instead of inline type-dispatch + try/catch + error-fallback blocks. This eliminates a class of string-template bugs where generated variable names can be misreferenced.

A custom `JsonConversionException` replaces `ClassCastException` as the internal control-flow mechanism, preventing unrelated ClassCastExceptions (from actual codegen bugs) from being silently swallowed by ON ERROR handling.

A shared `isSupportedJsonReturningType()` method serves as the single source of truth for accepted types, preventing validation and codegen type lists from diverging.

Also fixes:
- DECIMAL precision overflow (e.g. `123456789.99 RETURNING DECIMAL(5,2)`) silently returning null instead of triggering ON ERROR
- BigInteger overflow in BIGINT conversion silently truncating (Jayway returns BigInteger for numbers exceeding Long.MAX_VALUE)
- NULL ON ERROR in JSON_QUERY typed arrays returning a partially-filled array instead of null (codegen bug: wrong variable nulled in catch block)
- String-literal DEFAULT values with DECIMAL RETURNING causing a `CompileException`
- A copy-paste error in `JsonQueryCallGen` where the unsupported-type error message said "JSON_VALUE" instead of "JSON_QUERY"
- `CAST(JSON_VALUE(... RETURNING DOUBLE) AS BIGINT)` producing uncompilable code -- the codegen emits `((long)(java.lang.Double))` because JsonValueCallGen returns boxed types but cast rules expect primitives
- Whitespace in string-to-numeric JSON_VALUE conversion (e.g. `" 42 " RETURNING INT`) failing instead of trimming like PostgreSQL CAST
- Null elements in `ARRAY<T NOT NULL>` silently passing through instead of triggering ON ERROR behavior

## Brief change log

- Add `convertJsonScalar` and `convertJsonArray` methods to `SqlJsonUtils` with full type conversion, string coercion, and ON ERROR handling
- Add range-checked conversion methods (`toCheckedInt`, `toCheckedFloat`, `toCheckedDouble`, `parseStringAsBoolean`, etc.) to `SqlJsonUtils`
- Add `JsonConversionException` (package-private) for conversion control flow
- Add `isSupportedJsonReturningType` as a shared type allowlist
- Simplify `JsonValueCallGen` codegen to a single `convertJsonScalar` call for non-VARCHAR types
- Simplify `JsonQueryCallGen` codegen to a single `convertJsonArray` call for typed arrays
- Add `RAW_ARRAY` variant to `JsonQueryReturnType` for raw Jayway object arrays
- Update validation in `SqlJsonQueryFunctionWrapper` to use the shared type allowlist
- Normalize primitive-backed inputs in `ScalarOperatorGens.generateCast` to unbox before entering cast rules
- Trim whitespace in string-to-numeric conversion path in `convertToType`, matching PostgreSQL CAST semantics
- Enforce NOT NULL on array elements in `convertJsonArray` via `elementNullable` parameter threaded from `JsonQueryCallGen`
- Add unit tests (`SqlJsonUtilsConversionTest`) for all conversion methods: 87 tests covering overflow, string coercion, error behaviors, boundary values
- Add edge case tests for numeric boundaries (DECIMAL max precision, rounding, overflow), float/double precision loss, whitespace handling, and NOT NULL array enforcement
- Add integration tests for all new type combinations, overflow, ON ERROR, string coercion, boundary values: 976 total cases

## Verifying this change

This change added tests and can be verified as follows:

**Unit tests (SqlJsonUtilsConversionTest, 87 tests):**
- Parameterized valid conversions across all numeric types (TINYINT through DOUBLE)
- Parameterized overflow cases including negative overflow
- FLOAT/DOUBLE overflow (infinity/NaN rejection)
- BigInteger and BigDecimal overflow for BIGINT
- BigDecimal fractional truncation for BIGINT
- DECIMAL precision overflow and scientific notation
- DECIMAL boundary: max precision (38 digits), overflow (39 digits), HALF_UP rounding, rounding overflow
- Float/double silent precision loss (2^24+1, 2^53+1)
- String coercion: numeric strings, overflow, non-numeric strings, empty strings, NaN/Infinity strings
- Whitespace trimming in numeric and boolean string conversion
- Boolean string coercion: true/false/t/f/yes/no/1/0 and invalid strings
- Error behavior: NULL/DEFAULT/ERROR ON ERROR for scalar and array conversion
- Array atomicity: partial element failure fails the entire array
- NOT NULL enforcement on array elements
- DECIMAL array rounding and atomic overflow failure

**Integration tests (JsonFunctionsITCase, 976 tests):**
- JSON_VALUE RETURNING for all new types with various JSON values
- JSON_QUERY RETURNING ARRAY\<T\> for all element types including DECIMAL
- Overflow with NULL/DEFAULT/ERROR ON ERROR
- ARRAY\<BIGINT\> near Long.MAX_VALUE/MIN_VALUE boundaries and overflow
- Quoted number strings parsed as integers
- Nested arrays routed to ON ERROR
- Negative values within TINYINT range
- Outer `CAST` on `JSON_VALUE` results: narrowing and widening numeric casts
- Boxed equality regression: SMALLINT, BIGINT, FLOAT with values outside JVM cache
- DECIMAL boundary: max precision, overflow, HALF_UP rounding, rounding overflow
- Float/double precision loss documentation (2^24+1, 2^53+1)
- Whitespace handling: numeric trimming, boolean trimming
- ARRAY\<DECIMAL(5,2)\> with rounding and atomic overflow
- ARRAY\<T NOT NULL\> with null elements: NULL ON ERROR and ERROR ON ERROR

## Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): no
- The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
- The serializers: no
- The runtime per-record code paths (performance sensitive): no
- Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
- The S3 file system connector: no

## Documentation

- Does this pull request introduce a new feature? yes
- If yes, how is the feature documented? not documented (widens accepted types in existing SQL functions; could be added to the JSON functions docs page as a follow-up)

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: Claude Code
