### PR TITLE
[FLINK-40537][build] IDEA should use java version same as in `source.java.version`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -140,6 +140,9 @@ under the License.
 			 and thus is changing back to java 1.6 on each maven re-import -->
 		<maven.compiler.source>${source.java.version}</maven.compiler.source>
 		<maven.compiler.target>${target.java.version}</maven.compiler.target>
+		<!-- Apache parent pom 39 puts 8 here, IDEA uses it for project setting,
+		 so override with actual value -->
+		<maven.compiler.release>${source.java.version}</maven.compiler.release>
 		<scala.macros.version>2.1.1</scala.macros.version>
 		<scala.version>2.12.21</scala.version>
 		<scala.binary.version>2.12</scala.binary.version>


### PR DESCRIPTION


## What is the purpose of the change

The PR makes sure IDEA uses java version same as for `<source.java.version>` (by default IDEA picks from release, however Apache parent pom 39 sets there 8 which is wrong)

these 2 commits in Apache parent pom is the reason 
https://github.com/apache/maven-apache-parent/commit/2d0578a5e4379846fc27523041b97cb34a6c8578
https://github.com/apache/maven-apache-parent/commit/9d07debba70cc8b93eef083e9124bbda3b56f1bb

## Brief change log

pom

## Verifying this change

existing tests + locally run tests from IDEA
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable )

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change the checkbox below to `[X]` and replace the placeholder in the "Generated-by"
line with the tool name and version. Otherwise remove the "Generated-by" line.
See the ASF Generative Tooling Guidance for details:
https://www.apache.org/legal/generative-tooling.html

You are responsible for the quality and correctness of every change in this PR
regardless of the tooling used. Low-effort AI-generated PRs will be closed. See
AGENTS.md for the full guidance.
-->

- [ ] Yes (please specify the tool below)

Generated-by: [Tool Name and Version]
