### PR TITLE
[BP-1.20][FLINK-40451][ci] E2E test timeout keeps CI running until the timeout ends, even after the test passes

### DIFF
--- a/flink-end-to-end-tests/test-scripts/common.sh
+++ b/flink-end-to-end-tests/test-scripts/common.sh
@@ -974,7 +974,11 @@ internal_run_with_timeout() {
 
   (
       command_pid=$BASHPID
-      (sleep "${timeout_in_seconds}" # set a timeout for this command
+      (
+      # Kill the sleep on teardown so it doesn't keep the CI stdout pipe open until timeout.
+      trap 'kill $sleep_pid 2>/dev/null; exit 0' TERM
+      sleep "${timeout_in_seconds}" & sleep_pid=$! # set a timeout for this command
+      wait $sleep_pid
       echo "${command_label:-"The command '${command}'"} (pid: $command_pid) did not finish after $timeout_in_seconds seconds."
       eval "${on_failure}"
       kill "$command_pid") & watchdog_pid=$!


### PR DESCRIPTION

backport of https://github.com/apache/flink/commit/5c93893e4f14be35219404895f16b41a008f5c5f