### PR TITLE
[FLINK-40539][sql-gateway] Redact sensitive values in SET; and session config responses

### DIFF
--- a/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/rest/handler/session/GetSessionConfigHandler.java
+++ b/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/rest/handler/session/GetSessionConfigHandler.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.gateway.rest.handler.session;
 
+import org.apache.flink.configuration.ConfigurationUtils;
 import org.apache.flink.runtime.rest.handler.HandlerRequest;
 import org.apache.flink.runtime.rest.handler.RestHandlerException;
 import org.apache.flink.runtime.rest.messages.EmptyRequestBody;
@@ -59,8 +60,10 @@ public class GetSessionConfigHandler
             SessionHandle sessionHandle =
                     request.getPathParameter(SessionHandleIdPathParameter.class);
             Map<String, String> sessionConfig = this.service.getSessionConfig(sessionHandle);
+            Map<String, String> redactedSessionConfig =
+                    ConfigurationUtils.hideSensitiveValues(sessionConfig);
             return CompletableFuture.completedFuture(
-                    new GetSessionConfigResponseBody(sessionConfig));
+                    new GetSessionConfigResponseBody(redactedSessionConfig));
         } catch (SqlGatewayException e) {
             throw new RestHandlerException(
                     e.getMessage(), HttpResponseStatus.INTERNAL_SERVER_ERROR, e);

--- a/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/service/operation/OperationExecutor.java
+++ b/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/service/operation/OperationExecutor.java
@@ -28,6 +28,7 @@ import org.apache.flink.client.deployment.DefaultClusterClientServiceLoader;
 import org.apache.flink.client.program.ClusterClient;
 import org.apache.flink.configuration.CheckpointingOptions;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.ConfigurationUtils;
 import org.apache.flink.core.execution.SavepointFormatType;
 import org.apache.flink.runtime.client.JobStatusMessage;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
@@ -610,7 +611,9 @@ public class OperationExecutor {
             return ResultFetcher.fromTableResult(handle, TABLE_RESULT_OK, false);
         } else if (!setOp.getKey().isPresent() && !setOp.getValue().isPresent()) {
             // show all properties
-            Map<String, String> configMap = tableEnv.getConfig().getConfiguration().toMap();
+            Map<String, String> configMap =
+                    ConfigurationUtils.hideSensitiveValues(
+                            tableEnv.getConfig().getConfiguration().toMap());
             return ResultFetcher.fromResults(
                     handle,
                     ResolvedSchema.of(

--- a/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/rest/SessionRelatedITCase.java
+++ b/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/rest/SessionRelatedITCase.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.gateway.rest;
 
+import org.apache.flink.configuration.GlobalConfiguration;
 import org.apache.flink.runtime.rest.messages.EmptyMessageParameters;
 import org.apache.flink.runtime.rest.messages.EmptyRequestBody;
 import org.apache.flink.runtime.rest.messages.EmptyResponseBody;
@@ -156,6 +157,30 @@ class SessionRelatedITCase extends RestAPIITCaseBase {
         for (String key : properties.keySet()) {
             assertThat(properties).containsEntry(key, getProperties.get(key));
         }
+    }
+
+    @Test
+    void testGetSessionConfigurationHidesSensitiveValues() throws Exception {
+        Map<String, String> sensitiveProperties = new HashMap<>();
+        sensitiveProperties.put("s3.secret-key", "super-secret-value");
+        CompletableFuture<OpenSessionResponseBody> openResponse =
+                sendRequest(
+                        openSessionHeaders,
+                        emptyParameters,
+                        new OpenSessionRequestBody(SESSION_NAME, sensitiveProperties));
+        SessionHandle handle =
+                new SessionHandle(UUID.fromString(openResponse.get().getSessionHandle()));
+        SessionMessageParameters parameters = new SessionMessageParameters(handle);
+
+        CompletableFuture<GetSessionConfigResponseBody> future =
+                sendRequest(GetSessionConfigHeaders.getInstance(), parameters, emptyRequestBody);
+        Map<String, String> getProperties = future.get().getProperties();
+
+        assertThat(getProperties).containsKey("s3.secret-key");
+        assertThat(getProperties.get("s3.secret-key"))
+                .isEqualTo(GlobalConfiguration.HIDDEN_CONTENT);
+
+        sendRequest(closeSessionHeaders, parameters, emptyRequestBody).get();
     }
 
     @Test

--- a/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/service/SqlGatewayServiceStatementITCase.java
+++ b/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/service/SqlGatewayServiceStatementITCase.java
@@ -21,6 +21,7 @@ package org.apache.flink.table.gateway.service;
 import org.apache.flink.api.common.RuntimeExecutionMode;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.ExecutionOptions;
+import org.apache.flink.configuration.GlobalConfiguration;
 import org.apache.flink.core.testutils.CommonTestUtils;
 import org.apache.flink.table.api.ResultKind;
 import org.apache.flink.table.data.RowData;
@@ -46,14 +47,17 @@ import org.junit.jupiter.api.io.TempDir;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 
 import static org.apache.flink.table.gateway.api.config.SqlGatewayServiceConfigOptions.SQL_GATEWAY_SESSION_PLAN_CACHE_ENABLED;
 import static org.apache.flink.table.gateway.service.utils.SqlGatewayServiceTestUtil.awaitOperationTermination;
 import static org.apache.flink.table.gateway.service.utils.SqlGatewayServiceTestUtil.createInitializedSession;
+import static org.apache.flink.table.gateway.service.utils.SqlGatewayServiceTestUtil.fetchAllResults;
 import static org.apache.flink.table.gateway.service.utils.SqlGatewayServiceTestUtil.fetchResults;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -284,6 +288,32 @@ public class SqlGatewayServiceStatementITCase extends AbstractSqlGatewayStatemen
 
         validateResultSetField(
                 sessionHandle, "SET;", resultKindGetter, ResultKind.SUCCESS_WITH_CONTENT);
+    }
+
+    @Test
+    void testSetHidesSensitiveValues() throws Exception {
+        SessionHandle sessionHandle = createInitializedSession(service);
+
+        runAndAwait(sessionHandle, "SET 's3.secret-key' = 'super-secret-value';");
+
+        OperationHandle setAllHandle = runAndAwait(sessionHandle, "SET;");
+        List<RowData> rows = fetchAllResults(service, sessionHandle, setAllHandle);
+
+        Map<String, String> properties = new HashMap<>();
+        for (RowData row : rows) {
+            properties.put(row.getString(0).toString(), row.getString(1).toString());
+        }
+
+        assertThat(properties).containsKey("s3.secret-key");
+        assertThat(properties.get("s3.secret-key")).isEqualTo(GlobalConfiguration.HIDDEN_CONTENT);
+    }
+
+    private OperationHandle runAndAwait(SessionHandle sessionHandle, String statement)
+            throws Exception {
+        OperationHandle operationHandle =
+                service.executeStatement(sessionHandle, statement, -1, new Configuration());
+        awaitOperationTermination(service, sessionHandle, operationHandle);
+        return operationHandle;
     }
 
     private <T> void validateResultSetField(


### PR DESCRIPTION
## What is the purpose of the change

This is backport of https://github.com/apache/flink/pull/29071.

The SQL Gateway seeds each session's configuration with a full clone of the cluster configuration (loaded from `config.yaml`), which needs redaction:

  - Executing a bare `SET;` statement returns every session/table config entry as result rows (`OperationExecutor#callSetOperation`).
  - `GET /sessions/:sessionHandle` returns the session configuration as-is (`GetSessionConfigHandler`).

## Brief change log

  - `OperationExecutor#callSetOperation` now passes the configuration map through `ConfigurationUtils#hideSensitiveValues` before building the `SET;` result rows, mirroring `ConfigurationInfo#from`.
  - `GetSessionConfigHandler#handleRequest` now redacts sensitive keys in the session configuration before returning it in the `GET /sessions/:sessionHandle` response. The redaction is applied only at this REST response boundary, not inside `Session#getSessionConfig`/`SqlGatewayServiceImpl#getSessionConfig`, since those are also used internally (e.g. materialized table script deployment, result timezone conversion) where the real, unredacted values are required.

## Verifying this change

This change added tests and can be verified as follows:

  - Added `SqlGatewayServiceStatementITCase#testSetHidesSensitiveValues`, which sets a sensitive key (`s3.secret-key`) via `SET`, executes a bare `SET;`, and asserts the returned value is masked.
  - Added `SessionRelatedITCase#testGetSessionConfigurationHidesSensitiveValues`, which opens a session with a sensitive property and asserts `GET /sessions/:sessionHandle` returns the masked value.
  - Both tests were verified to fail against the unpatched code (returning the cleartext secret) and pass after the fix.
  - Ran `SqlGatewayServiceITCase`, `SqlGatewayServiceStatementITCase`, `SqlGatewayRestEndpointStatementITCase`, and `SessionRelatedITCase` in full to confirm no regressions in existing `SET`/`RESET`/session-config behavior.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (Claude Code)

<!--
Generated-by: Claude Code
-->
