### PR TITLE
[FLINK-XXXXX] [runtime] Detach per-split source metric groups when splits finish

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/AbstractMetricGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/AbstractMetricGroup.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.metrics.groups;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.events.EventBuilder;
 import org.apache.flink.metrics.CharacterFilter;
 import org.apache.flink.metrics.Counter;
@@ -341,6 +342,43 @@ public abstract class AbstractMetricGroup<A extends AbstractMetricGroup<?>> impl
 
     public final boolean isClosed() {
         return closed;
+    }
+
+    /**
+     * Closes the sub-group registered under {@code name} and removes it from this group.
+     *
+     * <p>{@link #close()} only clears a group's own children and metrics; it never detaches the
+     * group from its parent. That is harmless for groups that live as long as the job, but it leaks
+     * for groups created per transient entity - e.g. one per source split - because the emptied
+     * group, its {@code QueryScopeInfo} and its scope strings stay in the parent's map for the
+     * lifetime of the job.
+     *
+     * <p>The child is closed <i>outside</i> this group's monitor. {@link #close()} cascades from
+     * parent to child while holding the parent's monitor, so taking the child's monitor while still
+     * holding ours would invert that order. Removing first and closing afterwards also guarantees
+     * the cascading teardown never sees a child mutate the map it is iterating.
+     *
+     * @param name the name the sub-group was registered under
+     */
+    @VisibleForTesting
+    int numberOfSubgroups() {
+        synchronized (this) {
+            return groups.size();
+        }
+    }
+
+    public void closeAndRemoveGroup(String name) {
+        final AbstractMetricGroup<?> child;
+        synchronized (this) {
+            if (closed) {
+                // This group is already being torn down; close() clears the whole map anyway.
+                return;
+            }
+            child = groups.remove(name);
+        }
+        if (child != null) {
+            child.close();
+        }
     }
 
     // -----------------------------------------------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/InternalSourceSplitMetricGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/InternalSourceSplitMetricGroup.java
@@ -49,6 +49,7 @@ public class InternalSourceSplitMetricGroup extends ProxyMetricGroup<MetricGroup
     private long splitStartTime = SPLIT_NOT_STARTED;
     private final MetricGroup splitWatermarkMetricGroup;
     private final String splitId;
+    private final AbstractMetricGroup<?> splitMetricGroup;
 
     private InternalSourceSplitMetricGroup(
             MetricGroup parentMetricGroup,
@@ -58,7 +59,12 @@ public class InternalSourceSplitMetricGroup extends ProxyMetricGroup<MetricGroup
         super(parentMetricGroup);
         this.clock = clock;
         this.splitId = splitId;
-        splitWatermarkMetricGroup = parentMetricGroup.addGroup(SPLIT, splitId).addGroup(WATERMARK);
+        // Keep the per-split group itself, not just its watermark child, so that
+        // onSplitFinished() can detach it. addGroup(SPLIT, splitId) must stay as-is: it creates a
+        // KEY group plus a VALUE group, whereas assembling the same pair via addGroup(SPLIT) would
+        // create a GENERIC child instead and change the emitted metric names.
+        splitMetricGroup = (AbstractMetricGroup<?>) parentMetricGroup.addGroup(SPLIT, splitId);
+        splitWatermarkMetricGroup = splitMetricGroup.addGroup(WATERMARK);
         pausedTimePerSecond =
                 splitWatermarkMetricGroup.gauge(
                         MetricNames.SPLIT_PAUSED_TIME, new TimerGauge(clock));
@@ -187,14 +193,21 @@ public class InternalSourceSplitMetricGroup extends ProxyMetricGroup<MetricGroup
     }
 
     public void onSplitFinished() {
-        if (splitWatermarkMetricGroup instanceof AbstractMetricGroup) {
-            ((AbstractMetricGroup) splitWatermarkMetricGroup).close();
+        // Detach the whole per-split subtree from the "split" key group. Closing the split group
+        // cascades into its watermark child, which unregisters that child's gauges from the
+        // registry and therefore from every reporter; removing it from the parent lets the group,
+        // its QueryScopeInfo and its scope strings become collectable. Closing only the watermark
+        // child (the previous behaviour) left both groups registered for the life of the job.
+        //
+        // splitMetricGroup.parent is the "split" KEY group; this class is in the same package as
+        // AbstractMetricGroup, so the protected field needs no new accessor.
+        final AbstractMetricGroup<?> splitKeyGroup = splitMetricGroup.parent;
+        if (splitKeyGroup != null) {
+            splitKeyGroup.closeAndRemoveGroup(splitId);
         } else {
-            if (splitWatermarkMetricGroup != null) {
-                LOG.warn(
-                        "Split watermark metric group can not be closed, expecting an instance of AbstractMetricGroup but got: ",
-                        splitWatermarkMetricGroup.getClass().getName());
-            }
+            LOG.warn(
+                    "Per-split metric group for split {} has no parent group; not detaching.",
+                    splitId);
         }
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/InternalSourceSplitMetricGroupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/InternalSourceSplitMetricGroupTest.java
@@ -25,6 +25,8 @@ import org.apache.flink.util.clock.ManualClock;
 import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -94,5 +96,33 @@ class InternalSourceSplitMetricGroupTest {
                         totalDuration
                                 - metricGroup.getAccumulatedActiveTime()
                                 - metricGroup.getAccumulatedIdleTime());
+    }
+
+    @Test
+    void testSplitMetricGroupsAreDetachedWhenSplitsFinish() {
+        final InternalOperatorMetricGroup operatorMetricGroup =
+                UnregisteredMetricGroups.createUnregisteredOperatorMetricGroup();
+
+        final int numSplits = 5;
+        final List<InternalSourceSplitMetricGroup> splitMetricGroups = new ArrayList<>();
+        for (int i = 0; i < numSplits; i++) {
+            splitMetricGroups.add(
+                    InternalSourceSplitMetricGroup.mock(operatorMetricGroup, "split-" + i, null));
+        }
+
+        // addGroup(SPLIT, splitId) registers a single "split" KEY group that holds one VALUE group
+        // per split id. addGroup(String) returns the already-registered group when one exists and
+        // is not closed, so this retrieves that KEY group rather than creating a second one.
+        final AbstractMetricGroup<?> splitKeyGroup =
+                (AbstractMetricGroup<?>) operatorMetricGroup.addGroup("split");
+        assertThat(splitKeyGroup.numberOfSubgroups()).isEqualTo(numSplits);
+
+        splitMetricGroups.forEach(InternalSourceSplitMetricGroup::onSplitFinished);
+
+        // Previously onSplitFinished() closed only the "watermark" child, leaving the per-split
+        // group attached to its parent for the lifetime of the job. On a source that mints a new
+        // split id per split - a Paimon streaming read, for example - that retains two empty metric
+        // groups plus their scope strings per finished split, without bound.
+        assertThat(splitKeyGroup.numberOfSubgroups()).isZero();
     }
 }


### PR DESCRIPTION
> **Draft.** The ASF JIRA issue is not filed yet, so the title carries a `FLINK-XXXXX`
> placeholder — I will replace it in both the title and the commit message before marking this
> ready for review. Opened as a draft rather than held back so the analysis and the measurements
> are available to anyone hitting the same leak. Full `mvn clean verify` / CI has not run yet
> either; what has been run is stated precisely under "Verifying this change".

## What is the purpose of the change

Per-split source metric groups introduced by FLIP-513 / FLINK-37410 are never detached from their
parent when a split finishes, so they accumulate for the lifetime of the job.

FLINK-37596 ("Close metric groups for finished splits") closes the per-split `watermark` child on
completion. That part works — it deregisters the child's gauges from the registry and from every
reporter. What it does not do is release the group *objects*: `AbstractMetricGroup#close()` clears
a group's own children and metrics but never removes the group from its **parent's** map.

For groups that live as long as the job that is harmless. For groups created per transient entity
it leaks. Any source that mints a unique split id per split retains two emptied metric groups,
their `QueryScopeInfo` and their scope strings per finished split, without bound. A Paimon
streaming read guarantees unique ids — one per (snapshot × bucket).

Measured on a TaskManager with 1.4 days uptime:

```
GenericValueMetricGroup   301,792   key='split'       (99.90% of leaked groups)
GenericMetricGroup        301,709   name='watermark'
OperatorQueryScopeInfo    603,120   (2 per split)
HashMap$Node            7,964,229
=> 983 MB of a 1.67 GB live heap
```

Visible without a heap dump as `...split.<uuid>-<seq>.watermark.<metric>` metric identifiers
growing linearly with uptime. In production the heap fills, GC saturates (SerialGC measured at
418–1,340 ms/s), the source starves and consumer lag climbs. A restart clears it completely and
it starts over.

This is **not** FLINK-35321, where the sink committer's `pendingCommittables` gauge re-registers
under a stable name and is replaced by key — log spam, almost no heap. A job with a `DISCARD`
sink and no committer at all still leaks these groups.

## Brief change log

- `AbstractMetricGroup#closeAndRemoveGroup(String)` — removes the named sub-group from this
  group's map while holding this group's monitor, then closes the child *outside* that monitor so
  the map mutation completes before any callout into the registry and reporters.
- Returns early when this group is already closed: `close()` sets `closed = true` before iterating
  `groups.values()`, so a child detaching during a cascading teardown would otherwise mutate the
  map being iterated. `close()` clears the whole map anyway, making the early return correct.
- Removal is keyed by name so it is O(1). Removing by value (`groups.values().remove(child)`)
  would be O(n) per finished split — quadratic across hundreds of thousands of splits.
- `InternalSourceSplitMetricGroup` retains the per-split group in addition to its watermark child.
- `InternalSourceSplitMetricGroup#onSplitFinished()` asks the enclosing `split` KEY group to close
  and remove the per-split group, rather than closing only the watermark child. Closing the split
  group still cascades into the watermark child, so the gauge deregistration added by FLINK-37596
  is preserved.
- `@VisibleForTesting AbstractMetricGroup#numberOfSubgroups()` so the regression test can assert
  on the parent's child count. Happy to drop this in favour of reflection if reviewers prefer.

Metric names are unchanged: the KEY/VALUE group pair is still built by the same
`addGroup(SPLIT, splitId)` call. Assembling it via `addGroup(SPLIT)` instead would create a
GENERIC child and alter emitted names, which is why that call is left as-is.

Closing the split group *without* detaching it would not be sufficient — the emptied group, its
`QueryScopeInfo` and its scope arrays would remain in the parent map, leaving roughly half the
per-split footprint behind. A reporter-side filter such as
`metrics.reporter.<name>.filter.excludes` stops the reporter maps growing but not the group tree,
so it addresses metric cardinality rather than this leak.

## Verifying this change

This change added tests and can be verified as follows:

- Added `InternalSourceSplitMetricGroupTest#testSplitMetricGroupsAreDetachedWhenSplitsFinish`:
  creates five per-split metric groups, finishes each, and asserts the `split` group holds no
  children. Without this change it fails with `expected: 0 but was: 5`. Verified in both
  directions — the test was run against an unpatched tree to confirm it actually catches the
  regression, not only that it passes with the fix.

- Manually verified on a running job: a Paimon streaming read with a `DISCARD` sink (no sink
  committer at all), on Flink 2.2.0 with this change backported, sustaining ~424,000 split
  completions per hour. Three class histograms over 62 minutes, during which roughly 440,000
  splits finished:

  | class | t0 | +14m | +62m | delta |
  |---|---|---|---|---|
  | `GenericValueMetricGroup` | 339 | 303 | 288 | **−51** |
  | `GenericMetricGroup` | 256 | 220 | 205 | **−51** |
  | `InternalSourceSplitMetricGroup` | 51 | 15 | **0** | **−51** |
  | `QueryScopeInfo$OperatorQueryScopeInfo` | 215 | 143 | 113 | **−102** |
  | `TimerGauge` | 332 | 172 | 96 | −236 |
  | `HashMap$Node` | 126,633 | 124,665 | 105,501 | −21,132 |

  Monotonically decreasing across all three captures, and the counts move in exact proportion:
  51 splits released means 51 value groups, 51 watermark groups, 51 wrappers and 102
  `QueryScopeInfo` (two per split). Roughly 440,000 splits finished during that hour; unpatched,
  the same interval would have added on the order of 880,000 group objects, and these counts
  could only ever grow. `InternalSourceSplitMetricGroup` reaching 0 is the clearest single
  signal — with no live splits, nothing per-split is retained at all.

  Note `InternalSourceSplitMetricGroup` was never the leaking object —
  `SourceOperator#splitFinished` already removes the wrapper from its own map. It is included to
  show the wrapper lifecycle is unchanged by this patch, and because its count tracks live splits.

**Build status, stated precisely:** `mvn clean verify` on the whole project has *not* been run.
What was run, using the repository's Maven wrapper so the pinned Maven version is honoured:
`./mvnw -pl flink-runtime -am test -Dtest=InternalSourceSplitMetricGroupTest` — BUILD SUCCESS,
3 tests, 0 failures, with `checkstyle` reporting 0 violations and `spotless:check` passing.
Full CI verification is still outstanding.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no** — both
    `AbstractMetricGroup` and `InternalSourceSplitMetricGroup` are `@Internal`
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no** — `onSplitFinished()` is
    called once per split, from `SourceOperator#splitFinished`, never per record
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing,
    Kubernetes/Yarn, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no** — it is a memory-leak fix
  - If yes, how is the feature documented? **not applicable**

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: Claude Code (Claude Opus 5)
