### PR TITLE
[FLINK-40548][ci] Use image with ubuntu 24.04

### DIFF
--- a/.github/workflows/docs-legacy.yml
+++ b/.github/workflows/docs-legacy.yml
@@ -80,7 +80,7 @@ jobs:
           docker run --rm \
             --volume "$PWD:/root/flink" \
             --volume "$HOME/.m2/repository:/root/.m2/repository" \
-            apache/flink-ci-docker:java_8_11_17_21_25_maven_386_jammy \
+            apache/flink-ci-docker:java_8_11_17_21_25_maven_386_noble \
             bash -c "apt-get update && apt-get install -y rsync && cd /root/flink && ./.github/workflows/docs.sh"
 
       - name: Upload documentation

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -70,7 +70,7 @@ jobs:
           docker run --rm \
             --volume "$PWD:/root/flink" \
             --volume "$HOME/.m2/repository:/root/.m2/repository" \
-            apache/flink-ci-docker:java_8_11_17_21_25_maven_386_jammy \
+            apache/flink-ci-docker:java_8_11_17_21_25_maven_386_noble \
             bash -c "cd /root/flink && ./.github/workflows/docs.sh"
 
       - name: Upload documentation

--- a/.github/workflows/template.flink-ci.yml
+++ b/.github/workflows/template.flink-ci.yml
@@ -72,7 +72,7 @@ jobs:
     name: "Compile"
     runs-on: ubuntu-24.04
     container:
-      image: apache/flink-ci-docker:java_8_11_17_21_25_maven_386_jammy
+      image: apache/flink-ci-docker:java_8_11_17_21_25_maven_386_noble
       # --init makes the process in the container being started as an init process which will clean up any daemon processes during shutdown
       # --privileged allows writing coredumps in docker (FLINK-16973)
       options: --init --privileged
@@ -138,7 +138,7 @@ jobs:
     needs: compile
     runs-on: ubuntu-24.04
     container:
-      image: apache/flink-ci-docker:java_8_11_17_21_25_maven_386_jammy
+      image: apache/flink-ci-docker:java_8_11_17_21_25_maven_386_noble
       # --init makes the process in the container being started as an init process which will clean up any daemon processes during shutdown
       # --privileged allows writing coredumps in docker (FLINK-16973)
       options: --init --privileged
@@ -191,7 +191,7 @@ jobs:
     needs: compile
     runs-on: ubuntu-24.04
     container:
-      image: apache/flink-ci-docker:java_8_11_17_21_25_maven_386_jammy
+      image: apache/flink-ci-docker:java_8_11_17_21_25_maven_386_noble
       # --init makes the process in the container being started as an init process which will clean up any daemon processes during shutdown
       # --privileged allows writing coredumps in docker (FLINK-16973)
       options: --init --privileged

--- a/.github/workflows/template.pre-compile-checks.yml
+++ b/.github/workflows/template.pre-compile-checks.yml
@@ -43,7 +43,7 @@ jobs:
     name: "Basic QA"
     runs-on: ubuntu-24.04
     container:
-      image: apache/flink-ci-docker:java_8_11_17_21_25_maven_386_jammy
+      image: apache/flink-ci-docker:java_8_11_17_21_25_maven_386_noble
       # --init makes the process in the container being started as an init process which will clean up any daemon processes during shutdown
       # --privileged allows writing coredumps in docker (FLINK-16973)
       options: --init --privileged

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -39,7 +39,7 @@ resources:
   # Container with SSL to have the same environment everywhere.
   # see https://github.com/apache/flink-connector-shared-utils/tree/ci_utils
   - container: flink-build-container
-    image: apache/flink-ci-docker:java_8_11_17_21_25_maven_386_jammy
+    image: apache/flink-ci-docker:java_8_11_17_21_25_maven_386_noble
     # On AZP provided machines, set this flag to allow writing coredumps in docker
     options: --privileged
 

--- a/tools/azure-pipelines/build-apache-repo.yml
+++ b/tools/azure-pipelines/build-apache-repo.yml
@@ -39,7 +39,7 @@ resources:
   # Container with SSL to have the same environment everywhere.
   # see https://github.com/apache/flink-connector-shared-utils/tree/ci_utils
   - container: flink-build-container
-    image: apache/flink-ci-docker:java_8_11_17_21_25_maven_386_jammy
+    image: apache/flink-ci-docker:java_8_11_17_21_25_maven_386_noble
 
 variables:
   MAVEN_CACHE_FOLDER: $(Pipeline.Workspace)/.m2/repository


### PR DESCRIPTION


## What is the purpose of the change

Bump image to use ubuntu 24.04

## Brief change log

azure, gha
## Verifying this change

existing tests

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: ( no)
  - The S3 file system connector: (no )

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change the checkbox below to `[X]` and replace the placeholder in the "Generated-by"
line with the tool name and version. Otherwise remove the "Generated-by" line.
See the ASF Generative Tooling Guidance for details:
https://www.apache.org/legal/generative-tooling.html

You are responsible for the quality and correctness of every change in this PR
regardless of the tooling used. Low-effort AI-generated PRs will be closed. See
AGENTS.md for the full guidance.
-->

- [ ] Yes (please specify the tool below)

Generated-by: [Tool Name and Version]
