### PR TITLE
[FLINK-25453] [core] Ignore files deleted concurrently in LocalFileSystem#listStatus

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/core/fs/local/LocalFileSystem.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/local/LocalFileSystem.java
@@ -44,6 +44,7 @@ import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.StandardCopyOption;
+import java.util.Arrays;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 import static org.apache.flink.util.Preconditions.checkState;
@@ -162,11 +163,17 @@ public class LocalFileSystem extends FileSystem {
             return null;
         }
         results = new FileStatus[names.length];
-        for (int i = 0; i < names.length; i++) {
-            results[i] = getFileStatus(new Path(f, names[i]));
+        int resultCount = 0;
+        for (String name : names) {
+            try {
+                results[resultCount] = getFileStatus(new Path(f, name));
+                resultCount++;
+            } catch (FileNotFoundException ignored) {
+                // The directory contents may change after the entries have been listed.
+            }
         }
 
-        return results;
+        return resultCount == results.length ? results : Arrays.copyOf(results, resultCount);
     }
 
     @Override

--- a/flink-core/src/test/java/org/apache/flink/core/fs/local/LocalFileSystemTest.java
+++ b/flink-core/src/test/java/org/apache/flink/core/fs/local/LocalFileSystemTest.java
@@ -38,6 +38,7 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.channels.ClosedChannelException;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.UUID;
@@ -169,6 +170,31 @@ class LocalFileSystemTest {
         assertThat(lfs.delete(pathtotmpdir, true)).isTrue();
 
         assertThat(tempdir).doesNotExist();
+    }
+
+    @Test
+    void testListStatusIgnoresFilesDeletedConcurrently() throws Exception {
+        final File directory = TempDirUtils.newFolder(tempFolder);
+        final File retainedFile = new File(directory, "retained");
+        final File disappearingFile = new File(directory, "disappearing");
+        assertThat(retainedFile.createNewFile()).isTrue();
+        assertThat(disappearingFile.createNewFile()).isTrue();
+
+        final Path disappearingPath = new Path(disappearingFile.toURI());
+        final LocalFileSystem fileSystem =
+                new LocalFileSystem() {
+                    @Override
+                    public FileStatus getFileStatus(Path path) throws IOException {
+                        if (path.equals(disappearingPath)) {
+                            Files.delete(disappearingFile.toPath());
+                        }
+                        return super.getFileStatus(path);
+                    }
+                };
+
+        assertThat(fileSystem.listStatus(new Path(directory.toURI())))
+                .extracting(status -> status.getPath().getName())
+                .containsExactly("retained");
     }
 
     @Test


### PR DESCRIPTION
## What is the purpose of the change

This pull request fixes [FLINK-25453](https://issues.apache.org/jira/browse/FLINK-25453).

`LocalFileSystem.listStatus()` first obtains the names of the entries in a
directory and then retrieves the status of each entry. If an entry is deleted
between these operations, the status lookup throws `FileNotFoundException` and
the complete directory listing fails.

This change ignores an entry that disappears during its status lookup while
preserving the successfully retrieved entries. Other I/O failures continue to
be propagated.

## Brief change log

- Ignore `FileNotFoundException` for individual entries that disappear while
  `LocalFileSystem.listStatus()` is collecting their statuses.
- Return a compact result array containing only the entries whose statuses were
  retrieved successfully.
- Add a deterministic regression test that removes an entry between directory
  listing and status retrieval.

## Verifying this change

This change added tests and can be verified as follows:

- `./mvnw -pl flink-core -DskipITs -Dtest=LocalFileSystemTest test`
- `./mvnw -pl flink-core -DskipITs -Dtest=LocalFileSystemTest,LocalFileSystemBehaviorTest test`

The second command passed locally with 32 tests, 0 failures, 0 errors, and 1
skipped test. Checkstyle and Spotless also passed.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: OpenAI Codex (GPT-5)
reviewed by human, and I'm responsible for the quality.