### PR TITLE
[FLINK-40487][table] CAST between UUID and STRING / BINARY(16)

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/UuidType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/UuidType.java
@@ -38,6 +38,9 @@ public final class UuidType extends LogicalType {
 
     private static final long serialVersionUID = 1L;
 
+    /** Length of a UUID in bytes, as stored in its canonical big-endian encoding. */
+    public static final int BYTE_LENGTH = 16;
+
     private static final Set<String> INPUT_OUTPUT_CONVERSION =
             conversionSet(UUID.class.getName(), byte[].class.getName());
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/utils/LogicalTypeCasts.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/utils/LogicalTypeCasts.java
@@ -28,6 +28,7 @@ import org.apache.flink.table.types.logical.LogicalTypeFamily;
 import org.apache.flink.table.types.logical.LogicalTypeRoot;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.logical.StructuredType;
+import org.apache.flink.table.types.logical.UuidType;
 import org.apache.flink.table.types.logical.VarBinaryType;
 import org.apache.flink.table.types.logical.VarCharType;
 import org.apache.flink.table.types.logical.YearMonthIntervalType;
@@ -79,6 +80,7 @@ import static org.apache.flink.table.types.logical.LogicalTypeRoot.TIMESTAMP_WIT
 import static org.apache.flink.table.types.logical.LogicalTypeRoot.TIMESTAMP_WITH_TIME_ZONE;
 import static org.apache.flink.table.types.logical.LogicalTypeRoot.TIME_WITHOUT_TIME_ZONE;
 import static org.apache.flink.table.types.logical.LogicalTypeRoot.TINYINT;
+import static org.apache.flink.table.types.logical.LogicalTypeRoot.UUID;
 import static org.apache.flink.table.types.logical.LogicalTypeRoot.VARBINARY;
 import static org.apache.flink.table.types.logical.LogicalTypeRoot.VARCHAR;
 import static org.apache.flink.table.types.logical.LogicalTypeRoot.VARIANT;
@@ -211,7 +213,7 @@ public final class LogicalTypeCasts {
         castTo(CHAR)
                 .implicitFrom(CHAR)
                 .explicitFromFamily(PREDEFINED, CONSTRUCTED)
-                .explicitFrom(RAW, NULL, STRUCTURED_TYPE, BITMAP, VARIANT)
+                .explicitFrom(RAW, NULL, STRUCTURED_TYPE, BITMAP, VARIANT, UUID)
                 .injectiveFrom(WHEN_LENGTH_FITS, CHAR)
                 .injectiveFrom(WHEN_MAX_CHAR_LENGTH_FITS, STRING_INJECTIVE_SOURCES)
                 .injectiveFrom(WHEN_CHAR_LENGTH_FITS_UTF8, BINARY, VARBINARY)
@@ -220,7 +222,7 @@ public final class LogicalTypeCasts {
         castTo(VARCHAR)
                 .implicitFromFamily(CHARACTER_STRING)
                 .explicitFromFamily(PREDEFINED, CONSTRUCTED)
-                .explicitFrom(RAW, NULL, STRUCTURED_TYPE, BITMAP, VARIANT)
+                .explicitFrom(RAW, NULL, STRUCTURED_TYPE, BITMAP, VARIANT, UUID)
                 .injectiveFrom(WHEN_LENGTH_FITS, CHAR, VARCHAR)
                 .injectiveFrom(WHEN_MAX_CHAR_LENGTH_FITS, STRING_INJECTIVE_SOURCES)
                 .injectiveFrom(WHEN_CHAR_LENGTH_FITS_UTF8, BINARY, VARBINARY)
@@ -398,6 +400,15 @@ public final class LogicalTypeCasts {
                 .implicitFrom(INTERVAL_DAY_TIME)
                 .explicitFromFamily(EXACT_NUMERIC, CHARACTER_STRING)
                 .build();
+
+        // -----------------------------------------------------------------------------------------
+        // UUID type
+        // -----------------------------------------------------------------------------------------
+
+        // A UUID can be parsed from a character string and reinterpreted from its 16-byte encoding.
+        // The reverse direction (UUID to CHAR/VARCHAR and to BINARY(16)/BYTES) is declared on the
+        // respective target types.
+        castTo(UUID).implicitFrom(UUID).explicitFromFamily(CHARACTER_STRING, BINARY_STRING).build();
     }
 
     /**
@@ -687,6 +698,15 @@ public final class LogicalTypeCasts {
             // BITMAP can only be cast to BYTES (unbounded VARBINARY), because trimming or padding
             // would corrupt the serialized bitmap data.
             return allowExplicit && getLength(targetType) == VarBinaryType.MAX_LENGTH;
+        } else if (sourceRoot == UUID && targetRoot == BINARY) {
+            // A UUID is exactly BYTE_LENGTH bytes. BINARY is fixed width, so only
+            // BINARY(BYTE_LENGTH)
+            // holds it without padding or trimming.
+            return allowExplicit && getLength(targetType) == UuidType.BYTE_LENGTH;
+        } else if (sourceRoot == UUID && targetRoot == VARBINARY) {
+            // VARBINARY is variable width, so any VARBINARY(n) with n >= BYTE_LENGTH, up to BYTES,
+            // holds the bytes without trimming.
+            return allowExplicit && getLength(targetType) >= UuidType.BYTE_LENGTH;
         }
 
         if (implicitCastingRules.get(targetRoot).contains(sourceRoot)) {

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/utils/LogicalTypeCasts.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/utils/LogicalTypeCasts.java
@@ -698,15 +698,11 @@ public final class LogicalTypeCasts {
             // BITMAP can only be cast to BYTES (unbounded VARBINARY), because trimming or padding
             // would corrupt the serialized bitmap data.
             return allowExplicit && getLength(targetType) == VarBinaryType.MAX_LENGTH;
-        } else if (sourceRoot == UUID && targetRoot == BINARY) {
-            // A UUID is exactly BYTE_LENGTH bytes. BINARY is fixed width, so only
-            // BINARY(BYTE_LENGTH)
-            // holds it without padding or trimming.
-            return allowExplicit && getLength(targetType) == UuidType.BYTE_LENGTH;
-        } else if (sourceRoot == UUID && targetRoot == VARBINARY) {
-            // VARBINARY is variable width, so any VARBINARY(n) with n >= BYTE_LENGTH, up to BYTES,
-            // holds the bytes without trimming.
-            return allowExplicit && getLength(targetType) >= UuidType.BYTE_LENGTH;
+        } else if (sourceRoot == UUID && (targetRoot == BINARY || targetRoot == VARBINARY)) {
+            // A UUID maps to and from its 16-byte encoding.
+            return allowExplicit && uuidFitsBinaryType(targetType);
+        } else if (targetRoot == UUID && (sourceRoot == BINARY || sourceRoot == VARBINARY)) {
+            return allowExplicit && uuidFitsBinaryType(sourceType);
         }
 
         if (implicitCastingRules.get(targetRoot).contains(sourceRoot)) {
@@ -716,6 +712,16 @@ public final class LogicalTypeCasts {
             return explicitCastingRules.get(targetRoot).contains(sourceRoot);
         }
         return false;
+    }
+
+    /**
+     * Whether a UUID's 16-byte encoding fits the given binary type. BINARY is fixed width, so only
+     * BINARY(16) fits; a VARBINARY(n) fits when n >= 16, with the exact length checked at runtime.
+     */
+    private static boolean uuidFitsBinaryType(LogicalType binaryType) {
+        return binaryType.is(BINARY)
+                ? getLength(binaryType) == UuidType.BYTE_LENGTH
+                : getLength(binaryType) >= UuidType.BYTE_LENGTH;
     }
 
     private static boolean supportsStructuredCasting(

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LogicalTypeCastsTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LogicalTypeCastsTest.java
@@ -45,6 +45,7 @@ import org.apache.flink.table.types.logical.StructuredType.StructuredAttribute;
 import org.apache.flink.table.types.logical.TimeType;
 import org.apache.flink.table.types.logical.TimestampType;
 import org.apache.flink.table.types.logical.TinyIntType;
+import org.apache.flink.table.types.logical.UuidType;
 import org.apache.flink.table.types.logical.VarBinaryType;
 import org.apache.flink.table.types.logical.VarCharType;
 import org.apache.flink.table.types.logical.VariantType;
@@ -309,10 +310,34 @@ class LogicalTypeCastsTest {
                         false),
                 // MULTISET has no variant counterpart and stays unsupported
                 Arguments.of(
-                        new VariantType(),
-                        new MultisetType(VarCharType.STRING_TYPE),
-                        false,
-                        false));
+                        new VariantType(), new MultisetType(VarCharType.STRING_TYPE), false, false),
+                // UUID casts are explicit only, in both directions
+                Arguments.of(new UuidType(), VarCharType.STRING_TYPE, false, true),
+                Arguments.of(new UuidType(), new CharType(), false, true),
+                Arguments.of(VarCharType.STRING_TYPE, new UuidType(), false, true),
+                Arguments.of(new CharType(), new UuidType(), false, true),
+                // UUID maps to its 16-byte encoding. BINARY is fixed width, so only BINARY(16)
+                // fits. VARBINARY is variable width, so any VARBINARY(n >= 16), up to BYTES, fits.
+                Arguments.of(new UuidType(), new BinaryType(16), false, true),
+                Arguments.of(new UuidType(), new BinaryType(10), false, false),
+                Arguments.of(new UuidType(), new BinaryType(20), false, false),
+                Arguments.of(
+                        new UuidType(), new VarBinaryType(VarBinaryType.MAX_LENGTH), false, true),
+                Arguments.of(new UuidType(), new VarBinaryType(16), false, true),
+                Arguments.of(new UuidType(), new VarBinaryType(20), false, true),
+                Arguments.of(new UuidType(), new VarBinaryType(8), false, false),
+                // any binary source is accepted; the exact-16-bytes rule is enforced at runtime
+                Arguments.of(
+                        new VarBinaryType(VarBinaryType.MAX_LENGTH), new UuidType(), false, true),
+                Arguments.of(new BinaryType(16), new UuidType(), false, true),
+                Arguments.of(new BinaryType(10), new UuidType(), false, true),
+                // UUID identity cast is implicit
+                Arguments.of(new UuidType(), new UuidType(), true, true),
+                // numeric and VARIANT are not castable to or from UUID
+                Arguments.of(new UuidType(), new IntType(), false, false),
+                Arguments.of(new IntType(), new UuidType(), false, false),
+                Arguments.of(new UuidType(), new VariantType(), false, false),
+                Arguments.of(new VariantType(), new UuidType(), false, false));
     }
 
     @ParameterizedTest(name = "{index}: [From: {0}, To: {1}, Implicit: {2}, Explicit: {3}]")

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LogicalTypeCastsTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LogicalTypeCastsTest.java
@@ -326,11 +326,15 @@ class LogicalTypeCastsTest {
                 Arguments.of(new UuidType(), new VarBinaryType(16), false, true),
                 Arguments.of(new UuidType(), new VarBinaryType(20), false, true),
                 Arguments.of(new UuidType(), new VarBinaryType(8), false, false),
-                // any binary source is accepted; the exact-16-bytes rule is enforced at runtime
+                // A binary source maps back from the 16-byte encoding. BINARY is fixed width, so
+                // only BINARY(16) fits; a VARBINARY(n >= 16) may hold it, with the exact length
+                // checked at runtime.
                 Arguments.of(
                         new VarBinaryType(VarBinaryType.MAX_LENGTH), new UuidType(), false, true),
+                Arguments.of(new VarBinaryType(16), new UuidType(), false, true),
+                Arguments.of(new VarBinaryType(8), new UuidType(), false, false),
                 Arguments.of(new BinaryType(16), new UuidType(), false, true),
-                Arguments.of(new BinaryType(10), new UuidType(), false, true),
+                Arguments.of(new BinaryType(10), new UuidType(), false, false),
                 // UUID identity cast is implicit
                 Arguments.of(new UuidType(), new UuidType(), true, true),
                 // numeric and VARIANT are not castable to or from UUID

--- a/flink-table/flink-table-planner/src/main/java/org/apache/calcite/sql/fun/SqlCastFunction.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/calcite/sql/fun/SqlCastFunction.java
@@ -269,15 +269,23 @@ public class SqlCastFunction extends SqlFunction {
 
     private boolean canCastFrom(RelDataType toType, RelDataType fromType) {
         SqlTypeName fromTypeName = fromType.getSqlTypeName();
+        SqlTypeName toTypeName = toType.getSqlTypeName();
 
         // Cast to Variant is not support at the moment.
         // TODO: Support cast to variant (FLINK-37925，FLINK-37926)
-        if (toType.getSqlTypeName() == SqlTypeName.VARIANT) {
+        if (toTypeName == SqlTypeName.VARIANT) {
             return false;
         }
         // Cast to BITMAP is not supported at the moment.
         if (toType instanceof BitmapRelDataType) {
             return false;
+        }
+        // UUID casts are governed entirely by our own checker in both directions, because Calcite
+        // only allows a UUID to be cast from another UUID.
+        if (toTypeName == SqlTypeName.UUID || fromTypeName == SqlTypeName.UUID) {
+            return LogicalTypeCasts.supportsExplicitCast(
+                    FlinkTypeFactory.toLogicalType(fromType),
+                    FlinkTypeFactory.toLogicalType(toType));
         }
         switch (fromTypeName) {
             case ARRAY:

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/BinaryToUuidCastRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/BinaryToUuidCastRule.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.functions.casting;
+
+import org.apache.flink.table.runtime.functions.UuidCastUtils;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.LogicalTypeFamily;
+import org.apache.flink.table.types.logical.LogicalTypeRoot;
+
+import static org.apache.flink.table.planner.functions.casting.CastRuleUtils.staticCall;
+
+/**
+ * {@link LogicalTypeFamily#BINARY_STRING} to {@link LogicalTypeRoot#UUID} cast rule, the inverse of
+ * {@link UuidToBinaryCastRule}.
+ *
+ * <p>Reinterprets the bytes as a UUID via {@link UuidCastUtils#fromBytes(byte[])}, which requires
+ * exactly 16 bytes. A different length fails {@code CAST}; since the rule {@link #canFail}, the
+ * framework wraps the call in a {@code try/catch} that yields {@code null} for {@code TRY_CAST}.
+ * Example generated code:
+ *
+ * <pre>
+ * result$0 = UuidCastUtils.fromBytes(bytes$0);
+ * </pre>
+ */
+class BinaryToUuidCastRule extends AbstractExpressionCodeGeneratorCastRule<byte[], byte[]> {
+
+    static final BinaryToUuidCastRule INSTANCE = new BinaryToUuidCastRule();
+
+    private BinaryToUuidCastRule() {
+        super(
+                CastRulePredicate.builder()
+                        .input(LogicalTypeFamily.BINARY_STRING)
+                        .target(LogicalTypeRoot.UUID)
+                        .build());
+    }
+
+    @Override
+    public boolean canFail(LogicalType inputLogicalType, LogicalType targetLogicalType) {
+        return true;
+    }
+
+    @Override
+    public String generateExpression(
+            CodeGeneratorCastRule.Context context,
+            String inputTerm,
+            LogicalType inputLogicalType,
+            LogicalType targetLogicalType) {
+        return staticCall(UuidCastUtils.class, "fromBytes", inputTerm);
+    }
+}

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/BinaryToUuidCastRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/BinaryToUuidCastRule.java
@@ -22,6 +22,8 @@ import org.apache.flink.table.runtime.functions.UuidCastUtils;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.LogicalTypeFamily;
 import org.apache.flink.table.types.logical.LogicalTypeRoot;
+import org.apache.flink.table.types.logical.UuidType;
+import org.apache.flink.table.types.logical.utils.LogicalTypeChecks;
 
 import static org.apache.flink.table.planner.functions.casting.CastRuleUtils.staticCall;
 
@@ -29,8 +31,10 @@ import static org.apache.flink.table.planner.functions.casting.CastRuleUtils.sta
  * {@link LogicalTypeFamily#BINARY_STRING} to {@link LogicalTypeRoot#UUID} cast rule, the inverse of
  * {@link UuidToBinaryCastRule}.
  *
- * <p>Reinterprets the bytes as a UUID via {@link UuidCastUtils#fromBytes(byte[])}, which requires
- * exactly 16 bytes. A different length fails {@code CAST}; since the rule {@link #canFail}, the
+ * <p>Reinterprets the bytes as a UUID via {@link UuidCastUtils#fromBytes(byte[])}. Supported inputs
+ * are {@code BINARY(16)} and any {@code VARBINARY(n)} with {@code n >= 16} (including {@code
+ * BYTES}); a fixed {@code BINARY} of another width is rejected during validation. A variable-width
+ * value that is not exactly 16 bytes fails {@code CAST}; since the rule {@link #canFail}, the
  * framework wraps the call in a {@code try/catch} that yields {@code null} for {@code TRY_CAST}.
  * Example generated code:
  *
@@ -45,9 +49,20 @@ class BinaryToUuidCastRule extends AbstractExpressionCodeGeneratorCastRule<byte[
     private BinaryToUuidCastRule() {
         super(
                 CastRulePredicate.builder()
-                        .input(LogicalTypeFamily.BINARY_STRING)
-                        .target(LogicalTypeRoot.UUID)
+                        .predicate(
+                                (input, target) ->
+                                        isSupportedInput(input) && target.is(LogicalTypeRoot.UUID))
                         .build());
+    }
+
+    private static boolean isSupportedInput(LogicalType input) {
+        if (input.is(LogicalTypeRoot.BINARY)) {
+            return LogicalTypeChecks.getLength(input) == UuidType.BYTE_LENGTH;
+        }
+        if (input.is(LogicalTypeRoot.VARBINARY)) {
+            return LogicalTypeChecks.getLength(input) >= UuidType.BYTE_LENGTH;
+        }
+        return false;
     }
 
     @Override

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/CastRuleProvider.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/CastRuleProvider.java
@@ -102,6 +102,11 @@ public class CastRuleProvider {
                 // Bitmap rules
                 .addRule(BitmapToStringCastRule.INSTANCE)
                 .addRule(BitmapToBinaryCastRule.INSTANCE)
+                // UUID rules
+                .addRule(UuidToStringCastRule.INSTANCE)
+                .addRule(UuidToBinaryCastRule.INSTANCE)
+                .addRule(StringToUuidCastRule.INSTANCE)
+                .addRule(BinaryToUuidCastRule.INSTANCE)
                 // Special rules
                 .addRule(CharVarCharTrimPadCastRule.INSTANCE)
                 .addRule(NullToStringCastRule.INSTANCE);

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/StringToUuidCastRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/StringToUuidCastRule.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.functions.casting;
+
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.runtime.functions.UuidCastUtils;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.LogicalTypeFamily;
+import org.apache.flink.table.types.logical.LogicalTypeRoot;
+
+import static org.apache.flink.table.planner.functions.casting.CastRuleUtils.methodCall;
+import static org.apache.flink.table.planner.functions.casting.CastRuleUtils.staticCall;
+
+/**
+ * {@link LogicalTypeFamily#CHARACTER_STRING} to {@link LogicalTypeRoot#UUID} cast rule, the inverse
+ * of {@link UuidToStringCastRule}.
+ *
+ * <p>Parses the string with {@link UuidCastUtils#toUuidBytes(String)} (lenient, PostgreSQL style).
+ * A malformed value fails {@code CAST}; since the rule {@link #canFail}, the framework wraps the
+ * call in a {@code try/catch} that yields {@code null} for {@code TRY_CAST}. Example generated
+ * code:
+ *
+ * <pre>
+ * result$0 = UuidCastUtils.toUuidBytes(str$0.toString());
+ * </pre>
+ */
+class StringToUuidCastRule extends AbstractExpressionCodeGeneratorCastRule<StringData, byte[]> {
+
+    static final StringToUuidCastRule INSTANCE = new StringToUuidCastRule();
+
+    private StringToUuidCastRule() {
+        super(
+                CastRulePredicate.builder()
+                        .input(LogicalTypeFamily.CHARACTER_STRING)
+                        .target(LogicalTypeRoot.UUID)
+                        .build());
+    }
+
+    @Override
+    public boolean canFail(LogicalType inputLogicalType, LogicalType targetLogicalType) {
+        return true;
+    }
+
+    @Override
+    public String generateExpression(
+            CodeGeneratorCastRule.Context context,
+            String inputTerm,
+            LogicalType inputLogicalType,
+            LogicalType targetLogicalType) {
+        return staticCall(UuidCastUtils.class, "toUuidBytes", methodCall(inputTerm, "toString"));
+    }
+}

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/UuidToBinaryCastRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/UuidToBinaryCastRule.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.functions.casting;
+
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.LogicalTypeRoot;
+import org.apache.flink.table.types.logical.UuidType;
+import org.apache.flink.table.types.logical.utils.LogicalTypeChecks;
+
+/**
+ * {@link LogicalTypeRoot#UUID} to binary cast rule, the inverse of {@link BinaryToUuidCastRule}.
+ *
+ * <p>A UUID is its 16-byte big-endian encoding, so the internal {@code byte[]} is returned
+ * unchanged. Supported targets are {@code BINARY(16)} and any {@code VARBINARY(n)} with {@code n >=
+ * 16} (including {@code BYTES}); a narrower or padded width would trim or pad the value and thereby
+ * corrupt it. Example generated code:
+ *
+ * <pre>
+ * result$0 = uuid$0;
+ * </pre>
+ */
+class UuidToBinaryCastRule extends AbstractExpressionCodeGeneratorCastRule<byte[], byte[]> {
+
+    static final UuidToBinaryCastRule INSTANCE = new UuidToBinaryCastRule();
+
+    private UuidToBinaryCastRule() {
+        super(
+                CastRulePredicate.builder()
+                        .predicate(
+                                (input, target) ->
+                                        input.is(LogicalTypeRoot.UUID) && isSupportedTarget(target))
+                        .build());
+    }
+
+    private static boolean isSupportedTarget(LogicalType target) {
+        if (target.is(LogicalTypeRoot.BINARY)) {
+            return LogicalTypeChecks.getLength(target) == UuidType.BYTE_LENGTH;
+        }
+        if (target.is(LogicalTypeRoot.VARBINARY)) {
+            return LogicalTypeChecks.getLength(target) >= UuidType.BYTE_LENGTH;
+        }
+        return false;
+    }
+
+    @Override
+    public String generateExpression(
+            CodeGeneratorCastRule.Context context,
+            String inputTerm,
+            LogicalType inputLogicalType,
+            LogicalType targetLogicalType) {
+        return inputTerm;
+    }
+}

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/UuidToStringCastRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/UuidToStringCastRule.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.functions.casting;
+
+import org.apache.flink.table.runtime.functions.UuidCastUtils;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.LogicalTypeFamily;
+import org.apache.flink.table.types.logical.LogicalTypeRoot;
+
+import static org.apache.flink.table.planner.functions.casting.CastRuleUtils.staticCall;
+import static org.apache.flink.table.types.logical.VarCharType.STRING_TYPE;
+
+/**
+ * {@link LogicalTypeRoot#UUID} to {@link LogicalTypeFamily#CHARACTER_STRING} cast rule, the inverse
+ * of {@link StringToUuidCastRule}.
+ *
+ * <p>Renders the value with {@link UuidCastUtils#toStringValue(byte[])}; the base rule wraps the
+ * result in a {@code BinaryStringData}, and a bounded {@code CHAR(n)}/{@code VARCHAR(n)} target is
+ * trimmed or padded by {@link CharVarCharTrimPadCastRule}. Example generated code:
+ *
+ * <pre>
+ * result$0 = BinaryStringData.fromString(UuidCastUtils.toStringValue(uuid$0));
+ * </pre>
+ */
+class UuidToStringCastRule extends AbstractCharacterFamilyTargetRule<byte[]> {
+
+    static final UuidToStringCastRule INSTANCE = new UuidToStringCastRule();
+
+    private UuidToStringCastRule() {
+        super(CastRulePredicate.builder().input(LogicalTypeRoot.UUID).target(STRING_TYPE).build());
+    }
+
+    @Override
+    public String generateStringExpression(
+            CodeGeneratorCastRule.Context context,
+            String inputTerm,
+            LogicalType inputLogicalType,
+            LogicalType targetLogicalType) {
+        return staticCall(UuidCastUtils.class, "toStringValue", inputTerm);
+    }
+}

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CastFunctionITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CastFunctionITCase.java
@@ -20,6 +20,7 @@ package org.apache.flink.table.planner.functions;
 
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.table.api.TableException;
+import org.apache.flink.table.api.TableRuntimeException;
 import org.apache.flink.table.api.config.TableConfigOptions;
 import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
 import org.apache.flink.table.types.AbstractDataType;
@@ -32,6 +33,7 @@ import org.apache.flink.types.Row;
 import org.apache.flink.types.bitmap.Bitmap;
 
 import java.math.BigDecimal;
+import java.nio.ByteBuffer;
 import java.time.DateTimeException;
 import java.time.Duration;
 import java.time.Instant;
@@ -74,6 +76,7 @@ import static org.apache.flink.table.api.DataTypes.TIME;
 import static org.apache.flink.table.api.DataTypes.TIMESTAMP;
 import static org.apache.flink.table.api.DataTypes.TIMESTAMP_LTZ;
 import static org.apache.flink.table.api.DataTypes.TINYINT;
+import static org.apache.flink.table.api.DataTypes.UUID;
 import static org.apache.flink.table.api.DataTypes.VARBINARY;
 import static org.apache.flink.table.api.DataTypes.VARCHAR;
 import static org.apache.flink.table.api.DataTypes.VARIANT;
@@ -120,6 +123,18 @@ public class CastFunctionITCase extends BuiltInFunctionTestBase {
 
     private static final Bitmap DEFAULT_BITMAP = Bitmap.fromArray(new int[] {0, 1, 2});
 
+    private static final String DEFAULT_UUID_STRING = "550e8400-e29b-41d4-a716-446655440000";
+    private static final java.util.UUID DEFAULT_UUID =
+            java.util.UUID.fromString(DEFAULT_UUID_STRING);
+    private static final byte[] DEFAULT_UUID_BYTES = uuidBytes(DEFAULT_UUID);
+
+    private static byte[] uuidBytes(java.util.UUID uuid) {
+        return ByteBuffer.allocate(16)
+                .putLong(uuid.getMostSignificantBits())
+                .putLong(uuid.getLeastSignificantBits())
+                .array();
+    }
+
     @Override
     Configuration getConfiguration() {
         return super.getConfiguration().set(TableConfigOptions.LOCAL_TIME_ZONE, TEST_TZ.getId());
@@ -135,6 +150,7 @@ public class CastFunctionITCase extends BuiltInFunctionTestBase {
         specs.addAll(constructedTypes());
         specs.addAll(bitmapCasts());
         specs.addAll(variantCasts());
+        specs.addAll(uuidCasts());
         return specs.stream();
     }
 
@@ -492,6 +508,60 @@ public class CastFunctionITCase extends BuiltInFunctionTestBase {
                         .testTableApiValidationError(
                                 lit("[1]").parseJson().cast(ARRAY(INTERVAL(MONTH()))),
                                 "Unsupported cast"));
+    }
+
+    private static List<TestSetSpec> uuidCasts() {
+        // A UUID has no Table API literal, so a UUID source is produced from a string cast. The
+        // exhaustive value and lenient-parse matrix lives in CastRulesTest.
+        final String literal = "UUID '" + DEFAULT_UUID_STRING + "'";
+        return Arrays.asList(
+                // A string or a binary value casts to a UUID.
+                CastTestSpecBuilder.testCastTo(UUID())
+                        .fromCase(STRING(), DEFAULT_UUID_STRING, DEFAULT_UUID)
+                        .fromCase(BYTES(), DEFAULT_UUID_BYTES, DEFAULT_UUID)
+                        .fromCase(STRING(), null, null)
+                        .build(),
+                // A numeric source is rejected during validation.
+                CastTestSpecBuilder.testCastTo(UUID())
+                        .failValidation(INT(), DEFAULT_POSITIVE_INT)
+                        .build(),
+                // A malformed string or a binary value of the wrong length fails CAST at runtime
+                // and yields NULL for TRY_CAST.
+                TestSetSpec.forExpression("Cast a malformed value to UUID")
+                        .onFieldsWithData("not-a-uuid", new byte[] {1, 2, 3})
+                        .andDataTypes(STRING(), BYTES())
+                        .testTableApiRuntimeError(
+                                $("f0").cast(UUID()),
+                                TableRuntimeException.class,
+                                "32 hexadecimal digits")
+                        .testSqlRuntimeError(
+                                "CAST(f0 AS UUID)",
+                                TableRuntimeException.class,
+                                "32 hexadecimal digits")
+                        .testResult($("f0").tryCast(UUID()), "TRY_CAST(f0 AS UUID)", null, UUID())
+                        .testTableApiRuntimeError(
+                                $("f1").cast(UUID()),
+                                TableRuntimeException.class,
+                                "requires exactly 16 bytes")
+                        .testSqlRuntimeError(
+                                "CAST(f1 AS UUID)",
+                                TableRuntimeException.class,
+                                "requires exactly 16 bytes")
+                        .testResult($("f1").tryCast(UUID()), "TRY_CAST(f1 AS UUID)", null, UUID()),
+                // A UUID casts to its canonical string and to its 16-byte encoding.
+                TestSetSpec.forExpression("Cast a UUID to a string and to bytes")
+                        .onFieldsWithData("unused")
+                        .andDataTypes(STRING())
+                        .testResult(
+                                lit(DEFAULT_UUID_STRING).cast(UUID()).cast(STRING()),
+                                "CAST(" + literal + " AS STRING)",
+                                DEFAULT_UUID_STRING,
+                                STRING().notNull())
+                        .testResult(
+                                lit(DEFAULT_UUID_STRING).cast(UUID()).cast(BYTES()),
+                                "CAST(" + literal + " AS BYTES)",
+                                DEFAULT_UUID_BYTES,
+                                BYTES().notNull()));
     }
 
     private static List<TestSetSpec> allTypesBasic() {

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CastFunctionITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CastFunctionITCase.java
@@ -521,9 +521,11 @@ public class CastFunctionITCase extends BuiltInFunctionTestBase {
                         .fromCase(BYTES(), DEFAULT_UUID_BYTES, DEFAULT_UUID)
                         .fromCase(STRING(), null, null)
                         .build(),
-                // A numeric source is rejected during validation.
+                // A numeric source, and a fixed BINARY of a width other than 16, are rejected
+                // during validation rather than at runtime.
                 CastTestSpecBuilder.testCastTo(UUID())
                         .failValidation(INT(), DEFAULT_POSITIVE_INT)
+                        .failValidation(BINARY(10), new byte[10])
                         .build(),
                 // A malformed string or a binary value of the wrong length fails CAST at runtime
                 // and yields NULL for TRY_CAST.

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/casting/CastRulesTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/casting/CastRulesTest.java
@@ -44,6 +44,7 @@ import org.apache.flink.types.bitmap.Bitmap;
 import org.apache.flink.types.variant.Variant;
 import org.apache.flink.types.variant.VariantBuilder;
 
+import org.assertj.core.api.AbstractThrowableAssert;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.TestFactory;
 import org.junit.jupiter.api.parallel.Execution;
@@ -96,6 +97,7 @@ import static org.apache.flink.table.api.DataTypes.TIME;
 import static org.apache.flink.table.api.DataTypes.TIMESTAMP;
 import static org.apache.flink.table.api.DataTypes.TIMESTAMP_LTZ;
 import static org.apache.flink.table.api.DataTypes.TINYINT;
+import static org.apache.flink.table.api.DataTypes.UUID;
 import static org.apache.flink.table.api.DataTypes.VARBINARY;
 import static org.apache.flink.table.api.DataTypes.VARCHAR;
 import static org.apache.flink.table.api.DataTypes.VARIANT;
@@ -161,6 +163,18 @@ class CastRulesTest {
     private static final StringData TIMESTAMP_STRING_CET = fromString("2021-09-24 14:34:56.123456");
 
     private static final Bitmap DEFAULT_BITMAP = Bitmap.fromArray(new int[] {0, 1, 2});
+
+    private static final String UUID_STRING = "550e8400-e29b-41d4-a716-446655440000";
+    private static final byte[] UUID_BYTES = uuidBytes(UUID_STRING);
+
+    private static byte[] uuidBytes(String uuid) {
+        final java.util.UUID value = java.util.UUID.fromString(uuid);
+        final byte[] result = new byte[16];
+        java.nio.ByteBuffer.wrap(result)
+                .putLong(value.getMostSignificantBits())
+                .putLong(value.getLeastSignificantBits());
+        return result;
+    }
 
     /** A two-byte lead followed by a byte that is not a continuation byte. */
     private static final byte[] INVALID_UTF8 = new byte[] {(byte) 0xC3, (byte) 0x28};
@@ -1628,6 +1642,71 @@ class CastRulesTest {
                         .fromCase(BITMAP(), DEFAULT_BITMAP, DEFAULT_BITMAP.toBytes())
                         .fromCase(BITMAP(), Bitmap.empty(), Bitmap.empty().toBytes())
                         .fromCase(BITMAP(), null, null),
+                // UUID cast rules. A UUID renders as its canonical lower-case 8-4-4-4-12 form and
+                // maps to its 16-byte big-endian encoding.
+                CastTestSpecBuilder.testCastTo(STRING())
+                        .fromCase(UUID(), UUID_BYTES, fromString(UUID_STRING))
+                        .fromCase(UUID(), null, null),
+                // a bounded character target trims, and CHAR pads to its fixed width
+                CastTestSpecBuilder.testCastTo(VARCHAR(8))
+                        .fromCase(UUID(), UUID_BYTES, fromString("550e8400")),
+                CastTestSpecBuilder.testCastTo(CHAR(38))
+                        .fromCase(UUID(), UUID_BYTES, fromString(UUID_STRING + "  ")),
+                CastTestSpecBuilder.testCastTo(BINARY(16))
+                        .fromCase(UUID(), UUID_BYTES, UUID_BYTES)
+                        .fromCase(UUID(), null, null),
+                // a VARBINARY(n) with n >= 16 holds the value without trimming
+                CastTestSpecBuilder.testCastTo(VARBINARY(16))
+                        .fromCase(UUID(), UUID_BYTES, UUID_BYTES)
+                        .fromCase(UUID(), null, null),
+                CastTestSpecBuilder.testCastTo(BYTES())
+                        .fromCase(UUID(), UUID_BYTES, UUID_BYTES)
+                        .fromCase(UUID(), null, null),
+                // a UUID is parsed leniently from a string, following PostgreSQL conventions
+                CastTestSpecBuilder.testCastTo(UUID())
+                        .fromCase(STRING(), fromString(UUID_STRING), UUID_BYTES)
+                        .fromCase(STRING(), fromString(UUID_STRING.toUpperCase()), UUID_BYTES)
+                        .fromCase(STRING(), fromString("{" + UUID_STRING + "}"), UUID_BYTES)
+                        .fromCase(STRING(), fromString(UUID_STRING.replace("-", "")), UUID_BYTES)
+                        // a hyphen may follow any group of four digits, PostgreSQL style
+                        .fromCase(
+                                STRING(),
+                                fromString("550e-8400-e29b-41d4-a716-4466-5544-0000"),
+                                UUID_BYTES)
+                        .fromCase(STRING(), null, null)
+                        // a malformed value fails, and yields null for TRY_CAST
+                        .fail(
+                                STRING(),
+                                fromString("not-a-uuid"),
+                                TableRuntimeException.class,
+                                "32 hexadecimal digits")
+                        .fail(
+                                STRING(),
+                                fromString("550e8400"),
+                                TableRuntimeException.class,
+                                "32 hexadecimal digits")
+                        // too many hexadecimal digits
+                        .fail(
+                                STRING(),
+                                fromString(UUID_STRING + "00"),
+                                TableRuntimeException.class,
+                                "32 hexadecimal digits")
+                        // a hyphen inside a four-digit group is rejected
+                        .fail(
+                                STRING(),
+                                fromString("5-50e8400e29b41d4a716446655440000"),
+                                TableRuntimeException.class,
+                                "32 hexadecimal digits"),
+                // a binary value is reinterpreted, and has to be exactly 16 bytes long
+                CastTestSpecBuilder.testCastTo(UUID())
+                        .fromCase(BYTES(), UUID_BYTES, UUID_BYTES)
+                        .fromCase(BINARY(16), UUID_BYTES, UUID_BYTES)
+                        .fromCase(BYTES(), null, null)
+                        .fail(
+                                BYTES(),
+                                new byte[] {1, 2, 3},
+                                TableRuntimeException.class,
+                                "requires exactly 16 bytes"),
                 // From VARIANT to primitive types. A cast succeeds only when the target holds the
                 // stored value unaltered, except for the approximate FLOAT and DOUBLE.
                 // A character string renders like a regular cast of the stored kind, so these
@@ -2179,6 +2258,14 @@ class CastRulesTest {
 
         private CastTestSpecBuilder fail(
                 DataType dataType, Object src, Class<? extends Throwable> exception) {
+            return fail(dataType, src, exception, null);
+        }
+
+        private CastTestSpecBuilder fail(
+                DataType dataType,
+                Object src,
+                Class<? extends Throwable> exception,
+                String messageSubstring) {
             return fail(
                     dataType,
                     CastRule.Context.create(
@@ -2188,7 +2275,8 @@ class CastRulesTest {
                             Thread.currentThread().getContextClassLoader(),
                             CTX),
                     src,
-                    exception);
+                    exception,
+                    messageSubstring);
         }
 
         private CastTestSpecBuilder fail(
@@ -2196,10 +2284,25 @@ class CastRulesTest {
                 CastRule.Context castContext,
                 Object src,
                 Class<? extends Throwable> exception) {
+            return fail(dataType, castContext, src, exception, null);
+        }
+
+        private CastTestSpecBuilder fail(
+                DataType dataType,
+                CastRule.Context castContext,
+                Object src,
+                Class<? extends Throwable> exception,
+                String messageSubstring) {
             this.inputTypes.add(dataType);
             this.assertionExecutors.add(
-                    executor ->
-                            assertThatThrownBy(() -> executor.cast(src)).isInstanceOf(exception));
+                    executor -> {
+                        final AbstractThrowableAssert<?, ?> thrown =
+                                assertThatThrownBy(() -> executor.cast(src))
+                                        .isInstanceOf(exception);
+                        if (messageSubstring != null) {
+                            thrown.hasStackTraceContaining(messageSubstring);
+                        }
+                    });
             this.descriptions.add("{" + src + " => " + exception.getName() + "}");
             this.castContexts.add(castContext);
             return this;

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/casting/CastRulesTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/casting/CastRulesTest.java
@@ -51,6 +51,7 @@ import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
 
 import java.math.BigDecimal;
+import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.Instant;
@@ -170,7 +171,7 @@ class CastRulesTest {
     private static byte[] uuidBytes(String uuid) {
         final java.util.UUID value = java.util.UUID.fromString(uuid);
         final byte[] result = new byte[16];
-        java.nio.ByteBuffer.wrap(result)
+        ByteBuffer.wrap(result)
                 .putLong(value.getMostSignificantBits())
                 .putLong(value.getLeastSignificantBits());
         return result;

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/casting/CastRulesTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/casting/CastRulesTest.java
@@ -66,6 +66,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
 
@@ -169,7 +170,7 @@ class CastRulesTest {
     private static final byte[] UUID_BYTES = uuidBytes(UUID_STRING);
 
     private static byte[] uuidBytes(String uuid) {
-        final java.util.UUID value = java.util.UUID.fromString(uuid);
+        final UUID value = UUID.fromString(uuid);
         final byte[] result = new byte[16];
         ByteBuffer.wrap(result)
                 .putLong(value.getMostSignificantBits())

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/UuidCastUtils.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/UuidCastUtils.java
@@ -1,0 +1,138 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.functions;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.api.TableRuntimeException;
+import org.apache.flink.table.types.logical.UuidType;
+
+import java.nio.ByteBuffer;
+import java.util.UUID;
+
+/**
+ * Runtime helpers for casting to and from a {@code UUID} value.
+ *
+ * <p>A {@code UUID} is stored as the canonical 16-byte big-endian encoding, so casting to and from
+ * {@code BINARY(16)}/{@code BYTES} is a raw byte copy, while casting to and from a character string
+ * renders and parses the 8-4-4-4-12 form.
+ */
+@Internal
+public final class UuidCastUtils {
+
+    private UuidCastUtils() {}
+
+    /**
+     * Renders a {@code UUID} as its canonical lower-case 8-4-4-4-12 string. The input always holds
+     * the 16-byte big-endian encoding, so this never fails.
+     */
+    public static String toStringValue(byte[] uuidBytes) {
+        final ByteBuffer buffer = ByteBuffer.wrap(uuidBytes);
+        return new UUID(buffer.getLong(), buffer.getLong()).toString();
+    }
+
+    /**
+     * Parses a character string into the 16-byte big-endian encoding of a {@code UUID}, leniently,
+     * matching PostgreSQL's {@code uuid} input ({@code string_to_uuid} in {@code adt/uuid.c}):
+     *
+     * <ul>
+     *   <li>hexadecimal digits may be upper or lower case;
+     *   <li>the value may be wrapped in a single pair of braces;
+     *   <li>a single hyphen may follow any group of four digits, so the canonical 8-4-4-4-12
+     *       hyphens may be kept, omitted, or placed between other four-digit groups.
+     * </ul>
+     *
+     * <p>The value must contain exactly 32 hexadecimal digits. A hyphen anywhere else (leading,
+     * trailing, doubled, or inside a group) fails the cast.
+     */
+    public static byte[] toUuidBytes(String input) {
+        String value = input;
+        // A value may be wrapped in a pair of braces; a leading brace requires a trailing one.
+        final boolean braces = !value.isEmpty() && value.charAt(0) == '{';
+        if (braces) {
+            value = value.substring(1);
+        }
+
+        final byte[] result = new byte[UuidType.BYTE_LENGTH];
+        int pos = 0;
+        for (int i = 0; i < UuidType.BYTE_LENGTH; i++) {
+            if (pos + 2 > value.length()) {
+                throw invalidString(input);
+            }
+            final int high = hexDigit(value.charAt(pos));
+            final int low = hexDigit(value.charAt(pos + 1));
+            if (high < 0 || low < 0) {
+                throw invalidString(input);
+            }
+            result[i] = (byte) ((high << 4) | low);
+            pos += 2;
+            // A single hyphen may follow any group of four digits, i.e. after every second byte
+            // except the last one.
+            if (i % 2 == 1
+                    && i < UuidType.BYTE_LENGTH - 1
+                    && pos < value.length()
+                    && value.charAt(pos) == '-') {
+                pos++;
+            }
+        }
+        if (braces && (pos >= value.length() || value.charAt(pos) != '}')) {
+            throw invalidString(input);
+        }
+        if (pos + (braces ? 1 : 0) != value.length()) {
+            throw invalidString(input);
+        }
+        return result;
+    }
+
+    private static int hexDigit(char c) {
+        if (c >= '0' && c <= '9') {
+            return c - '0';
+        }
+        if (c >= 'a' && c <= 'f') {
+            return c - 'a' + 10;
+        }
+        if (c >= 'A' && c <= 'F') {
+            return c - 'A' + 10;
+        }
+        return -1;
+    }
+
+    /**
+     * Reinterprets a binary value as the 16-byte big-endian encoding of a {@code UUID}. The value
+     * has to be exactly 16 bytes long, otherwise the cast fails.
+     */
+    public static byte[] fromBytes(byte[] bytes) {
+        if (bytes.length != UuidType.BYTE_LENGTH) {
+            throw new TableRuntimeException(
+                    String.format(
+                            "Cannot cast a binary value of length %d to UUID because a UUID requires "
+                                    + "exactly %d bytes.",
+                            bytes.length, UuidType.BYTE_LENGTH));
+        }
+        return bytes;
+    }
+
+    private static TableRuntimeException invalidString(String input) {
+        return new TableRuntimeException(
+                String.format(
+                        "Cannot cast the string '%s' to UUID. Provide the 32 hexadecimal digits of a "
+                                + "UUID, optionally using the 8-4-4-4-12 hyphenation and wrapping the "
+                                + "value in braces.",
+                        input));
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

This is a sub-task of [FLINK-40485](https://issues.apache.org/jira/browse/FLINK-40485) / FLIP-604 (Complete VARIANT Primitive Coverage with UUID and Timestamps).

It adds explicit `CAST` and `TRY_CAST` support between the `UUID` type and character strings and binary. The `UUID` type was introduced in FLINK-40486 and its runtime in FLINK-40490. Until now a `UUID` could only be produced as a literal and round-tripped through sources and sinks. It could not be converted to or from any other type. This change makes `UUID` usable together with the string and binary types that carry it in practice.

## Brief change log

- Add `UuidCastUtils` in `flink-table-runtime` with the runtime helpers: render a `UUID` to its canonical string, parse a string to the 16-byte encoding, and validate a 16-byte binary value.
- Add four cast rules in `flink-table-planner` and register them in `CastRuleProvider`: `UuidToStringCastRule`, `UuidToBinaryCastRule`, `StringToUuidCastRule`, `BinaryToUuidCastRule`.
- Route `UUID` casts through `LogicalTypeCasts` in `SqlCastFunction#canCastFrom`, in both directions. Calcite's own checker only allows a `UUID` to be cast from another `UUID`, so the type-level matrix has to govern it.
- Extend `LogicalTypeCasts` with the `UUID` cast matrix: `UUID` to `CHAR`/`VARCHAR`, `UUID` to `BINARY(16)`/`BYTES` only, and `CHAR`/`VARCHAR`/`BINARY`/`VARBINARY` to `UUID`.

## Cast semantics

All casts are explicit. There are no implicit coercions to or from `UUID`. `VARIANT` and `UUID` conversion is out of scope and handled by a separate issue.

**`UUID` to `STRING`.** Renders the canonical lower-case 8-4-4-4-12 form.

**`STRING` to `UUID`.** Parsed leniently, matching PostgreSQL's `uuid` input (`string_to_uuid` in `adt/uuid.c`). The digits may be upper or lower case, the value may be wrapped in a single pair of braces, and a single hyphen may follow any group of four digits. A malformed value fails `CAST` and returns `NULL` for `TRY_CAST`.

| Input                                     | Result                              |
|-------------------------------------------|-------------------------------------|
| `A0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A11`    | passes (upper case)                 |
| `{a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11}`  | passes (braces)                     |
| `a0eebc999c0b4ef8bb6d6bb9bd380a11`        | passes (no hyphens)                 |
| `a0ee-bc99-9c0b-4ef8-bb6d-6bb9-bd38-0a11` | passes (a hyphen after every group) |
| `{a0eebc99-9c0b4ef8-bb6d6bb9-bd380a11}`   | passes (braces, hyphens at 8/16/24) |
| `a0e-ebc999c0b4ef8bb6d6bb9bd380a11`       | fails (hyphen inside a group)       |
| `-a0eebc999c0b4ef8bb6d6bb9bd380a11`       | fails (leading hyphen)              |
| `a0eebc99--9c0b4ef8bb6d6bb9bd380a11`      | fails (doubled hyphen)              |
| `{a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11`   | fails (unmatched brace)             |
| `a0eebc999c0b4ef8bb6d6bb9bd380a1`         | fails (31 digits)                   |
| `g0eebc999c0b4ef8bb6d6bb9bd380a11`        | fails (non-hex digit)               |

The five passing examples all decode to the same value `a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11`.

**`UUID` to `BINARY(16)` / `BYTES`.** Produces the 16 big-endian bytes. Any other target width is rejected during validation, since padding or trimming would corrupt the value.

**`BINARY` / `BYTES` to `UUID`.** Reinterprets the bytes as a `UUID`. The value has to be exactly 16 bytes, which is checked at runtime. A different length fails `CAST` and returns `NULL` for `TRY_CAST`.

## Verifying this change

This change added tests and can be verified as follows:

- `CastRulesTest` covers the exhaustive value and lenient-parse matrix at the cast-executor level.
- `LogicalTypeCastsTest` covers the type-level cast matrix in both directions.
- `CastFunctionITCase#uuidCasts` covers the end-to-end SQL and Table API paths, validation failures, and `TRY_CAST` returning `NULL`.

## Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): no
- The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
- The serializers: no
- The runtime per-record code paths (performance sensitive): no
- Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
- The S3 file system connector: no

## Documentation

- Does this pull request introduce a new feature? yes
- If yes, how is the feature documented? The `UUID` type documentation, including casting, is tracked in FLINK-40494 and is not part of this PR.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: Claude Code (Opus 4.8)