### PR TITLE
[FLINK-40557][table] Make operation column optional in `TO_CHANGELOG`…

### DIFF
--- a/docs/content/docs/sql/reference/queries/changelog.md
+++ b/docs/content/docs/sql/reference/queries/changelog.md
@@ -286,7 +286,7 @@ Table result = cdcStream
 
 ## TO_CHANGELOG
 
-The `TO_CHANGELOG` PTF converts a dynamic table (i.e. an updating table) into an append-only table with an explicit operation code column. Each input row - regardless of its original change operation (INSERT, UPDATE_BEFORE, UPDATE_AFTER, DELETE) - is emitted as an INSERT-only row with a string column indicating the original operation.
+The `TO_CHANGELOG` PTF converts a dynamic table (i.e. an updating table) into an append-only table. By default, each input row - regardless of its original change operation (INSERT, UPDATE_BEFORE, UPDATE_AFTER, DELETE) - is emitted as an INSERT-only row with a string column indicating the original operation. Set `include_op_column` to `false` to omit that column.
 
 This is useful when you need to materialize changelog events into a downstream system that only supports appends (e.g., a message queue, log store, or append-only file sink). It is also useful to filter out certain types of updates, for example DELETEs.
 
@@ -297,7 +297,8 @@ SELECT * FROM TO_CHANGELOG(
   input => TABLE source_table [PARTITION BY key_col],
   [op => DESCRIPTOR(op_column_name),]
   [op_mapping => MAP['INSERT', 'I', 'DELETE', 'D', ...],]
-  [produces_full_deletes => BOOLEAN]
+  [produces_full_deletes => BOOLEAN,]
+  [include_op_column => BOOLEAN]
 )
 ```
 
@@ -309,6 +310,7 @@ SELECT * FROM TO_CHANGELOG(
 | `op`                    | No       | A `DESCRIPTOR` with a single column name for the operation code column. Defaults to `op`.                                                                                                                                                                                                                                                                |
 | `op_mapping`            | No       | A `MAP<STRING, STRING>` mapping change operation names to custom output codes. Keys can contain comma-separated names to map multiple operations to the same code (e.g., `'INSERT, UPDATE_AFTER'`). When provided, only mapped operations are forwarded - unmapped events are dropped. Each change operation may appear at most once across all entries. |
 | `produces_full_deletes` | No       | A `BOOLEAN` literal that controls how DELETE rows are emitted. When `true` (default), DELETE rows carry all columns, the full image. When `false`, only the identifying key columns are preserved and the rest are nulled. See [Full vs partial deletes](#full-vs-partial-deletes) for more details.                                                     |
+| `include_op_column`     | No       | A `BOOLEAN` literal that controls whether the operation code column is included in the output. When `true` (default), the operation code column is prepended to the output. When `false`, the output schema contains only the input columns.                                                                                                             |
 
 #### Default op_mapping
 
@@ -323,11 +325,13 @@ When `op_mapping` is omitted, all four change operations are mapped to their sta
 
 ### Output Schema
 
-The output schema is:
+By default, the output schema is:
 
 ```
 [op_column, all_input_columns]
 ```
+
+With `include_op_column => false`, the output schema contains only the input columns.
 
 All output rows have `INSERT` - the table is always append-only.
 

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/PartitionedTable.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/PartitionedTable.java
@@ -171,13 +171,12 @@ public interface PartitionedTable {
     Table process(Class<? extends UserDefinedFunction> function, Object... arguments);
 
     /**
-     * Converts this partitioned dynamic table into an append-only table with an explicit operation
-     * code column using the built-in {@code TO_CHANGELOG} process table function with set
-     * semantics.
+     * Converts this partitioned dynamic table into an append-only table using the built-in {@code
+     * TO_CHANGELOG} process table function with set semantics.
      *
      * <p>Each input row - regardless of its original change operation - is emitted as an
-     * INSERT-only row with a string {@code "op"} column indicating the original operation (INSERT,
-     * UPDATE_AFTER, DELETE, etc.). With set semantics, rows for the same partition key are
+     * INSERT-only row. By default, a string {@code "op"} column indicates the original operation
+     * (INSERT, UPDATE_AFTER, DELETE, etc.). With set semantics, rows for the same partition key are
      * co-located in the same parallel operator instance.
      *
      * <p>For row semantics (each row processed independently), use {@link Table#toChangelog} on the
@@ -211,12 +210,18 @@ public interface PartitionedTable {
      * Table result = table
      *     .partitionBy($("id"))
      *     .toChangelog(lit(false).asArgument("produces_full_deletes"));
+     *
+     * // Omit the operation code column from the output schema.
+     * Table result = table
+     *     .partitionBy($("id"))
+     *     .toChangelog(lit(false).asArgument("include_op_column"));
      * }</pre>
      *
      * @param arguments optional named arguments for {@code op}, {@code op_mapping}, and {@code
-     *     produces_full_deletes}
-     * @return an append-only {@link Table} with output schema {@code [partition_keys, op,
-     *     non_partition_input_columns]}
+     *     produces_full_deletes}, and {@code include_op_column}
+     * @return an append-only {@link Table} with output schema {@code [partition_keys,
+     *     non_partition_input_columns]}, optionally with {@code op} before the non-partition input
+     *     columns
      * @see Table#toChangelog(Expression...)
      */
     Table toChangelog(Expression... arguments);

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/Table.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/Table.java
@@ -1424,12 +1424,12 @@ public interface Table extends Explainable<Table>, Executable {
     Table process(Class<? extends UserDefinedFunction> function, Object... arguments);
 
     /**
-     * Converts this dynamic table into an append-only table with an explicit operation code column
-     * using the built-in {@code TO_CHANGELOG} process table function.
+     * Converts this dynamic table into an append-only table using the built-in {@code TO_CHANGELOG}
+     * process table function.
      *
      * <p>Each input row - regardless of its original change operation - is emitted as an
-     * INSERT-only row with a string {@code "op"} column indicating the original operation (INSERT,
-     * UPDATE_AFTER, DELETE, etc.).
+     * INSERT-only row. By default, a string {@code "op"} column indicates the original operation
+     * (INSERT, UPDATE_AFTER, DELETE, etc.).
      *
      * <p>By default, the input is processed with row semantics (each row independently). To
      * co-locate rows with the same key in the same parallel operator instance, partition the input
@@ -1466,11 +1466,17 @@ public interface Table extends Explainable<Table>, Executable {
      * Table result = table.toChangelog(
      *     lit(false).asArgument("produces_full_deletes")
      * );
+     *
+     * // Omit the operation code column from the output schema.
+     * Table result = table.toChangelog(
+     *     lit(false).asArgument("include_op_column")
+     * );
      * }</pre>
      *
-     * @param arguments optional named arguments for {@code op}, {@code op_mapping}, and {@code
-     *     produces_full_deletes}
-     * @return an append-only {@link Table} with an {@code op} column prepended to the input columns
+     * @param arguments optional named arguments for {@code op}, {@code op_mapping}, {@code
+     *     produces_full_deletes}, and {@code include_op_column}
+     * @return an append-only {@link Table}, optionally with an {@code op} column prepended to the
+     *     input columns
      */
     Table toChangelog(Expression... arguments);
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
@@ -888,7 +888,8 @@ public final class BuiltInFunctionDefinitions {
                                     DataTypes.MAP(DataTypes.STRING(), DataTypes.STRING()),
                                     true),
                             StaticArgument.scalar(
-                                    "produces_full_deletes", DataTypes.BOOLEAN(), true))
+                                    "produces_full_deletes", DataTypes.BOOLEAN(), true),
+                            StaticArgument.scalar("include_op_column", DataTypes.BOOLEAN(), true))
                     .inputTypeStrategy(TO_CHANGELOG_INPUT_TYPE_STRATEGY)
                     .outputTypeStrategy(TO_CHANGELOG_OUTPUT_TYPE_STRATEGY)
                     .runtimeClass(

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/ToChangelogTypeStrategy.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/ToChangelogTypeStrategy.java
@@ -50,6 +50,7 @@ public final class ToChangelogTypeStrategy {
     public static final int ARG_OP = 1;
     public static final int ARG_OP_MAPPING = 2;
     public static final int ARG_PRODUCES_FULL_DELETES = 3;
+    public static final int ARG_INCLUDE_OP_COLUMN = 4;
 
     private static final Set<String> VALID_ROW_KIND_NAMES =
             Set.of("INSERT", "UPDATE_BEFORE", "UPDATE_AFTER", "DELETE");
@@ -83,15 +84,16 @@ public final class ToChangelogTypeStrategy {
                                                 new ValidationException(
                                                         "First argument must be a table for TO_CHANGELOG."));
 
-                final String opColumnName =
-                        ChangelogTypeStrategyUtils.resolveOpColumnName(callContext);
                 final boolean producesFullDeletes =
                         callContext
                                 .getArgumentValue(ARG_PRODUCES_FULL_DELETES, Boolean.class)
                                 .orElse(true);
 
+                final boolean includeOpColumn = shouldIncludeOpColumn(callContext);
+
                 final List<Field> outputFields =
-                        buildOutputFields(semantics, opColumnName, producesFullDeletes);
+                        buildOutputFields(
+                                semantics, producesFullDeletes, includeOpColumn, callContext);
 
                 return Optional.of(DataTypes.ROW(outputFields).notNull());
             };
@@ -99,6 +101,17 @@ public final class ToChangelogTypeStrategy {
     // --------------------------------------------------------------------------------------------
     // Helpers
     // --------------------------------------------------------------------------------------------
+
+    /**
+     * Returns whether {@code TO_CHANGELOG} should include the operation column in its output.
+     *
+     * <p>Compiled plans created before this argument was introduced have only four arguments and
+     * retain the default value of {@code true}.
+     */
+    public static boolean shouldIncludeOpColumn(final CallContext callContext) {
+        return callContext.getArgumentDataTypes().size() <= ARG_INCLUDE_OP_COLUMN
+                || callContext.getArgumentValue(ARG_INCLUDE_OP_COLUMN, Boolean.class).orElse(true);
+    }
 
     private static Optional<List<DataType>> validateInputs(
             final CallContext callContext, final boolean throwOnFailure) {
@@ -227,12 +240,16 @@ public final class ToChangelogTypeStrategy {
      */
     private static List<Field> buildOutputFields(
             final TableSemantics semantics,
-            final String opColumnName,
-            final boolean producesFullDeletes) {
+            final boolean producesFullDeletes,
+            final boolean includeOpColumn,
+            final CallContext callContext) {
         final List<Field> inputFields = DataType.getFields(semantics.dataType());
         final int[] outputIndices = ChangelogTypeStrategyUtils.computeOutputIndices(semantics);
         final List<Field> outputFields = new ArrayList<>();
-        outputFields.add(DataTypes.FIELD(opColumnName, DataTypes.STRING()));
+        if (includeOpColumn) {
+            final String opColumnName = ChangelogTypeStrategyUtils.resolveOpColumnName(callContext);
+            outputFields.add(DataTypes.FIELD(opColumnName, DataTypes.STRING()));
+        }
         final Set<Integer> preserved =
                 producesFullDeletes
                         ? Collections.emptySet()

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/inference/strategies/ToChangelogOutputTypeStrategyTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/inference/strategies/ToChangelogOutputTypeStrategyTest.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.stream.Stream;
 
 import static org.apache.flink.table.types.inference.strategies.SpecificTypeStrategies.TO_CHANGELOG_OUTPUT_TYPE_STRATEGY;
+import static org.apache.flink.table.types.inference.strategies.ToChangelogTypeStrategy.ARG_INCLUDE_OP_COLUMN;
 import static org.apache.flink.table.types.inference.strategies.ToChangelogTypeStrategy.ARG_OP;
 import static org.apache.flink.table.types.inference.strategies.ToChangelogTypeStrategy.ARG_OP_MAPPING;
 import static org.apache.flink.table.types.inference.strategies.ToChangelogTypeStrategy.ARG_PRODUCES_FULL_DELETES;
@@ -76,10 +77,35 @@ class ToChangelogOutputTypeStrategyTest extends TypeStrategiesTestBase {
                                                         "score", DataTypes.BIGINT().notNull()))
                                         .notNull()),
                 TestSpec.forStrategy(
+                                "include_op_column=false omits the operation column",
+                                TO_CHANGELOG_OUTPUT_TYPE_STRATEGY)
+                        .inputTypes(
+                                TABLE_TYPE_NOT_NULL_SCORE,
+                                DESCRIPTOR_TYPE,
+                                MAP_TYPE,
+                                BOOLEAN_TYPE,
+                                BOOLEAN_TYPE)
+                        .calledWithTableSemanticsAt(
+                                ARG_TABLE, new TableSemanticsMock(TABLE_TYPE_NOT_NULL_SCORE))
+                        .calledWithLiteralAt(ARG_OP, ColumnList.of("op"))
+                        .calledWithLiteralAt(ARG_OP_MAPPING, null)
+                        .calledWithLiteralAt(ARG_INCLUDE_OP_COLUMN, false)
+                        .expectDataType(
+                                DataTypes.ROW(
+                                                DataTypes.FIELD(
+                                                        "name", DataTypes.STRING().notNull()),
+                                                DataTypes.FIELD(
+                                                        "score", DataTypes.BIGINT().notNull()))
+                                        .notNull()),
+                TestSpec.forStrategy(
                                 "produces_full_deletes=false widens non-upsert-key columns to nullable",
                                 TO_CHANGELOG_OUTPUT_TYPE_STRATEGY)
                         .inputTypes(
-                                TABLE_TYPE_NOT_NULL_SCORE, DESCRIPTOR_TYPE, MAP_TYPE, BOOLEAN_TYPE)
+                                TABLE_TYPE_NOT_NULL_SCORE,
+                                DESCRIPTOR_TYPE,
+                                MAP_TYPE,
+                                BOOLEAN_TYPE,
+                                BOOLEAN_TYPE)
                         .calledWithTableSemanticsAt(
                                 ARG_TABLE,
                                 new TableSemanticsMock(
@@ -103,7 +129,11 @@ class ToChangelogOutputTypeStrategyTest extends TypeStrategiesTestBase {
                                 "produces_full_deletes=false without upsert key widens all columns",
                                 TO_CHANGELOG_OUTPUT_TYPE_STRATEGY)
                         .inputTypes(
-                                TABLE_TYPE_NOT_NULL_SCORE, DESCRIPTOR_TYPE, MAP_TYPE, BOOLEAN_TYPE)
+                                TABLE_TYPE_NOT_NULL_SCORE,
+                                DESCRIPTOR_TYPE,
+                                MAP_TYPE,
+                                BOOLEAN_TYPE,
+                                BOOLEAN_TYPE)
                         .calledWithTableSemanticsAt(
                                 ARG_TABLE, new TableSemanticsMock(TABLE_TYPE_NOT_NULL_SCORE))
                         .calledWithLiteralAt(ARG_OP, ColumnList.of("op"))
@@ -123,7 +153,11 @@ class ToChangelogOutputTypeStrategyTest extends TypeStrategiesTestBase {
                                 "produces_full_deletes=true in set semantics preserves NOT NULL on non-partition columns",
                                 TO_CHANGELOG_OUTPUT_TYPE_STRATEGY)
                         .inputTypes(
-                                TABLE_TYPE_NOT_NULL_SCORE, DESCRIPTOR_TYPE, MAP_TYPE, BOOLEAN_TYPE)
+                                TABLE_TYPE_NOT_NULL_SCORE,
+                                DESCRIPTOR_TYPE,
+                                MAP_TYPE,
+                                BOOLEAN_TYPE,
+                                BOOLEAN_TYPE)
                         .calledWithTableSemanticsAt(
                                 ARG_TABLE,
                                 new TableSemanticsMock(
@@ -146,7 +180,11 @@ class ToChangelogOutputTypeStrategyTest extends TypeStrategiesTestBase {
                                 "produces_full_deletes=false in set semantics widens non-partition-key columns",
                                 TO_CHANGELOG_OUTPUT_TYPE_STRATEGY)
                         .inputTypes(
-                                TABLE_TYPE_NOT_NULL_SCORE, DESCRIPTOR_TYPE, MAP_TYPE, BOOLEAN_TYPE)
+                                TABLE_TYPE_NOT_NULL_SCORE,
+                                DESCRIPTOR_TYPE,
+                                MAP_TYPE,
+                                BOOLEAN_TYPE,
+                                BOOLEAN_TYPE)
                         .calledWithTableSemanticsAt(
                                 ARG_TABLE,
                                 new TableSemanticsMock(

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/ToChangelogSemanticTests.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/ToChangelogSemanticTests.java
@@ -47,6 +47,7 @@ public class ToChangelogSemanticTests extends SemanticTestBase {
                 ToChangelogTestPrograms.RETRACT_PARTITION_BY,
                 ToChangelogTestPrograms.CUSTOM_OP_MAPPING,
                 ToChangelogTestPrograms.CUSTOM_OP_NAME,
+                ToChangelogTestPrograms.WITHOUT_OP_COLUMN,
                 ToChangelogTestPrograms.TABLE_API_DEFAULT,
                 ToChangelogTestPrograms.TABLE_API_RETRACT_PARTITION_BY,
                 ToChangelogTestPrograms.LAG_ON_UPSERT_VIA_CHANGELOG,

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/ToChangelogTestPrograms.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/ToChangelogTestPrograms.java
@@ -62,6 +62,36 @@ public class ToChangelogTestPrograms {
                     .runSql("INSERT INTO sink SELECT * FROM TO_CHANGELOG(input => TABLE t)")
                     .build();
 
+    public static final TableTestProgram WITHOUT_OP_COLUMN =
+            TableTestProgram.of(
+                            "to-changelog-without-op-column",
+                            "include_op_column=false preserves the input schema and emits insert-only rows")
+                    .setupTableSource(
+                            SourceTestStep.newBuilder("t")
+                                    .addSchema("id INT", "name STRING")
+                                    .addMode(ChangelogMode.all())
+                                    .producedValues(
+                                            Row.ofKind(RowKind.INSERT, 1, "Alice"),
+                                            Row.ofKind(RowKind.INSERT, 2, "Bob"),
+                                            Row.ofKind(RowKind.UPDATE_BEFORE, 1, "Alice"),
+                                            Row.ofKind(RowKind.UPDATE_AFTER, 1, "Alicia"),
+                                            Row.ofKind(RowKind.DELETE, 2, "Bob"))
+                                    .build())
+                    .setupTableSink(
+                            SinkTestStep.newBuilder("sink")
+                                    .addSchema("id INT", "name STRING")
+                                    .consumedValues(
+                                            "+I[1, Alice]",
+                                            "+I[2, Bob]",
+                                            "+I[1, Alice]",
+                                            "+I[1, Alicia]",
+                                            "+I[2, Bob]")
+                                    .build())
+                    .runSql(
+                            "INSERT INTO sink SELECT * FROM TO_CHANGELOG("
+                                    + "input => TABLE t, include_op_column => false)")
+                    .build();
+
     public static final TableTestProgram RETRACT =
             TableTestProgram.of(
                             "to-changelog-updating-input",

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/ToChangelogTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/ToChangelogTest.xml
@@ -23,14 +23,14 @@ limitations under the License.
     <Resource name="ast">
       <![CDATA[
 LogicalProject(op=[$0], id=[$1], name=[$2])
-+- LogicalTableFunctionScan(invocation=[TO_CHANGELOG(TABLE(#0), DEFAULT(), DEFAULT(), DEFAULT(), DEFAULT(), DEFAULT())], rowType=[RecordType(VARCHAR(2147483647) op, INTEGER id, VARCHAR(2147483647) name)])
++- LogicalTableFunctionScan(invocation=[TO_CHANGELOG(TABLE(#0), DEFAULT(), DEFAULT(), DEFAULT(), DEFAULT(), DEFAULT(), DEFAULT())], rowType=[RecordType(VARCHAR(2147483647) op, INTEGER id, VARCHAR(2147483647) name)])
    +- LogicalProject(id=[$0], name=[$1])
       +- LogicalTableScan(table=[[default_catalog, default_database, insert_only_source]])
 ]]>
     </Resource>
     <Resource name="optimized rel plan">
       <![CDATA[
-ProcessTableFunction(invocation=[TO_CHANGELOG(TABLE(#0), DEFAULT(), DEFAULT(), DEFAULT(), DEFAULT(), DEFAULT())], uid=[null], select=[op,id,name], rowType=[RecordType(VARCHAR(2147483647) op, INTEGER id, VARCHAR(2147483647) name)], changelogMode=[I])
+ProcessTableFunction(invocation=[TO_CHANGELOG(TABLE(#0), DEFAULT(), DEFAULT(), DEFAULT(), DEFAULT(), DEFAULT(), DEFAULT())], uid=[null], select=[op,id,name], rowType=[RecordType(VARCHAR(2147483647) op, INTEGER id, VARCHAR(2147483647) name)], changelogMode=[I])
 +- TableSourceScan(table=[[default_catalog, default_database, insert_only_source]], fields=[id, name], changelogMode=[I])
 ]]>
     </Resource>
@@ -42,14 +42,14 @@ ProcessTableFunction(invocation=[TO_CHANGELOG(TABLE(#0), DEFAULT(), DEFAULT(), D
     <Resource name="ast">
       <![CDATA[
 LogicalProject(id=[$0], op=[$1], name=[$2])
-+- LogicalTableFunctionScan(invocation=[TO_CHANGELOG(TABLE(#0) PARTITION BY($0), DEFAULT(), DEFAULT(), DEFAULT(), DEFAULT(), DEFAULT())], rowType=[RecordType(INTEGER id, VARCHAR(2147483647) op, VARCHAR(2147483647) name)])
++- LogicalTableFunctionScan(invocation=[TO_CHANGELOG(TABLE(#0) PARTITION BY($0), DEFAULT(), DEFAULT(), DEFAULT(), DEFAULT(), DEFAULT(), DEFAULT())], rowType=[RecordType(INTEGER id, VARCHAR(2147483647) op, VARCHAR(2147483647) name)])
    +- LogicalProject(id=[$0], name=[$1])
       +- LogicalTableScan(table=[[default_catalog, default_database, retract_source]])
 ]]>
     </Resource>
     <Resource name="optimized rel plan">
       <![CDATA[
-ProcessTableFunction(invocation=[TO_CHANGELOG(TABLE(#0) PARTITION BY($0), DEFAULT(), DEFAULT(), DEFAULT(), DEFAULT(), DEFAULT())], uid=[TO_CHANGELOG], select=[id,op,name], rowType=[RecordType(INTEGER id, VARCHAR(2147483647) op, VARCHAR(2147483647) name)], changelogMode=[I])
+ProcessTableFunction(invocation=[TO_CHANGELOG(TABLE(#0) PARTITION BY($0), DEFAULT(), DEFAULT(), DEFAULT(), DEFAULT(), DEFAULT(), DEFAULT())], uid=[TO_CHANGELOG], select=[id,op,name], rowType=[RecordType(INTEGER id, VARCHAR(2147483647) op, VARCHAR(2147483647) name)], changelogMode=[I])
 +- Exchange(distribution=[hash[id]], changelogMode=[I,UB,UA,D])
    +- TableSourceScan(table=[[default_catalog, default_database, retract_source]], fields=[id, name], changelogMode=[I,UB,UA,D])
 ]]>
@@ -62,14 +62,14 @@ ProcessTableFunction(invocation=[TO_CHANGELOG(TABLE(#0) PARTITION BY($0), DEFAUL
     <Resource name="ast">
       <![CDATA[
 LogicalProject(op=[$0], id=[$1], name=[$2])
-+- LogicalTableFunctionScan(invocation=[TO_CHANGELOG(TABLE(#0), DEFAULT(), DEFAULT(), DEFAULT(), DEFAULT(), DEFAULT())], rowType=[RecordType(VARCHAR(2147483647) op, INTEGER id, VARCHAR(2147483647) name)])
++- LogicalTableFunctionScan(invocation=[TO_CHANGELOG(TABLE(#0), DEFAULT(), DEFAULT(), DEFAULT(), DEFAULT(), DEFAULT(), DEFAULT())], rowType=[RecordType(VARCHAR(2147483647) op, INTEGER id, VARCHAR(2147483647) name)])
    +- LogicalProject(id=[$0], name=[$1])
       +- LogicalTableScan(table=[[default_catalog, default_database, retract_source]])
 ]]>
     </Resource>
     <Resource name="optimized rel plan">
       <![CDATA[
-ProcessTableFunction(invocation=[TO_CHANGELOG(TABLE(#0), DEFAULT(), DEFAULT(), DEFAULT(), DEFAULT(), DEFAULT())], uid=[null], select=[op,id,name], rowType=[RecordType(VARCHAR(2147483647) op, INTEGER id, VARCHAR(2147483647) name)], changelogMode=[I])
+ProcessTableFunction(invocation=[TO_CHANGELOG(TABLE(#0), DEFAULT(), DEFAULT(), DEFAULT(), DEFAULT(), DEFAULT(), DEFAULT())], uid=[null], select=[op,id,name], rowType=[RecordType(VARCHAR(2147483647) op, INTEGER id, VARCHAR(2147483647) name)], changelogMode=[I])
 +- TableSourceScan(table=[[default_catalog, default_database, retract_source]], fields=[id, name], changelogMode=[I,UB,UA,D])
 ]]>
     </Resource>
@@ -81,14 +81,14 @@ ProcessTableFunction(invocation=[TO_CHANGELOG(TABLE(#0), DEFAULT(), DEFAULT(), D
     <Resource name="ast">
       <![CDATA[
 LogicalProject(id=[$0], op=[$1], name=[$2])
-+- LogicalTableFunctionScan(invocation=[TO_CHANGELOG(TABLE(#0) PARTITION BY($0), DESCRIPTOR(_UTF-16LE'op'), MAP(_UTF-16LE'INSERT,UPDATE_AFTER':VARCHAR(19) CHARACTER SET "UTF-16LE", _UTF-16LE'C', _UTF-16LE'DELETE':VARCHAR(19) CHARACTER SET "UTF-16LE", _UTF-16LE'D'), DEFAULT(), DEFAULT(), DEFAULT())], rowType=[RecordType(INTEGER id, VARCHAR(2147483647) op, VARCHAR(2147483647) name)])
++- LogicalTableFunctionScan(invocation=[TO_CHANGELOG(TABLE(#0) PARTITION BY($0), DESCRIPTOR(_UTF-16LE'op'), MAP(_UTF-16LE'INSERT,UPDATE_AFTER':VARCHAR(19) CHARACTER SET "UTF-16LE", _UTF-16LE'C', _UTF-16LE'DELETE':VARCHAR(19) CHARACTER SET "UTF-16LE", _UTF-16LE'D'), DEFAULT(), DEFAULT(), DEFAULT(), DEFAULT())], rowType=[RecordType(INTEGER id, VARCHAR(2147483647) op, VARCHAR(2147483647) name)])
    +- LogicalProject(id=[$0], name=[$1])
       +- LogicalTableScan(table=[[default_catalog, default_database, upsert_source]])
 ]]>
     </Resource>
     <Resource name="optimized rel plan">
       <![CDATA[
-ProcessTableFunction(invocation=[TO_CHANGELOG(TABLE(#0) PARTITION BY($0), DESCRIPTOR(_UTF-16LE'op'), MAP(_UTF-16LE'INSERT,UPDATE_AFTER':VARCHAR(19) CHARACTER SET "UTF-16LE", _UTF-16LE'C', _UTF-16LE'DELETE':VARCHAR(19) CHARACTER SET "UTF-16LE", _UTF-16LE'D'), DEFAULT(), DEFAULT(), DEFAULT())], uid=[TO_CHANGELOG], select=[id,op,name], rowType=[RecordType(INTEGER id, VARCHAR(2147483647) op, VARCHAR(2147483647) name)], changelogMode=[I])
+ProcessTableFunction(invocation=[TO_CHANGELOG(TABLE(#0) PARTITION BY($0), DESCRIPTOR(_UTF-16LE'op'), MAP(_UTF-16LE'INSERT,UPDATE_AFTER':VARCHAR(19) CHARACTER SET "UTF-16LE", _UTF-16LE'C', _UTF-16LE'DELETE':VARCHAR(19) CHARACTER SET "UTF-16LE", _UTF-16LE'D'), DEFAULT(), DEFAULT(), DEFAULT(), DEFAULT())], uid=[TO_CHANGELOG], select=[id,op,name], rowType=[RecordType(INTEGER id, VARCHAR(2147483647) op, VARCHAR(2147483647) name)], changelogMode=[I])
 +- Exchange(distribution=[hash[id]], changelogMode=[I,UA,D])
    +- TableSourceScan(table=[[default_catalog, default_database, upsert_source]], fields=[id, name], changelogMode=[I,UA,D])
 ]]>
@@ -101,14 +101,14 @@ ProcessTableFunction(invocation=[TO_CHANGELOG(TABLE(#0) PARTITION BY($0), DESCRI
     <Resource name="ast">
       <![CDATA[
 LogicalProject(id=[$0], op=[$1], name=[$2])
-+- LogicalTableFunctionScan(invocation=[TO_CHANGELOG(TABLE(#0) PARTITION BY($0), DESCRIPTOR(_UTF-16LE'op'), MAP(_UTF-16LE'INSERT,UPDATE_AFTER', _UTF-16LE'C'), DEFAULT(), DEFAULT(), DEFAULT())], rowType=[RecordType(INTEGER id, VARCHAR(2147483647) op, VARCHAR(2147483647) name)])
++- LogicalTableFunctionScan(invocation=[TO_CHANGELOG(TABLE(#0) PARTITION BY($0), DESCRIPTOR(_UTF-16LE'op'), MAP(_UTF-16LE'INSERT,UPDATE_AFTER', _UTF-16LE'C'), DEFAULT(), DEFAULT(), DEFAULT(), DEFAULT())], rowType=[RecordType(INTEGER id, VARCHAR(2147483647) op, VARCHAR(2147483647) name)])
    +- LogicalProject(id=[$0], name=[$1])
       +- LogicalTableScan(table=[[default_catalog, default_database, upsert_source]])
 ]]>
     </Resource>
     <Resource name="optimized rel plan">
       <![CDATA[
-ProcessTableFunction(invocation=[TO_CHANGELOG(TABLE(#0) PARTITION BY($0), DESCRIPTOR(_UTF-16LE'op'), MAP(_UTF-16LE'INSERT,UPDATE_AFTER', _UTF-16LE'C'), DEFAULT(), DEFAULT(), DEFAULT())], uid=[TO_CHANGELOG], select=[id,op,name], rowType=[RecordType(INTEGER id, VARCHAR(2147483647) op, VARCHAR(2147483647) name)], changelogMode=[I])
+ProcessTableFunction(invocation=[TO_CHANGELOG(TABLE(#0) PARTITION BY($0), DESCRIPTOR(_UTF-16LE'op'), MAP(_UTF-16LE'INSERT,UPDATE_AFTER', _UTF-16LE'C'), DEFAULT(), DEFAULT(), DEFAULT(), DEFAULT())], uid=[TO_CHANGELOG], select=[id,op,name], rowType=[RecordType(INTEGER id, VARCHAR(2147483647) op, VARCHAR(2147483647) name)], changelogMode=[I])
 +- Exchange(distribution=[hash[id]], changelogMode=[I,UA,D])
    +- TableSourceScan(table=[[default_catalog, default_database, upsert_source]], fields=[id, name], changelogMode=[I,UA,D])
 ]]>
@@ -121,14 +121,14 @@ ProcessTableFunction(invocation=[TO_CHANGELOG(TABLE(#0) PARTITION BY($0), DESCRI
     <Resource name="ast">
       <![CDATA[
 LogicalProject(op=[$0], id=[$1], name=[$2])
-+- LogicalTableFunctionScan(invocation=[TO_CHANGELOG(TABLE(#0), DEFAULT(), DEFAULT(), DEFAULT(), DEFAULT(), DEFAULT())], rowType=[RecordType(VARCHAR(2147483647) op, INTEGER id, VARCHAR(2147483647) name)])
++- LogicalTableFunctionScan(invocation=[TO_CHANGELOG(TABLE(#0), DEFAULT(), DEFAULT(), DEFAULT(), DEFAULT(), DEFAULT(), DEFAULT())], rowType=[RecordType(VARCHAR(2147483647) op, INTEGER id, VARCHAR(2147483647) name)])
    +- LogicalProject(id=[$0], name=[$1])
       +- LogicalTableScan(table=[[default_catalog, default_database, upsert_source]])
 ]]>
     </Resource>
     <Resource name="optimized rel plan">
       <![CDATA[
-ProcessTableFunction(invocation=[TO_CHANGELOG(TABLE(#0), DEFAULT(), DEFAULT(), DEFAULT(), DEFAULT(), DEFAULT())], uid=[null], select=[op,id,name], rowType=[RecordType(VARCHAR(2147483647) op, INTEGER id, VARCHAR(2147483647) name)], changelogMode=[I])
+ProcessTableFunction(invocation=[TO_CHANGELOG(TABLE(#0), DEFAULT(), DEFAULT(), DEFAULT(), DEFAULT(), DEFAULT(), DEFAULT())], uid=[null], select=[op,id,name], rowType=[RecordType(VARCHAR(2147483647) op, INTEGER id, VARCHAR(2147483647) name)], changelogMode=[I])
 +- ChangelogNormalize(key=[id], changelogMode=[I,UB,UA,D])
    +- Exchange(distribution=[hash[id]], changelogMode=[I,UA,D])
       +- TableSourceScan(table=[[default_catalog, default_database, upsert_source]], fields=[id, name], changelogMode=[I,UA,D])
@@ -142,14 +142,14 @@ ProcessTableFunction(invocation=[TO_CHANGELOG(TABLE(#0), DEFAULT(), DEFAULT(), D
     <Resource name="ast">
       <![CDATA[
 LogicalProject(op=[$0], id=[$1], name=[$2])
-+- LogicalTableFunctionScan(invocation=[TO_CHANGELOG(TABLE(#0), DEFAULT(), DEFAULT(), false, DEFAULT(), DEFAULT())], rowType=[RecordType(VARCHAR(2147483647) op, INTEGER id, VARCHAR(2147483647) name)])
++- LogicalTableFunctionScan(invocation=[TO_CHANGELOG(TABLE(#0), DEFAULT(), DEFAULT(), false, DEFAULT(), DEFAULT(), DEFAULT())], rowType=[RecordType(VARCHAR(2147483647) op, INTEGER id, VARCHAR(2147483647) name)])
    +- LogicalProject(id=[$0], name=[$1])
       +- LogicalTableScan(table=[[default_catalog, default_database, upsert_source]])
 ]]>
     </Resource>
     <Resource name="optimized rel plan">
       <![CDATA[
-ProcessTableFunction(invocation=[TO_CHANGELOG(TABLE(#0), DEFAULT(), DEFAULT(), false, DEFAULT(), DEFAULT())], uid=[null], select=[op,id,name], rowType=[RecordType(VARCHAR(2147483647) op, INTEGER id, VARCHAR(2147483647) name)], changelogMode=[I])
+ProcessTableFunction(invocation=[TO_CHANGELOG(TABLE(#0), DEFAULT(), DEFAULT(), false, DEFAULT(), DEFAULT(), DEFAULT())], uid=[null], select=[op,id,name], rowType=[RecordType(VARCHAR(2147483647) op, INTEGER id, VARCHAR(2147483647) name)], changelogMode=[I])
 +- ChangelogNormalize(key=[id], changelogMode=[I,UB,UA,D])
    +- Exchange(distribution=[hash[id]], changelogMode=[I,UA,D])
       +- TableSourceScan(table=[[default_catalog, default_database, upsert_source]], fields=[id, name], changelogMode=[I,UA,D])
@@ -163,14 +163,14 @@ ProcessTableFunction(invocation=[TO_CHANGELOG(TABLE(#0), DEFAULT(), DEFAULT(), f
     <Resource name="ast">
       <![CDATA[
 LogicalProject(op=[$0], id=[$1], name=[$2])
-+- LogicalTableFunctionScan(invocation=[TO_CHANGELOG(TABLE(#0), DEFAULT(), DEFAULT(), true, DEFAULT(), DEFAULT())], rowType=[RecordType(VARCHAR(2147483647) op, INTEGER id, VARCHAR(2147483647) name)])
++- LogicalTableFunctionScan(invocation=[TO_CHANGELOG(TABLE(#0), DEFAULT(), DEFAULT(), true, DEFAULT(), DEFAULT(), DEFAULT())], rowType=[RecordType(VARCHAR(2147483647) op, INTEGER id, VARCHAR(2147483647) name)])
    +- LogicalProject(id=[$0], name=[$1])
       +- LogicalTableScan(table=[[default_catalog, default_database, upsert_source]])
 ]]>
     </Resource>
     <Resource name="optimized rel plan">
       <![CDATA[
-ProcessTableFunction(invocation=[TO_CHANGELOG(TABLE(#0), DEFAULT(), DEFAULT(), true, DEFAULT(), DEFAULT())], uid=[null], select=[op,id,name], rowType=[RecordType(VARCHAR(2147483647) op, INTEGER id, VARCHAR(2147483647) name)], changelogMode=[I])
+ProcessTableFunction(invocation=[TO_CHANGELOG(TABLE(#0), DEFAULT(), DEFAULT(), true, DEFAULT(), DEFAULT(), DEFAULT())], uid=[null], select=[op,id,name], rowType=[RecordType(VARCHAR(2147483647) op, INTEGER id, VARCHAR(2147483647) name)], changelogMode=[I])
 +- ChangelogNormalize(key=[id], changelogMode=[I,UB,UA,D])
    +- Exchange(distribution=[hash[id]], changelogMode=[I,UA,D])
       +- TableSourceScan(table=[[default_catalog, default_database, upsert_source]], fields=[id, name], changelogMode=[I,UA,D])

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/ptf/ToChangelogFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/ptf/ToChangelogFunction.java
@@ -49,13 +49,14 @@ import java.util.Set;
 import static org.apache.flink.table.types.inference.strategies.ToChangelogTypeStrategy.ARG_OP_MAPPING;
 import static org.apache.flink.table.types.inference.strategies.ToChangelogTypeStrategy.ARG_PRODUCES_FULL_DELETES;
 import static org.apache.flink.table.types.inference.strategies.ToChangelogTypeStrategy.ARG_TABLE;
+import static org.apache.flink.table.types.inference.strategies.ToChangelogTypeStrategy.shouldIncludeOpColumn;
 
 /**
  * Runtime implementation of {@link BuiltInFunctionDefinitions#TO_CHANGELOG}.
  *
- * <p>Converts each input row into an INSERT-only output row with an operation code column. Output
- * schema is {@code [op_column, ...projected_input_columns...]}. Partition columns are prepended by
- * the framework outside this function and are not part of the projection.
+ * <p>Converts each input row into an INSERT-only output row. When requested, an operation code
+ * column is prepended to the projected input columns. Partition columns are prepended by the
+ * framework outside this function and are not part of the projection.
  *
  * <p>Uses {@link JoinedRowData} to combine the op column with the full input row.
  */
@@ -75,6 +76,7 @@ public class ToChangelogFunction extends BuiltInProcessTableFunction<RowData> {
     private final int[] outputIndices;
     private final RowType inputRowType;
     private final boolean producesFullDelete;
+    private final boolean includeOpColumn;
     private final boolean[] upsertKeyColumn;
 
     private transient Map<RowKind, StringData> opMap;
@@ -94,9 +96,10 @@ public class ToChangelogFunction extends BuiltInProcessTableFunction<RowData> {
         final Map<String, String> opMapping =
                 callContext.getArgumentValue(ARG_OP_MAPPING, Map.class).orElse(null);
         this.rawOpMap = buildOpMap(opMapping);
-
         this.producesFullDelete =
                 callContext.getArgumentValue(ARG_PRODUCES_FULL_DELETES, Boolean.class).orElse(true);
+        this.includeOpColumn = shouldIncludeOpColumn(callContext);
+
         final boolean isExplicit = !callContext.isArgumentNull(ARG_PRODUCES_FULL_DELETES);
         validateProducesPartialDeletes(producesFullDelete, isExplicit, tableSemantics);
 
@@ -126,7 +129,7 @@ public class ToChangelogFunction extends BuiltInProcessTableFunction<RowData> {
         super.open(context);
         opMap = new EnumMap<>(RowKind.class);
         rawOpMap.forEach((kind, code) -> opMap.put(kind, StringData.fromString(code)));
-        opRow = new GenericRowData(1);
+        opRow = new GenericRowData(includeOpColumn ? 1 : 0);
         output = new JoinedRowData();
         projectedOutput = ProjectedRowData.from(outputIndices);
         partialDeletePayload = new GenericRowData(outputIndices.length);
@@ -192,24 +195,41 @@ public class ToChangelogFunction extends BuiltInProcessTableFunction<RowData> {
         }
     }
 
+    /** Maintains compatibility with compiled plans created before {@code include_op_column}. */
     public void eval(
             final Context ctx,
             final RowData input,
             @Nullable final ColumnList op,
             @Nullable final MapData opMapping,
             @Nullable final Boolean producesFullDeletes) {
+
+        eval(ctx, input, op, opMapping, producesFullDeletes, null);
+    }
+
+    public void eval(
+            final Context ctx,
+            final RowData input,
+            @Nullable final ColumnList op,
+            @Nullable final MapData opMapping,
+            @Nullable final Boolean producesFullDeletes,
+            @Nullable final Boolean includeOpColumn) {
+
         final StringData opCode = opMap.get(input.getRowKind());
         if (opCode == null) {
             return;
         }
 
-        opRow.setField(0, opCode);
+        if (this.includeOpColumn) {
+            opRow.setField(0, opCode);
+        }
+
         final RowData payload;
         if (input.getRowKind() == RowKind.DELETE && !producesFullDelete) {
             payload = buildPartialDeletePayload(input);
         } else {
             payload = projectedOutput.replaceRow(input);
         }
+
         collect(output.replace(opRow, payload));
     }
 


### PR DESCRIPTION
## What is the purpose of the change

Makes the operation column in `TO_CHANGELOG` optional. This supports append-only output that retains the input schema without prepending an operation code.

The change remains compatible with compiled plans created before the new argument was introduced.

## Brief change log

- Adds optional `include_op_column` argument to `TO_CHANGELOG`, defaulting to `true`.
- Omits the operation column from inferred and runtime output when set to `false`.
- Preserves compatibility with existing compiled plans by defaulting a missing argument to `true` and supporting the previous `eval` signature.
- Adds type-inference and semantic test coverage.
- Documents the new argument in SQL documentation and Table API JavaDocs.

## Verifying this change

This change added tests and was verified with:

- `mvn -pl flink-table/flink-table-common -Dtest=ToChangelogOutputTypeStrategyTest test`
- `mvn -pl flink-table/flink-table-planner -Dtest=ToChangelogSemanticTests test`
- `mvn -pl flink-table/flink-table-planner -Dtest=ToChangelogRestoreTest test`
- `mvn spotless:check -pl flink-table/flink-table-common,flink-table/flink-table-runtime,flink-table/flink-table-api-java,flink-table/flink-table-planner`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes, adds a user-facing `TO_CHANGELOG` argument
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? docs + JavaDocs

##### Was generative AI tooling used to co-author this PR?

- [X] Yes

Generated-by: OpenCode (openai/gpt-6-astra)
