### PR TITLE
[FLINK-40515][core] Extend BinaryVariant to support UUID

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/types/variant/BinaryVariant.java
+++ b/flink-core/src/main/java/org/apache/flink/types/variant/BinaryVariant.java
@@ -38,6 +38,7 @@ import java.util.Arrays;
 import java.util.Base64;
 import java.util.List;
 import java.util.Objects;
+import java.util.UUID;
 
 import static org.apache.flink.types.variant.BinaryVariantUtil.BINARY_SEARCH_THRESHOLD;
 import static org.apache.flink.types.variant.BinaryVariantUtil.SIZE_LIMIT;
@@ -225,6 +226,12 @@ public final class BinaryVariant implements Variant {
     }
 
     @Override
+    public UUID getUUID() throws VariantTypeException {
+        checkType(Type.UUID, getType());
+        return BinaryVariantUtil.getUUID(value, pos);
+    }
+
+    @Override
     public Object get() throws VariantTypeException {
         switch (getType()) {
             case NULL:
@@ -259,6 +266,8 @@ public final class BinaryVariant implements Variant {
                 return getInstant();
             case BYTES:
                 return getBytes();
+            case UUID:
+                return getUUID();
             default:
                 throw new VariantTypeException(
                         String.format("Expecting a primitive variant but got %s", getType()));
@@ -458,6 +467,9 @@ public final class BinaryVariant implements Variant {
                         sb,
                         Base64.getEncoder()
                                 .encodeToString(BinaryVariantUtil.getBinary(value, pos)));
+                break;
+            case UUID:
+                appendQuoted(sb, BinaryVariantUtil.getUUID(value, pos).toString());
                 break;
             default:
                 throw unexpectedType(BinaryVariantUtil.getType(value, pos));

--- a/flink-core/src/main/java/org/apache/flink/types/variant/BinaryVariant.java
+++ b/flink-core/src/main/java/org/apache/flink/types/variant/BinaryVariant.java
@@ -226,9 +226,9 @@ public final class BinaryVariant implements Variant {
     }
 
     @Override
-    public UUID getUUID() throws VariantTypeException {
+    public UUID getUuid() throws VariantTypeException {
         checkType(Type.UUID, getType());
-        return BinaryVariantUtil.getUUID(value, pos);
+        return BinaryVariantUtil.getUuid(value, pos);
     }
 
     @Override
@@ -267,7 +267,7 @@ public final class BinaryVariant implements Variant {
             case BYTES:
                 return getBytes();
             case UUID:
-                return getUUID();
+                return getUuid();
             default:
                 throw new VariantTypeException(
                         String.format("Expecting a primitive variant but got %s", getType()));
@@ -469,7 +469,7 @@ public final class BinaryVariant implements Variant {
                                 .encodeToString(BinaryVariantUtil.getBinary(value, pos)));
                 break;
             case UUID:
-                appendQuoted(sb, BinaryVariantUtil.getUUID(value, pos).toString());
+                appendQuoted(sb, BinaryVariantUtil.getUuid(value, pos).toString());
                 break;
             default:
                 throw unexpectedType(BinaryVariantUtil.getType(value, pos));

--- a/flink-core/src/main/java/org/apache/flink/types/variant/BinaryVariantBuilder.java
+++ b/flink-core/src/main/java/org/apache/flink/types/variant/BinaryVariantBuilder.java
@@ -29,6 +29,7 @@ import java.time.LocalTime;
 import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
+import java.util.UUID;
 
 /** Builder for binary encoded variant. */
 @Internal
@@ -165,6 +166,13 @@ public class BinaryVariantBuilder implements VariantBuilder {
     public Variant of(LocalTime localTime) {
         BinaryVariantInternalBuilder builder = new BinaryVariantInternalBuilder(false);
         builder.appendTime(localTime.toNanoOfDay() / 1000);
+        return builder.build();
+    }
+
+    @Override
+    public Variant of(UUID uuid) {
+        BinaryVariantInternalBuilder builder = new BinaryVariantInternalBuilder(false);
+        builder.appendUUID(uuid);
         return builder.build();
     }
 

--- a/flink-core/src/main/java/org/apache/flink/types/variant/BinaryVariantBuilder.java
+++ b/flink-core/src/main/java/org/apache/flink/types/variant/BinaryVariantBuilder.java
@@ -172,7 +172,7 @@ public class BinaryVariantBuilder implements VariantBuilder {
     @Override
     public Variant of(UUID uuid) {
         BinaryVariantInternalBuilder builder = new BinaryVariantInternalBuilder(false);
-        builder.appendUUID(uuid);
+        builder.appendUuid(uuid);
         return builder.build();
     }
 

--- a/flink-core/src/main/java/org/apache/flink/types/variant/BinaryVariantInternalBuilder.java
+++ b/flink-core/src/main/java/org/apache/flink/types/variant/BinaryVariantInternalBuilder.java
@@ -35,6 +35,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.UUID;
 
 import static org.apache.flink.types.variant.BinaryVariantUtil.ARRAY;
 import static org.apache.flink.types.variant.BinaryVariantUtil.BASIC_TYPE_MASK;
@@ -326,6 +327,18 @@ public class BinaryVariantInternalBuilder {
         writePos += U32_SIZE;
         System.arraycopy(binary, 0, writeBuffer, writePos, binary.length);
         writePos += binary.length;
+    }
+
+    public void appendUUID(UUID uuid) {
+        checkCapacity(1 + 16);
+        writeBuffer[writePos++] = primitiveHeader(BinaryVariantUtil.UUID);
+        // The variant spec stores UUIDs as 16 big-endian bytes: the most significant 8 bytes
+        // followed by the least significant 8 bytes. UUID is the only primitive that is not
+        // little-endian, so we use the big-endian writer instead of writeLong.
+        BinaryVariantUtil.writeLongBigEndian(writeBuffer, writePos, uuid.getMostSignificantBits());
+        BinaryVariantUtil.writeLongBigEndian(
+                writeBuffer, writePos + 8, uuid.getLeastSignificantBits());
+        writePos += 16;
     }
 
     // Add a key to the variant dictionary. If the key already exists, the dictionary is not

--- a/flink-core/src/main/java/org/apache/flink/types/variant/BinaryVariantInternalBuilder.java
+++ b/flink-core/src/main/java/org/apache/flink/types/variant/BinaryVariantInternalBuilder.java
@@ -329,7 +329,7 @@ public class BinaryVariantInternalBuilder {
         writePos += binary.length;
     }
 
-    public void appendUUID(UUID uuid) {
+    public void appendUuid(UUID uuid) {
         checkCapacity(1 + 16);
         writeBuffer[writePos++] = primitiveHeader(BinaryVariantUtil.UUID);
         // The variant spec stores UUIDs as 16 big-endian bytes: the most significant 8 bytes

--- a/flink-core/src/main/java/org/apache/flink/types/variant/BinaryVariantUtil.java
+++ b/flink-core/src/main/java/org/apache/flink/types/variant/BinaryVariantUtil.java
@@ -28,6 +28,7 @@ import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
 import java.util.Arrays;
 import java.util.Locale;
+import java.util.UUID;
 
 /* This file is based on source code from the Spark Project (http://spark.apache.org/), licensed by the Apache
  * Software Foundation (ASF) under the Apache License, Version 2.0. See the NOTICE file distributed with this work for
@@ -201,6 +202,9 @@ public class BinaryVariantUtil {
      */
     public static final int TIMESTAMP_NS = 19;
 
+    /** UUID value */
+    public static final int UUID = 20;
+
     public static final byte VERSION = 1;
 
     /** The lower 4 bits of the first metadata byte contain the version. */
@@ -246,6 +250,16 @@ public class BinaryVariantUtil {
     public static void writeLong(byte[] bytes, int pos, long value, int numBytes) {
         for (int i = 0; i < numBytes; ++i) {
             bytes[pos + i] = (byte) ((value >>> (8 * i)) & 0xFF);
+        }
+    }
+
+    /**
+     * Write a big-endian 8-byte long value to {@code bytes[pos, pos + 8)}. Variant primitives are
+     * little-endian except for UUID, which the spec stores as 16 big-endian bytes.
+     */
+    static void writeLongBigEndian(byte[] bytes, int pos, long value) {
+        for (int i = 0; i < 8; ++i) {
+            bytes[pos + i] = (byte) ((value >>> (8 * (7 - i))) & 0xFF);
         }
     }
 
@@ -319,6 +333,17 @@ public class BinaryVariantUtil {
         }
         long signedByteValue = bytes[pos + numBytes - 1];
         result |= signedByteValue << (8 * (numBytes - 1));
+        return result;
+    }
+
+    /** Read a big-endian 8-byte long value from {@code bytes[pos, pos + 8)}. */
+    static long readLongBigEndian(byte[] bytes, int pos) {
+        checkIndex(pos, bytes.length);
+        checkIndex(pos + 7, bytes.length);
+        long result = 0;
+        for (int i = 0; i < 8; ++i) {
+            result = (result << 8) | (bytes[pos + i] & 0xFF);
+        }
         return result;
     }
 
@@ -403,6 +428,8 @@ public class BinaryVariantUtil {
                         return Type.TIMESTAMP_LTZ_NS;
                     case TIMESTAMP_NS:
                         return Type.TIMESTAMP_NS;
+                    case UUID:
+                        return Type.UUID;
                     default:
                         throw unknownPrimitiveTypeInVariant(typeInfo);
                 }
@@ -470,6 +497,8 @@ public class BinaryVariantUtil {
                         return 6;
                     case DECIMAL8:
                         return 10;
+                    case UUID:
+                        return 17;
                     case DECIMAL16:
                         return 18;
                     case BINARY:
@@ -672,6 +701,20 @@ public class BinaryVariantUtil {
             return new String(value, start, length, StandardCharsets.UTF_8);
         }
         throw unexpectedType(Type.STRING);
+    }
+
+    public static UUID getUUID(byte[] value, int pos) {
+        checkIndex(pos, value.length);
+        int basicType = value[pos] & BASIC_TYPE_MASK;
+        int typeInfo = (value[pos] >> BASIC_TYPE_BITS) & TYPE_INFO_MASK;
+        if (basicType != PRIMITIVE || typeInfo != UUID) {
+            throw unexpectedType(Type.UUID);
+        }
+        // The 16 UUID bytes are big-endian (most significant bytes first): the most significant 8
+        // bytes followed by the least significant 8 bytes.
+        long msb = readLongBigEndian(value, pos + 1);
+        long lsb = readLongBigEndian(value, pos + 9);
+        return new UUID(msb, lsb);
     }
 
     /** A handler that receives the decoded header fields of a variant object. */

--- a/flink-core/src/main/java/org/apache/flink/types/variant/BinaryVariantUtil.java
+++ b/flink-core/src/main/java/org/apache/flink/types/variant/BinaryVariantUtil.java
@@ -336,10 +336,11 @@ public class BinaryVariantUtil {
         return result;
     }
 
-    /** Read a big-endian 8-byte long value from {@code bytes[pos, pos + 8)}. */
-    static long readLongBigEndian(byte[] bytes, int pos) {
-        checkIndex(pos, bytes.length);
-        checkIndex(pos + 7, bytes.length);
+    /**
+     * Read a big-endian 8-byte long value from {@code bytes[pos, pos + 8)}. The caller must ensure
+     * those 8 bytes are within bounds.
+     */
+    private static long readLongBigEndian(byte[] bytes, int pos) {
         long result = 0;
         for (int i = 0; i < 8; ++i) {
             result = (result << 8) | (bytes[pos + i] & 0xFF);
@@ -704,7 +705,10 @@ public class BinaryVariantUtil {
     }
 
     public static UUID getUuid(byte[] value, int pos) {
+        // The header byte and the 16 UUID bytes occupy value[pos, pos + 16], so checking the first
+        // and last index once covers the whole read.
         checkIndex(pos, value.length);
+        checkIndex(pos + 16, value.length);
         int basicType = value[pos] & BASIC_TYPE_MASK;
         int typeInfo = (value[pos] >> BASIC_TYPE_BITS) & TYPE_INFO_MASK;
         if (basicType != PRIMITIVE || typeInfo != UUID) {

--- a/flink-core/src/main/java/org/apache/flink/types/variant/BinaryVariantUtil.java
+++ b/flink-core/src/main/java/org/apache/flink/types/variant/BinaryVariantUtil.java
@@ -703,7 +703,7 @@ public class BinaryVariantUtil {
         throw unexpectedType(Type.STRING);
     }
 
-    public static UUID getUUID(byte[] value, int pos) {
+    public static UUID getUuid(byte[] value, int pos) {
         checkIndex(pos, value.length);
         int basicType = value[pos] & BASIC_TYPE_MASK;
         int typeInfo = (value[pos] >> BASIC_TYPE_BITS) & TYPE_INFO_MASK;

--- a/flink-core/src/main/java/org/apache/flink/types/variant/Variant.java
+++ b/flink-core/src/main/java/org/apache/flink/types/variant/Variant.java
@@ -27,6 +27,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
+import java.util.UUID;
 
 /**
  * Variant represent a semi-structured data.
@@ -172,6 +173,14 @@ public interface Variant extends Serializable {
     byte[] getBytes() throws VariantTypeException;
 
     /**
+     * Get the scalar value of variant as UUID, if the variant type is {@link Type#UUID}.
+     *
+     * @throws VariantTypeException If this variant is not a scalar value or is not {@link
+     *     Type#UUID}.
+     */
+    UUID getUUID() throws VariantTypeException;
+
+    /**
      * Get the scalar value of variant.
      *
      * @throws VariantTypeException If this variant is not a scalar value.
@@ -249,7 +258,8 @@ public interface Variant extends Serializable {
         TIMESTAMP_LTZ,
         TIMESTAMP_NS,
         TIMESTAMP_LTZ_NS,
-        BYTES
+        BYTES,
+        UUID
     }
 
     static VariantBuilder newBuilder() {

--- a/flink-core/src/main/java/org/apache/flink/types/variant/Variant.java
+++ b/flink-core/src/main/java/org/apache/flink/types/variant/Variant.java
@@ -178,7 +178,7 @@ public interface Variant extends Serializable {
      * @throws VariantTypeException If this variant is not a scalar value or is not {@link
      *     Type#UUID}.
      */
-    UUID getUUID() throws VariantTypeException;
+    UUID getUuid() throws VariantTypeException;
 
     /**
      * Get the scalar value of variant.

--- a/flink-core/src/main/java/org/apache/flink/types/variant/VariantBuilder.java
+++ b/flink-core/src/main/java/org/apache/flink/types/variant/VariantBuilder.java
@@ -25,6 +25,7 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.util.UUID;
 
 /** Builder for variants. */
 @PublicEvolving
@@ -71,6 +72,9 @@ public interface VariantBuilder {
 
     /** Create a variant from a LocalTime. Sub-microsecond precision is truncated. */
     Variant of(LocalTime localTime);
+
+    /** Create a variant from a UUID. */
+    Variant of(UUID uuid);
 
     /** Create a variant of null. */
     Variant ofNull();

--- a/flink-core/src/test/java/org/apache/flink/types/variant/BinaryVariantTest.java
+++ b/flink-core/src/test/java/org/apache/flink/types/variant/BinaryVariantTest.java
@@ -34,6 +34,7 @@ import java.time.LocalTime;
 import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
 import java.util.Collections;
+import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -104,6 +105,10 @@ class BinaryVariantTest {
         LocalTime localTime = LocalTime.now().truncatedTo(ChronoUnit.MICROS);
         assertThat(builder.of(localTime).getTime()).isEqualTo(localTime);
         assertThat(builder.of(localTime).get()).isEqualTo(localTime);
+
+        UUID uuid = UUID.randomUUID();
+        assertThat(builder.of(uuid).getUUID()).isEqualTo(uuid);
+        assertThat(builder.of(uuid).get()).isEqualTo(uuid);
 
         assertThat(builder.ofNull().get()).isEqualTo(null);
         assertThat(builder.ofNull().isNull()).isTrue();
@@ -289,6 +294,7 @@ class BinaryVariantTest {
         LocalTime localTime = LocalTime.of(13, 45, 30, 123456789);
         Instant nanoInstant = Instant.EPOCH.plusNanos(123456789);
         LocalDateTime nanoLocalDateTime = LocalDateTime.of(2000, 1, 1, 0, 0, 0, 123456789);
+        UUID uuid = UUID.fromString("00112233-4455-6677-8899-aabbccddeeff");
 
         assertThat(builder.of((byte) 1).toJson()).isEqualTo("1");
         assertThat(builder.of((short) 1).toJson()).isEqualTo("1");
@@ -308,7 +314,44 @@ class BinaryVariantTest {
         assertThat(builder.of(nanoLocalDateTime).toJson())
                 .isEqualTo("\"2000-01-01T00:00:00.123456789\"");
         assertThat(builder.of("hello".getBytes()).toJson()).isEqualTo("\"aGVsbG8=\"");
+        assertThat(builder.of(uuid).toJson()).isEqualTo("\"00112233-4455-6677-8899-aabbccddeeff\"");
         assertThat(builder.ofNull().toJson()).isEqualTo("null");
+    }
+
+    @Test
+    void testUuidDecodeFromSpecBytes() {
+        // Interop check against the shared variant wire format: this is the exact byte sequence
+        // from Iceberg's TestSerializedPrimitives#testUUID (primitive header for type 20 followed
+        // by 16 big-endian UUID bytes). Decoding it must produce the same UUID, which proves Flink
+        // reads variants written by other implementations of the spec.
+        // https://github.com/apache/iceberg/blob/9da109dd2537e77e8e5034068933575aa4e235ff/api/src/test/java/org/apache/iceberg/variants/TestSerializedPrimitives.java#L586
+        byte[] value = {
+            BinaryVariantUtil.primitiveHeader(BinaryVariantUtil.UUID),
+            (byte) 0xf2,
+            0x4f,
+            (byte) 0x9b,
+            0x64,
+            (byte) 0x81,
+            (byte) 0xfa,
+            0x49,
+            (byte) 0xd1,
+            (byte) 0xb7,
+            0x4e,
+            (byte) 0x8c,
+            0x09,
+            (byte) 0xa6,
+            (byte) 0xe3,
+            0x1c,
+            0x56
+        };
+        // A primitive carries no dictionary keys, so reuse an empty metadata block.
+        byte[] metadata = ((BinaryVariant) builder.of(0)).getMetadata();
+        Variant variant = new BinaryVariant(value, metadata);
+
+        UUID expected = UUID.fromString("f24f9b64-81fa-49d1-b74e-8c09a6e31c56");
+        assertThat(variant.getType()).isEqualTo(Variant.Type.UUID);
+        assertThat(variant.getUUID()).isEqualTo(expected);
+        assertThat(variant.get()).isEqualTo(expected);
     }
 
     @Test

--- a/flink-core/src/test/java/org/apache/flink/types/variant/BinaryVariantTest.java
+++ b/flink-core/src/test/java/org/apache/flink/types/variant/BinaryVariantTest.java
@@ -470,6 +470,27 @@ class BinaryVariantTest {
     }
 
     @Test
+    void testUuidGetThrowException() {
+        // Reading a UUID from a non-UUID variant, and reading another type from a UUID variant,
+        // must both fail with a type exception.
+        assertThatThrownBy(builder.of(10)::getUUID)
+                .isInstanceOf(VariantTypeException.class)
+                .hasMessage("Expected type UUID but got INT");
+
+        assertThatThrownBy(builder.of(UUID.randomUUID())::getString)
+                .isInstanceOf(VariantTypeException.class)
+                .hasMessage("Expected type STRING but got UUID");
+
+        // A UUID header followed by fewer than 16 bytes is malformed and must be rejected
+        byte[] truncated = {
+            BinaryVariantUtil.primitiveHeader(BinaryVariantUtil.UUID), 0x00, 0x01, 0x02, 0x03
+        };
+        assertThatThrownBy(() -> BinaryVariantUtil.getUUID(truncated, 0))
+                .isInstanceOf(VariantTypeException.class)
+                .hasMessage("MALFORMED_VARIANT");
+    }
+
+    @Test
     void testJavaSerialization() throws Exception {
         Variant variant =
                 builder.object()

--- a/flink-core/src/test/java/org/apache/flink/types/variant/BinaryVariantTest.java
+++ b/flink-core/src/test/java/org/apache/flink/types/variant/BinaryVariantTest.java
@@ -107,7 +107,7 @@ class BinaryVariantTest {
         assertThat(builder.of(localTime).get()).isEqualTo(localTime);
 
         UUID uuid = UUID.randomUUID();
-        assertThat(builder.of(uuid).getUUID()).isEqualTo(uuid);
+        assertThat(builder.of(uuid).getUuid()).isEqualTo(uuid);
         assertThat(builder.of(uuid).get()).isEqualTo(uuid);
 
         assertThat(builder.ofNull().get()).isEqualTo(null);
@@ -350,7 +350,7 @@ class BinaryVariantTest {
 
         UUID expected = UUID.fromString("f24f9b64-81fa-49d1-b74e-8c09a6e31c56");
         assertThat(variant.getType()).isEqualTo(Variant.Type.UUID);
-        assertThat(variant.getUUID()).isEqualTo(expected);
+        assertThat(variant.getUuid()).isEqualTo(expected);
         assertThat(variant.get()).isEqualTo(expected);
     }
 
@@ -473,7 +473,7 @@ class BinaryVariantTest {
     void testUuidGetThrowException() {
         // Reading a UUID from a non-UUID variant, and reading another type from a UUID variant,
         // must both fail with a type exception.
-        assertThatThrownBy(builder.of(10)::getUUID)
+        assertThatThrownBy(builder.of(10)::getUuid)
                 .isInstanceOf(VariantTypeException.class)
                 .hasMessage("Expected type UUID but got INT");
 
@@ -485,7 +485,7 @@ class BinaryVariantTest {
         byte[] truncated = {
             BinaryVariantUtil.primitiveHeader(BinaryVariantUtil.UUID), 0x00, 0x01, 0x02, 0x03
         };
-        assertThatThrownBy(() -> BinaryVariantUtil.getUUID(truncated, 0))
+        assertThatThrownBy(() -> BinaryVariantUtil.getUuid(truncated, 0))
                 .isInstanceOf(VariantTypeException.class)
                 .hasMessage("MALFORMED_VARIANT");
     }


### PR DESCRIPTION
## What is the purpose of the change

Adds UUID (primitive type code 20) as a supported VARIANT primitive in `BinaryVariant`. 

The 16-byte layout follows the open variant spec, which stores UUID big-endian. UUID is the only variant primitive that is not little-endian, so it uses dedicated big-endian read/write helpers. 
## Brief change log

  - Add the UUID primitive (code 20) to `BinaryVariantUtil`: type mapping in `getType`, a `case UUID` in `valueSize`, and the `getUUID` reader
  - Add big-endian long helpers `writeLongBigEndian` / `readLongBigEndian`; a UUID is stored as its two 64-bit halves in 16 big-endian bytes
  - Add `appendUUID` to `BinaryVariantInternalBuilder` and `of(UUID)` to `BinaryVariantBuilder`
  - Add `getUUID()` and `Type.UUID` to the `Variant` interface and `of(UUID)` to `VariantBuilder`, and wire UUID into `get()` and `toJson()`

## Verifying this change

This change added tests and can be verified as follows:

  - Added scalar round-trip and `toJson` assertions for UUID variants
  - Added `testUuidDecodeFromSpecBytes`, which decodes the exact byte sequence from Iceberg's `TestSerializedPrimitives#testUUID` to confirm the wire format is compatible across implementations of the spec
 
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **yes** (`Variant` and `VariantBuilder` are `@PublicEvolving`, this adds new enum constants and new interface methods)
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **yes** 
  - If yes, how is the feature documented? **not documented** (documentation is tracked separately in [FLINK-40494](https://issues.apache.org/jira/browse/FLINK-40494))

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: Claude Code (Claude Opus 4.8)
