### PR TITLE
[FLINK-40423][python] Add Top-N support to the DataFrame API

### DIFF
--- a/flink-python/docs/reference/pyflink.dataframe/dataframe.rst
+++ b/flink-python/docs/reference/pyflink.dataframe/dataframe.rst
@@ -63,6 +63,7 @@ Transformations
     DataFrame.drop_duplicates
     DataFrame.distinct
     DataFrame.unique
+    DataFrame.top_n
     DataFrame.limit
     DataFrame.offset
     DataFrame.head

--- a/flink-python/pyflink/dataframe/dataframe.py
+++ b/flink-python/pyflink/dataframe/dataframe.py
@@ -542,11 +542,71 @@ class DataFrame:
                     "subset column '%s' does not exist, available columns: %s" % (name, columns)
                 )
 
+        order_list = order_keys if order_keys is not None else [None]
+        descending_flags = [keep == "last"] * len(order_list)
+        rank_nulls = nulls if nulls is not None else [None] * len(order_list)
         return DataFrame(
-            _build_deduplication_query(
-                self._table, columns, subset_keys, order_keys, keep, nulls
-            )
-        )
+            _build_rank_sql(self._table, subset_keys, order_list, descending_flags, rank_nulls, 1))
+
+    @PublicEvolving()
+    def top_n(
+        self,
+        n: int,
+        *,
+        partition_by: Union[str, List[str]] = None,
+        order_by: Union[str, Expression, List[Union[str, Expression]]] = None,
+        descending: Union[bool, List[bool]] = False,
+        nulls_first: Union[bool, List[bool]] = None,
+    ) -> "DataFrame":
+        """
+        Keep the top ``n`` rows per group, ordered by ``order_by``.
+
+        With ``partition_by`` the ranking is per group; without it the ranking is global.
+        ``top_n(1, ...)`` keeps a single row per group.
+
+        The default ranking direction is ascending (``descending=False``), so ``top_n`` keeps
+        the SMALLEST ``n`` rows by ``order_by``. Pass ``descending=True`` to keep the largest.
+
+        :param n: Number of rows to keep per group. Must be >= 1.
+        :param partition_by: Column name or list of column names defining the groups.
+        :param order_by: Column name or expression (or a list of them) defining the ranking order.
+        :param descending: Ranking direction (default ``False``); a bool or one per ``order_by``.
+        :param nulls_first: Where NULLs rank in ``order_by``: a single boolean applied to every key,
+            or a list with one boolean per key. When omitted, the engine default applies. Requires
+            ``order_by``.
+        :return: A new DataFrame with the top ``n`` rows per group.
+        :raises ValueError: If ``n`` is not an int or is < 1, if a ``descending``
+            or ``nulls_first`` list has a length different from ``order_by``, or if a named
+            column does not exist.
+        :raises TypeError: If an argument has an unsupported type, or ``order_by`` is missing
+            or empty.
+
+        Example::
+
+            >>> import pyflink.dataframe as pf
+            >>> df = pf.from_records([{"cat": "a", "amount": 10}])
+            >>> top3 = df.top_n(3, partition_by="cat", order_by="amount", descending=True)
+
+        .. versionadded:: 2.4.0
+        """
+        if not isinstance(n, int) or n < 1:
+            raise ValueError("n must be an integer >= 1")
+
+        if order_by is None or (isinstance(order_by, (list, tuple)) and not order_by):
+            raise TypeError("top_n requires a non-empty order_by")
+        order_keys = _normalize_order_by(order_by)
+
+        if partition_by is None or (isinstance(partition_by, (list, tuple)) and not partition_by):
+            partition_keys = []
+        else:
+            partition_keys = _normalize_subset(partition_by)
+
+        descending_flags = _normalize_descending(descending, len(order_keys))
+        nulls = _normalize_nulls_first(nulls_first, len(order_keys))
+        rank_nulls = nulls if nulls is not None else [None] * len(order_keys)
+        return DataFrame(
+            _build_rank_sql(self._table, partition_keys, order_keys, descending_flags, rank_nulls,
+                            n))
 
     distinct = drop_duplicates
     unique = drop_duplicates
@@ -1063,58 +1123,61 @@ def _normalize_nulls_first(
     return values
 
 
-def _build_deduplication_query(
-    table: Table,
-    columns: List[str],
-    subset_keys: List[str],
-    order_keys: Optional[List[Union[str, Expression]]],
-    keep: str,
-    nulls: Optional[List[bool]],
-) -> Table:
-    direction = "DESC" if keep == "last" else "ASC"
+def _normalize_descending(descending, order_len):
+    if isinstance(descending, bool):
+        return [descending] * order_len
+    if isinstance(descending, (list, tuple)):
+        if len(descending) != order_len:
+            raise ValueError("descending must have the same length as order_by")
+        if not all(isinstance(v, bool) for v in descending):
+            raise TypeError("descending must be a boolean or a list of booleans")
+        return list(descending)
+    raise TypeError("descending must be a boolean or a list of booleans")
+
+
+def _build_rank_sql(table, partition_keys, order_keys, descending_flags, nulls, n) -> Table:
+    columns = table.get_resolved_schema().get_column_names()
+    for name in partition_keys:
+        if name not in columns:
+            raise ValueError(
+                "partition_by column '%s' does not exist, available columns: %s" % (name, columns))
     taken = set(columns)
 
-    if order_keys is None:
-        # Arrival order (processing time); keep decides its direction.
-        order_terms = ["PROCTIME() " + direction]
-    else:
-        order_terms = []
-        for index, key in enumerate(order_keys):
-            if isinstance(key, str):
-                if key not in columns:
-                    raise ValueError(
-                        "order_by column '%s' does not exist, available columns: %s"
-                        % (key, columns)
-                    )
-                name = key
-            else:
-                # An Expression cannot be rendered to SQL text, so materialize it as a helper
-                # column and reference it by name.
-                name = _unique_name("__pf_order_%d" % index, taken)
-                taken.add(name)
-                table = table.add_columns(key.alias(name))
-            term = _quote_identifier(name) + " " + direction
-            if nulls is not None:
-                term += " NULLS FIRST" if nulls[index] else " NULLS LAST"
-            order_terms.append(term)
+    order_terms = []
+    for index, key in enumerate(order_keys):
+        direction = "DESC" if descending_flags[index] else "ASC"
+        if key is None:
+            expr_sql = "PROCTIME()"
+        elif isinstance(key, str):
+            if key not in columns:
+                raise ValueError(
+                    "order_by column '%s' does not exist, available columns: %s" % (key, columns))
+            expr_sql = _quote_identifier(key)
+        else:
+            name = _unique_name("__pf_order_%d" % index, taken)
+            taken.add(name)
+            table = table.add_columns(key.alias(name))
+            expr_sql = _quote_identifier(name)
+        term = expr_sql + " " + direction
+        if nulls is not None and nulls[index] is not None:
+            term += " NULLS FIRST" if nulls[index] else " NULLS LAST"
+        order_terms.append(term)
 
     rank_column = _quote_identifier(_unique_name("__pf_row_number", taken))
     source = _quote_identifier(str(table))
     select_list = ", ".join(_quote_identifier(name) for name in columns)
-    partition_by = ", ".join(_quote_identifier(name) for name in subset_keys)
+    over_clause = "ORDER BY " + ", ".join(order_terms)
+    if partition_keys:
+        over_clause = (
+            "PARTITION BY %s " % ", ".join(_quote_identifier(k) for k in partition_keys)
+        ) + over_clause
+    rank_filter = "= 1" if n == 1 else "<= %d" % n
     query = (
         "SELECT %s FROM (\n"
-        "  SELECT *, ROW_NUMBER() OVER (PARTITION BY %s ORDER BY %s) AS %s\n"
+        "  SELECT *, ROW_NUMBER() OVER (%s) AS %s\n"
         "  FROM %s\n"
-        ") WHERE %s = 1"
-        % (
-            select_list,
-            partition_by,
-            ", ".join(order_terms),
-            rank_column,
-            source,
-            rank_column,
-        )
+        ") WHERE %s %s"
+        % (select_list, over_clause, rank_column, source, rank_column, rank_filter)
     )
     return table._t_env.sql_query(query)
 

--- a/flink-python/pyflink/dataframe/tests/test_dataframe.py
+++ b/flink-python/pyflink/dataframe/tests/test_dataframe.py
@@ -28,7 +28,7 @@ from unittest.mock import Mock, patch
 import pandas as pd
 import pyarrow as pa
 import pyflink.dataframe as pf
-from pyflink.common import Row, RowKind
+from pyflink.common import Row
 from pyflink.table import (
     DataTypes as TableDataTypes,
     EnvironmentSettings,
@@ -1469,30 +1469,55 @@ class DataFrameUniqueTests(PyFlinkDataFrameUTTestCase):
         )
 
 
+class DataFrameTopNTests(PyFlinkDataFrameUTTestCase):
+    def setUp(self):
+        super().setUp()
+        self.df = pf.from_records([{"id": 1, "cat": "a", "amount": 10}])
+
+    def test_output_schema_equals_input(self):
+        self.assert_dataframe_schema(
+            self.df.top_n(3, partition_by="cat", order_by="amount", descending=True),
+            self.df.columns)
+
+    def test_empty_partition_by_is_global(self):
+        self.assert_dataframe_schema(
+            self.df.top_n(2, partition_by=[], order_by="amount"),
+            self.df.columns)
+
+    def test_requires_order_by(self):
+        with self.assertRaisesRegex(TypeError, "top_n requires a non-empty order_by"):
+            self.df.top_n(3, partition_by="cat")
+
+    def test_rejects_empty_order_by(self):
+        with self.assertRaisesRegex(TypeError, "top_n requires a non-empty order_by"):
+            self.df.top_n(3, partition_by="cat", order_by=[])
+
+    def test_rejects_non_positive_n(self):
+        with self.assertRaisesRegex(ValueError, "n must be an integer >= 1"):
+            self.df.top_n(0, order_by="amount")
+
+    def test_unknown_partition_column(self):
+        with self.assertRaisesRegex(ValueError, "partition_by column 'nope' does not exist"):
+            self.df.top_n(2, partition_by="nope", order_by="amount")
+
+    def test_sql_global_has_no_partition_by(self):
+        df = pf.from_records([{"id": 1, "name": "a", "score": 10}])
+
+        self.assert_dataframe_sql(
+            df,
+            "SELECT `id`, `name`, `score` FROM (\n"
+            "  SELECT *, ROW_NUMBER() OVER (ORDER BY `score` ASC) AS `__pf_row_number`\n"
+            "  FROM `SRC`\n"
+            ") WHERE `__pf_row_number` <= 2",
+            lambda: df.top_n(2, order_by="score"),
+        )
+
+
 class DataFrameDropDuplicatesITTests(PyFlinkStreamDataFrameTestCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
         cls.t_env.get_config().set("table.exec.resource.default-parallelism", "1")
-
-    @staticmethod
-    def _materialize(dataframe, key=None):
-        # Fold the collected changelog into the final table so assertions read as the
-        # resulting rows rather than the raw +I/-U/+U events.
-        columns = dataframe._table.get_resolved_schema().get_column_names()
-        if key is None:
-            indices = list(range(len(columns)))
-        else:
-            indices = [columns.index(name) for name in key]
-
-        state = {}
-        for row in dataframe.collect():
-            key_value = tuple(row[index] for index in indices)
-            if row.get_row_kind() in (RowKind.INSERT, RowKind.UPDATE_AFTER):
-                state[key_value] = tuple(row)
-            else:
-                state.pop(key_value, None)
-        return sorted(state.values())
 
     def test_whole_row_removes_identical_rows(self):
         dataframe = pf.from_records(
@@ -1666,6 +1691,54 @@ class DataFrameDropDuplicatesITTests(PyFlinkStreamDataFrameTestCase):
             self._materialize(result, key=["id"]),
             [(2, "c", 30)],
         )
+
+
+class DataFrameTopNITTests(PyFlinkStreamDataFrameTestCase):
+    def test_per_group_top_2(self):
+        df = pf.from_records([{"cat": "a", "v": 3}, {"cat": "a", "v": 1},
+                              {"cat": "a", "v": 2}, {"cat": "b", "v": 5}])
+
+        self.assertEqual(
+            self._materialize(df.top_n(2, partition_by="cat", order_by="v", descending=True)),
+            [("a", 2), ("a", 3), ("b", 5)])
+
+    def test_global_top_1(self):
+        df = pf.from_records([{"v": 3}, {"v": 1}, {"v": 2}])
+
+        self.assertEqual(self._materialize(df.top_n(1, order_by="v", descending=True)), [(3,)])
+
+    def test_nulls_first(self):
+        df = pf.from_records([{"cat": "a", "v": 3}, {"cat": "a", "v": None}])
+
+        self.assertEqual(
+            self._materialize(df.top_n(1, partition_by="cat", order_by="v",
+                                       descending=True, nulls_first=True)),
+            [("a", None)])
+
+    def test_expression_order_key(self):
+        df = pf.from_records([{"cat": "a", "v": -3}, {"cat": "a", "v": 2}])
+
+        self.assertEqual(
+            self._materialize(df.top_n(1, partition_by="cat", order_by=pf.col("v").abs,
+                                       descending=True)),
+            [("a", -3)])
+
+    def test_descending_per_key_list(self):
+        df = pf.from_records([{"a": 2, "b": 1}, {"a": 2, "b": 9},
+                              {"a": 2, "b": 5}, {"a": 1, "b": 100}])
+
+        self.assertEqual(
+            self._materialize(df.top_n(2, order_by=["a", "b"], descending=[True, False])),
+            [(2, 1), (2, 5)])
+
+    def test_nulls_first_per_key_list(self):
+        df = pf.from_records([{"cat": "x", "a": 1, "b": None}, {"cat": "x", "a": 1, "b": 5},
+                              {"cat": "y", "a": 2, "b": 3}])
+
+        self.assertEqual(
+            self._materialize(df.top_n(1, partition_by="cat", order_by=["a", "b"],
+                                       nulls_first=[False, True])),
+            [("x", 1, None), ("y", 2, 3)])
 
 
 class DataFrameITTests(PyFlinkStreamDataFrameTestCase):

--- a/flink-python/pyflink/testing/test_case_utils.py
+++ b/flink-python/pyflink/testing/test_case_utils.py
@@ -31,7 +31,7 @@ from decimal import Decimal
 from functools import wraps
 from py4j.java_gateway import JavaObject
 
-from pyflink.common import JobExecutionResult, Time, Instant, Row
+from pyflink.common import JobExecutionResult, Time, Instant, Row, RowKind
 from pyflink.datastream.execution_mode import RuntimeExecutionMode
 from pyflink.datastream.stream_execution_environment import StreamExecutionEnvironment
 from pyflink.find_flink_home import _find_flink_home, _find_flink_source_root
@@ -237,6 +237,25 @@ class PyFlinkStreamDataFrameTestCase(PyFlinkStreamTableTestCase):
             super(PyFlinkStreamDataFrameTestCase, cls).tearDownClass()
         finally:
             set_table_environment(cls._previous_table_environment)
+
+    @staticmethod
+    def _materialize(dataframe, key=None):
+        # Fold the collected changelog into the final table so assertions read as the
+        # resulting rows rather than the raw +I/-U/+U events.
+        columns = dataframe._table.get_resolved_schema().get_column_names()
+        if key is None:
+            indices = list(range(len(columns)))
+        else:
+            indices = [columns.index(name) for name in key]
+
+        state = {}
+        for row in dataframe.collect():
+            key_value = tuple(row[index] for index in indices)
+            if row.get_row_kind() in (RowKind.INSERT, RowKind.UPDATE_AFTER):
+                state[key_value] = tuple(row)
+            else:
+                state.pop(key_value, None)
+        return sorted(state.values())
 
 
 class PyFlinkBatchTableTestCase(PyFlinkITTestCase):


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

This change adds `DataFrame.top_n(...)` for global and per-group Top-N, and refactors the existing `drop_duplicates` onto the same shared SQL builder so both produce the same plan (`StreamPhysicalRank`, or `StreamPhysicalDeduplicate` for `n == 1` on a time attribute). 


## Brief change log

- Add `DataFrame.top_n`
- Generalize `_build_deduplication_query` into the shared `_build_rank_sql`
- Route `drop_duplicates` through `_build_rank_sql`
- Add `_normalize_descending` helper
- Move `_materialize` test helper to `PyFlinkStreamDataFrameTestCase`
- Add `DataFrameTopNTests` + `DataFrameTopNITTests`
- List `DataFrame.top_n` in the API reference


## Verifying this change

- Added unit tests: `DataFrameTopNTests`
- Added integration tests: `DataFrameTopNITTests`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? docs `flink-python/docs/reference/pyflink.dataframe/dataframe.rst` + Python docstrings

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change the checkbox below to `[X]` and replace the placeholder in the "Generated-by"
line with the tool name and version. Otherwise remove the "Generated-by" line.
See the ASF Generative Tooling Guidance for details:
https://www.apache.org/legal/generative-tooling.html

You are responsible for the quality and correctness of every change in this PR
regardless of the tooling used. Low-effort AI-generated PRs will be closed. See
AGENTS.md for the full guidance.
-->

- [x] Yes (please specify the tool below)

Generated-by: Opus 4.8 (1M context)