### PR TITLE
[FLINK-40554][runtime] Skipping job recovery for jobs with broken execution plan instead of failing cluster recovery hidden behind newly introduced config parameter cluster.job-error-isolation.enabled

### DIFF
--- a/docs/layouts/shortcodes/generated/cluster_configuration.html
+++ b/docs/layouts/shortcodes/generated/cluster_configuration.html
@@ -27,6 +27,12 @@
             <td>The size of the IO executor pool used by the cluster to execute blocking IO operations (Master as well as TaskManager processes). By default it will use 4 * the number of CPU cores (hardware contexts) that the cluster process has access to. Increasing the pool size allows to run more IO operations concurrently.</td>
         </tr>
         <tr>
+            <td><h5>cluster.job-error-isolation.enabled</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>Whether errors that can be scoped to a single job are handled by failing only the affected job instead of the whole cluster. For example, if a job's persisted execution plan cannot be recovered because its state handle is broken, enabling this option marks only that job as failed instead of aborting recovery for every job in the cluster.</td>
+        </tr>
+        <tr>
             <td><h5>cluster.processes.halt-on-fatal-error</h5></td>
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>

--- a/docs/layouts/shortcodes/generated/expert_cluster_section.html
+++ b/docs/layouts/shortcodes/generated/expert_cluster_section.html
@@ -21,6 +21,12 @@
             <td>Flag to check user code exiting system by terminating JVM (e.g., System.exit()). Note that this configuration option can interfere with <code class="highlighter-rouge">cluster.processes.halt-on-fatal-error</code>: In intercepted user-code, a call to System.exit() will not cause the JVM to halt, when <code class="highlighter-rouge">THROW</code> is configured.<br /><br />Possible values:<ul><li>"DISABLED": Flink is not monitoring or intercepting calls to System.exit()</li><li>"LOG": Log exit attempt with stack trace but still allowing exit to be performed</li><li>"THROW": Throw exception when exit is attempted disallowing JVM termination</li></ul></td>
         </tr>
         <tr>
+            <td><h5>cluster.job-error-isolation.enabled</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>Whether errors that can be scoped to a single job are handled by failing only the affected job instead of the whole cluster. For example, if a job's persisted execution plan cannot be recovered because its state handle is broken, enabling this option marks only that job as failed instead of aborting recovery for every job in the cluster.</td>
+        </tr>
+        <tr>
             <td><h5>cluster.processes.halt-on-fatal-error</h5></td>
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>

--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/application/ApplicationDispatcherLeaderProcessFactoryFactory.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/application/ApplicationDispatcherLeaderProcessFactoryFactory.java
@@ -20,6 +20,7 @@ package org.apache.flink.client.deployment.application;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.client.program.PackagedProgram;
+import org.apache.flink.configuration.ClusterOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.dispatcher.DispatcherFactory;
 import org.apache.flink.runtime.dispatcher.PartialDispatcherServices;
@@ -78,6 +79,7 @@ public class ApplicationDispatcherLeaderProcessFactoryFactory
                 persistenceComponentFactory,
                 partialDispatcherServices.getBlobServer(),
                 ioExecutor,
+                configuration.get(ClusterOptions.JOB_ERROR_ISOLATION_ENABLED),
                 fatalErrorHandler);
     }
 

--- a/flink-core/src/main/java/org/apache/flink/configuration/ClusterOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ClusterOptions.java
@@ -118,6 +118,21 @@ public class ClusterOptions {
                                     .build());
 
     @Documentation.Section(Documentation.Sections.EXPERT_CLUSTER)
+    public static final ConfigOption<Boolean> JOB_ERROR_ISOLATION_ENABLED =
+            key("cluster.job-error-isolation.enabled")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription(
+                            Description.builder()
+                                    .text(
+                                            "Whether errors that can be scoped to a single job are handled by failing "
+                                                    + "only the affected job instead of the whole cluster. For example, if a "
+                                                    + "job's persisted execution plan cannot be recovered because its state "
+                                                    + "handle is broken, enabling this option marks only that job as failed "
+                                                    + "instead of aborting recovery for every job in the cluster.")
+                                    .build());
+
+    @Documentation.Section(Documentation.Sections.EXPERT_CLUSTER)
     public static final ConfigOption<UserSystemExitMode> INTERCEPT_USER_SYSTEM_EXIT =
             key("cluster.intercept-user-system-exit")
                     .enumType(UserSystemExitMode.class)

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/runner/SessionDispatcherLeaderProcess.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/runner/SessionDispatcherLeaderProcess.java
@@ -34,6 +34,7 @@ import org.apache.flink.runtime.highavailability.ApplicationResultStore;
 import org.apache.flink.runtime.highavailability.JobResultStore;
 import org.apache.flink.runtime.jobmanager.ApplicationStore;
 import org.apache.flink.runtime.jobmanager.ApplicationStoreEntry;
+import org.apache.flink.runtime.jobmanager.BrokenExecutionPlanStateHandleException;
 import org.apache.flink.runtime.jobmanager.ExecutionPlanStore;
 import org.apache.flink.runtime.jobmaster.JobResult;
 import org.apache.flink.runtime.messages.FlinkApplicationNotFoundException;
@@ -82,6 +83,8 @@ public class SessionDispatcherLeaderProcess extends AbstractDispatcherLeaderProc
 
     private final Executor ioExecutor;
 
+    private final boolean jobErrorIsolationEnabled;
+
     private CompletableFuture<Void> onGoingRecoveryOperation = FutureUtils.completedVoidFuture();
 
     private SessionDispatcherLeaderProcess(
@@ -93,6 +96,7 @@ public class SessionDispatcherLeaderProcess extends AbstractDispatcherLeaderProc
             ApplicationResultStore applicationResultStore,
             BlobServer blobServer,
             Executor ioExecutor,
+            boolean jobErrorIsolationEnabled,
             FatalErrorHandler fatalErrorHandler) {
         super(leaderSessionId, fatalErrorHandler);
 
@@ -103,6 +107,7 @@ public class SessionDispatcherLeaderProcess extends AbstractDispatcherLeaderProc
         this.applicationResultStore = applicationResultStore;
         this.blobServer = blobServer;
         this.ioExecutor = ioExecutor;
+        this.jobErrorIsolationEnabled = jobErrorIsolationEnabled;
     }
 
     @Override
@@ -262,6 +267,7 @@ public class SessionDispatcherLeaderProcess extends AbstractDispatcherLeaderProc
 
     private Optional<ExecutionPlan> tryRecoverJob(JobID jobId) {
         log.info("Trying to recover job with job id {}.", jobId);
+        final String errorMessage = String.format("Could not recover job with job id %s.", jobId);
         try {
             final ExecutionPlan executionPlan = executionPlanStore.recoverExecutionPlan(jobId);
             if (executionPlan == null) {
@@ -270,9 +276,20 @@ public class SessionDispatcherLeaderProcess extends AbstractDispatcherLeaderProc
                         jobId);
             }
             return Optional.ofNullable(executionPlan);
+        } catch (BrokenExecutionPlanStateHandleException e) {
+            if (!jobErrorIsolationEnabled) {
+                throw new FlinkRuntimeException(errorMessage, e);
+            }
+            log.error(
+                    "The persisted ExecutionPlan of job {} is broken beyond repair and cannot be recovered. Skipping "
+                            + "recovery for this job. This job will not be resubmitted and no automatic cleanup will "
+                            + "be performed for it; manual cleanup of its dangling HA state is required. See cause "
+                            + "for details.",
+                    jobId,
+                    e);
+            return Optional.empty();
         } catch (Exception e) {
-            throw new FlinkRuntimeException(
-                    String.format("Could not recover job with job id %s.", jobId), e);
+            throw new FlinkRuntimeException(errorMessage, e);
         }
     }
 
@@ -553,6 +570,7 @@ public class SessionDispatcherLeaderProcess extends AbstractDispatcherLeaderProc
             ApplicationResultStore applicationResultStore,
             BlobServer blobServer,
             Executor ioExecutor,
+            boolean jobErrorIsolationEnabled,
             FatalErrorHandler fatalErrorHandler) {
         return new SessionDispatcherLeaderProcess(
                 leaderSessionId,
@@ -563,6 +581,7 @@ public class SessionDispatcherLeaderProcess extends AbstractDispatcherLeaderProc
                 applicationResultStore,
                 blobServer,
                 ioExecutor,
+                jobErrorIsolationEnabled,
                 fatalErrorHandler);
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/runner/SessionDispatcherLeaderProcessFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/runner/SessionDispatcherLeaderProcessFactory.java
@@ -35,6 +35,7 @@ public class SessionDispatcherLeaderProcessFactory implements DispatcherLeaderPr
     private final PersistenceComponentFactory persistenceComponentFactory;
     private final BlobServer blobServer;
     private final Executor ioExecutor;
+    private final boolean jobErrorIsolationEnabled;
     private final FatalErrorHandler fatalErrorHandler;
 
     public SessionDispatcherLeaderProcessFactory(
@@ -43,11 +44,13 @@ public class SessionDispatcherLeaderProcessFactory implements DispatcherLeaderPr
             PersistenceComponentFactory persistenceComponentFactory,
             BlobServer blobServer,
             Executor ioExecutor,
+            boolean jobErrorIsolationEnabled,
             FatalErrorHandler fatalErrorHandler) {
         this.dispatcherGatewayServiceFactory = dispatcherGatewayServiceFactory;
         this.persistenceComponentFactory = persistenceComponentFactory;
         this.blobServer = blobServer;
         this.ioExecutor = ioExecutor;
+        this.jobErrorIsolationEnabled = jobErrorIsolationEnabled;
         this.fatalErrorHandler = fatalErrorHandler;
     }
 
@@ -62,6 +65,7 @@ public class SessionDispatcherLeaderProcessFactory implements DispatcherLeaderPr
                 persistenceComponentFactory.createApplicationResultStore(),
                 blobServer,
                 ioExecutor,
+                jobErrorIsolationEnabled,
                 fatalErrorHandler);
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/runner/SessionDispatcherLeaderProcessFactoryFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/runner/SessionDispatcherLeaderProcessFactoryFactory.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.dispatcher.runner;
 
+import org.apache.flink.configuration.ClusterOptions;
 import org.apache.flink.runtime.dispatcher.DispatcherFactory;
 import org.apache.flink.runtime.dispatcher.PartialDispatcherServices;
 import org.apache.flink.runtime.jobmanager.PersistenceComponentFactory;
@@ -53,6 +54,9 @@ public class SessionDispatcherLeaderProcessFactoryFactory
                 persistenceComponentFactory,
                 partialDispatcherServices.getBlobServer(),
                 ioExecutor,
+                partialDispatcherServices
+                        .getConfiguration()
+                        .get(ClusterOptions.JOB_ERROR_ISOLATION_ENABLED),
                 fatalErrorHandler);
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/BrokenExecutionPlanStateHandleException.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/BrokenExecutionPlanStateHandleException.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.jobmanager;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.util.FlinkException;
+
+/**
+ * Thrown by {@link ExecutionPlanStore#recoverExecutionPlan(JobID)} when a job's persisted {@link
+ * org.apache.flink.streaming.api.graph.ExecutionPlan} cannot be deserialized because its state
+ * handle is broken (e.g. the backing file is missing/corrupted, or written by an incompatible Flink
+ * version). Unlike other recovery failures (e.g. a temporarily unreachable backend), this is not
+ * transient, so callers can react by skipping just the affected job instead of failing the whole
+ * recovery.
+ */
+public class BrokenExecutionPlanStateHandleException extends FlinkException {
+
+    private static final long serialVersionUID = 1L;
+
+    public BrokenExecutionPlanStateHandleException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/DefaultExecutionPlanStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/DefaultExecutionPlanStore.java
@@ -168,14 +168,14 @@ public class DefaultExecutionPlanStore<R extends ResourceVersion<R>>
                 try {
                     executionPlan = executionPlanRetrievableStateHandle.retrieveState();
                 } catch (ClassNotFoundException cnfe) {
-                    throw new FlinkException(
+                    throw new BrokenExecutionPlanStateHandleException(
                             "Could not retrieve submitted ExecutionPlan from state handle under "
                                     + name
                                     + ". This indicates that you are trying to recover from state written by an "
                                     + "older Flink version which is not compatible. Try cleaning the state handle store.",
                             cnfe);
                 } catch (IOException ioe) {
-                    throw new FlinkException(
+                    throw new BrokenExecutionPlanStateHandleException(
                             "Could not retrieve submitted ExecutionPlan from state handle under "
                                     + name
                                     + ". This indicates that the retrieved state handle is broken. Try cleaning the state handle "

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/runner/SessionDispatcherLeaderProcessTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/runner/SessionDispatcherLeaderProcessTest.java
@@ -34,6 +34,7 @@ import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobGraphTestUtils;
 import org.apache.flink.runtime.jobmanager.ApplicationStore;
 import org.apache.flink.runtime.jobmanager.ApplicationStoreEntry;
+import org.apache.flink.runtime.jobmanager.BrokenExecutionPlanStateHandleException;
 import org.apache.flink.runtime.jobmanager.ExecutionPlanStore;
 import org.apache.flink.runtime.jobmanager.TestingApplicationStoreEntry;
 import org.apache.flink.runtime.jobmaster.JobResult;
@@ -59,6 +60,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -103,6 +105,8 @@ class SessionDispatcherLeaderProcessTest {
 
     private BlobServer blobServer;
 
+    private boolean jobErrorIsolationEnabled;
+
     private AbstractDispatcherLeaderProcess.DispatcherGatewayServiceFactory
             dispatcherServiceFactory;
 
@@ -125,6 +129,7 @@ class SessionDispatcherLeaderProcessTest {
         jobResultStore = TestingJobResultStore.builder().build();
         applicationStore = TestingApplicationStore.newBuilder().build();
         applicationResultStore = TestingApplicationResultStore.builder().build();
+        jobErrorIsolationEnabled = true;
         dispatcherServiceFactory =
                 createFactoryBasedOnGenericSupplier(
                         () -> TestingDispatcherGatewayService.newBuilder().build());
@@ -897,6 +902,84 @@ class SessionDispatcherLeaderProcessTest {
     }
 
     @Test
+    void recoverJobs_withBrokenExecutionPlan_skipsJobAndRecoversRemainingJobs() throws Exception {
+        final ExecutionPlan healthyJobGraph = JobGraphTestUtils.emptyJobGraph();
+        healthyJobGraph.setApplicationId(JOB_GRAPH.getApplicationId().get());
+        final BrokenExecutionPlanStateHandleException brokenStateException =
+                new BrokenExecutionPlanStateHandleException(
+                        "Broken state handle.", new IOException("Test IO exception."));
+
+        executionPlanStore =
+                TestingExecutionPlanStore.newBuilder()
+                        .setJobIdsFunction(
+                                ignored ->
+                                        Arrays.asList(
+                                                JOB_GRAPH.getJobID(), healthyJobGraph.getJobID()))
+                        .setRecoverExecutionPlanFunction(
+                                (jobId, jobs) -> {
+                                    if (jobId.equals(JOB_GRAPH.getJobID())) {
+                                        throw brokenStateException;
+                                    }
+                                    return healthyJobGraph;
+                                })
+                        .build();
+
+        final CompletableFuture<Collection<ExecutionPlan>> recoveredExecutionPlansFuture =
+                new CompletableFuture<>();
+        final CompletableFuture<Collection<JobResult>> recoveredDirtyJobResultsFuture =
+                new CompletableFuture<>();
+        dispatcherServiceFactory =
+                (ignoredDispatcherId,
+                        recoveredJobs,
+                        recoveredDirtyJobResults,
+                        ignoredRecoveredApplications,
+                        ignoredRecoveredDirtyApplicationResults,
+                        ignoredExecutionPlanWriter,
+                        ignoredJobResultStore,
+                        ignoredApplicationStore,
+                        ignoredApplicationResultStore) -> {
+                    recoveredExecutionPlansFuture.complete(recoveredJobs);
+                    recoveredDirtyJobResultsFuture.complete(recoveredDirtyJobResults);
+                    return TestingDispatcherGatewayService.newBuilder().build();
+                };
+
+        try (final SessionDispatcherLeaderProcess dispatcherLeaderProcess =
+                createDispatcherLeaderProcess()) {
+            dispatcherLeaderProcess.start();
+
+            assertThat(recoveredExecutionPlansFuture.get())
+                    .singleElement()
+                    .isEqualTo(healthyJobGraph);
+
+            // the broken job is silently skipped: no JobResult is recorded for it, since this
+            // codebase requires every dirty JobResult's application to be independently
+            // recoverable (either a real, persisted multi-job application, or a still-recoverable
+            // ExecutionPlan re-wrapped into a fresh SingleJobApplication), neither of which holds
+            // for a job whose plan is permanently unreadable
+            assertThat(recoveredDirtyJobResultsFuture.get()).isEmpty();
+        }
+    }
+
+    @Test
+    void recoverJobs_withBrokenExecutionPlanAndIsolationDisabled_failsFatally() throws Exception {
+        final BrokenExecutionPlanStateHandleException brokenStateException =
+                new BrokenExecutionPlanStateHandleException(
+                        "Broken state handle.", new IOException("Test IO exception."));
+
+        jobErrorIsolationEnabled = false;
+        executionPlanStore =
+                TestingExecutionPlanStore.newBuilder()
+                        .setRecoverExecutionPlanFunction(
+                                (jobId, jobs) -> {
+                                    throw brokenStateException;
+                                })
+                        .setInitialExecutionPlans(Collections.singleton(JOB_GRAPH))
+                        .build();
+
+        runRecoveryFailureTest(brokenStateException);
+    }
+
+    @Test
     void recoverApplications_withRecoveryFailure_failsFatally() throws Exception {
         final FlinkException testException = new FlinkException("Test exception");
         applicationStore =
@@ -1072,6 +1155,7 @@ class SessionDispatcherLeaderProcessTest {
                 applicationResultStore,
                 blobServer,
                 ioExecutor,
+                jobErrorIsolationEnabled,
                 fatalErrorHandler);
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/DefaultExecutionPlanStoreTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/DefaultExecutionPlanStoreTest.java
@@ -39,6 +39,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
@@ -141,6 +142,22 @@ public class DefaultExecutionPlanStoreTest extends TestLogger {
                 .hasCause(testException);
         String actual = releaseFuture.get(timeout, TimeUnit.MILLISECONDS);
         assertThat(testingExecutionPlan.getJobID()).hasToString(actual);
+    }
+
+    @Test
+    public void testRecoverExecutionPlanWithBrokenStateHandleThrowsDedicatedException()
+            throws Exception {
+        final TestingStateHandleStore<ExecutionPlan> stateHandleStore =
+                builder.setGetFunction(ignore -> new BrokenRetrievableStateHandle()).build();
+
+        final ExecutionPlanStore executionPlanStore =
+                createAndStartExecutionPlanStore(stateHandleStore);
+
+        assertThatThrownBy(
+                        () ->
+                                executionPlanStore.recoverExecutionPlan(
+                                        testingExecutionPlan.getJobID()))
+                .isInstanceOf(BrokenExecutionPlanStateHandleException.class);
     }
 
     @Test
@@ -480,5 +497,30 @@ public class DefaultExecutionPlanStoreTest extends TestLogger {
                         });
         executionPlanStore.start(testingExecutionPlanListener);
         return executionPlanStore;
+    }
+
+    /**
+     * A {@link RetrievableStateHandle} whose {@link #retrieveState()} always fails, simulating a
+     * corrupted/broken state handle. Deliberately a named (not anonymous) class: subtypes of {@link
+     * org.apache.flink.runtime.state.StateObject} must not be anonymous, see {@link
+     * org.apache.flink.test.state.StateHandleSerializationTest}.
+     */
+    private static final class BrokenRetrievableStateHandle
+            implements RetrievableStateHandle<ExecutionPlan> {
+
+        private static final long serialVersionUID = 1L;
+
+        @Override
+        public ExecutionPlan retrieveState() throws IOException {
+            throw new IOException("Test IO exception simulating a broken handle.");
+        }
+
+        @Override
+        public void discardState() {}
+
+        @Override
+        public long getStateSize() {
+            return 0;
+        }
     }
 }


### PR DESCRIPTION
The old implementation treated ExecutionPlan recovery errors as cluster-wide fatal causing the JobManager to fail over. This would cause other jobs on the same JobManager to failover as well. Enabling the new feature through the newly added configuration parameter makes the job recovery being skipped rather than failing the JobManager since the job wouldn't recover anyway. Cleanup needs to be handled manually by the operator. The error is revealed via error logs.

## What is the purpose of the change

Creates new configuration parameter (with the feature being disabled by default). Enabling the feature would skip job recovery for that job and emits an error log message instead for manual cleanup. This prevents JobManager failover.

## Brief change log

* Introduces new exception that's used when an error occurs during ExecutionPlan loading
* The new error is handled through an error log message instead of forwarding the error if the feature is enabled.

## Verifying this change

* Added separate unit tests to cover the behavior

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? docs

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: Claude
