### PR TITLE
[hotfix][docs] Add 2.3 to PreviousDocs list

### DIFF
--- a/docs/config.toml
+++ b/docs/config.toml
@@ -73,6 +73,7 @@ pygmentsUseClasses = true
   ]
 
   PreviousDocs = [
+    ["2.3", "http://nightlies.apache.org/flink/flink-docs-release-2.3"],
     ["2.2", "http://nightlies.apache.org/flink/flink-docs-release-2.2"],
     ["2.1", "http://nightlies.apache.org/flink/flink-docs-release-2.1"],
     ["2.0", "http://nightlies.apache.org/flink/flink-docs-release-2.0"],


### PR DESCRIPTION
Realized we’re still missing a link to the 2.3 docs when browsing 2.4 snapshot docs.