### PR TITLE
[FLINK-39108][checkpoint] Respect disabled interval-during-backlog for the first checkpoint

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
@@ -483,6 +483,12 @@ public class CheckpointCoordinator {
                         < nextCheckpointTriggeringRelativeTime) {
                     rescheduleTrigger(currentRelativeTime, currentCheckpointInterval);
                 }
+            } else {
+                // Periodic checkpointing is disabled for the current backlog status. Cancel any
+                // trigger that has already been scheduled (e.g. by the checkpoint scheduler before
+                // the backlog was reported) so that no checkpoint is triggered until the status
+                // changes again (FLINK-39108).
+                cancelPeriodicTrigger();
             }
         }
     }
@@ -2224,9 +2230,14 @@ public class CheckpointCoordinator {
                                                     - clock.relativeTimeMillis()),
                                     TimeUnit.MILLISECONDS);
                 } else {
+                    // Periodic checkpointing has been disabled in the meantime (e.g. a source
+                    // reported backlog with a disabled interval-during-backlog). Do not trigger
+                    // this run either; the trigger will be rescheduled when the effective
+                    // interval becomes enabled again (FLINK-39108).
                     nextCheckpointTriggeringRelativeTime = Long.MAX_VALUE;
                     currentPeriodicTrigger = null;
                     currentPeriodicTriggerFuture = null;
+                    return;
                 }
             }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTriggeringTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTriggeringTest.java
@@ -29,6 +29,7 @@ import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.executiongraph.ExecutionGraph;
 import org.apache.flink.runtime.executiongraph.ExecutionVertex;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings;
 import org.apache.flink.runtime.jobgraph.tasks.CheckpointCoordinatorConfiguration;
 import org.apache.flink.runtime.jobgraph.tasks.CheckpointCoordinatorConfiguration.CheckpointCoordinatorConfigurationBuilder;
@@ -39,6 +40,7 @@ import org.apache.flink.testutils.executor.TestExecutorExtension;
 import org.apache.flink.testutils.junit.utils.TempDirUtils;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.ExecutorUtils;
+import org.apache.flink.util.clock.ManualClock;
 import org.apache.flink.util.concurrent.FutureUtils;
 import org.apache.flink.util.concurrent.ManuallyTriggeredScheduledExecutor;
 import org.apache.flink.util.concurrent.ScheduledExecutorServiceAdapter;
@@ -181,6 +183,139 @@ class CheckpointCoordinatorTriggeringTest {
 
             lastId = checkpoint.checkpointId;
             lastTs = checkpoint.timestamp;
+        }
+    }
+
+    /**
+     * Tests that no periodic checkpoint is triggered while a source is processing backlog and
+     * {@code execution.checkpointing.interval-during-backlog} is disabled, even if the first
+     * periodic trigger was already scheduled before the source reported the backlog (FLINK-39108).
+     */
+    @Test
+    void testFirstScheduledCheckpointNotTriggeredWhenBacklogCheckpointingDisabled()
+            throws Exception {
+        CheckpointCoordinatorTestingUtils.CheckpointRecorderTaskManagerGateway gateway =
+                new CheckpointCoordinatorTestingUtils.CheckpointRecorderTaskManagerGateway();
+
+        JobVertexID jobVertexID = new JobVertexID();
+        ExecutionGraph graph =
+                new CheckpointCoordinatorTestingUtils.CheckpointExecutionGraphBuilder()
+                        .addJobVertex(jobVertexID)
+                        .setTaskManagerGateway(gateway)
+                        .build(EXECUTOR_RESOURCE.getExecutor());
+
+        ExecutionVertex vertex = graph.getJobVertex(jobVertexID).getTaskVertices()[0];
+        ExecutionAttemptID attemptID = vertex.getCurrentExecutionAttempt().getAttemptId();
+
+        CheckpointCoordinatorConfiguration checkpointCoordinatorConfiguration =
+                new CheckpointCoordinatorConfigurationBuilder()
+                        .setCheckpointInterval(10)
+                        .setCheckpointIntervalDuringBacklog(
+                                CheckpointCoordinatorConfiguration.DISABLED_CHECKPOINT_INTERVAL)
+                        .setCheckpointTimeout(200000)
+                        .setMaxConcurrentCheckpoints(Integer.MAX_VALUE)
+                        .build();
+        CheckpointCoordinator checkpointCoordinator =
+                new CheckpointCoordinatorBuilder()
+                        .setCheckpointCoordinatorConfiguration(checkpointCoordinatorConfiguration)
+                        .setTimer(manuallyTriggeredScheduledExecutor)
+                        .setClock(new ManualClock())
+                        .build(graph);
+
+        try {
+            checkpointCoordinator.startCheckpointScheduler();
+
+            // a source reports isProcessingBacklog=true before the first periodic checkpoint
+            // has been triggered; with a disabled backlog interval no checkpoint may be
+            // triggered until the backlog is processed
+            OperatorID operatorID = new OperatorID();
+            checkpointCoordinator.setIsProcessingBacklog(operatorID, true);
+            assertThat(checkpointCoordinator.isCurrentPeriodicTriggerAvailable())
+                    .as("the armed periodic trigger is cancelled right away")
+                    .isFalse();
+
+            manuallyTriggeredScheduledExecutor.triggerNonPeriodicScheduledTasks(
+                    CheckpointCoordinator.ScheduledTrigger.class);
+            manuallyTriggeredScheduledExecutor.triggerAll();
+
+            assertThat(checkpointCoordinator.getNumberOfPendingCheckpoints())
+                    .as(
+                            "No checkpoint should be triggered during backlog if the checkpoint "
+                                    + "interval during backlog is disabled")
+                    .isZero();
+            assertThat(gateway.getTriggeredCheckpoints(attemptID)).isEmpty();
+
+            // the backlog ends: the periodic trigger is re-armed and checkpointing resumes
+            checkpointCoordinator.setIsProcessingBacklog(operatorID, false);
+            assertThat(checkpointCoordinator.isCurrentPeriodicTriggerAvailable()).isTrue();
+            manuallyTriggeredScheduledExecutor.triggerNonPeriodicScheduledTasks(
+                    CheckpointCoordinator.ScheduledTrigger.class);
+            manuallyTriggeredScheduledExecutor.triggerAll();
+            assertThat(gateway.getTriggeredCheckpoints(attemptID)).hasSize(1);
+        } finally {
+            checkpointCoordinator.shutdown();
+        }
+    }
+
+    /**
+     * Tests that a periodic trigger armed while a source is already processing backlog does not
+     * trigger a checkpoint if {@code execution.checkpointing.interval-during-backlog} is disabled,
+     * and that checkpointing resumes once the backlog is processed (FLINK-39108).
+     */
+    @Test
+    void testSchedulerStartedDuringBacklogDoesNotTriggerWhenBacklogCheckpointingDisabled()
+            throws Exception {
+        CheckpointCoordinatorTestingUtils.CheckpointRecorderTaskManagerGateway gateway =
+                new CheckpointCoordinatorTestingUtils.CheckpointRecorderTaskManagerGateway();
+
+        JobVertexID jobVertexID = new JobVertexID();
+        ExecutionGraph graph =
+                new CheckpointCoordinatorTestingUtils.CheckpointExecutionGraphBuilder()
+                        .addJobVertex(jobVertexID)
+                        .setTaskManagerGateway(gateway)
+                        .build(EXECUTOR_RESOURCE.getExecutor());
+
+        ExecutionVertex vertex = graph.getJobVertex(jobVertexID).getTaskVertices()[0];
+        ExecutionAttemptID attemptID = vertex.getCurrentExecutionAttempt().getAttemptId();
+
+        CheckpointCoordinatorConfiguration checkpointCoordinatorConfiguration =
+                new CheckpointCoordinatorConfigurationBuilder()
+                        .setCheckpointInterval(10)
+                        .setCheckpointIntervalDuringBacklog(
+                                CheckpointCoordinatorConfiguration.DISABLED_CHECKPOINT_INTERVAL)
+                        .setCheckpointTimeout(200000)
+                        .setMaxConcurrentCheckpoints(Integer.MAX_VALUE)
+                        .build();
+        CheckpointCoordinator checkpointCoordinator =
+                new CheckpointCoordinatorBuilder()
+                        .setCheckpointCoordinatorConfiguration(checkpointCoordinatorConfiguration)
+                        .setTimer(manuallyTriggeredScheduledExecutor)
+                        .setClock(new ManualClock())
+                        .build(graph);
+
+        try {
+            // the source reports backlog first, the scheduler is started afterwards (this is the
+            // order in a running job: the enumerator reports on start, the scheduler starts once
+            // all tasks are running)
+            OperatorID operatorID = new OperatorID();
+            checkpointCoordinator.setIsProcessingBacklog(operatorID, true);
+            checkpointCoordinator.startCheckpointScheduler();
+
+            manuallyTriggeredScheduledExecutor.triggerNonPeriodicScheduledTasks(
+                    CheckpointCoordinator.ScheduledTrigger.class);
+            manuallyTriggeredScheduledExecutor.triggerAll();
+
+            assertThat(checkpointCoordinator.getNumberOfPendingCheckpoints()).isZero();
+            assertThat(gateway.getTriggeredCheckpoints(attemptID)).isEmpty();
+            assertThat(checkpointCoordinator.isCurrentPeriodicTriggerAvailable()).isFalse();
+
+            checkpointCoordinator.setIsProcessingBacklog(operatorID, false);
+            manuallyTriggeredScheduledExecutor.triggerNonPeriodicScheduledTasks(
+                    CheckpointCoordinator.ScheduledTrigger.class);
+            manuallyTriggeredScheduledExecutor.triggerAll();
+            assertThat(gateway.getTriggeredCheckpoints(attemptID)).hasSize(1);
+        } finally {
+            checkpointCoordinator.shutdown();
         }
     }
 

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/CheckpointIntervalDuringBacklogITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/CheckpointIntervalDuringBacklogITCase.java
@@ -44,7 +44,6 @@ import org.apache.flink.test.util.NumberSequenceSourceWithWaitForCheckpoint;
 import org.apache.flink.util.CloseableIterator;
 
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -140,7 +139,6 @@ class CheckpointIntervalDuringBacklogITCase {
     }
 
     @Test
-    @Disabled("FLINK-39018") // FLINK-39108
     void testNoCheckpointDuringBacklog() throws Exception {
         final int recordsBeforeSwitch = NUM_RECORDS / 2;
         Duration expectedSwitchTime = Duration.ofMillis(recordsBeforeSwitch * SLEEP_MS_PER_RECORD);


### PR DESCRIPTION
## What is the purpose of the change

Fixes FLINK-39108. `execution.checkpointing.interval-during-backlog` is honored for steady-state scheduling but not for the first checkpoint. Two things combine to let it through:

- `ScheduledTrigger#run` parks itself when it finds the effective interval disabled, but still triggers the current run. This is the path the disabled ITCase hits: the source reports backlog before its task is running, the scheduler is (re)started at task RUNNING with a zero initial delay, and that first run fires a checkpoint before parking.
- `CheckpointCoordinator#setIsProcessingBacklog` only reschedules the periodic trigger when the new effective interval would fire earlier and skips the disabled case, so a trigger that is already armed when the backlog is reported stays armed and wakes up only to park.

Net effect: at least one checkpoint is triggered during backlog even when checkpointing during backlog is disabled, which is what the ticket and the disabled `CheckpointIntervalDuringBacklogITCase#testNoCheckpointDuringBacklog` describe.

## Brief change log

- `ScheduledTrigger#run` no longer triggers a checkpoint when it finds the effective interval disabled; it only parks
- `setIsProcessingBacklog` cancels an already armed periodic trigger when the effective interval becomes disabled instead of letting it wake up and park; when the backlog ends, the existing reschedule-if-earlier path re-arms it (the parked trigger's next fire time is `Long.MAX_VALUE`), so the first checkpoint after a backlog comes one full interval after the backlog ends
- re-enabled `CheckpointIntervalDuringBacklogITCase#testNoCheckpointDuringBacklog`; the `@Disabled` annotation referenced FLINK-39018, a typo for FLINK-39108

## Verifying this change

This change added tests and can be verified as follows:

- `CheckpointIntervalDuringBacklogITCase#testNoCheckpointDuringBacklog` (the test disabled in #27630) reproduces the reported behavior against unmodified master: it fails with `Expecting AtomicInteger(2) to have value: 0`, i.e. two checkpoints ran while the first source was still in backlog. With the change the whole class passes, 4/4.
- `CheckpointCoordinatorTriggeringTest#testFirstScheduledCheckpointNotTriggeredWhenBacklogCheckpointingDisabled`: new unit test for a periodic trigger that is already armed when the backlog is reported. It checks that the trigger is cancelled right away, that no checkpoint is triggered during the backlog, and that exactly one checkpoint is triggered once the backlog ends. Fails on master at the first assertion (the trigger stays armed), passes with the change.
- `CheckpointCoordinatorTriggeringTest#testSchedulerStartedDuringBacklogDoesNotTriggerWhenBacklogCheckpointingDisabled`: new unit test for the ordering the ITCase hits (backlog reported before the scheduler is started). It checks that the first run of the armed trigger does not trigger a checkpoint and that checkpointing resumes once the backlog ends. Fails on master (one checkpoint is triggered), passes with the change.
- End to end on a local MiniCluster: a job reading a HybridSource of two NumberSequenceSources with interval 1s and interval-during-backlog 0. On master, checkpoints 1 and 2 complete while the first source is still in backlog; with this change no checkpoint runs during backlog and checkpointing resumes right after the switch to the second source (7 checkpoints). Same result in 4 runs each.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: yes, Checkpointing (scheduling of the periodic trigger)
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
