### PR TITLE
[FLINK-XXXXX][state-backends] Migrate RocksDB state backend tests to …

### DIFF
--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/state/rocksdb/RocksDBMemoryControllerUtilsTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/state/rocksdb/RocksDBMemoryControllerUtilsTest.java
@@ -18,34 +18,30 @@
 
 package org.apache.flink.state.rocksdb;
 
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.rocksdb.Cache;
 import org.rocksdb.NativeLibraryLoader;
 import org.rocksdb.WriteBufferManager;
 
 import java.io.IOException;
+import java.nio.file.Path;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests to guard {@link RocksDBMemoryControllerUtils}. */
-public class RocksDBMemoryControllerUtilsTest {
+class RocksDBMemoryControllerUtilsTest {
 
-    @Rule public final TemporaryFolder temporaryFolder = new TemporaryFolder();
+    @TempDir static Path tempDir;
 
-    @Before
-    public void ensureRocksDbNativeLibraryLoaded() throws IOException {
-        NativeLibraryLoader.getInstance()
-                .loadLibrary(temporaryFolder.newFolder().getAbsolutePath());
+    @BeforeAll
+    static void ensureRocksDbNativeLibraryLoaded() throws IOException {
+        NativeLibraryLoader.getInstance().loadLibrary(tempDir.toAbsolutePath().toString());
     }
 
     @Test
-    public void testCreateSharedResourcesWithExpectedCapacity() {
+    void testCreateSharedResourcesWithExpectedCapacity() {
         long totalMemorySize = 2048L;
         double writeBufferRatio = 0.5;
         double highPriPoolRatio = 0.1;
@@ -60,53 +56,57 @@ public class RocksDBMemoryControllerUtilsTest {
                 RocksDBMemoryControllerUtils.calculateWriteBufferManagerCapacity(
                         totalMemorySize, writeBufferRatio);
 
-        assertThat(factory.actualCacheCapacity, is(expectedCacheCapacity));
-        assertThat(factory.actualWbmCapacity, is(expectedWbmCapacity));
-        assertThat(rocksDBSharedResources.getWriteBufferManagerCapacity(), is(expectedWbmCapacity));
+        assertThat(factory.actualCacheCapacity).isEqualTo(expectedCacheCapacity);
+        assertThat(factory.actualWbmCapacity).isEqualTo(expectedWbmCapacity);
+        assertThat(rocksDBSharedResources.getWriteBufferManagerCapacity())
+                .isEqualTo(expectedWbmCapacity);
     }
 
     @Test
-    public void testCalculateRocksDBDefaultArenaBlockSize() {
+    void testCalculateRocksDBDefaultArenaBlockSize() {
         final long align = 4 * 1024;
         final long writeBufferSize = 64 * 1024 * 1024;
         final long expectArenaBlockSize = writeBufferSize / 8;
 
         // Normal case test
         assertThat(
-                "Arena block size calculation error for normal case",
-                RocksDBMemoryControllerUtils.calculateRocksDBDefaultArenaBlockSize(writeBufferSize),
-                is(expectArenaBlockSize));
+                        RocksDBMemoryControllerUtils.calculateRocksDBDefaultArenaBlockSize(
+                                writeBufferSize))
+                .as("Arena block size calculation error for normal case")
+                .isEqualTo(expectArenaBlockSize);
 
         // Alignment tests
         assertThat(
-                "Arena block size calculation error for alignment case",
-                RocksDBMemoryControllerUtils.calculateRocksDBDefaultArenaBlockSize(
-                        writeBufferSize - 1),
-                is(expectArenaBlockSize));
+                        RocksDBMemoryControllerUtils.calculateRocksDBDefaultArenaBlockSize(
+                                writeBufferSize - 1))
+                .as("Arena block size calculation error for alignment case")
+                .isEqualTo(expectArenaBlockSize);
         assertThat(
-                "Arena block size calculation error for alignment case2",
-                RocksDBMemoryControllerUtils.calculateRocksDBDefaultArenaBlockSize(
-                        writeBufferSize + 8),
-                is(expectArenaBlockSize + align));
+                        RocksDBMemoryControllerUtils.calculateRocksDBDefaultArenaBlockSize(
+                                writeBufferSize + 8))
+                .as("Arena block size calculation error for alignment case2")
+                .isEqualTo(expectArenaBlockSize + align);
     }
 
     @Test
-    public void testCalculateRocksDBMutableLimit() {
+    void testCalculateRocksDBMutableLimit() {
         long bufferSize = 64 * 1024 * 1024;
         long limit = bufferSize * 7 / 8;
-        assertThat(
-                RocksDBMemoryControllerUtils.calculateRocksDBMutableLimit(bufferSize), is(limit));
+        assertThat(RocksDBMemoryControllerUtils.calculateRocksDBMutableLimit(bufferSize))
+                .isEqualTo(limit);
     }
 
     @Test
-    public void testValidateArenaBlockSize() {
+    void testValidateArenaBlockSize() {
         long arenaBlockSize = 8 * 1024 * 1024;
-        assertFalse(
-                RocksDBMemoryControllerUtils.validateArenaBlockSize(
-                        arenaBlockSize, (long) (arenaBlockSize * 0.5)));
-        assertTrue(
-                RocksDBMemoryControllerUtils.validateArenaBlockSize(
-                        arenaBlockSize, (long) (arenaBlockSize * 1.5)));
+        assertThat(
+                        RocksDBMemoryControllerUtils.validateArenaBlockSize(
+                                arenaBlockSize, (long) (arenaBlockSize * 0.5)))
+                .isFalse();
+        assertThat(
+                        RocksDBMemoryControllerUtils.validateArenaBlockSize(
+                                arenaBlockSize, (long) (arenaBlockSize * 1.5)))
+                .isTrue();
     }
 
     private static final class TestingRocksDBMemoryFactory

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/state/rocksdb/RocksDBNativeMetricOptionsTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/state/rocksdb/RocksDBNativeMetricOptionsTest.java
@@ -20,15 +20,15 @@ package org.apache.flink.state.rocksdb;
 
 import org.apache.flink.configuration.Configuration;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.apache.flink.configuration.ConfigurationUtils.getBooleanConfigOption;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Test all native metrics can be set using configuration. */
-public class RocksDBNativeMetricOptionsTest {
+class RocksDBNativeMetricOptionsTest {
     @Test
-    public void testNativeMetricsConfigurable() {
+    void testNativeMetricsConfigurable() {
         for (RocksDBProperty property : RocksDBProperty.values()) {
             Configuration config = new Configuration();
             if (property.getConfigKey().contains("num-files-at-level")) {
@@ -39,17 +39,13 @@ public class RocksDBNativeMetricOptionsTest {
 
             RocksDBNativeMetricOptions options = RocksDBNativeMetricOptions.fromConfig(config);
 
-            Assert.assertTrue(
-                    String.format(
-                            "Failed to enable native metrics with property %s",
-                            property.getConfigKey()),
-                    options.isEnabled());
+            assertThat(options.isEnabled())
+                    .as("Failed to enable native metrics with property %s", property.getConfigKey())
+                    .isTrue();
 
-            Assert.assertTrue(
-                    String.format(
-                            "Failed to enable native metric %s using config",
-                            property.getConfigKey()),
-                    options.getProperties().contains(property));
+            assertThat(options.getProperties())
+                    .as("Failed to enable native metric %s using config", property.getConfigKey())
+                    .contains(property);
         }
     }
 }

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/state/rocksdb/RocksDBResourceContainerTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/state/rocksdb/RocksDBResourceContainerTest.java
@@ -21,10 +21,9 @@ package org.apache.flink.state.rocksdb;
 import org.apache.flink.runtime.memory.OpaqueMemoryResource;
 import org.apache.flink.util.function.ThrowingRunnable;
 
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.rocksdb.BlockBasedTableConfig;
 import org.rocksdb.BloomFilter;
 import org.rocksdb.Cache;
@@ -40,38 +39,37 @@ import org.rocksdb.WriteOptions;
 
 import java.io.IOException;
 import java.lang.reflect.Field;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 /** Tests to guard {@link RocksDBResourceContainer}. */
-public class RocksDBResourceContainerTest {
+class RocksDBResourceContainerTest {
 
-    @ClassRule public static final TemporaryFolder TMP_FOLDER = new TemporaryFolder();
+    @TempDir static Path tempDir;
 
-    @BeforeClass
-    public static void ensureRocksDbNativeLibraryLoaded() throws IOException {
-        NativeLibraryLoader.getInstance().loadLibrary(TMP_FOLDER.newFolder().getAbsolutePath());
+    @BeforeAll
+    static void ensureRocksDbNativeLibraryLoaded() throws IOException {
+        NativeLibraryLoader.getInstance().loadLibrary(tempDir.toAbsolutePath().toString());
     }
 
     // ------------------------------------------------------------------------
 
     @Test
-    public void testFreeDBOptionsAfterClose() throws Exception {
+    void testFreeDBOptionsAfterClose() throws Exception {
         RocksDBResourceContainer container = new RocksDBResourceContainer();
         DBOptions dbOptions = container.getDbOptions();
-        assertThat(dbOptions.isOwningHandle(), is(true));
+        assertThat(dbOptions.isOwningHandle()).isTrue();
         container.close();
-        assertThat(dbOptions.isOwningHandle(), is(false));
+        assertThat(dbOptions.isOwningHandle()).isFalse();
     }
 
     @Test
-    public void testFreeMultipleDBOptionsAfterClose() throws Exception {
+    void testFreeMultipleDBOptionsAfterClose() throws Exception {
         RocksDBResourceContainer container = new RocksDBResourceContainer();
         final int optionNumber = 20;
         ArrayList<DBOptions> dbOptions = new ArrayList<>(optionNumber);
@@ -80,7 +78,7 @@ public class RocksDBResourceContainerTest {
         }
         container.close();
         for (DBOptions dbOption : dbOptions) {
-            assertThat(dbOption.isOwningHandle(), is(false));
+            assertThat(dbOption.isOwningHandle()).isFalse();
         }
     }
 
@@ -92,14 +90,14 @@ public class RocksDBResourceContainerTest {
      * @throws Exception if unexpected error happened.
      */
     @Test
-    public void testSharedResourcesAfterClose() throws Exception {
+    void testSharedResourcesAfterClose() throws Exception {
         OpaqueMemoryResource<RocksDBSharedResources> sharedResources = getSharedResources();
         RocksDBResourceContainer container =
                 new RocksDBResourceContainer(PredefinedOptions.DEFAULT, null, sharedResources);
         container.close();
         RocksDBSharedResources rocksDBSharedResources = sharedResources.getResourceHandle();
-        assertThat(rocksDBSharedResources.getCache().isOwningHandle(), is(false));
-        assertThat(rocksDBSharedResources.getWriteBufferManager().isOwningHandle(), is(false));
+        assertThat(rocksDBSharedResources.getCache().isOwningHandle()).isFalse();
+        assertThat(rocksDBSharedResources.getWriteBufferManager().isOwningHandle()).isFalse();
     }
 
     /**
@@ -110,7 +108,7 @@ public class RocksDBResourceContainerTest {
      * @throws Exception if unexpected error happened.
      */
     @Test
-    public void testGetDbOptionsWithSharedResources() throws Exception {
+    void testGetDbOptionsWithSharedResources() throws Exception {
         final int optionNumber = 20;
         OpaqueMemoryResource<RocksDBSharedResources> sharedResources = getSharedResources();
         RocksDBResourceContainer container =
@@ -121,10 +119,9 @@ public class RocksDBResourceContainerTest {
             WriteBufferManager writeBufferManager = getWriteBufferManager(dbOptions);
             writeBufferManagers.add(writeBufferManager);
         }
-        assertThat(writeBufferManagers.size(), is(1));
-        assertThat(
-                writeBufferManagers.iterator().next(),
-                is(sharedResources.getResourceHandle().getWriteBufferManager()));
+        assertThat(writeBufferManagers).hasSize(1);
+        assertThat(writeBufferManagers.iterator().next())
+                .isSameAs(sharedResources.getResourceHandle().getWriteBufferManager());
         container.close();
     }
 
@@ -136,7 +133,7 @@ public class RocksDBResourceContainerTest {
      * @throws Exception if unexpected error happened.
      */
     @Test
-    public void testGetColumnFamilyOptionsWithSharedResources() throws Exception {
+    void testGetColumnFamilyOptionsWithSharedResources() throws Exception {
         final int optionNumber = 20;
         OpaqueMemoryResource<RocksDBSharedResources> sharedResources = getSharedResources();
         RocksDBResourceContainer container =
@@ -147,8 +144,9 @@ public class RocksDBResourceContainerTest {
             Cache cache = getBlockCache(columnOptions);
             caches.add(cache);
         }
-        assertThat(caches.size(), is(1));
-        assertThat(caches.iterator().next(), is(sharedResources.getResourceHandle().getCache()));
+        assertThat(caches).hasSize(1);
+        assertThat(caches.iterator().next())
+                .isSameAs(sharedResources.getResourceHandle().getCache());
         container.close();
     }
 
@@ -202,16 +200,16 @@ public class RocksDBResourceContainerTest {
     }
 
     @Test
-    public void testFreeColumnOptionsAfterClose() throws Exception {
+    void testFreeColumnOptionsAfterClose() throws Exception {
         RocksDBResourceContainer container = new RocksDBResourceContainer();
         ColumnFamilyOptions columnFamilyOptions = container.getColumnOptions();
-        assertThat(columnFamilyOptions.isOwningHandle(), is(true));
+        assertThat(columnFamilyOptions.isOwningHandle()).isTrue();
         container.close();
-        assertThat(columnFamilyOptions.isOwningHandle(), is(false));
+        assertThat(columnFamilyOptions.isOwningHandle()).isFalse();
     }
 
     @Test
-    public void testFreeMultipleColumnOptionsAfterClose() throws Exception {
+    void testFreeMultipleColumnOptionsAfterClose() throws Exception {
         RocksDBResourceContainer container = new RocksDBResourceContainer();
         final int optionNumber = 20;
         ArrayList<ColumnFamilyOptions> columnFamilyOptions = new ArrayList<>(optionNumber);
@@ -220,12 +218,12 @@ public class RocksDBResourceContainerTest {
         }
         container.close();
         for (ColumnFamilyOptions columnFamilyOption : columnFamilyOptions) {
-            assertThat(columnFamilyOption.isOwningHandle(), is(false));
+            assertThat(columnFamilyOption.isOwningHandle()).isFalse();
         }
     }
 
     @Test
-    public void testFreeMultipleColumnOptionsWithPredefinedOptions() throws Exception {
+    void testFreeMultipleColumnOptionsWithPredefinedOptions() throws Exception {
         for (PredefinedOptions predefinedOptions : PredefinedOptions.values()) {
             RocksDBResourceContainer container =
                     new RocksDBResourceContainer(predefinedOptions, null);
@@ -236,13 +234,13 @@ public class RocksDBResourceContainerTest {
             }
             container.close();
             for (ColumnFamilyOptions columnFamilyOption : columnFamilyOptions) {
-                assertThat(columnFamilyOption.isOwningHandle(), is(false));
+                assertThat(columnFamilyOption.isOwningHandle()).isFalse();
             }
         }
     }
 
     @Test
-    public void testFreeSharedResourcesAfterClose() throws Exception {
+    void testFreeSharedResourcesAfterClose() throws Exception {
         LRUCache cache = new LRUCache(1024L);
         WriteBufferManager wbm = new WriteBufferManager(1024L, cache);
         RocksDBSharedResources sharedResources =
@@ -255,24 +253,24 @@ public class RocksDBResourceContainerTest {
                 new RocksDBResourceContainer(PredefinedOptions.DEFAULT, null, opaqueResource);
 
         container.close();
-        assertThat(cache.isOwningHandle(), is(false));
-        assertThat(wbm.isOwningHandle(), is(false));
+        assertThat(cache.isOwningHandle()).isFalse();
+        assertThat(wbm.isOwningHandle()).isFalse();
     }
 
     @Test
-    public void testFreeWriteReadOptionsAfterClose() throws Exception {
+    void testFreeWriteReadOptionsAfterClose() throws Exception {
         RocksDBResourceContainer container = new RocksDBResourceContainer();
         WriteOptions writeOptions = container.getWriteOptions();
         ReadOptions readOptions = container.getReadOptions();
-        assertThat(writeOptions.isOwningHandle(), is(true));
-        assertThat(readOptions.isOwningHandle(), is(true));
+        assertThat(writeOptions.isOwningHandle()).isTrue();
+        assertThat(readOptions.isOwningHandle()).isTrue();
         container.close();
-        assertThat(writeOptions.isOwningHandle(), is(false));
-        assertThat(readOptions.isOwningHandle(), is(false));
+        assertThat(writeOptions.isOwningHandle()).isFalse();
+        assertThat(readOptions.isOwningHandle()).isFalse();
     }
 
     @Test
-    public void testGetColumnFamilyOptionsWithPartitionedIndex() throws Exception {
+    void testGetColumnFamilyOptionsWithPartitionedIndex() throws Exception {
         LRUCache cache = new LRUCache(1024L);
         WriteBufferManager wbm = new WriteBufferManager(1024L, cache);
         RocksDBSharedResources sharedResources =
@@ -313,11 +311,13 @@ public class RocksDBResourceContainerTest {
             ColumnFamilyOptions columnOptions = container.getColumnOptions();
             BlockBasedTableConfig actual =
                     (BlockBasedTableConfig) columnOptions.tableFormatConfig();
-            assertThat(actual.indexType(), is(IndexType.kTwoLevelIndexSearch));
-            assertThat(actual.partitionFilters(), is(true));
-            assertThat(actual.pinTopLevelIndexAndFilter(), is(true));
-            assertFalse(actual.filterPolicy() == blockBasedFilter);
+            assertThat(actual.indexType()).isEqualTo(IndexType.kTwoLevelIndexSearch);
+            assertThat(actual.partitionFilters()).isTrue();
+            assertThat(actual.pinTopLevelIndexAndFilter()).isTrue();
+            assertThat(actual.filterPolicy()).isNotSameAs(blockBasedFilter);
         }
-        assertFalse("Block based filter is left unclosed.", blockBasedFilter.isOwningHandle());
+        assertThat(blockBasedFilter.isOwningHandle())
+                .as("Block based filter is left unclosed.")
+                .isFalse();
     }
 }

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/state/rocksdb/RocksDBWriteBatchWrapperTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/state/rocksdb/RocksDBWriteBatchWrapperTest.java
@@ -22,16 +22,15 @@ import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.core.fs.CloseableRegistry;
 import org.apache.flink.runtime.execution.CancelTaskException;
 
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.rocksdb.ColumnFamilyDescriptor;
 import org.rocksdb.ColumnFamilyHandle;
 import org.rocksdb.RocksDB;
 import org.rocksdb.WriteOptions;
 
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -39,17 +38,15 @@ import java.util.concurrent.ThreadLocalRandom;
 
 import static org.apache.flink.state.rocksdb.RocksDBConfigurableOptions.WRITE_BATCH_SIZE;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Tests to guard {@link RocksDBWriteBatchWrapper}. */
-public class RocksDBWriteBatchWrapperTest {
+class RocksDBWriteBatchWrapperTest {
 
-    @Rule public TemporaryFolder folder = new TemporaryFolder();
+    @TempDir Path folder;
 
-    @Test(expected = CancelTaskException.class)
-    public void testAsyncCancellation() throws Exception {
+    @Test
+    void testAsyncCancellation() throws Exception {
         final CompletableFuture<Void> writeStartedFuture = new CompletableFuture<>();
         final CompletableFuture<Void> cancellationRequestedFuture = new CompletableFuture<>();
         final CloseableRegistry registry = new CloseableRegistry();
@@ -69,56 +66,66 @@ public class RocksDBWriteBatchWrapperTest {
         final int cancellationCheckInterval = 1;
         long batchSizeBytes = WRITE_BATCH_SIZE.defaultValue().getBytes();
 
-        try (RocksDB db = RocksDB.open(folder.newFolder().getAbsolutePath());
-                WriteOptions options = new WriteOptions().setDisableWAL(true);
-                ColumnFamilyHandle handle =
-                        db.createColumnFamily(new ColumnFamilyDescriptor("test".getBytes()));
-                RocksDBWriteBatchWrapper writeBatchWrapper =
-                        new RocksDBWriteBatchWrapper(
-                                db,
-                                options,
-                                capacity,
-                                batchSizeBytes,
-                                cancellationCheckInterval,
-                                batchSizeBytes)) {
-            registry.registerCloseable(writeBatchWrapper.getCancelCloseable());
-            // After the `writeStartedFuture` completes, the registry will start to close.
-            writeStartedFuture.complete(null);
+        assertThatThrownBy(
+                        () -> {
+                            try (RocksDB db = RocksDB.open(folder.toAbsolutePath().toString());
+                                    WriteOptions options =
+                                            new WriteOptions().setDisableWAL(true);
+                                    ColumnFamilyHandle handle =
+                                            db.createColumnFamily(
+                                                    new ColumnFamilyDescriptor("test".getBytes()));
+                                    RocksDBWriteBatchWrapper writeBatchWrapper =
+                                            new RocksDBWriteBatchWrapper(
+                                                    db,
+                                                    options,
+                                                    capacity,
+                                                    batchSizeBytes,
+                                                    cancellationCheckInterval,
+                                                    batchSizeBytes)) {
+                                registry.registerCloseable(writeBatchWrapper.getCancelCloseable());
+                                // After the `writeStartedFuture` completes, the registry will start to close.
+                                writeStartedFuture.complete(null);
 
-            // In the infinite loop, we want to verify that the `put` method will check cancellation
-            // state on every `batch.count() % cancellationCheckInterval == 0`. We set
-            // cancellationCheckInterval to 1, So, we expect it will throw CancelTaskException
-            // no later than batch count becoming 2 in this test case.
-            //noinspection InfiniteLoopStatement
-            for (int i = 0; ; i++) {
-                try {
-                    writeBatchWrapper.put(
-                            handle, ("key:" + i).getBytes(), ("value:" + i).getBytes());
-                } catch (Exception e) {
-                    cancellationRequestedFuture.join(); // shouldn't have any errors
-                    throw e;
-                }
-                // make sure that cancellation is triggered earlier than periodic flush
-                // but allow some delay of cancellation propagation
-                assertThat(i).isLessThan(cancellationCheckInterval * 2);
-                if (i == 0) {
-                    // make sure the registry is closed at least after the first run, so that we
-                    // can verify the cancellation check is validating correctly.
-                    cancellationRequestedFuture.join();
-                }
-            }
-        }
+                                // In the infinite loop, we want to verify that the `put` method will check cancellation
+                                // state on every `batch.count() % cancellationCheckInterval == 0`. We set
+                                // cancellationCheckInterval to 1, So, we expect it will throw CancelTaskException
+                                // no later than batch count becoming 2 in this test case.
+                                //noinspection InfiniteLoopStatement
+                                for (int i = 0; ; i++) {
+                                    try {
+                                        writeBatchWrapper.put(
+                                                handle,
+                                                ("key:" + i).getBytes(),
+                                                ("value:" + i).getBytes());
+                                    } catch (Exception e) {
+                                        cancellationRequestedFuture.join(); // shouldn't have any
+                                        // errors
+                                        throw e;
+                                    }
+                                    // make sure that cancellation is triggered earlier than periodic
+                                    // flush but allow some delay of cancellation propagation
+                                    assertThat(i).isLessThan(cancellationCheckInterval * 2);
+                                    if (i == 0) {
+                                        // make sure the registry is closed at least after the first
+                                        // run, so that we can verify the cancellation check is
+                                        // validating correctly.
+                                        cancellationRequestedFuture.join();
+                                    }
+                                }
+                            }
+                        })
+                .isInstanceOf(CancelTaskException.class);
     }
 
     @Test
-    public void basicTest() throws Exception {
+    void basicTest() throws Exception {
 
         List<Tuple2<byte[], byte[]>> data = new ArrayList<>(10000);
         for (int i = 0; i < 10000; ++i) {
             data.add(new Tuple2<>(("key:" + i).getBytes(), ("value:" + i).getBytes()));
         }
 
-        try (RocksDB db = RocksDB.open(folder.newFolder().getAbsolutePath());
+        try (RocksDB db = RocksDB.open(folder.toAbsolutePath().toString());
                 WriteOptions options = new WriteOptions().setDisableWAL(true);
                 ColumnFamilyHandle handle =
                         db.createColumnFamily(new ColumnFamilyDescriptor("test".getBytes()));
@@ -134,7 +141,7 @@ public class RocksDBWriteBatchWrapperTest {
 
             // valid result
             for (Tuple2<byte[], byte[]> item : data) {
-                Assert.assertArrayEquals(item.f1, db.get(handle, item.f0));
+                assertThat(db.get(handle, item.f0)).isEqualTo(item.f1);
             }
         }
     }
@@ -144,8 +151,8 @@ public class RocksDBWriteBatchWrapperTest {
      * preconfigured value.
      */
     @Test
-    public void testWriteBatchWrapperFlushAfterMemorySizeExceed() throws Exception {
-        try (RocksDB db = RocksDB.open(folder.newFolder().getAbsolutePath());
+    void testWriteBatchWrapperFlushAfterMemorySizeExceed() throws Exception {
+        try (RocksDB db = RocksDB.open(folder.toAbsolutePath().toString());
                 WriteOptions options = new WriteOptions().setDisableWAL(true);
                 ColumnFamilyHandle handle =
                         db.createColumnFamily(new ColumnFamilyDescriptor("test".getBytes()));
@@ -159,12 +166,12 @@ public class RocksDBWriteBatchWrapperTest {
             // format is [handleType|kvType|keyLen|key|valueLen|value]
             // more information please ref write_batch.cc in RocksDB
             writeBatchWrapper.put(handle, dummy, dummy);
-            assertEquals(initBatchSize + 16, writeBatchWrapper.getDataSize());
+            assertThat(writeBatchWrapper.getDataSize()).isEqualTo(initBatchSize + 16);
             writeBatchWrapper.put(handle, dummy, dummy);
-            assertEquals(initBatchSize + 32, writeBatchWrapper.getDataSize());
+            assertThat(writeBatchWrapper.getDataSize()).isEqualTo(initBatchSize + 32);
             writeBatchWrapper.put(handle, dummy, dummy);
             // will flush all, then an empty write batch
-            assertEquals(initBatchSize, writeBatchWrapper.getDataSize());
+            assertThat(writeBatchWrapper.getDataSize()).isEqualTo(initBatchSize);
         }
     }
 
@@ -173,8 +180,8 @@ public class RocksDBWriteBatchWrapperTest {
      * preconfigured value.
      */
     @Test
-    public void testWriteBatchWrapperFlushAfterCountExceed() throws Exception {
-        try (RocksDB db = RocksDB.open(folder.newFolder().getAbsolutePath());
+    void testWriteBatchWrapperFlushAfterCountExceed() throws Exception {
+        try (RocksDB db = RocksDB.open(folder.toAbsolutePath().toString());
                 WriteOptions options = new WriteOptions().setDisableWAL(true);
                 ColumnFamilyHandle handle =
                         db.createColumnFamily(new ColumnFamilyDescriptor("test".getBytes()));
@@ -186,10 +193,10 @@ public class RocksDBWriteBatchWrapperTest {
             for (int i = 1; i < 100; ++i) {
                 writeBatchWrapper.put(handle, dummy, dummy);
                 // each kv consumes 8 bytes
-                assertEquals(initBatchSize + 8 * i, writeBatchWrapper.getDataSize());
+                assertThat(writeBatchWrapper.getDataSize()).isEqualTo(initBatchSize + 8 * i);
             }
             writeBatchWrapper.put(handle, dummy, dummy);
-            assertEquals(initBatchSize, writeBatchWrapper.getDataSize());
+            assertThat(writeBatchWrapper.getDataSize()).isEqualTo(initBatchSize);
         }
     }
 
@@ -198,16 +205,16 @@ public class RocksDBWriteBatchWrapperTest {
      * WAL and closes them correctly.
      */
     @Test
-    public void testDefaultWriteOptionsHaveDisabledWAL() throws Exception {
+    void testDefaultWriteOptionsHaveDisabledWAL() throws Exception {
         WriteOptions options;
-        try (RocksDB db = RocksDB.open(folder.newFolder().getAbsolutePath());
+        try (RocksDB db = RocksDB.open(folder.toAbsolutePath().toString());
                 RocksDBWriteBatchWrapper writeBatchWrapper =
                         new RocksDBWriteBatchWrapper(db, null, 200, 50)) {
             options = writeBatchWrapper.getOptions();
-            assertTrue(options.isOwningHandle());
-            assertTrue(options.disableWAL());
+            assertThat(options.isOwningHandle()).isTrue();
+            assertThat(options.disableWAL()).isTrue();
         }
-        assertFalse(options.isOwningHandle());
+        assertThat(options.isOwningHandle()).isFalse();
     }
 
     /**
@@ -215,16 +222,16 @@ public class RocksDBWriteBatchWrapperTest {
      * not close them.
      */
     @Test
-    public void testNotClosingPassedInWriteOption() throws Exception {
+    void testNotClosingPassedInWriteOption() throws Exception {
         try (WriteOptions passInOption = new WriteOptions().setDisableWAL(false)) {
-            try (RocksDB db = RocksDB.open(folder.newFolder().getAbsolutePath());
+            try (RocksDB db = RocksDB.open(folder.toAbsolutePath().toString());
                     RocksDBWriteBatchWrapper writeBatchWrapper =
                             new RocksDBWriteBatchWrapper(db, passInOption, 200, 50)) {
                 WriteOptions options = writeBatchWrapper.getOptions();
-                assertTrue(options.isOwningHandle());
-                assertFalse(options.disableWAL());
+                assertThat(options.isOwningHandle()).isTrue();
+                assertThat(options.disableWAL()).isFalse();
             }
-            assertTrue(passInOption.isOwningHandle());
+            assertThat(passInOption.isOwningHandle()).isTrue();
         }
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

This pull request migrates legacy JUnit 4 and Hamcrest test assertions in `flink-statebackend-rocksdb` to JUnit 5 (Jupiter) and AssertJ in accordance with Apache Flink test standards.

## Brief change log

- Migrated `RocksDBMemoryControllerUtilsTest` to JUnit 5 (`@TempDir`, `@BeforeAll`) and AssertJ assertions.
- Migrated `RocksDBResourceContainerTest` to JUnit 5 and AssertJ assertions.
- Migrated `RocksDBWriteBatchWrapperTest` to JUnit 5 and `assertThatThrownBy(...)` / AssertJ assertions.
- Migrated `RocksDBNativeMetricOptionsTest` to JUnit 5 and AssertJ assertions.

## Verifying this change

This change is a code refactoring of test suites without any changes to existing production runtime logic.

- Run maven tests:
  `mvn test -pl flink-state-backends/flink-statebackend-rocksdb -am -Dfast -Dtest=RocksDBMemoryControllerUtilsTest,RocksDBResourceContainerTest,RocksDBWriteBatchWrapperTest,RocksDBNativeMetricOptionsTest -Dsurefire.failIfNoSpecifiedTests=false`
- All 30 tests pass cleanly with 0 failures and 0 errors.

## Does this pull request potentially affect one of the following parts:
  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation
  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable