### PR TITLE
[FLINK-40565] Bump netty to 4.2.17

### DIFF
--- a/flink-filesystems/flink-s3-fs-native/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-s3-fs-native/src/main/resources/META-INF/NOTICE
@@ -44,20 +44,20 @@ This project bundles the following dependencies under the Apache Software Licens
 - org.apache.httpcomponents:httpcore:4.4.14
 - commons-codec:commons-codec:1.15
 - commons-logging:commons-logging:1.1.3
-- io.netty:netty-buffer:4.2.15.Final
-- io.netty:netty-codec:4.2.15.Final
-- io.netty:netty-codec-base:4.2.15.Final
-- io.netty:netty-codec-compression:4.2.15.Final
-- io.netty:netty-codec-http:4.2.15.Final
-- io.netty:netty-codec-http2:4.2.15.Final
-- io.netty:netty-codec-marshalling:4.2.15.Final
-- io.netty:netty-codec-protobuf:4.2.15.Final
-- io.netty:netty-common:4.2.15.Final
-- io.netty:netty-handler:4.2.15.Final
-- io.netty:netty-resolver:4.2.15.Final
-- io.netty:netty-transport:4.2.15.Final
-- io.netty:netty-transport-classes-epoll:4.2.15.Final
-- io.netty:netty-transport-native-unix-common:4.2.15.Final
+- io.netty:netty-buffer:4.2.17.Final
+- io.netty:netty-codec:4.2.17.Final
+- io.netty:netty-codec-base:4.2.17.Final
+- io.netty:netty-codec-compression:4.2.17.Final
+- io.netty:netty-codec-http:4.2.17.Final
+- io.netty:netty-codec-http2:4.2.17.Final
+- io.netty:netty-codec-marshalling:4.2.17.Final
+- io.netty:netty-codec-protobuf:4.2.17.Final
+- io.netty:netty-common:4.2.17.Final
+- io.netty:netty-handler:4.2.17.Final
+- io.netty:netty-resolver:4.2.17.Final
+- io.netty:netty-transport:4.2.17.Final
+- io.netty:netty-transport-classes-epoll:4.2.17.Final
+- io.netty:netty-transport-native-unix-common:4.2.17.Final
 
 This project bundles the following dependencies under the MIT License (https://opensource.org/licenses/MIT)
 

--- a/flink-python/src/main/resources/META-INF/NOTICE
+++ b/flink-python/src/main/resources/META-INF/NOTICE
@@ -61,8 +61,8 @@ The bundled Apache Beam dependencies bundle the following dependencies under the
 - io.grpc:grpc-protobuf:1.59.1
 - io.grpc:grpc-stub:1.59.1
 - io.grpc:grpc-testing:1.59.1
-- io.netty:netty-buffer:4.2.15.Final
-- io.netty:netty-common:4.2.15.Final
+- io.netty:netty-buffer:4.2.17.Final
+- io.netty:netty-common:4.2.17.Final
 - io.opencensus:opencensus-api:0.31.0
 - io.opencensus:opencensus-contrib-grpc-metrics:0.31.0
 - io.perfmark:perfmark-api:0.26.0

--- a/flink-rpc/flink-rpc-akka/src/main/resources/META-INF/NOTICE
+++ b/flink-rpc/flink-rpc-akka/src/main/resources/META-INF/NOTICE
@@ -16,13 +16,13 @@ This project bundles the following dependencies under the Apache Software Licens
 - org.apache.pekko:pekko-protobuf-v3_2.12:1.7.0
 - org.apache.pekko:pekko-slf4j_2.12:1.7.0
 - org.apache.pekko:pekko-stream_2.12:1.7.0
-- io.netty:netty-buffer:4.2.15.Final
-- io.netty:netty-transport-native-unix-common:4.2.15.Final
-- io.netty:netty-common:4.2.15.Final
-- io.netty:netty-codec-base:4.2.15.Final
-- io.netty:netty-handler:4.2.15.Final
-- io.netty:netty-resolver:4.2.15.Final
-- io.netty:netty-transport:4.2.15.Final
+- io.netty:netty-buffer:4.2.17.Final
+- io.netty:netty-transport-native-unix-common:4.2.17.Final
+- io.netty:netty-common:4.2.17.Final
+- io.netty:netty-codec-base:4.2.17.Final
+- io.netty:netty-handler:4.2.17.Final
+- io.netty:netty-resolver:4.2.17.Final
+- io.netty:netty-transport:4.2.17.Final
 
 
 The following dependencies all share the same BSD license which you find under licenses/LICENSE.scala.

--- a/pom.xml
+++ b/pom.xml
@@ -926,7 +926,7 @@ under the License.
 			<dependency>
 				<groupId>io.netty</groupId>
 				<artifactId>netty-bom</artifactId>
-				<version>4.2.15.Final</version>
+				<version>4.2.17.Final</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>


### PR DESCRIPTION
## What is the purpose of the change

The PR aligns  netty version with flink-shaded
 
## Brief change log

pom, NOTICE

## Verifying this change

existing tests

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes )
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change the checkbox below to `[X]` and replace the placeholder in the "Generated-by"
line with the tool name and version. Otherwise remove the "Generated-by" line.
See the ASF Generative Tooling Guidance for details:
https://www.apache.org/legal/generative-tooling.html

You are responsible for the quality and correctness of every change in this PR
regardless of the tooling used. Low-effort AI-generated PRs will be closed. See
AGENTS.md for the full guidance.
-->

- [ ] Yes (please specify the tool below)

Generated-by: [Tool Name and Version]
