### PR TITLE
[FLINK-40567][tests] Avoid @TempDir cleanup race in HistoryServerArchiveFetcherTest

### DIFF
--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/history/HistoryServerArchiveFetcherTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/history/HistoryServerArchiveFetcherTest.java
@@ -71,6 +71,7 @@ class HistoryServerArchiveFetcherTest {
     private ArchiveStorage<Object> archiveStorage;
     private ConcurrentHashMap<String, ArchiveMetaInfo> archiveMetaInfoCache;
     private List<HistoryServerArchiveFetcher.ArchiveEvent> archiveEvents;
+    private HistoryServerArchiveFetcher<?> fetcher;
 
     @Parameters(name = "storageFactory={0}")
     private static Collection<ArchiveStorageFactory<?>> storageFactories() {
@@ -95,9 +96,19 @@ class HistoryServerArchiveFetcherTest {
     @AfterEach
     void tearDown() throws Exception {
         archiveEvents.clear();
-        if (archiveStorage != null) {
-            archiveStorage.close();
-            archiveStorage = null;
+        // Shut the fetcher down before deleting the @TempDir: its executor threads write into
+        // localArchiveRootPath, and a task still running during cleanup fails the temp-dir
+        // deletion.
+        try {
+            if (fetcher != null) {
+                fetcher.close();
+            }
+        } finally {
+            fetcher = null;
+            if (archiveStorage != null) {
+                archiveStorage.close();
+                archiveStorage = null;
+            }
         }
     }
 
@@ -139,8 +150,7 @@ class HistoryServerArchiveFetcherTest {
             createJobArchive(remoteArchiveRootPath, jobId, true);
         }
 
-        HistoryServerArchiveFetcher<?> fetcher =
-                createArchiveFetcher(remoteArchiveRootPath, false, archiveStorage);
+        fetcher = createArchiveFetcher(remoteArchiveRootPath, false, archiveStorage);
         fetcher.fetchArchives(EAGER);
 
         assertThat(archiveEvents).hasSize(numJobs);
@@ -170,8 +180,7 @@ class HistoryServerArchiveFetcherTest {
         // Replace the field so that close() in tearDown() releases the underlying storage too.
         archiveStorage = blockingStorage;
 
-        HistoryServerArchiveFetcher<?> fetcher =
-                createArchiveFetcher(remoteArchiveRootPath, false, blockingStorage);
+        fetcher = createArchiveFetcher(remoteArchiveRootPath, false, blockingStorage);
 
         fetcher.fetchArchives(LAZY);
 
@@ -202,8 +211,7 @@ class HistoryServerArchiveFetcherTest {
             createJobArchive(remoteArchiveRootPath, jobId, true);
         }
 
-        HistoryServerArchiveFetcher<?> fetcher =
-                createArchiveFetcher(remoteArchiveRootPath, false, archiveStorage);
+        fetcher = createArchiveFetcher(remoteArchiveRootPath, false, archiveStorage);
         fetcher.fetchArchives(LAZY);
 
         assertThat(archiveEvents).hasSize(numJobs);
@@ -229,8 +237,7 @@ class HistoryServerArchiveFetcherTest {
         Path archivePath = new Path(remoteArchiveRootPath.toURI().toString(), jobId.toString());
         FsJsonArchivist.writeArchivedJsons(archivePath, Collections.emptyList());
 
-        HistoryServerArchiveFetcher<?> fetcher =
-                createArchiveFetcher(remoteArchiveRootPath, false, archiveStorage);
+        fetcher = createArchiveFetcher(remoteArchiveRootPath, false, archiveStorage);
 
         assertThatThrownBy(
                         () -> fetcher.lazyProcessJobArchive(jobId.toString(), archivePath, false))
@@ -258,8 +265,7 @@ class HistoryServerArchiveFetcherTest {
                         archiveStorage, "jobs/" + jobIdWithDetail + "/config");
         archiveStorage = blockingStorage;
 
-        HistoryServerArchiveFetcher<?> fetcher =
-                createArchiveFetcher(remoteArchiveRootPath, false, blockingStorage);
+        fetcher = createArchiveFetcher(remoteArchiveRootPath, false, blockingStorage);
 
         fetcher.fetchArchives(LAZY);
 
@@ -313,8 +319,7 @@ class HistoryServerArchiveFetcherTest {
         createJobArchive(remoteArchiveRootPath, job1, true);
         createJobArchive(remoteArchiveRootPath, job2, true);
 
-        HistoryServerArchiveFetcher<?> fetcher =
-                createArchiveFetcher(remoteArchiveRootPath, true, archiveStorage);
+        fetcher = createArchiveFetcher(remoteArchiveRootPath, true, archiveStorage);
         fetcher.fetchArchives(EAGER);
 
         Object overviewObject = archiveStorage.getEntry("jobs/overview.json");
@@ -345,8 +350,7 @@ class HistoryServerArchiveFetcherTest {
     void testLegacyJobOverviewMigration() throws Exception {
         JobID jobId = createLegacyArchive(remoteArchiveRootPath.toPath(), false);
 
-        HistoryServerArchiveFetcher<?> fetcher =
-                createArchiveFetcher(remoteArchiveRootPath, false, archiveStorage);
+        fetcher = createArchiveFetcher(remoteArchiveRootPath, false, archiveStorage);
         fetcher.fetchArchives(LAZY);
 
         assertThat(archiveEvents).hasSize(1);
@@ -361,8 +365,7 @@ class HistoryServerArchiveFetcherTest {
         JobID jobId = JobID.generate();
         createJobArchive(remoteArchiveRootPath, jobId, true);
 
-        HistoryServerArchiveFetcher<?> fetcher =
-                createArchiveFetcher(remoteArchiveRootPath, true, archiveStorage);
+        fetcher = createArchiveFetcher(remoteArchiveRootPath, true, archiveStorage);
 
         fetcher.scanArchives(EAGER, false);
         assertThat(archiveEvents).isEmpty();
@@ -375,8 +378,7 @@ class HistoryServerArchiveFetcherTest {
         JobID jobId = JobID.generate();
         Path archivePath = createJobArchive(remoteArchiveRootPath, jobId, true);
 
-        HistoryServerArchiveFetcher<?> fetcher =
-                createArchiveFetcher(remoteArchiveRootPath, false, archiveStorage);
+        fetcher = createArchiveFetcher(remoteArchiveRootPath, false, archiveStorage);
 
         fetcher.lazyFetchArchiveProactively(jobId.toString(), archivePath);
         waitForArchiveLoaded(archiveMetaInfoCache, jobId.toString());
@@ -410,8 +412,7 @@ class HistoryServerArchiveFetcherTest {
                         archiveStorage, "jobs/" + jobId + "/config");
         archiveStorage = blockingStorage;
 
-        HistoryServerArchiveFetcher<?> fetcher =
-                createArchiveFetcher(remoteArchiveRootPath, false, blockingStorage);
+        fetcher = createArchiveFetcher(remoteArchiveRootPath, false, blockingStorage);
         fetcher.fetchArchives(LAZY);
         // make sure the async detail task has started
         assertThat(blockingStorage.asyncStartLatch.await(10, TimeUnit.SECONDS)).isTrue();


### PR DESCRIPTION
## What is the purpose of the change

Fixes the flaky `HistoryServerArchiveFetcherTest`, which intermittently fails in CI during JUnit teardown (seen on `testLazyFetchArchiveProactively`):

```
org.junit.platform.commons.JUnitException: Failed to close extension context
Caused by: java.io.IOException: Failed to delete temp directory /tmp/junit-....
  The following paths could not be deleted: <root>, jobs
    Suppressed: java.nio.file.DirectoryNotEmptyException: /tmp/junit-.../jobs
```

Each test creates a `HistoryServerArchiveFetcher`, which owns two fixed thread pools that write archives into `localArchiveRootPath` (a `@TempDir`). The fetcher was never closed — `tearDown()` only closed the storage — so its executor threads could still be creating files under `jobs/` while JUnit was deleting the temp directory, causing the `DirectoryNotEmptyException`.

## Brief change log

- Track the per-test `HistoryServerArchiveFetcher` in a field.
- Close it in `@AfterEach` before closing the storage, so `HistoryServerArchiveFetcher#close()` (`ExecutorUtils.gracefulShutdown`) drains both thread pools before the `@TempDir` is removed. This also removes the same latent executor leak in the other test methods.

Test-only change; no production code is touched.

## Verifying this change

This change is a test-stability fix, verified by running the affected test in a loop on the exact commit that failed in CI (JDK 17):

- `HistoryServerArchiveFetcherTest` (10 methods × 2 storage backends) passed **62 consecutive runs** with **0** temp-directory cleanup failures.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**

## AI usage disclosure

- Claude Code
