### PR TITLE
[BP-2.2][FLINK-40549] Fix closed metricGroup leak on split finish

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/AbstractMetricGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/AbstractMetricGroup.java
@@ -337,6 +337,17 @@ public abstract class AbstractMetricGroup<A extends AbstractMetricGroup<?>> impl
                 metrics.clear();
             }
         }
+        if (parent != null) {
+            parent.removeChildGroup(this);
+        }
+    }
+
+    void removeChildGroup(AbstractMetricGroup<?> childGroup) {
+        synchronized (this) {
+            if (!closed) {
+                groups.values().remove(childGroup);
+            }
+        }
     }
 
     public final boolean isClosed() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/InternalSourceSplitMetricGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/InternalSourceSplitMetricGroup.java
@@ -47,6 +47,7 @@ public class InternalSourceSplitMetricGroup extends ProxyMetricGroup<MetricGroup
     private static final String WATERMARK = "watermark";
     private static final long SPLIT_NOT_STARTED = -1L;
     private long splitStartTime = SPLIT_NOT_STARTED;
+    private final MetricGroup splitMetricGroup;
     private final MetricGroup splitWatermarkMetricGroup;
     private final String splitId;
 
@@ -58,7 +59,8 @@ public class InternalSourceSplitMetricGroup extends ProxyMetricGroup<MetricGroup
         super(parentMetricGroup);
         this.clock = clock;
         this.splitId = splitId;
-        splitWatermarkMetricGroup = parentMetricGroup.addGroup(SPLIT, splitId).addGroup(WATERMARK);
+        splitMetricGroup = parentMetricGroup.addGroup(SPLIT, splitId);
+        splitWatermarkMetricGroup = splitMetricGroup.addGroup(WATERMARK);
         pausedTimePerSecond =
                 splitWatermarkMetricGroup.gauge(
                         MetricNames.SPLIT_PAUSED_TIME, new TimerGauge(clock));
@@ -187,15 +189,20 @@ public class InternalSourceSplitMetricGroup extends ProxyMetricGroup<MetricGroup
     }
 
     public void onSplitFinished() {
-        if (splitWatermarkMetricGroup instanceof AbstractMetricGroup) {
-            ((AbstractMetricGroup) splitWatermarkMetricGroup).close();
+        if (splitMetricGroup instanceof AbstractMetricGroup) {
+            ((AbstractMetricGroup<?>) splitMetricGroup).close();
         } else {
-            if (splitWatermarkMetricGroup != null) {
+            if (splitMetricGroup != null) {
                 LOG.warn(
-                        "Split watermark metric group can not be closed, expecting an instance of AbstractMetricGroup but got: ",
-                        splitWatermarkMetricGroup.getClass().getName());
+                        "Split metric group can not be closed, expecting an instance of AbstractMetricGroup but got: {}",
+                        splitMetricGroup.getClass().getName());
             }
         }
+    }
+
+    @VisibleForTesting
+    public MetricGroup getSplitMetricGroup() {
+        return splitMetricGroup;
     }
 
     @VisibleForTesting

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/InternalSourceSplitMetricGroupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/InternalSourceSplitMetricGroupTest.java
@@ -41,6 +41,18 @@ class InternalSourceSplitMetricGroupTest {
     }
 
     @Test
+    void testOnSplitFinishedClosesSplitMetricGroup() {
+        InternalSourceSplitMetricGroup metricGroup = getMetricGroupWithClock(new ManualClock());
+
+        metricGroup.onSplitFinished();
+
+        assertThat(((AbstractMetricGroup<?>) metricGroup.getSplitMetricGroup()).isClosed())
+                .isTrue();
+        assertThat(((AbstractMetricGroup<?>) metricGroup.getSplitWatermarkMetricGroup()).isClosed())
+                .isTrue();
+    }
+
+    @Test
     void testClocksStartTickingAfterSplitStarted() throws InterruptedException {
         ManualClock clock = new ManualClock(System.currentTimeMillis());
         InternalSourceSplitMetricGroup metricGroup = getMetricGroupWithClock(clock);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/MetricGroupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/MetricGroupTest.java
@@ -374,6 +374,55 @@ public class MetricGroupTest {
                 .isTrue();
     }
 
+    /**
+     * Verifies that a group is no longer referenced by its parent once it is closed. Otherwise
+     * groups with unique names that are closed before their parent, e.g. per-split groups of a
+     * source, would leak until the parent is closed.
+     */
+    @Test
+    void closedGroupIsRemovedFromParent() {
+        GenericMetricGroup parent =
+                new GenericMetricGroup(
+                        exceptionOnRegister,
+                        new DummyAbstractMetricGroup(exceptionOnRegister),
+                        "parent") {
+                    @Override
+                    protected GenericMetricGroup createChildGroup(
+                            String name, ChildType childType) {
+                        return new CloseCountingMetricGroup(exceptionOnRegister, this, name);
+                    }
+                };
+        CloseCountingMetricGroup closedBeforeParent =
+                (CloseCountingMetricGroup) parent.addGroup("closedBeforeParent");
+        CloseCountingMetricGroup closedWithParent =
+                (CloseCountingMetricGroup) parent.addGroup("closedWithParent");
+
+        closedBeforeParent.close();
+        assertThat(closedBeforeParent.closeCalls).isOne();
+
+        // the parent closes every group it still references
+        parent.close();
+        assertThat(closedWithParent.closeCalls).isOne();
+        assertThat(closedBeforeParent.closeCalls)
+                .withFailMessage("The parent must not reference a group that was closed before")
+                .isOne();
+    }
+
+    private static class CloseCountingMetricGroup extends GenericMetricGroup {
+        int closeCalls = 0;
+
+        CloseCountingMetricGroup(
+                MetricRegistry registry, AbstractMetricGroup<?> parent, String name) {
+            super(registry, parent, name);
+        }
+
+        @Override
+        public void close() {
+            closeCalls++;
+            super.close();
+        }
+    }
+
     @Test
     void tolerateMetricNameCollisions() {
         final String name = "abctestname";


### PR DESCRIPTION
Backporting https://github.com/apache/flink/pull/29083