### PR TITLE
[FLINK-40578][table-runtime] `OVERLAY` discards the rest of the string and splits supplementary-plane characters

### DIFF
--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/expressions/ScalarFunctionsTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/expressions/ScalarFunctionsTest.scala
@@ -106,6 +106,26 @@ class ScalarFunctionsTest extends ScalarTypesTestBase {
       // invalid length
       ($"f0".overlay("IS", 6, -1), "OVERLAY(f0 PLACING 'IS' FROM 6 FOR -1)", "This IS"),
 
+      // a zero length replaces nothing, so the whole tail survives
+      ("abcdef".overlay("X", 2, 0), "OVERLAY('abcdef' PLACING 'X' FROM 2 FOR 0)", "aXbcdef"),
+      ("abcdef".overlay("X", 1, 0), "OVERLAY('abcdef' PLACING 'X' FROM 1 FOR 0)", "Xabcdef"),
+      ("abcdef".overlay("X", 6, 0), "OVERLAY('abcdef' PLACING 'X' FROM 6 FOR 0)", "abcdeXf"),
+
+      // a supplementary-plane character is one character and is never split into half a pair
+      ("a😀b".overlay("X", 2, 1), "OVERLAY('a😀b' PLACING 'X' FROM 2 FOR 1)", "aXb"),
+      ("a😀b".overlay("X", 3, 1), "OVERLAY('a😀b' PLACING 'X' FROM 3 FOR 1)", "a😀X"),
+      ("😀😀".overlay("X", 1, 1), "OVERLAY('😀😀' PLACING 'X' FROM 1 FOR 1)", "X😀"),
+
+      // without FOR, the replaced length is the character count of the replacement
+      ("a😀b".overlay("X", 2), "OVERLAY('a😀b' PLACING 'X' FROM 2)", "aXb"),
+      ("abc".overlay("😀", 2), "OVERLAY('abc' PLACING '😀' FROM 2)", "a😀c"),
+
+      // a length large enough to overflow the end offset still replaces the whole tail
+      (
+        "123456789".overlay("abc", 2, 2147483647),
+        "OVERLAY('123456789' PLACING 'abc' FROM 2 FOR 2147483647)",
+        "1abc"),
+
       // null field. f40 is NULL.
       ($"f40".overlay("It", 1, 4), "OVERLAY(f40 PLACING 'It' FROM 1 FOR 2)", "NULL")
     )

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/SqlFunctionUtils.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/SqlFunctionUtils.java
@@ -689,23 +689,55 @@ public class SqlFunctionUtils {
     }
 
     public static String overlay(String s, String r, long start, long length) {
-        if (start <= 0 || start > s.length()) {
+        final int sLength = s.length();
+        // A string never holds more code points than chars, so an out-of-range start can be
+        // rejected here without walking it.
+        if (start <= 0 || start > sLength) {
             return s;
-        } else {
-            StringBuilder sb = new StringBuilder();
-            int startPos = (int) start;
-            int len = (int) length;
-            sb.append(s, 0, startPos - 1);
-            sb.append(r);
-            if ((startPos + len) <= s.length() && len > 0) {
-                sb.append(s.substring(startPos - 1 + len));
-            }
-            return sb.toString();
         }
+
+        // Offsets count code points, as CHAR_LENGTH and SUBSTRING do, so that a supplementary
+        // character is never cut in half.
+        int prefixEnd = 0;
+        int prefixCodePoints = 0;
+        while (prefixCodePoints < start - 1 && prefixEnd < sLength) {
+            prefixEnd += Character.charCount(s.codePointAt(prefixEnd));
+            prefixCodePoints++;
+        }
+        if (prefixEnd == sLength) {
+            // Only reachable for a string holding supplementary characters, where the char
+            // count checked above is larger than the code point count.
+            return s;
+        }
+
+        // What is left holds at most as many code points as chars, so a length that reaches
+        // the char count already consumes the rest without walking it. length stays a long:
+        // casting it first would wrap a huge FOR into a small one.
+        int tailStart = sLength;
+        if (length >= 0 && length < sLength - prefixEnd) {
+            // Walking on from the prefix rather than from the start keeps this to one pass.
+            // Running out of string leaves tailStart at sLength, which is the empty tail the
+            // region running past the end should produce anyway.
+            tailStart = prefixEnd;
+            int replaced = 0;
+            while (replaced < length && tailStart < sLength) {
+                tailStart += Character.charCount(s.codePointAt(tailStart));
+                replaced++;
+            }
+        }
+
+        final int rLength = r.length();
+        final char[] data = new char[prefixEnd + rLength + sLength - tailStart];
+
+        s.getChars(0, prefixEnd, data, 0);
+        r.getChars(0, rLength, data, prefixEnd);
+        s.getChars(tailStart, sLength, data, prefixEnd + rLength);
+
+        return new String(data);
     }
 
     public static String overlay(String s, String r, long start) {
-        return overlay(s, r, start, r.length());
+        return overlay(s, r, start, r.codePointCount(0, r.length()));
     }
 
     public static int position(BinaryStringData seek, BinaryStringData s) {

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/functions/SqlFunctionUtilsTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/functions/SqlFunctionUtilsTest.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.functions;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link SqlFunctionUtils}. */
+class SqlFunctionUtilsTest {
+
+    /**
+     * A SQL literal cannot carry an unpaired surrogate, but one can still reach the function from a
+     * UDF or a connector. It is a character of its own there, so it is neither skipped nor treated
+     * as half of a pair.
+     */
+    @Test
+    void testOverlayCountsAnUnpairedSurrogateAsOneCharacter() {
+        assertThat(SqlFunctionUtils.overlay("a\ud83db", "X", 2, 1)).isEqualTo("aXb");
+        assertThat(SqlFunctionUtils.overlay("a\ude00b", "X", 2, 1)).isEqualTo("aXb");
+        assertThat(SqlFunctionUtils.overlay("a\ud83db", "X", 1, 1)).isEqualTo("X\ud83db");
+        assertThat(SqlFunctionUtils.overlay("a\ud83db", "X", 3, 1)).isEqualTo("a\ud83dX");
+    }
+
+    @Test
+    void testOverlayOnAStringHoldingOnlySurrogates() {
+        assertThat(SqlFunctionUtils.overlay("\ud83d\ud83d", "X", 1, 1)).isEqualTo("X\ud83d");
+        assertThat(SqlFunctionUtils.overlay("\ud83d\ud83d", "X", 2, 1)).isEqualTo("\ud83dX");
+        assertThat(SqlFunctionUtils.overlay("\ude00\ude00", "X", 2, 1)).isEqualTo("\ude00X");
+        assertThat(SqlFunctionUtils.overlay("\ud83d\ud83d", "X", 3, 1)).isEqualTo("\ud83d\ud83d");
+
+        // the same two chars as a well-formed pair are one character, not two
+        assertThat(SqlFunctionUtils.overlay("😀", "X", 1, 1)).isEqualTo("X");
+        assertThat(SqlFunctionUtils.overlay("😀", "X", 2, 1)).isEqualTo("😀");
+    }
+
+    @Test
+    void testOverlayMeasuresTheReplacementInCharacters() {
+        // without FOR, the replaced length is the character count of the replacement
+        assertThat(SqlFunctionUtils.overlay("abc", "\ud83d", 2)).isEqualTo("a\ud83dc");
+        assertThat(SqlFunctionUtils.overlay("abc", "😀", 2)).isEqualTo("a😀c");
+        assertThat(SqlFunctionUtils.overlay("a\ud83db", "😀", 2, 1)).isEqualTo("a😀b");
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

`OVERLAY` returns wrong results for several argument combinations. The first row needs no unusual data:

| Expression | Returns | Expected |
|---|---|---|
| `OVERLAY('abcdef' PLACING 'X' FROM 2 FOR 0)` | `aX` | `aXbcdef` |
| `OVERLAY('a😀b' PLACING 'X' FROM 2 FOR 1)` | `aX` + unpaired surrogate + `b` | `aXb` |
| `OVERLAY('abc' PLACING '😀' FROM 2)` | `a😀` | `a😀c` |
| `OVERLAY('123456789' PLACING 'abc' FROM 2 FOR 2147483647)` | `StringIndexOutOfBoundsException` | `1abc` |

In `SqlFunctionUtils#overlay`: a `len > 0` guard drops the tail when the replaced length is zero,
offsets count UTF-16 code units rather than characters, and `int len = (int) length` wraps.

## Brief change log

- Count the start position and the replaced length in code points, using the walk
  `BinaryStringData#substring` already uses for `SUBSTRING`.
- A zero length replaces nothing, so the tail survives.
- `length` stays a `long`, so a large `FOR` neither wraps nor overflows the end offset.
- Default the three-argument length to the replacement's code point count.

Left unchanged, because existing tests assert it: a start of zero or less, or past the end,
returns the input; a negative `FOR` leaves no tail.

## Verifying this change

This change added tests and can be verified as follows:

- 9 cases added to `ScalarFunctionsTest#testOverlay`, all failing without the fix.
- `ScalarFunctionsTest` and `SqlExpressionTest` pass, including the 18 existing `OVERLAY` expectations.
- Differentially checked against an independent implementation of the SQL:2016 formula over 60,192
  argument combinations covering the start and length boundaries: no differences.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **yes**
  - Anything that affects deployment or recovery: **no**
  - The S3 file system connector: **no**

Replacing in a short string is faster (46 ns to 29 ns), one exactly-sized `char[]` instead of a
growing `StringBuilder`. Replacing near the tail of a 2000-character string is slower (940 ns to
2021 ns): converting a code point position to a char offset needs the same walk `SUBSTRING` does.

## Documentation

  - Does this pull request introduce a new feature? **no**

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: Claude Code (Opus 5)
