### PR TITLE
[FLINK-40597][core] Fix input type validation for Types.UUID

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/TypeExtractor.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/TypeExtractor.java
@@ -77,6 +77,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 
 import static org.apache.flink.api.java.typeutils.TypeExtractionUtils.checkAndExtractLambda;
 import static org.apache.flink.api.java.typeutils.TypeExtractionUtils.getAllDeclaredMethods;
@@ -1498,10 +1499,16 @@ public class TypeExtractor {
             // check for Java Basic Types
             if (typeInfo instanceof BasicTypeInfo) {
 
-                TypeInformation<?> actual;
                 // check if basic type at all
-                if (!(type instanceof Class<?>)
-                        || (actual = BasicTypeInfo.getInfoFor((Class<?>) type)) == null) {
+                if (!(type instanceof Class<?>)) {
+                    throw new InvalidTypesException("Basic type expected.");
+                }
+                // UUID is not registered for automatic extraction to preserve existing serializers.
+                final TypeInformation<?> actual =
+                        type == UUID.class
+                                ? BasicTypeInfo.UUID_TYPE_INFO
+                                : BasicTypeInfo.getInfoFor((Class<?>) type);
+                if (actual == null) {
                     throw new InvalidTypesException("Basic type expected.");
                 }
                 // check if correct basic type

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/DataStreamTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/DataStreamTest.java
@@ -90,6 +90,7 @@ import javax.annotation.Nullable;
 import java.lang.reflect.Method;
 import java.time.Duration;
 import java.util.List;
+import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -834,6 +835,31 @@ class DataStreamTest {
                                 .getStreamNode(sink.getTransformation().getId())
                                 .getPreferredResources())
                 .isEqualTo(preferredResource7);
+    }
+
+    @Test
+    void testMapWithExplicitUuidType() {
+        final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        // A lambda would bypass the input validation exercised by this test.
+        final MapFunction<UUID, String> mapper =
+                new MapFunction<UUID, String>() {
+                    @Override
+                    public String map(UUID value) {
+                        return value.toString();
+                    }
+                };
+
+        final DataStream<String> stream = env.fromData(Types.UUID, new UUID(0L, 0L)).map(mapper);
+
+        assertThat(stream.getType()).isEqualTo(Types.STRING);
+    }
+
+    @Test
+    void testUuidIsNotAutomaticallyExtracted() {
+        final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+
+        assertThat(env.fromData(new UUID(0L, 0L)).getType())
+                .isEqualTo(new GenericTypeInfo<>(UUID.class));
     }
 
     @Test


### PR DESCRIPTION
## What is the purpose of the change

Fix [FLINK-40597](https://issues.apache.org/jira/browse/FLINK-40597): a DataStream created with explicit `Types.UUID` can fail input type validation for a non-lambda `MapFunction<UUID, String>` with `Input mismatch: Basic type expected.`

## Brief change log

- Recognize `java.util.UUID` when validating explicitly specified basic type information.
- Leave UUID extraction without explicit type information unchanged (`GenericTypeInfo<UUID>` with Kryo by default). Automatic extraction as `Types.UUID` is tracked separately in [FLINK-40546](https://issues.apache.org/jira/browse/FLINK-40546).

## Verifying this change

- Added a `fromData(Types.UUID, ...).map(...)` regression test and a check that `fromData(...)` still infers `GenericTypeInfo<UUID>`.
- Confirmed the regression test fails without the fix and passes with it.
- `DataStreamTest` and `TypeExtractorTest`: 102 tests passed after rebasing onto master.
- Full `./mvnw clean verify` was attempted. After resolving a local Python executable issue and resuming, verification stopped at `flink-s3-fs-base`: `SeaweedFsTestContainerTest` requires Docker, which is not installed locally. Subsequent modules have not been verified.

## Does this pull request potentially affect one of the following parts:

- Dependencies: no
- Public API: yes, fixes validation in the existing `@Public` `TypeExtractor`; no API signatures change
- Serializers: no
- Runtime per-record code paths: no
- Deployment or recovery: no
- S3 file system connector: no

## Documentation

- Does this pull request introduce a new feature? no
- If yes, how is the feature documented? not applicable

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: Codex 0.147.0 (model: gpt-6)
