### PR TITLE
[FLINK-40602][runtime] JobManager silently omits running jobs whose JobMaster fails or times out on GET /jobs/overview

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
@@ -1627,15 +1627,27 @@ public abstract class Dispatcher extends FencedRpcEndpoint<DispatcherId>
 
     @Override
     public CompletableFuture<MultipleJobsDetails> requestMultipleJobDetails(Duration timeout) {
-        List<CompletableFuture<Optional<JobDetails>>> individualOptionalJobDetails =
-                queryJobMastersForInformation(
-                        jobManagerRunner -> jobManagerRunner.requestJobDetails(timeout));
-
-        CompletableFuture<Collection<Optional<JobDetails>>> optionalCombinedJobDetails =
-                FutureUtils.combineAll(individualOptionalJobDetails);
+        // A job whose JobMaster cannot answer must fail the whole request rather than be
+        // silently left out: clients treat absence from this list as the job being gone.
+        final List<CompletableFuture<JobDetails>> individualJobDetails =
+                new ArrayList<>(jobManagerRunnerRegistry.size());
+        for (JobManagerRunner jobManagerRunner : jobManagerRunnerRegistry.getJobManagerRunners()) {
+            individualJobDetails.add(
+                    jobManagerRunner
+                            .requestJobDetails(timeout)
+                            .exceptionally(
+                                    throwable -> {
+                                        throw new CompletionException(
+                                                new FlinkException(
+                                                        String.format(
+                                                                "Could not retrieve the details of job %s.",
+                                                                jobManagerRunner.getJobID()),
+                                                        throwable));
+                                    }));
+        }
 
         CompletableFuture<Collection<JobDetails>> combinedJobDetails =
-                optionalCombinedJobDetails.thenApply(this::flattenOptionalCollection);
+                FutureUtils.combineAll(individualJobDetails);
 
         final Collection<JobDetails> completedJobDetails = getCompletedJobDetails();
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherTest.java
@@ -1444,8 +1444,11 @@ public class DispatcherTest extends AbstractDispatcherTest {
         try {
             multipleJobsDetails = multipleJobsDetailsFuture.get();
         } catch (ExecutionException e) {
-            // Failing the whole request is acceptable: the client learns that the view is
-            // incomplete instead of concluding that the job is gone.
+            // Failing the whole request is acceptable, but it must fail for the right reason:
+            // an exception naming the job whose JobMaster could not be queried.
+            assertThat(e)
+                    .hasStackTraceContaining("Could not retrieve the details of job")
+                    .hasStackTraceContaining(secondJobID.toString());
             return;
         }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherTest.java
@@ -1407,6 +1407,54 @@ public class DispatcherTest extends AbstractDispatcherTest {
                 Stream.of(jobId, secondJobID).sorted().collect(Collectors.toList()));
     }
 
+    /**
+     * A JobMaster that fails or times out on {@code requestJobDetails} must not cause its running
+     * job to be silently omitted from an otherwise successful response: clients (such as the
+     * Kubernetes operator) treat absence from this list as "job not found".
+     */
+    @Test
+    public void testRequestMultipleJobDetails_doesNotSilentlyOmitJobWhoseJobMasterQueryFails()
+            throws Exception {
+        final JobID secondJobID = new JobID();
+        JobGraph secondJobGraph = JobGraphTestUtils.streamingJobGraph();
+        secondJobGraph.setJobID(secondJobID);
+        secondJobGraph.setApplicationId(applicationId);
+        final JobManagerRunner unresponsiveJobManagerRunner =
+                TestingJobManagerRunner.newBuilder()
+                        .setJobId(secondJobID)
+                        .setJobDetailsFutureFunction(
+                                () ->
+                                        FutureUtils.completedExceptionally(
+                                                new TimeoutException(
+                                                        "JobMaster did not answer in time")))
+                        .build();
+        final JobManagerRunnerFactory jobManagerRunnerFactory =
+                new QueuedJobManagerRunnerFactory(
+                        runningJobManagerRunnerWithJobStatus(JobStatus.RUNNING, jobId, 10L),
+                        unresponsiveJobManagerRunner);
+
+        DispatcherGateway dispatcherGateway =
+                createDispatcherAndStartJobs(
+                        jobManagerRunnerFactory, Arrays.asList(jobGraph, secondJobGraph));
+
+        final CompletableFuture<MultipleJobsDetails> multipleJobsDetailsFuture =
+                dispatcherGateway.requestMultipleJobDetails(TIMEOUT);
+
+        final MultipleJobsDetails multipleJobsDetails;
+        try {
+            multipleJobsDetails = multipleJobsDetailsFuture.get();
+        } catch (ExecutionException e) {
+            // Failing the whole request is acceptable: the client learns that the view is
+            // incomplete instead of concluding that the job is gone.
+            return;
+        }
+
+        assertThat(multipleJobsDetails.getJobs())
+                .extracting(JobDetails::getJobId)
+                .as("a successful response must list every registered running job")
+                .containsExactlyInAnyOrder(jobId, secondJobID);
+    }
+
     @Test
     public void testRequestMultipleJobDetails_isSerializable() throws Exception {
         final JobManagerRunnerFactory blockingJobMaster =

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/TestingJobManagerRunner.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/TestingJobManagerRunner.java
@@ -49,7 +49,7 @@ public class TestingJobManagerRunner implements JobManagerRunner {
 
     private final CompletableFuture<JobManagerRunnerResult> resultFuture;
 
-    private final Supplier<JobDetails> jobDetailsFunction;
+    private final Supplier<CompletableFuture<JobDetails>> jobDetailsFunction;
 
     private final OneShotLatch closeAsyncCalledLatch = new OneShotLatch();
 
@@ -60,7 +60,7 @@ public class TestingJobManagerRunner implements JobManagerRunner {
             boolean blockingTermination,
             CompletableFuture<JobMasterGateway> jobMasterGatewayFuture,
             CompletableFuture<JobManagerRunnerResult> resultFuture,
-            Supplier<JobDetails> jobDetailsFunction) {
+            Supplier<CompletableFuture<JobDetails>> jobDetailsFunction) {
         this.jobId = jobId;
         this.blockingTermination = blockingTermination;
         this.jobMasterGatewayFuture = jobMasterGatewayFuture;
@@ -116,7 +116,7 @@ public class TestingJobManagerRunner implements JobManagerRunner {
 
     @Override
     public CompletableFuture<JobDetails> requestJobDetails(Duration timeout) {
-        return CompletableFuture.completedFuture(jobDetailsFunction.get());
+        return jobDetailsFunction.get();
     }
 
     @Override
@@ -183,7 +183,7 @@ public class TestingJobManagerRunner implements JobManagerRunner {
         private CompletableFuture<JobMasterGateway> jobMasterGatewayFuture =
                 new CompletableFuture<>();
         private CompletableFuture<JobManagerRunnerResult> resultFuture = new CompletableFuture<>();
-        private Supplier<JobDetails> jobDetailsFunction =
+        private Supplier<CompletableFuture<JobDetails>> jobDetailsFunction =
                 () -> {
                     throw new UnsupportedOperationException();
                 };
@@ -216,7 +216,14 @@ public class TestingJobManagerRunner implements JobManagerRunner {
         }
 
         public Builder setJobDetailsFunction(Supplier<JobDetails> jobDetailsFunction) {
-            this.jobDetailsFunction = Preconditions.checkNotNull(jobDetailsFunction);
+            Preconditions.checkNotNull(jobDetailsFunction);
+            return setJobDetailsFutureFunction(
+                    () -> CompletableFuture.completedFuture(jobDetailsFunction.get()));
+        }
+
+        public Builder setJobDetailsFutureFunction(
+                Supplier<CompletableFuture<JobDetails>> jobDetailsFutureFunction) {
+            this.jobDetailsFunction = Preconditions.checkNotNull(jobDetailsFutureFunction);
             return this;
         }
 


### PR DESCRIPTION
## What is the purpose of the change

GET /jobs/overview (backed by Dispatcher.requestMultipleJobDetails) queries every registered JobMaster, but it swallows any failure. A running job whose JobMaster fails or times out on requestJobDetails is therefore silently omitted while the request still succeeds. Clients that use /jobs/overview as the source of truth for job existence (e.g. the Flink Kubernetes Operator) conclude the job is gone.

This pull request makes requestMultipleJobDetails fail the whole request instead, with a FlinkException naming the job whose details could not be retrieved, so an incomplete view is never reported as a successful one.

## Brief change log

- Dispatcher.requestMultipleJobDetails no longer uses the failure-swallowing queryJobMastersForInformation; a failed requestJobDetails on any JobMaster fails the combined future
- requestClusterOverview is unchanged (it only produces aggregate counts and keeps the lenient behaviour)
- TestingJobManagerRunner.Builder gains setJobDetailsFutureFunction so a test runner can return a failed requestJobDetails future; the existing setJobDetailsFunction delegates to it

## Verifying this change

This change added tests and can be verified as follows:

- Added DispatcherTest#testRequestMultipleJobDetails_doesNotSilentlyOmitJobWhoseJobMasterQueryFails: registers two running jobs, one of whose JobMaster fails requestJobDetails with a TimeoutException, and asserts the request either fails or lists both jobs. The test fails on master (only one job returned) and passes with the fix.
- Existing DispatcherTest#testRequestMultipleJobDetails_* tests continue to pass.

## Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): no
- The public API, i.e., is any changed class annotated with @Public(Evolving): no
- The serializers: no
- The runtime per-record code paths (performance sensitive): no
- Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: **yes**
- The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: Claude Code Fable 5.1
