### PR TITLE
[FLINK-40603][build] Use hadoop 3.4.3 for jdk25

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1211,6 +1211,8 @@ under the License.
 
 			<properties>
 				<surefire.excludedGroups.jdk>org.apache.flink.testutils.junit.FailsOnJava25,</surefire.excludedGroups.jdk>
+				<!-- Minimum Hadoop version working with jdk 25 according to https://issues.apache.org/jira/browse/HADOOP-19212 -->
+				<flink.hadoop.version>3.4.3</flink.hadoop.version>
 			</properties>
 
 			<build>


### PR DESCRIPTION
## What is the purpose of the change

The PR edures that for the case jdk25 hadoop 3.4.3 will be used

## Brief change log

pom
## Verifying this change

existing tests
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable )

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change the checkbox below to `[X]` and replace the placeholder in the "Generated-by"
line with the tool name and version. Otherwise remove the "Generated-by" line.
See the ASF Generative Tooling Guidance for details:
https://www.apache.org/legal/generative-tooling.html

You are responsible for the quality and correctness of every change in this PR
regardless of the tooling used. Low-effort AI-generated PRs will be closed. See
AGENTS.md for the full guidance.
-->

- [ ] Yes (please specify the tool below)

Generated-by: [Tool Name and Version]
