### PR TITLE
[FLINK-40605][table-code-splitter] Allow splitting if blocks containing loops with jump statements

### DIFF
--- a/flink-table/flink-table-code-splitter/src/main/java/org/apache/flink/table/codesplit/BlockStatementSplitter.java
+++ b/flink-table/flink-table-code-splitter/src/main/java/org/apache/flink/table/codesplit/BlockStatementSplitter.java
@@ -181,7 +181,13 @@ public class BlockStatementSplitter {
 
         public void visitStatement(StatementContext ctx, String context) {
 
-            if (ctx.getChildCount() == 0 || getNumOfReturnOrJumpStatements(ctx) != 0) {
+            if (ctx.getChildCount() == 0 || getNumOfReturn(ctx) != 0) {
+                return;
+            }
+
+            // Keep jumps with their loop, but allow moving a complete loop with an enclosing block.
+            if ((ctx.WHILE() != null || ctx.FOR() != null)
+                    && getNumOfReturnOrJumpStatements(ctx) != 0) {
                 return;
             }
 
@@ -268,6 +274,12 @@ public class BlockStatementSplitter {
                     && (statement.IF() != null
                             || statement.ELSE() != null
                             || statement.WHILE() != null);
+        }
+
+        private int getNumOfReturn(ParserRuleContext ctx) {
+            ReturnAndJumpCounter counter = new ReturnAndJumpCounter();
+            counter.visit(ctx);
+            return counter.getReturnCounter();
         }
 
         private int getNumOfReturnOrJumpStatements(ParserRuleContext ctx) {

--- a/flink-table/flink-table-code-splitter/src/main/java/org/apache/flink/table/codesplit/ReturnAndJumpCounter.java
+++ b/flink-table/flink-table-code-splitter/src/main/java/org/apache/flink/table/codesplit/ReturnAndJumpCounter.java
@@ -23,16 +23,24 @@ import org.apache.flink.table.codesplit.JavaParser.StatementContext;
 public class ReturnAndJumpCounter extends JavaParserBaseVisitor<Void> {
 
     private int counter = 0;
+    private int returnCounter = 0;
 
     @Override
     public Void visitStatement(StatementContext ctx) {
         if (ctx.RETURN() != null || ctx.BREAK() != null || ctx.CONTINUE() != null) {
             counter++;
+            if (ctx.RETURN() != null) {
+                returnCounter++;
+            }
         }
         return visitChildren(ctx);
     }
 
     public int getCounter() {
         return counter;
+    }
+
+    public int getReturnCounter() {
+        return returnCounter;
     }
 }

--- a/flink-table/flink-table-code-splitter/src/test/java/org/apache/flink/table/codesplit/BlockStatementRewriterTest.java
+++ b/flink-table/flink-table-code-splitter/src/test/java/org/apache/flink/table/codesplit/BlockStatementRewriterTest.java
@@ -62,6 +62,16 @@ class BlockStatementRewriterTest extends CodeRewriterTestBase<BlockStatementRewr
     }
 
     @Test
+    void testIfStatementRewrite4() {
+        runTest("TestIfStatementRewrite4");
+    }
+
+    @Test
+    void testIfStatementRewrite5() {
+        runTest("TestIfStatementRewrite5");
+    }
+
+    @Test
     void testIfMultipleSingleLineStatementRewrite() {
         runTest("TestIfMultipleSingleLineStatementRewrite");
     }

--- a/flink-table/flink-table-code-splitter/src/test/java/org/apache/flink/table/codesplit/JavaCodeSplitterTest.java
+++ b/flink-table/flink-table-code-splitter/src/test/java/org/apache/flink/table/codesplit/JavaCodeSplitterTest.java
@@ -19,10 +19,14 @@ package org.apache.flink.table.codesplit;
 
 import org.apache.flink.util.FileUtils;
 
+import org.codehaus.janino.SimpleCompiler;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 import java.io.File;
+import java.lang.reflect.Method;
 
 import static org.apache.flink.table.codesplit.CodeSplitTestUtil.trimLines;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -39,6 +43,101 @@ class JavaCodeSplitterTest {
     @Test
     void testNotSplitJavaCode() {
         runTest("TestNotSplitJavaCode", 4000, 10000);
+    }
+
+    @ParameterizedTest
+    @CsvSource({"break, 3, 2", "continue, 5, 4"})
+    void testSplitLargeIfBlockContainingLoopWithJump(
+            String jump, int expectedIterations, int expectedCompletedIterations) throws Exception {
+        String code =
+                "public class TestSplitWithJumps {\n"
+                        + "  public void myFun(int[] a) {\n"
+                        + "    if (a[0] >= 0) {\n"
+                        // The unsplit branch exceeds the JVM's 64 KB method limit.
+                        + "      a[1] += 1;\n".repeat(15000)
+                        + "      for (int i = 0; i < 5; i++) {\n"
+                        + "        a[2]++;\n"
+                        + "        if (i == 2) { "
+                        + jump
+                        + "; }\n"
+                        + "        a[3]++;\n"
+                        + "      }\n"
+                        + "    }\n"
+                        + "    a[4] = 1;\n"
+                        + "  }\n"
+                        + "}\n";
+
+        Object instance = compileSplitCode(code, 4000);
+        Method method = instance.getClass().getMethod("myFun", int[].class);
+
+        int[] takenBranch = {0, 0, 0, 0, 0};
+        method.invoke(instance, takenBranch);
+        assertThat(takenBranch)
+                .containsExactly(0, 15000, expectedIterations, expectedCompletedIterations, 1);
+
+        int[] skippedBranch = {-1, 0, 0, 0, 0};
+        method.invoke(instance, skippedBranch);
+        assertThat(skippedBranch).containsExactly(-1, 0, 0, 0, 1);
+    }
+
+    @Test
+    void testSplitIfBlockPreservesLabeledJumps() throws Exception {
+        String code =
+                "public class TestSplitWithJumps {\n"
+                        + "  public void myFun(int[] a) {\n"
+                        + "    if (a[0] >= 0) {\n"
+                        + "      a[1] = 3;\n"
+                        + "      outer: for (int i = 0; i < 5; i++) {\n"
+                        + "        for (int j = 0; j < 5; j++) {\n"
+                        + "          a[1]++;\n"
+                        + "          if (i == 1) { continue outer; }\n"
+                        + "          if (i == 3) { break outer; }\n"
+                        + "        }\n"
+                        + "      }\n"
+                        + "      a[2] = 17;\n"
+                        + "    }\n"
+                        + "    a[3] = 7;\n"
+                        + "  }\n"
+                        + "}\n";
+
+        Object instance = compileSplitCode(code, 60);
+        int[] values = {0, 0, 0, 0};
+        instance.getClass().getMethod("myFun", int[].class).invoke(instance, values);
+        assertThat(values).containsExactly(0, 15, 17, 7);
+    }
+
+    @Test
+    void testSplitIfBlockPreservesEarlyReturn() throws Exception {
+        String code =
+                "public class TestSplitWithJumps {\n"
+                        + "  public void myFun(int[] a) {\n"
+                        + "    if (a[0] == 0) {\n"
+                        + "      a[1] = 3;\n"
+                        + "      a[2] = 4;\n"
+                        + "    } else if (a[0] == 1) {\n"
+                        + "      a[1] = 7;\n"
+                        + "      return;\n"
+                        + "    } else {\n"
+                        + "      for (int i = 0; i < 5; i++) {\n"
+                        + "        if (i == 2) { break; }\n"
+                        + "        a[1] += i;\n"
+                        + "      }\n"
+                        + "      a[2] = 17;\n"
+                        + "    }\n"
+                        + "    a[3] = 7;\n"
+                        + "  }\n"
+                        + "}\n";
+
+        Object instance = compileSplitCode(code, 60);
+        Method method = instance.getClass().getMethod("myFun", int[].class);
+
+        int[] returned = {1, 0, 0, 0};
+        method.invoke(instance, returned);
+        assertThat(returned).containsExactly(1, 7, 0, 0);
+
+        int[] completed = {2, 0, 0, 0};
+        method.invoke(instance, completed);
+        assertThat(completed).containsExactly(2, 1, 17, 7);
     }
 
     @Test
@@ -93,6 +192,19 @@ class JavaCodeSplitterTest {
     void shouldCompileGivenAndExpectedCode() throws Exception {
         CodeSplitTestUtil.tryCompile("splitter/code/");
         CodeSplitTestUtil.tryCompile("splitter/expected/");
+    }
+
+    private Object compileSplitCode(String code, int maxLength) throws Exception {
+        try {
+            SimpleCompiler compiler = new SimpleCompiler();
+            compiler.cook(JavaCodeSplitter.split(code, maxLength, 10000));
+            return compiler.getClassLoader()
+                    .loadClass("TestSplitWithJumps")
+                    .getDeclaredConstructor()
+                    .newInstance();
+        } finally {
+            CodeSplitUtil.getCounter().set(0L);
+        }
     }
 
     private void runTest(String filename, int maxLength, int maxMembers) {

--- a/flink-table/flink-table-code-splitter/src/test/resources/block/code/TestIfStatementRewrite4.java
+++ b/flink-table/flink-table-code-splitter/src/test/resources/block/code/TestIfStatementRewrite4.java
@@ -1,0 +1,23 @@
+public class TestIfStatementRewrite4 {
+    public void myFun1(int[] a, int[] b) throws RuntimeException {
+        if (a[0] == 0) {
+            a[0] = 1;
+            a[1] = 1;
+        } else if (a[1] == 22) {
+            a[1] = b[12];
+            a[2] = b[22];
+        } else if (a[3] == 0) {
+            a[3] = b[3];
+            return;
+        } else if (a[4] == 0) {
+            a[4] = b[4];
+            a[44] = b[44];
+        } else {
+            a[0] = b[0];
+            a[1] = b[1];
+            a[2] = b[2];
+        }
+        a[10] = b[10];
+        a[11] = b[11];
+    }
+}

--- a/flink-table/flink-table-code-splitter/src/test/resources/block/code/TestIfStatementRewrite5.java
+++ b/flink-table/flink-table-code-splitter/src/test/resources/block/code/TestIfStatementRewrite5.java
@@ -1,0 +1,15 @@
+public class TestIfStatementRewrite5 {
+    public void myFun1(int[] a, int[] b) throws RuntimeException {
+        if (a[0] == 0) {
+            a[0] = 1;
+            for (int i = 0; i < a[3]; i++) {
+                a[0] += b[i];
+                if (a[0] > 999) {
+                    break;
+                }
+            }
+        } else {
+            a[13] = b[12];
+        }
+    }
+}

--- a/flink-table/flink-table-code-splitter/src/test/resources/block/expected/TestIfStatementRewrite4.java
+++ b/flink-table/flink-table-code-splitter/src/test/resources/block/expected/TestIfStatementRewrite4.java
@@ -1,0 +1,29 @@
+public class TestIfStatementRewrite4 {
+    public void myFun1(int[] a, int[] b) throws RuntimeException {
+
+        if (a[0] == 0) {
+            myFun1_0_0_rewriteGroup1(a, b);
+        } else if (a[1] == 22) {
+            a[1] = b[12];
+            a[2] = b[22];
+        } else if (a[3] == 0) {
+            a[3] = b[3];
+            return;
+        } else if (a[4] == 0) {
+            a[4] = b[4];
+            a[44] = b[44];
+        } else {
+            a[0] = b[0];
+            a[1] = b[1];
+            a[2] = b[2];
+        }
+        a[10] = b[10];
+        a[11] = b[11];
+    }
+
+    void myFun1_0_0_rewriteGroup1(int[] a, int[] b) throws RuntimeException {
+        a[0] = 1;
+        a[1] = 1;
+    }
+
+}

--- a/flink-table/flink-table-code-splitter/src/test/resources/block/expected/TestIfStatementRewrite5.java
+++ b/flink-table/flink-table-code-splitter/src/test/resources/block/expected/TestIfStatementRewrite5.java
@@ -1,0 +1,21 @@
+public class TestIfStatementRewrite5 {
+    public void myFun1(int[] a, int[] b) throws RuntimeException {
+
+        if (a[0] == 0) {
+            myFun1_0_0(a, b);
+        } else {
+            a[13] = b[12];
+        }
+    }
+
+    void myFun1_0_0(int[] a, int[] b) throws RuntimeException {
+        a[0] = 1;
+        for (int i = 0; i < a[3]; i++) {
+            a[0] += b[i];
+            if (a[0] > 999) {
+                break;
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
## What is the purpose of the change

Fix code splitting for large `if` blocks containing nested loops with `break` or `continue`.

Currently, `BlockStatementSplitter` skips a statement whenever its subtree contains any `return`, `break`, or `continue`. This is overly conservative for an enclosing block containing a self-contained loop: even a small loop with a jump can prevent the surrounding large block from being split, leaving generated methods that fail compilation with `Code grows beyond 64 KB`.

This change allows such enclosing blocks to be split while retaining conservative guards for return statements and loop-body extraction.

## Brief change log

- Track return statements separately from the combined return/jump count.
- Allow enclosing blocks containing self-contained loops with jumps to be extracted.
- Preserve the restrictions on extracting blocks containing returns and loop bodies containing jumps.
- Add rewrite fixtures and compilation/execution regression tests covering oversized branches, `break`, `continue`, labeled jumps, and early returns.

## Verifying this change

Added regression tests that generate an oversized `if` branch containing a short loop with either `break` or `continue`, run the complete `JavaCodeSplitter` pipeline, compile the output with Janino, and verify execution results.

Both oversized-branch test cases fail on the unmodified base commit with `Code grows beyond 64 KB` and pass with this change. The tests also verify that skipped branches remain unexecuted and that statements following a jump execute correctly.

Additional execution tests verify labeled `break`/`continue` and early-return behavior.

The complete code-splitter module test suite was run with its reactor dependencies using JDK 17 and the repository's Maven wrapper:

```bash
./mvnw -pl flink-table/flink-table-code-splitter -am \
  -Drat.skip=true \
  '-Dtest=org.apache.flink.table.codesplit.*Test' \
  -Dsurefire.failIfNoSpecifiedTests=false \
  test
```

Result: 54 tests, 0 failures, 0 errors, and 1 pre-existing skipped test.

Spotless and Checkstyle checks also passed. The reactor command skips the repository-wide RAT scan; a module-scoped RAT check was run separately and passed. The full repository test suite was not run.

## Does this pull request potentially affect one of the following parts:

- Dependencies: no.
- Public API: no.
- Serializers: no.
- Runtime per-record code paths: yes, generated code may be split into additional helper methods; no hand-written runtime operator changes.
- Deployment or recovery infrastructure: no.
- S3 file system connector: no.

## Documentation

- Does this pull request introduce a new feature? No, this is a code-splitting bug fix.
- How is the feature documented? Not applicable.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes.

Generated-by: Codex CLI 0.153.4