### PR TITLE
[FLINK-40606][table-planner] Fix code generation for binary array casts

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/CastRuleUtils.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/CastRuleUtils.java
@@ -72,7 +72,10 @@ final class CastRuleUtils {
     }
 
     static String newArray(String innerType, String arraySize) {
-        return "new " + innerType + "[" + arraySize + "]";
+        final int arrayIndex = innerType.indexOf('[');
+        final String baseType = arrayIndex < 0 ? innerType : innerType.substring(0, arrayIndex);
+        final String dimensions = arrayIndex < 0 ? "" : innerType.substring(arrayIndex);
+        return "new " + baseType + "[" + arraySize + "]" + dimensions;
     }
 
     static String stringConcat(Object... args) {

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/casting/CastRulesTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/casting/CastRulesTest.java
@@ -1543,6 +1543,21 @@ class CastRulesTest {
                                             null,
                                             fromString("2021-09-24 14:34:56.123456")
                                         })),
+                CastTestSpecBuilder.testCastTo(ARRAY(VARBINARY(1)))
+                        .fromCase(ARRAY(BYTES()), null, null)
+                        .fromCase(
+                                ARRAY(BYTES()),
+                                new GenericArrayData(new byte[][] {}),
+                                new GenericArrayData(new byte[][] {}))
+                        .fromCase(
+                                ARRAY(BYTES()),
+                                new GenericArrayData(new byte[][] {{1}, {2, 3}, null, {}}),
+                                new GenericArrayData(new byte[][] {{1}, {2}, null, {}})),
+                CastTestSpecBuilder.testCastTo(ARRAY(BINARY(2).notNull()))
+                        .fromCase(
+                                ARRAY(BYTES().notNull()),
+                                new GenericArrayData(new byte[][] {{1}, {2, 3, 4}}),
+                                new GenericArrayData(new byte[][] {{1, 0}, {2, 3}})),
                 CastTestSpecBuilder.testCastTo(ARRAY(BIGINT().nullable()))
                         .fromCase(
                                 ARRAY(INT().nullable()),
@@ -2098,6 +2113,16 @@ class CastRulesTest {
                                 new GenericArrayData(new int[] {1, 2, 3}))
                         // a VARIANT null element fails a NOT NULL element type
                         .fail(VARIANT(), VARIANT_INT_ARRAY_WITH_NULL, TableRuntimeException.class),
+                CastTestSpecBuilder.testCastTo(ARRAY(BYTES()))
+                        .fromCase(
+                                VARIANT(),
+                                VARIANT_BUILDER
+                                        .array()
+                                        .add(VARIANT_BUILDER.of(new byte[] {1}))
+                                        .add(VARIANT_BUILDER.of(new byte[] {2, 3}))
+                                        .add(VARIANT_BUILDER.ofNull())
+                                        .build(),
+                                new GenericArrayData(new byte[][] {{1}, {2, 3}, null})),
                 CastTestSpecBuilder.testCastTo(ARRAY(STRING()))
                         // each element renders to string like the scalar cast
                         .fromCase(


### PR DESCRIPTION
## What is the purpose of the change

Fix binary-array CAST code generation described in [FLINK-40606](https://issues.apache.org/jira/browse/FLINK-40606). Array-to-array and VARIANT-to-array casts can generate invalid Java such as `new byte[][size]`, causing Janino compilation to fail.

## Brief change log

- Place the allocated dimension before existing array dimensions, generating `new byte[size][]`.
- Add `CastRulesTest` regressions for binary-array truncation/padding, null and empty arrays, and VARIANT arrays containing binary and null elements.

## Verifying this change

- Red/green verification: all five new cases fail with the original allocation code and pass with the fix.
- `CastRulesTest` and `CastRuleProviderTest`: 735 tests passed.
- Spotless and Checkstyle passed.

## Does this pull request potentially affect one of the following parts:

- Dependencies: no.
- Public API: no.
- Serializers: no.
- Runtime per-record code paths: yes, the generated array allocation for affected CASTs; the element loop is unchanged.
- Deployment or recovery: no.
- S3 file system connector: no.

## Documentation

- New feature: no.
- Feature documentation: not applicable. The JIRA Release Notes field describes the fix.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes

Generated-by: Codex (GPT-6)
