### PR TITLE
[FLINK-23758][python] Fix semantics of Expression.__invert__

### DIFF
--- a/flink-python/pyflink/table/expression.py
+++ b/flink-python/pyflink/table/expression.py
@@ -487,7 +487,7 @@ class Expression(Generic[T]):
     # logic functions
     __and__ = _binary_op("and")
     __or__ = _binary_op("or")
-    __invert__ = _unary_op('isNotTrue')
+    __invert__ = _unary_op("not")
 
     __rand__ = _binary_op("and")
     __ror__ = _binary_op("or")

--- a/flink-python/pyflink/table/tests/test_calc.py
+++ b/flink-python/pyflink/table/tests/test_calc.py
@@ -37,6 +37,16 @@ class StreamTableCalcTests(PyFlinkStreamTableTestCase):
         self.assertEqual('[plus(a, 1), b, c]',
                          query_operation.getProjectList().toString())
 
+    def test_invert_nullable_boolean_expression(self):
+        schema = DataTypes.ROW([
+            DataTypes.FIELD("a", DataTypes.BOOLEAN())
+        ])
+        table = self.t_env.from_elements([(True,), (False,), (None,)], schema)
+
+        actual = [tuple(row) for row in table.select(table.a, ~table.a).execute().collect()]
+
+        self.assertCountEqual(actual, [(True, False), (False, True), (None, None)])
+
     def test_alias(self):
         t = self.t_env.from_elements([(1, 'Hi', 'Hello')], ['a', 'b', 'c'])
         t = t.alias("d", "e", "f")

--- a/flink-python/pyflink/table/tests/test_expression.py
+++ b/flink-python/pyflink/table/tests/test_expression.py
@@ -56,7 +56,7 @@ class PyFlinkBatchExpressionTests(PyFlinkTestCase):
         self.assertEqual('and(a, b)', str(expr1 & expr2))
         self.assertEqual('or(a, b)', str(expr1 | expr2))
         self.assertEqual('isNotTrue(a)', str(expr1.is_not_true))
-        self.assertEqual('isNotTrue(a)', str(~expr1))
+        self.assertEqual('not(a)', str(~expr1))
 
         # arithmetic functions
         self.assertEqual('plus(a, b)', str(expr1 + expr2))


### PR DESCRIPTION
## What is the purpose of the change

PyFlink maps Python's `~` operator for `Expression` to `isNotTrue`. Although `NOT`
and `IS NOT TRUE` return the same result for non-null booleans, they differ for
`NULL`: `NOT NULL` is `NULL`, while `NULL IS NOT TRUE` is `TRUE`.

This pull request fixes `Expression.__invert__` to preserve SQL three-valued logic.

## Brief change log

- Map `Expression.__invert__` to the Java Table API `not` expression.
- Update expression summary-string coverage to expect `not(a)`.
- Add a runtime regression test for `TRUE`, `FALSE`, and `NULL` inputs.

## Verifying this change

This change added tests and can be verified as follows:

- `test_expression.py` verifies that `~a` produces `not(a)` while
  `a.is_not_true` continues to produce `isNotTrue(a)`.
- `test_calc.py` executes a nullable Boolean expression and verifies the mappings
  `(TRUE, FALSE)`, `(FALSE, TRUE)`, and `(NULL, NULL)`.
- The related expression, API completeness, and calc tests pass (`17 passed`).
- Flake8 passes for the complete `pyflink.table` package.
- Mypy passes for all 82 source files selected by the project configuration.

## Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): no
- The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes,
  this corrects existing operator behavior without changing the API signature
- The serializers: no
- The runtime per-record code paths (performance sensitive): yes, only the selected
  built-in Boolean expression changes; no runtime implementation is added
- Anything that affects deployment or recovery: JobManager (and its components),
  Checkpointing, Kubernetes/Yarn, ZooKeeper: no
- The S3 file system connector: no

## Documentation

- Does this pull request introduce a new feature? no
- If yes, how is the feature documented? not applicable

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: OpenAI Codex (GPT-5)
