### PR TITLE
[FLINK-20986][table-planner] Avoid cross-job RAW type cache reuse

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/calcite/FlinkTypeFactory.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/calcite/FlinkTypeFactory.java
@@ -74,6 +74,7 @@ import org.apache.flink.util.Preconditions;
 import org.apache.calcite.avatica.util.TimeUnit;
 import org.apache.calcite.jdbc.JavaTypeFactoryImpl;
 import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.type.RelCrossType;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.rel.type.RelDataTypeField;
@@ -87,6 +88,8 @@ import org.apache.calcite.sql.type.BasicSqlType;
 import org.apache.calcite.sql.type.MapSqlType;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.util.ConversionUtil;
+
+import javax.annotation.Nullable;
 
 import java.lang.reflect.Type;
 import java.nio.charset.Charset;
@@ -121,6 +124,49 @@ public class FlinkTypeFactory extends JavaTypeFactoryImpl implements ExtendedRel
 
     public FlinkTypeFactory(ClassLoader classLoader) {
         this(classLoader, FlinkTypeSystem.INSTANCE);
+    }
+
+    // Calcite's canonical type caches are shared across factories and user-code classloaders.
+    // RAW type digests do not distinguish classes with the same name from different classloaders.
+    // Keep RAW types and their containers out of those caches so that later jobs retain their own
+    // classes and serializers. Logical types are still cached in this factory's seenTypes map.
+    @Override
+    protected RelDataType canonize(RelDataType relDataType) {
+        return containsRawType(relDataType) ? relDataType : super.canonize(relDataType);
+    }
+
+    @Override
+    protected RelDataType canonize(
+            StructKind kind,
+            List<String> fieldNames,
+            List<RelDataType> fieldTypes,
+            boolean nullable) {
+        if (fieldTypes.stream().noneMatch(FlinkTypeFactory::containsRawType)) {
+            return super.canonize(kind, fieldNames, fieldTypes, nullable);
+        }
+
+        final List<RelDataTypeField> fields = new ArrayList<>();
+        for (int i = 0; i < fieldTypes.size(); i++) {
+            fields.add(new RelDataTypeFieldImpl(fieldNames.get(i), i, fieldTypes.get(i)));
+        }
+        return new RelRecordType(kind, fields, nullable);
+    }
+
+    private static boolean containsRawType(@Nullable RelDataType relDataType) {
+        if (relDataType == null) {
+            return false;
+        }
+        return relDataType instanceof RawRelDataType
+                || relDataType instanceof GenericRelDataType
+                || containsRawType(relDataType.getComponentType())
+                || containsRawType(relDataType.getKeyType())
+                || containsRawType(relDataType.getValueType())
+                || (relDataType instanceof RelCrossType
+                        && ((RelCrossType) relDataType)
+                                .getTypes().stream().anyMatch(FlinkTypeFactory::containsRawType))
+                || (relDataType.isStruct()
+                        && relDataType.getFieldList().stream()
+                                .anyMatch(field -> containsRawType(field.getType())));
     }
 
     @Override

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/calcite/FlinkTypeFactoryTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/calcite/FlinkTypeFactoryTest.java
@@ -37,6 +37,7 @@ import org.apache.flink.table.types.logical.FloatType;
 import org.apache.flink.table.types.logical.IntType;
 import org.apache.flink.table.types.logical.LocalZonedTimestampType;
 import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.LogicalTypeRoot;
 import org.apache.flink.table.types.logical.MapType;
 import org.apache.flink.table.types.logical.MultisetType;
 import org.apache.flink.table.types.logical.NullType;
@@ -50,6 +51,7 @@ import org.apache.flink.table.types.logical.UuidType;
 import org.apache.flink.table.types.logical.VarBinaryType;
 import org.apache.flink.table.types.logical.VarCharType;
 import org.apache.flink.table.types.logical.utils.LogicalTypeMerging;
+import org.apache.flink.testutils.ClassLoaderUtils;
 
 import org.apache.calcite.avatica.util.TimeUnit;
 import org.apache.calcite.rel.type.RelDataType;
@@ -61,10 +63,14 @@ import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
+import java.lang.ref.Reference;
 import java.time.DayOfWeek;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -74,6 +80,11 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 /** Tests for {@link FlinkTypeFactory}. */
 @Execution(ExecutionMode.CONCURRENT)
 class FlinkTypeFactoryTest {
+
+    private static final Class<?> FIRST_JOB_CLASS =
+            ClassLoaderUtils.createSerializableObjectFromNewClassLoader().getObject().getClass();
+    private static final Class<?> SECOND_JOB_CLASS =
+            ClassLoaderUtils.createSerializableObjectFromNewClassLoader().getObject().getClass();
 
     static Stream<LogicalType> testInternalToRelType() {
         return Stream.of(
@@ -220,6 +231,174 @@ class FlinkTypeFactoryTest {
         assertThat(typeFactory.builder().add("f0", genericRelType).build())
                 .as("The type expect to be not canonized")
                 .isNotEqualTo(typeFactory.builder().add("f0", genericRelType3).build());
+    }
+
+    static Stream<Arguments> testRawTypeClassLoaderIsolation() {
+        final List<Arguments> arguments = new ArrayList<>();
+        for (boolean legacy : new boolean[] {false, true}) {
+            for (LogicalTypeRoot root :
+                    new LogicalTypeRoot[] {
+                        LogicalTypeRoot.RAW,
+                        LogicalTypeRoot.ARRAY,
+                        LogicalTypeRoot.MAP,
+                        LogicalTypeRoot.MULTISET,
+                        LogicalTypeRoot.ROW
+                    }) {
+                for (boolean rawNullable : new boolean[] {false, true}) {
+                    for (boolean nullable : new boolean[] {false, true}) {
+                        if (root != LogicalTypeRoot.RAW || rawNullable == nullable) {
+                            arguments.add(Arguments.of(legacy, root, rawNullable, nullable));
+                        }
+                    }
+                }
+            }
+        }
+        return arguments.stream();
+    }
+
+    @MethodSource
+    @ParameterizedTest
+    void testRawTypeClassLoaderIsolation(
+            boolean legacy, LogicalTypeRoot root, boolean rawNullable, boolean nullable) {
+        assertRawTypeClassLoaderIsolation(
+                legacy, rawNullable, rawType -> wrapRawType(rawType, root, nullable));
+    }
+
+    static Stream<Arguments> testAdditionalRawTypeClassLoaderIsolation() {
+        return Stream.of(false, true)
+                .flatMap(
+                        legacy ->
+                                Stream.of(false, true).map(mapKey -> Arguments.of(legacy, mapKey)));
+    }
+
+    @MethodSource
+    @ParameterizedTest
+    void testAdditionalRawTypeClassLoaderIsolation(boolean legacy, boolean mapKey) {
+        assertRawTypeClassLoaderIsolation(
+                legacy,
+                true,
+                rawType ->
+                        mapKey
+                                ? new MapType(rawType, new IntType(false))
+                                : RowType.of(new ArrayType(rawType)));
+    }
+
+    @ValueSource(booleans = {false, true})
+    @ParameterizedTest
+    void testRawJoinTypeClassLoaderIsolation(boolean legacy) {
+        final LogicalType firstRaw = createRawType(FIRST_JOB_CLASS, legacy, true);
+        final LogicalType secondRaw = createRawType(SECOND_JOB_CLASS, legacy, true);
+        final FlinkTypeFactory firstFactory =
+                new FlinkTypeFactory(FIRST_JOB_CLASS.getClassLoader(), FlinkTypeSystem.INSTANCE);
+        final FlinkTypeFactory secondFactory =
+                new FlinkTypeFactory(SECOND_JOB_CLASS.getClassLoader(), FlinkTypeSystem.INSTANCE);
+        final RelDataType firstJoinType =
+                firstFactory.createJoinType(
+                        firstFactory.createFieldTypeFromLogicalType(RowType.of(firstRaw)));
+        try {
+            final RelDataType secondJoinType =
+                    secondFactory.createJoinType(
+                            secondFactory.createFieldTypeFromLogicalType(RowType.of(secondRaw)));
+            assertThat(
+                            FlinkTypeFactory.toLogicalType(
+                                    firstJoinType.getFieldList().get(0).getType()))
+                    .isEqualTo(firstRaw);
+            assertThat(
+                            FlinkTypeFactory.toLogicalType(
+                                    secondJoinType.getFieldList().get(0).getType()))
+                    .as("A join type must retain the next job's RAW class and serializer")
+                    .isEqualTo(secondRaw);
+        } finally {
+            Reference.reachabilityFence(firstJoinType);
+        }
+    }
+
+    private void assertRawTypeClassLoaderIsolation(
+            boolean legacy, boolean rawNullable, UnaryOperator<LogicalType> wrapper) {
+        assertThat(FIRST_JOB_CLASS.getName()).isEqualTo(SECOND_JOB_CLASS.getName());
+        assertThat(FIRST_JOB_CLASS).isNotSameAs(SECOND_JOB_CLASS);
+        final LogicalType firstRaw = createRawType(FIRST_JOB_CLASS, legacy, rawNullable);
+        final LogicalType secondRaw = createRawType(SECOND_JOB_CLASS, legacy, rawNullable);
+        assertThat(firstRaw).isNotEqualTo(secondRaw);
+        assertThat(firstRaw.asSummaryString()).isEqualTo(secondRaw.asSummaryString());
+        if (!legacy) {
+            assertThat(firstRaw.asSerializableString()).isEqualTo(secondRaw.asSerializableString());
+        }
+        final LogicalType firstType = wrapper.apply(firstRaw);
+        final LogicalType secondType = wrapper.apply(secondRaw);
+        final FlinkTypeFactory firstFactory =
+                new FlinkTypeFactory(FIRST_JOB_CLASS.getClassLoader(), FlinkTypeSystem.INSTANCE);
+        final FlinkTypeFactory secondFactory =
+                new FlinkTypeFactory(SECOND_JOB_CLASS.getClassLoader(), FlinkTypeSystem.INSTANCE);
+        final RelDataType firstRelType = firstFactory.createFieldTypeFromLogicalType(firstType);
+        try {
+            final RelDataType secondRelType =
+                    secondFactory.createFieldTypeFromLogicalType(secondType);
+            assertThat(FlinkTypeFactory.toLogicalType(firstRelType)).isEqualTo(firstType);
+            assertThat(FlinkTypeFactory.toLogicalType(secondRelType))
+                    .as("The next job must retain its own RAW class and serializer")
+                    .isEqualTo(secondType);
+            assertThat(secondRelType.getFullTypeString())
+                    .isEqualTo(firstRelType.getFullTypeString());
+            // Nullable RAW uses seenTypes directly, without allocating a nullability copy.
+            final LogicalType cachedRaw = secondRaw.copy(true);
+            final RelDataType secondRawRelType =
+                    secondFactory.createFieldTypeFromLogicalType(cachedRaw);
+            assertThat(secondFactory.createFieldTypeFromLogicalType(cachedRaw))
+                    .as("RAW types remain cached within their factory")
+                    .isSameAs(secondRawRelType);
+        } finally {
+            // Calcite's shared caches use weak references; keep the previous job's type live.
+            Reference.reachabilityFence(firstRelType);
+        }
+    }
+
+    static Stream<LogicalType> testPrimitiveTypeCanonicalizationAcrossFactories() {
+        return Stream.of(
+                new IntType(),
+                new ArrayType(new IntType()),
+                new MapType(new IntType(), new IntType()),
+                new MultisetType(new IntType()),
+                RowType.of(new IntType()));
+    }
+
+    @MethodSource
+    @ParameterizedTest
+    void testPrimitiveTypeCanonicalizationAcrossFactories(LogicalType type) {
+        final FlinkTypeFactory firstFactory =
+                new FlinkTypeFactory(getClass().getClassLoader(), FlinkTypeSystem.INSTANCE);
+        final FlinkTypeFactory secondFactory =
+                new FlinkTypeFactory(getClass().getClassLoader(), FlinkTypeSystem.INSTANCE);
+        final RelDataType firstRelType = firstFactory.createFieldTypeFromLogicalType(type);
+        assertThat(secondFactory.createFieldTypeFromLogicalType(type)).isSameAs(firstRelType);
+    }
+
+    private static <T> LogicalType createRawType(
+            Class<T> typeClass, boolean legacy, boolean nullable) {
+        return legacy
+                ? new TypeInformationRawType<>(nullable, Types.GENERIC(typeClass))
+                : new RawType<>(
+                        nullable,
+                        typeClass,
+                        new KryoSerializer<>(typeClass, new SerializerConfigImpl()));
+    }
+
+    private static LogicalType wrapRawType(
+            LogicalType rawType, LogicalTypeRoot root, boolean nullable) {
+        switch (root) {
+            case RAW:
+                return rawType;
+            case ARRAY:
+                return new ArrayType(nullable, rawType);
+            case MAP:
+                return new MapType(nullable, new IntType(false), rawType);
+            case MULTISET:
+                return new MultisetType(nullable, rawType);
+            case ROW:
+                return RowType.of(nullable, rawType);
+            default:
+                throw new IllegalArgumentException("Unexpected type root: " + root);
+        }
     }
 
     static Stream<Arguments> testLeastRestrictive() {

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/RelDataTypeJsonSerdeTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/RelDataTypeJsonSerdeTest.java
@@ -21,6 +21,7 @@ package org.apache.flink.table.planner.plan.nodes.exec.serde;
 import org.apache.flink.api.common.typeutils.base.VoidSerializer;
 import org.apache.flink.table.planner.calcite.FlinkTypeFactory;
 import org.apache.flink.table.planner.calcite.FlinkTypeSystem;
+import org.apache.flink.table.planner.plan.schema.RawRelDataType;
 import org.apache.flink.table.planner.typeutils.LogicalRelDataTypeConverterTest.PojoClass;
 import org.apache.flink.table.types.logical.BitmapType;
 import org.apache.flink.table.types.logical.DayTimeIntervalType;
@@ -64,7 +65,14 @@ public class RelDataTypeJsonSerdeTest {
         final String json = toJson(serdeContext, relDataType);
         final RelDataType actual = toObject(serdeContext, json, RelDataType.class);
 
-        assertThat(actual).isSameAs(relDataType);
+        if (relDataType instanceof RawRelDataType) {
+            // RAW types are not shared across factories because their classloaders may differ.
+            assertThat(FlinkTypeFactory.toLogicalType(actual))
+                    .isEqualTo(FlinkTypeFactory.toLogicalType(relDataType));
+            assertThat(toJson(serdeContext, actual)).isEqualTo(json);
+        } else {
+            assertThat(actual).isSameAs(relDataType);
+        }
     }
 
     @Test


### PR DESCRIPTION
## What is the purpose of the change

Fix repeated Table API job submissions that use RAW types loaded from the job jar. Calcite's static type caches can replace a later job's type with one that retains an earlier job's classloader. The same class name and serializer snapshot do not make those Java classes interchangeable.

This addresses [FLINK-20986](https://issues.apache.org/jira/browse/FLINK-20986) and the same failure reported in apache/sedona#1052, where the first REST submission succeeds and the second fails during `ST_S2CellIDs` type inference.

## Brief change log

- Bypass both global canonicalization paths for modern and legacy RAW types, including RAW nested in arrays, maps, multisets, rows, and join types.
- Preserve the factory's existing logical-type cache and global canonicalization for types without RAW fields.
- Add tests with separate classloaders for both RAW representations, nullability, map keys, and nested rows. Check that primitive types still use the global cache.
- Verify RAW JSON round trips preserve the logical type and serialized representation without requiring a shared object across factories.

## Verifying this change

Added 42 classloader cases and 5 cache controls in `FlinkTypeFactoryTest`. The regressions were checked before and after the fix.

On Java 17, a clean planner build with eight selected suites passed all 770 tests: `FlinkTypeFactoryTest`, `LogicalRelDataTypeConverterTest`, `RelDataTypeJsonSerdeTest`, `LogicalTypeJsonSerdeTest`, `TimeIndicatorRelDataTypeTest`, stream SQL `CalcTest`, and batch/stream Table API `CorrelateTest`. Spotless and Checkstyle passed. The full repository test suite was not run.

The modern RAW cache change was also tested separately on Flink 1.19.3 with Java 11, one JobManager and two TaskManager JVMs on one host. Three consecutive REST submissions of the unchanged Sedona job completed. Each produced 2,048 ARRAY rows and 2,048 UNNEST rows, with both workers and network exchange verified. The unmodified cluster fails on the second submission. This cluster check used the Scala 1.19 implementation; the current Java implementation is covered by the native tests above.

## Does this pull request potentially affect one of the following parts

- Dependencies: no
- Public API: no
- Serializers: no format changes
- Runtime per-record code paths: no
- Deployment or recovery: fixes repeated job planning; no deployment or recovery protocol changes
- S3 file system connector: no

## Documentation

- New feature: no
- Feature documentation: not applicable
