### PR TITLE
[FLINK-40556][table] Support UUID value literals backed by byte[] values

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/expressions/ValueLiteralExpression.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/expressions/ValueLiteralExpression.java
@@ -41,6 +41,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import java.math.BigDecimal;
+import java.nio.ByteBuffer;
 import java.sql.Date;
 import java.sql.Time;
 import java.sql.Timestamp;
@@ -138,6 +139,8 @@ public final class ValueLiteralExpression implements ResolvedExpression {
                 convertedValue = convertToInstant(value, valueClass);
             } else if (clazz == BigDecimal.class) {
                 convertedValue = convertToBigDecimal(value);
+            } else if (clazz == UUID.class) {
+                convertedValue = convertToUuid(value, valueClass);
             }
         }
 
@@ -211,6 +214,15 @@ public final class ValueLiteralExpression implements ResolvedExpression {
     private @Nullable BigDecimal convertToBigDecimal(Object value) {
         if (Number.class.isAssignableFrom(value.getClass())) {
             return new BigDecimal(String.valueOf(value));
+        }
+
+        return null;
+    }
+
+    private @Nullable UUID convertToUuid(Object value, Class<?> valueClass) {
+        if (valueClass == byte[].class) {
+            final ByteBuffer buffer = ByteBuffer.wrap((byte[]) value);
+            return new UUID(buffer.getLong(), buffer.getLong());
         }
 
         return null;

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/expressions/ExpressionTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/expressions/ExpressionTest.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import java.math.BigDecimal;
+import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.sql.Date;
 import java.sql.Time;
@@ -245,14 +246,18 @@ class ExpressionTest {
                 .isEqualTo(instant.minusMillis(100));
     }
 
-    @Test
-    void testUuidValueLiteralExtraction() {
-        final UUID uuid = UUID.fromString("550e8400-e29b-41d4-a716-446655440000");
-        assertThat(
-                        new ValueLiteralExpression(uuid)
-                                .getValueAs(UUID.class)
-                                .orElseThrow(AssertionError::new))
-                .isEqualTo(uuid);
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("uuidValueLiteralTestCases")
+    void testUuidValueLiteralExtraction(
+            String caseName, ValueLiteralExpression literal, UUID uuid) {
+        assertThat(literal.getValueAs(UUID.class).orElseThrow(AssertionError::new)).isEqualTo(uuid);
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("uuidValueLiteralTestCases")
+    void testUuidAsSerializableString(String caseName, ValueLiteralExpression literal, UUID uuid) {
+        assertThat(literal.asSerializableString(DefaultSqlFactory.INSTANCE))
+                .isEqualTo(String.format("UUID '%s'", uuid));
     }
 
     @Test
@@ -341,6 +346,25 @@ class ExpressionTest {
                                                 DataTypes.INT())),
                                 DataTypes.BOOLEAN())),
                 DataTypes.BOOLEAN());
+    }
+
+    private static byte[] uuidToBytes(UUID uuid) {
+        return ByteBuffer.allocate(16)
+                .putLong(uuid.getMostSignificantBits())
+                .putLong(uuid.getLeastSignificantBits())
+                .array();
+    }
+
+    private static Stream<Arguments> uuidValueLiteralTestCases() {
+        final UUID uuid = UUID.fromString("550e8400-e29b-41d4-a716-446655440000");
+        return Stream.of(
+                Arguments.of("UUID value", new ValueLiteralExpression(uuid), uuid),
+                Arguments.of(
+                        "UUID bridged to byte[]",
+                        new ValueLiteralExpression(
+                                uuidToBytes(uuid),
+                                DataTypes.UUID().notNull().bridgedTo(byte[].class)),
+                        uuid));
     }
 
     private static Stream<Arguments> timestampLtzPrecisionTestCases() {

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/expressions/converter/ExpressionConverterTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/expressions/converter/ExpressionConverterTest.java
@@ -33,12 +33,14 @@ import org.apache.calcite.util.TimestampString;
 import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
+import java.nio.ByteBuffer;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.Period;
+import java.util.UUID;
 
 import static org.apache.flink.table.expressions.ApiExpressionUtils.valueLiteral;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -193,5 +195,29 @@ class ExpressionConverterTest {
         RexNode rex = converter.visit(valueLiteral(TimePointUnit.MICROSECOND));
         assertThat(((RexLiteral) rex).getValueAs(TimeUnit.class)).isEqualTo(TimeUnit.MICROSECOND);
         assertThat(rex.getType().getSqlTypeName()).isEqualTo(SqlTypeName.SYMBOL);
+    }
+
+    @Test
+    void testUuidLiteral() {
+        UUID uuid = UUID.fromString("550e8400-e29b-41d4-a716-446655440000");
+        RexNode rex = converter.visit(valueLiteral(uuid));
+        assertThat(((RexLiteral) rex).getValueAs(UUID.class)).isEqualTo(uuid);
+        assertThat(rex.getType().getSqlTypeName()).isEqualTo(SqlTypeName.UUID);
+    }
+
+    @Test
+    void testUuidLiteralFromBytes() {
+        UUID uuid = UUID.fromString("550e8400-e29b-41d4-a716-446655440000");
+        byte[] uuidBytes =
+                ByteBuffer.allocate(16)
+                        .putLong(uuid.getMostSignificantBits())
+                        .putLong(uuid.getLeastSignificantBits())
+                        .array();
+        RexNode rex =
+                converter.visit(
+                        valueLiteral(
+                                uuidBytes, DataTypes.UUID().notNull().bridgedTo(byte[].class)));
+        assertThat(((RexLiteral) rex).getValueAs(UUID.class)).isEqualTo(uuid);
+        assertThat(rex.getType().getSqlTypeName()).isEqualTo(SqlTypeName.UUID);
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

`UuidType` allows both `UUID` and `byte[]` as conversion classes, so a `ValueLiteralExpression` can legally hold a UUID literal internally as a `byte[]`. `ValueLiteralExpression#getValueAs(UUID.class)` didn't handle that case and returned empty, so both `asSerializableString` and `ExpressionConverter` threw `NoSuchElementException`/`IllegalStateException` instead of producing a literal.

## Brief change log

  - Added a `byte[]` to `UUID` conversion arm in `ValueLiteralExpression#getValueAs`, matching the existing coercion pattern for `LocalDate`, `Instant`, and other multi-representation types.
  - Fixes both affected call sites (`asSerializableString` and `ExpressionConverter#visit`) with a single change, since both go through `getValueAs`.

## Verifying this change

This change added tests and can be verified as follows:

  - `ExpressionTest#testUuidValueLiteralExtraction` and `#testUuidAsSerializableString` are parameterized over a direct `UUID` literal and a `byte[]`-bridged literal.
  - `ExpressionConverterTest#testUuidLiteral` and `#testUuidLiteralFromBytes` cover the same two cases through the planner's RexNode conversion path.
  - All four `byte[]`-backed cases reproduce the original exception before the fix and pass after it.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: Claude Code (Sonnet 5)