### PR TITLE
[FLINK-40632][s3] Annotate native-s3-fs to PublicEvolving

### DIFF
--- a/docs/content.zh/docs/deployment/filesystems/s3.md
+++ b/docs/content.zh/docs/deployment/filesystems/s3.md
@@ -68,10 +68,10 @@ Note that these examples are *not* exhaustive and you can use S3 in other places
 
 Flink provides three independent S3 filesystem implementations:
 
-| Implementation | Checkpointing | FileSink | Notes |
-|---------------|:---:|:---:|-------|
-| **Native S3** (`flink-s3-fs-native`) | ✓ | ✓ | **Experimental** in Flink 2.3. Built on AWS SDK v2; no Hadoop dependency. |
-| **Presto S3** (`flink-s3-fs-presto`) | ✓ | x | Production-proven for checkpointing. |
+| Implementation | Checkpointing | FileSink | Notes                                                                                      |
+|---------------|:---:|:---:|--------------------------------------------------------------------------------------------|
+| **Native S3** (`flink-s3-fs-native`) | ✓ | ✓ | Built on AWS SDK v2; no Hadoop dependency. Generally available since Flink 2.4.            |
+| **Presto S3** (`flink-s3-fs-presto`) | ✓ | x | Production-proven for checkpointing.                                                       |
 | **Hadoop S3** (`flink-s3-fs-hadoop`) | ✓ | ✓ | Mature; the only stable implementation that provides `RecoverableWriter` for the FileSink. |
 
 Previously, users had to choose between Presto (recommended for checkpointing throughput) and Hadoop (the only implementation with `RecoverableWriter`, required by the [FileSink]({{< ref "docs/connectors/datastream/filesystem" >}})). The Native S3 implementation unifies both capabilities in a single plugin and measurements show significant checkpoint throughput improvements over the Presto implementation.
@@ -149,11 +149,7 @@ The legacy configuration key `s3.path.style.access` is still supported as a fall
 
 ## Implementation Details
 
-### Native S3 FileSystem (Experimental)
-
-{{< hint warning >}}
-**Experimental**: The Native S3 FileSystem is experimental in Flink 2.3. It is functionally complete and has demonstrated strong performance in benchmarks.
-{{< /hint >}}
+### Native S3 FileSystem
 
 The Native S3 FileSystem is a pure-Java implementation built on the AWS SDK v2 completely removing the dependency on Hadoop. It is registered under the schemes *s3://* and *s3a://*. It provides a drop-in replacement for the Presto and Hadoop implementations, supporting checkpointing, the [FileSink]({{< ref "docs/connectors/datastream/filesystem" >}}) (via `RecoverableWriter`), server-side encryption (SSE-S3, SSE-KMS), cross-account access via IAM role assumption, entropy injection, and bulk copy via S3TransferManager.
 

--- a/docs/content/docs/deployment/filesystems/s3.md
+++ b/docs/content/docs/deployment/filesystems/s3.md
@@ -68,10 +68,10 @@ Note that these examples are *not* exhaustive and you can use S3 in other places
 
 Flink provides three independent S3 filesystem implementations:
 
-| Implementation | Checkpointing | FileSink | Notes |
-|---------------|:---:|:---:|-------|
-| **Native S3** (`flink-s3-fs-native`) | ✓ | ✓ | **Experimental** in Flink 2.3. Built on AWS SDK v2; no Hadoop dependency. |
-| **Presto S3** (`flink-s3-fs-presto`) | ✓ | x | Production-proven for checkpointing. |
+| Implementation | Checkpointing | FileSink | Notes                                                                                      |
+|---------------|:---:|:---:|--------------------------------------------------------------------------------------------|
+| **Native S3** (`flink-s3-fs-native`) | ✓ | ✓ | Built on AWS SDK v2; no Hadoop dependency. Generally available since Flink 2.4.            |
+| **Presto S3** (`flink-s3-fs-presto`) | ✓ | x | Production-proven for checkpointing.                                                       |
 | **Hadoop S3** (`flink-s3-fs-hadoop`) | ✓ | ✓ | Mature; the only stable implementation that provides `RecoverableWriter` for the FileSink. |
 
 Previously, users had to choose between Presto (recommended for checkpointing throughput) and Hadoop (the only implementation with `RecoverableWriter`, required by the [FileSink]({{< ref "docs/connectors/datastream/filesystem" >}})). The Native S3 implementation unifies both capabilities in a single plugin and measurements show significant checkpoint throughput improvements over the Presto implementation.
@@ -149,11 +149,7 @@ The legacy configuration key `s3.path.style.access` is still supported as a fall
 
 ## Implementation Details
 
-### Native S3 FileSystem (Experimental)
-
-{{< hint warning >}}
-**Experimental**: The Native S3 FileSystem is experimental in Flink 2.3. It is functionally complete and has demonstrated strong performance in benchmarks.
-{{< /hint >}}
+### Native S3 FileSystem
 
 The Native S3 FileSystem is a pure-Java implementation built on the AWS SDK v2 completely removing the dependency on Hadoop. It is registered under the schemes *s3://* and *s3a://*. It provides a drop-in replacement for the Presto and Hadoop implementations, supporting checkpointing, the [FileSink]({{< ref "docs/connectors/datastream/filesystem" >}}) (via `RecoverableWriter`), server-side encryption (SSE-S3, SSE-KMS), cross-account access via IAM role assumption, entropy injection, and bulk copy via S3TransferManager.
 

--- a/flink-filesystems/flink-s3-fs-native/src/main/java/org/apache/flink/fs/s3native/NativeS3AFileSystemFactory.java
+++ b/flink-filesystems/flink-s3-fs-native/src/main/java/org/apache/flink/fs/s3native/NativeS3AFileSystemFactory.java
@@ -18,7 +18,7 @@
 
 package org.apache.flink.fs.s3native;
 
-import org.apache.flink.annotation.Experimental;
+import org.apache.flink.annotation.PublicEvolving;
 
 /**
  * Factory for the native S3 file system registered for the {@code s3a://} scheme.
@@ -29,7 +29,7 @@ import org.apache.flink.annotation.Experimental;
  * <p>All configuration options are the same as for the {@code s3://} scheme. See {@link
  * NativeS3FileSystemFactory} for available options.
  */
-@Experimental
+@PublicEvolving
 public class NativeS3AFileSystemFactory extends NativeS3FileSystemFactory {
 
     @Override

--- a/flink-filesystems/flink-s3-fs-native/src/main/java/org/apache/flink/fs/s3native/NativeS3FileSystemFactory.java
+++ b/flink-filesystems/flink-s3-fs-native/src/main/java/org/apache/flink/fs/s3native/NativeS3FileSystemFactory.java
@@ -18,7 +18,7 @@
 
 package org.apache.flink.fs.s3native;
 
-import org.apache.flink.annotation.Experimental;
+import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.ConfigOptions;
 import org.apache.flink.configuration.Configuration;
@@ -61,7 +61,7 @@ import java.util.Map;
  * @see NativeS3FileSystem
  * @see org.apache.flink.core.fs.FileSystemFactory
  */
-@Experimental
+@PublicEvolving
 public class NativeS3FileSystemFactory implements FileSystemFactory, MetricsAware {
 
     private static final Logger LOG = LoggerFactory.getLogger(NativeS3FileSystemFactory.class);

--- a/flink-filesystems/flink-s3-fs-native/src/main/java/org/apache/flink/fs/s3native/writer/NativeS3RecoverableWriter.java
+++ b/flink-filesystems/flink-s3-fs-native/src/main/java/org/apache/flink/fs/s3native/writer/NativeS3RecoverableWriter.java
@@ -18,7 +18,7 @@
 
 package org.apache.flink.fs.s3native.writer;
 
-import org.apache.flink.annotation.Experimental;
+import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.core.fs.RecoverableFsDataOutputStream;
 import org.apache.flink.core.fs.RecoverableWriter;
@@ -36,7 +36,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /** Recoverable writer for S3 using multipart uploads for exactly-once semantics. */
-@Experimental
+@PublicEvolving
 public class NativeS3RecoverableWriter implements RecoverableWriter, AutoCloseable {
 
     private static final Logger LOG = LoggerFactory.getLogger(NativeS3RecoverableWriter.class);


### PR DESCRIPTION
## What is the purpose of the change

Mark native-s3-fs from Experimental to PublicEvolving


## Brief change log
These are the files marked as PublicEvolving 
1. NativeS3AFileSystemFactory 
2. NativeS3RecoverableWriter
3. NativeS3AFileSystemFactory


## Verifying this change

1. Existing UT and IT Suite 
2. CI / CD 

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know) yes

## Documentation

  - Does this pull request introduce a new feature? (yes / no) no
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented) documented

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change the checkbox below to `[X]` and replace the placeholder in the "Generated-by"
line with the tool name and version. Otherwise remove the "Generated-by" line.
See the ASF Generative Tooling Guidance for details:
https://www.apache.org/legal/generative-tooling.html

You are responsible for the quality and correctness of every change in this PR
regardless of the tooling used. Low-effort AI-generated PRs will be closed. See
AGENTS.md for the full guidance.
-->

- [ ] Yes (please specify the tool below)

Generated-by: [Tool Name and Version]
