### PR TITLE
[FLINK-40639][kubernetes] Deprecated kubernetes.pod-template-file takes precedence over kubernetes.pod-template-file.default

### DIFF
--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/configuration/KubernetesConfigOptions.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/configuration/KubernetesConfigOptions.java
@@ -735,7 +735,7 @@ public class KubernetesConfigOptions {
                         .stringType()
                         .noDefaultValue()
                         .withFallbackKeys(defaultPodTemplate.key())
-                        .withFallbackKeys(getDeprecatedKeys(defaultPodTemplate))
+                        .withDeprecatedKeys(getDeprecatedKeys(defaultPodTemplate))
                         .withDescription(
                                 "Specify a local file that contains the jobmanager pod template definition. "
                                         + "It will be used to initialize the jobmanager pod. "
@@ -750,7 +750,7 @@ public class KubernetesConfigOptions {
                         .stringType()
                         .noDefaultValue()
                         .withFallbackKeys(defaultPodTemplate.key())
-                        .withFallbackKeys(getDeprecatedKeys(defaultPodTemplate))
+                        .withDeprecatedKeys(getDeprecatedKeys(defaultPodTemplate))
                         .withDescription(
                                 "Specify a local file that contains the taskmanager pod template definition. "
                                         + "It will be used to initialize the taskmanager pod. "

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/configuration/KubernetesConfigOptionsTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/configuration/KubernetesConfigOptionsTest.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.configuration;
+
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.FallbackKey;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.stream.StreamSupport;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link KubernetesConfigOptions}. */
+class KubernetesConfigOptionsTest {
+
+    private static final String DEPRECATED_KEY = "kubernetes.pod-template-file";
+    private static final String DEFAULT_KEY = "kubernetes.pod-template-file.default";
+
+    @Test
+    void testPodTemplateDefaultKeyTakesPrecedenceOverDeprecatedKey() {
+        final Configuration configuration = new Configuration();
+        configuration.setString(DEPRECATED_KEY, "/deprecated.yaml");
+        configuration.setString(DEFAULT_KEY, "/default.yaml");
+
+        assertThat(configuration.getOptional(KubernetesConfigOptions.JOB_MANAGER_POD_TEMPLATE))
+                .hasValue("/default.yaml");
+        assertThat(configuration.getOptional(KubernetesConfigOptions.TASK_MANAGER_POD_TEMPLATE))
+                .hasValue("/default.yaml");
+        assertThat(configuration.getOptional(KubernetesConfigOptions.KUBERNETES_POD_TEMPLATE))
+                .hasValue("/default.yaml");
+    }
+
+    @Test
+    void testPodTemplateDeprecatedKeyIsStillHonoredOnItsOwn() {
+        final Configuration configuration = new Configuration();
+        configuration.setString(DEPRECATED_KEY, "/deprecated.yaml");
+
+        assertThat(configuration.getOptional(KubernetesConfigOptions.JOB_MANAGER_POD_TEMPLATE))
+                .hasValue("/deprecated.yaml");
+        assertThat(configuration.getOptional(KubernetesConfigOptions.TASK_MANAGER_POD_TEMPLATE))
+                .hasValue("/deprecated.yaml");
+    }
+
+    @Test
+    void testPodTemplateLegacyKeyIsRegisteredAsDeprecated() {
+        assertThat(isDeprecatedKey(KubernetesConfigOptions.JOB_MANAGER_POD_TEMPLATE))
+                .as(
+                        "%s must be deprecated so that using it logs a deprecation warning",
+                        DEPRECATED_KEY)
+                .isTrue();
+        assertThat(isDeprecatedKey(KubernetesConfigOptions.TASK_MANAGER_POD_TEMPLATE))
+                .as(
+                        "%s must be deprecated so that using it logs a deprecation warning",
+                        DEPRECATED_KEY)
+                .isTrue();
+    }
+
+    private static boolean isDeprecatedKey(ConfigOption<?> option) {
+        return StreamSupport.stream(option.fallbackKeys().spliterator(), false)
+                .filter(fallbackKey -> DEPRECATED_KEY.equals(fallbackKey.getKey()))
+                .anyMatch(FallbackKey::isDeprecated);
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

`JOB_MANAGER_POD_TEMPLATE` and `TASK_MANAGER_POD_TEMPLATE` register the deprecated `kubernetes.pod-template-file` through `withFallbackKeys(getDeprecatedKeys(defaultPodTemplate))`. `getDeprecatedKeys` returns keys whose `FallbackKey#isDeprecated` is true, but `withFallbackKeys` rebuilds them with `FallbackKey#createFallbackKey`, dropping the flag. Two problems follow.

**The deprecated key wins over the current one.** `withFallbackKeys` prepends ("put fallback keys first so that they are prioritized") while `withDeprecatedKeys` appends ("put deprecated keys last so that they are de-prioritized"), so the legacy key is checked ahead of `kubernetes.pod-template-file.default`. A user who moves to the new key but leaves the old one in their configuration silently keeps running the old pod template.

**No deprecation warning is logged.** `Configuration#loggingFallback` logs WARN only for deprecated keys and INFO otherwise. The only option still carrying the flag is `KUBERNETES_POD_TEMPLATE`, which no main source reads (`KubernetesJobManagerParameters` reads `JOB_MANAGER_POD_TEMPLATE`, `PodTemplateMountDecorator` reads `TASK_MANAGER_POD_TEMPLATE`), so users of the legacy key have never seen a deprecation warning.

## Brief change log

  - Register the legacy pod-template key with `withDeprecatedKeys` instead of `withFallbackKeys`, restoring both the precedence and the deprecation flag
  - Add `KubernetesConfigOptionsTest`

## Verifying this change

This change added tests and can be verified as follows:

  - `testPodTemplateDefaultKeyTakesPrecedenceOverDeprecatedKey` resolves to `/deprecated.yaml` before the change and `/default.yaml` after
  - `testPodTemplateLegacyKeyIsRegisteredAsDeprecated` is false before and true after
  - `testPodTemplateDeprecatedKeyIsStillHonoredOnItsOwn` passes either way and guards the legacy path

Both failing cases were confirmed red against unmodified master before the fix. Existing Kubernetes suites stay green locally (199 tests across `*PodTemplate*`, `Kubernetes{JobManager,TaskManager}Parameters*`, `Kubernetes{JobManager,TaskManager}Factory*`, `*Decorator*`). Generated config docs are unaffected: the options' key, type, default and description do not change, and the docs generator does not render fallback or deprecated keys.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: **yes**, Kubernetes pod template resolution
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: Claude Code (Claude Opus 5)
